### PR TITLE
protocol cleanups

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -9,13 +9,13 @@ ActionEnvelope {
   action: Action
   serverSeq: number                                     // monotonic, assigned by server
   origin: { clientId: string, clientSeq: number } | undefined  // undefined = server-originated
-  rejected?: true
+  rejectionReason?: string                              // present when the server rejected the action
 }
 ```
 
 - `serverSeq` — Monotonically increasing sequence number assigned by the server, used for ordering and replay.
 - `origin` — Identifies who produced this action. `undefined` means the server itself (e.g. from an agent backend). Otherwise identifies the client that dispatched it.
-- `rejected` — Set to `true` when the server rejected the action. The client should revert its optimistic prediction.
+- `rejectionReason` — When present, indicates the server rejected the action. The client should revert its optimistic prediction. Contains a human-readable explanation (e.g. `"no active turn to cancel"`, `"unknown permission request ID"`).
 
 ## Root Actions
 
@@ -55,6 +55,10 @@ When a client dispatches an action, the server applies it to the state and also 
 |---|---|---|
 | `session/toolStart` | No | Tool execution began |
 | `session/toolComplete` | No | Tool execution finished |
+
+::: tip FUTURE WORK
+A `session/toolUpdate` action for streaming incremental tool output (e.g. terminal output during a shell command) is planned for a future protocol version.
+:::
 
 ### Permissions
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,10 +8,10 @@ Every AHP session starts with a JSON-RPC handshake over the transport (WebSocket
 
 ```
 1. Client → Server:  initialize(protocolVersion, clientId, initialSubscriptions?)
-2. Server → Client:  serverHello(protocolVersion, serverSeq, snapshots[])
+2. Server → Client:  { protocolVersion, serverSeq, snapshots[] }
 ```
 
-The `initialSubscriptions` field allows the client to subscribe to root state and any previously-open sessions in the same round-trip as the handshake. The server responds with snapshots for each.
+The `initialSubscriptions` field allows the client to subscribe to root state and any previously-open sessions in the same round-trip as the handshake. The server returns snapshots for each in the response.
 
 ## Subscribing to State
 

--- a/docs/guide/reconciliation.md
+++ b/docs/guide/reconciliation.md
@@ -26,8 +26,8 @@ When the client receives an `ActionEnvelope` from the server:
 2. **Foreign action** (different origin or server-originated):
    - Apply to `confirmedState`, rebase remaining `pendingActions`.
 
-3. **Rejected action** (server echoed with `rejected: true`):
-   - Remove from pending (optimistic effect reverted).
+3. **Rejected action** (server echoed with `rejectionReason` present):
+   - Remove from pending (optimistic effect reverted). The `rejectionReason` MAY be surfaced to the user.
 
 4. Recompute `optimisticState` from `confirmedState` + remaining `pendingActions`.
 
@@ -64,9 +64,10 @@ The rare true conflict (two clients abort the same turn) is resolved by **server
 If the transport connection drops:
 
 ```jsonc
-// Client → Server
+// Client → Server (request)
 {
   "jsonrpc": "2.0",
+  "id": 2,
   "method": "reconnect",
   "params": {
     "clientId": "client-1",
@@ -76,7 +77,9 @@ If the transport connection drops:
 }
 ```
 
-The server replays actions since `lastSeenServerSeq` from a bounded replay buffer. If the gap exceeds the buffer, the server sends fresh snapshots via a `reconnectResponse` notification. Notifications (like `sessionAdded`/`sessionRemoved`) are **not** replayed — the client should re-fetch the session list.
+The server MUST include all replayed data in the response. If the gap is within the replay buffer, the response contains missed action envelopes. If the gap exceeds the buffer, the response contains fresh snapshots instead. In both cases, the client resets `confirmedState` accordingly and clears `pendingActions`.
+
+Protocol notifications (like `sessionAdded`/`sessionRemoved`) are **not** replayed — the client should re-fetch the session list.
 
 ## Next Steps
 

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -97,8 +97,8 @@ ActiveTurn {
   userMessage: UserMessage
   streamingText: string
   responseParts: ResponsePart[]
-  toolCalls: Map<toolCallId, ToolCallState>
-  pendingPermissions: Map<requestId, PermissionRequest>
+  toolCalls: Record<toolCallId, ToolCallState>
+  pendingPermissions: Record<requestId, PermissionRequest>
   reasoning: string
   usage: UsageInfo | undefined
 }

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -11,7 +11,7 @@ interface IActionEnvelope {
   readonly action: IStateAction;
   readonly serverSeq: number;
   readonly origin: { clientId: string; clientSeq: number } | undefined;
-  readonly rejected?: true;
+  readonly rejectionReason?: string;
 }
 ```
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,72 @@
 # Commands
 
-Commands are imperative JSON-RPC requests for operations that don't map to a single state action (session creation, data fetching, etc.). They return a result or a JSON-RPC error.
+Commands are JSON-RPC requests from the client to the server. They return a result or a JSON-RPC error.
+
+## `initialize`
+
+Establishes a new connection and negotiates the protocol version. This MUST be the first message sent by the client.
+
+| Property | Value |
+|---|---|
+| Direction | Client → Server |
+| Type | Request |
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `protocolVersion` | `number` | Yes | Protocol version the client speaks |
+| `clientId` | `string` | Yes | Unique client identifier |
+| `initialSubscriptions` | `URI[]` | No | URIs to subscribe to during handshake |
+
+**Result:**
+
+| Field | Type | Description |
+|---|---|---|
+| `protocolVersion` | `number` | Protocol version the server speaks |
+| `serverSeq` | `number` | Current server sequence number |
+| `snapshots` | `ISnapshot[]` | Snapshots for each `initialSubscriptions` URI |
+
+If the server does not support the client's protocol version, it MUST return error code `-32005` (`UnsupportedProtocolVersion`).
+
+See [Lifecycle](/specification/lifecycle) for the full handshake flow.
+
+---
+
+## `reconnect`
+
+Re-establishes a dropped connection. The server replays missed actions or provides fresh snapshots.
+
+| Property | Value |
+|---|---|
+| Direction | Client → Server |
+| Type | Request |
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `clientId` | `string` | Yes | Client identifier from the original connection |
+| `lastSeenServerSeq` | `number` | Yes | Last `serverSeq` the client received |
+| `subscriptions` | `URI[]` | Yes | URIs the client was subscribed to |
+
+**Result (replay):** When the server can replay from the requested sequence:
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | `'replay'` | Discriminant |
+| `actions` | `IActionEnvelope[]` | Missed action envelopes since `lastSeenServerSeq` |
+
+**Result (snapshot):** When the gap exceeds the replay buffer:
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | `'snapshot'` | Discriminant |
+| `snapshots` | `ISnapshot[]` | Fresh snapshots for each subscription |
+
+The server MUST include all replayed data in the response. See [Lifecycle](/specification/lifecycle) for details.
+
+---
 
 ## `createSession`
 
@@ -21,6 +87,8 @@ Creates a new session with the specified agent provider.
 
 **Result:** `null` on success.
 
+If the session URI already exists, the server MUST return an error with code `-32003` (`SessionAlreadyExists`). See [Error Codes](/reference/error-codes).
+
 **Example:**
 
 ```jsonc
@@ -31,8 +99,11 @@ Creates a new session with the specified agent provider.
 // Server → Client (success)
 { "jsonrpc": "2.0", "id": 2, "result": null }
 
-// Server → Client (failure)
-{ "jsonrpc": "2.0", "id": 2, "error": { "code": -32603, "message": "No agent for provider" } }
+// Server → Client (failure — provider not found)
+{ "jsonrpc": "2.0", "id": 2, "error": { "code": -32002, "message": "No agent for provider" } }
+
+// Server → Client (failure — session already exists)
+{ "jsonrpc": "2.0", "id": 2, "error": { "code": -32003, "message": "Session already exists" } }
 ```
 
 After creation, the client should subscribe to the session URI to receive state updates. The server also broadcasts a `notify/sessionAdded` notification to all clients.
@@ -96,7 +167,30 @@ Fetches large content referenced by a `ContentRef` in the state tree.
 |---|---|---|---|
 | `uri` | `string` | Yes | Content URI from a `ContentRef` |
 
-**Result:** The content bytes.
+**Result:**
+
+| Field | Type | Description |
+|---|---|---|
+| `data` | `string` | Content encoded as a string |
+| `encoding` | `'base64' \| 'utf-8'` | How `data` is encoded |
+| `mimeType` | `string?` | MIME type of the content |
+
+Binary content (images, etc.) MUST use `base64` encoding. Text content MAY use `utf-8` encoding.
+
+**Example:**
+
+```jsonc
+// Client → Server
+{ "jsonrpc": "2.0", "id": 10, "method": "fetchContent",
+  "params": { "uri": "copilot:/<uuid>/content/img-1" } }
+
+// Server → Client
+{ "jsonrpc": "2.0", "id": 10, "result": {
+  "data": "iVBORw0KGgo...",
+  "encoding": "base64",
+  "mimeType": "image/png"
+}}
+```
 
 Content references keep the state tree small by storing large data (images, long tool outputs) by reference rather than inline.
 
@@ -116,9 +210,33 @@ Fetches historical turns for a session. Used for lazy loading of conversation hi
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `session` | `URI` | Yes | Session URI |
-| `range` | `object` | No | Range of turns to fetch |
+| `before` | `string` | No | Turn ID to fetch before (exclusive). Omit to fetch from the most recent turn. |
+| `limit` | `number` | No | Maximum number of turns to return. Server MAY impose its own upper bound. |
 
-**Result:** `ITurn[]`
+**Result:**
+
+| Field | Type | Description |
+|---|---|---|
+| `turns` | `ITurn[]` | The requested turns, ordered oldest-first |
+| `hasMore` | `boolean` | Whether more turns exist before the returned range |
+
+**Example:**
+
+```jsonc
+// Client → Server (fetch the 20 most recent turns)
+{ "jsonrpc": "2.0", "id": 8, "method": "fetchTurns",
+  "params": { "session": "copilot:/<uuid>", "limit": 20 } }
+
+// Server → Client
+{ "jsonrpc": "2.0", "id": 8, "result": {
+  "turns": [ { "id": "t1", ... }, { "id": "t2", ... } ],
+  "hasMore": true
+}}
+
+// Client → Server (fetch 20 turns before t1)
+{ "jsonrpc": "2.0", "id": 9, "method": "fetchTurns",
+  "params": { "session": "copilot:/<uuid>", "before": "t1", "limit": 20 } }
+```
 
 ---
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1,237 +1,48 @@
-# Actions Reference
+# Error Codes
 
-Complete reference for all action types in the Agent Host Protocol. Actions are the sole mutation mechanism for subscribable state.
+AHP uses [JSON-RPC 2.0](https://www.jsonrpc.org/specification) error codes. In addition to the standard JSON-RPC codes, AHP defines application-specific error codes in the `-32000` to `-32099` range.
 
-## Action Envelope
+## Standard JSON-RPC Codes
 
-Every action is wrapped in an `ActionEnvelope`:
+These codes are defined by the JSON-RPC 2.0 specification:
 
-```typescript
-interface IActionEnvelope {
-  readonly action: IStateAction;
-  readonly serverSeq: number;
-  readonly origin: { clientId: string; clientSeq: number } | undefined;
-  readonly rejected?: true;
+| Code | Name | Description |
+|---|---|---|
+| `-32700` | Parse error | Invalid JSON |
+| `-32600` | Invalid request | Not a valid JSON-RPC request |
+| `-32601` | Method not found | Unknown method name |
+| `-32602` | Invalid params | Invalid method parameters |
+| `-32603` | Internal error | Unspecified server error |
+
+## AHP Application Codes
+
+| Code | Name | Description |
+|---|---|---|
+| `-32001` | `SessionNotFound` | The referenced session URI does not exist |
+| `-32002` | `ProviderNotFound` | The requested agent provider is not registered |
+| `-32003` | `SessionAlreadyExists` | A session with the given URI already exists |
+| `-32004` | `TurnInProgress` | The operation requires no active turn, but one is in progress |
+| `-32005` | `UnsupportedProtocolVersion` | The client's protocol version is not supported by the server |
+| `-32006` | `ContentNotFound` | The requested content URI does not exist |
+
+## Error Response Format
+
+All error responses follow the JSON-RPC 2.0 error format:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32002,
+    "message": "No agent registered for provider 'unknown'",
+    "data": {}
+  }
 }
 ```
 
-## Root Actions
-
-Mutate `RootState`. All are server-only.
-
-### `root/agentsChanged`
-
-Fired when available agent backends or their models change.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'root/agentsChanged'` | Discriminant |
-| `agents` | `IAgentInfo[]` | Updated agent list |
-
-## Session Actions
-
-Mutate `SessionState`. Scoped to a session URI.
-
-### `session/ready`
-
-Session backend initialized successfully.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/ready'` | Discriminant |
-| `session` | `URI` | Session URI |
-
-### `session/creationFailed`
-
-Session backend failed to initialize.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/creationFailed'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `error` | `IErrorInfo` | Error details |
-
-### `session/turnStarted`
-
-**Client-dispatchable.** User sent a message; server starts agent processing.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/turnStarted'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `userMessage` | `IUserMessage` | User's message |
-
-### `session/delta`
-
-Streaming text chunk from the assistant.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/delta'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `content` | `string` | Text chunk |
-
-### `session/responsePart`
-
-Structured content appended to the response.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/responsePart'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `part` | `IResponsePart` | Response part (markdown or content ref) |
-
-### `session/toolStart`
-
-Tool execution began.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/toolStart'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `toolCall` | `IToolCallState` | Full tool call state |
-
-### `session/toolComplete`
-
-Tool execution finished.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/toolComplete'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `toolCallId` | `string` | Tool call to complete |
-| `result` | `IToolCompleteResult` | Completion result |
-
-#### `IToolCompleteResult`
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `success` | `boolean` | Yes | Whether the tool succeeded |
-| `pastTenseMessage` | `string` | Yes | Past-tense description |
-| `toolOutput` | `string` | No | Tool output text |
-| `error` | `{ message: string; code?: string }` | No | Error details |
-
-### `session/permissionRequest`
-
-Permission needed from the user to proceed.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/permissionRequest'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `request` | `IPermissionRequest` | Permission request details |
-
-### `session/permissionResolved`
-
-**Client-dispatchable.** Permission granted or denied.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/permissionResolved'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `requestId` | `string` | Permission request ID |
-| `approved` | `boolean` | Whether permission was granted |
-
-### `session/turnComplete`
-
-Turn finished — the assistant is idle.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/turnComplete'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-
-### `session/turnCancelled`
-
-**Client-dispatchable.** Turn was aborted; server stops processing.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/turnCancelled'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-
-### `session/error`
-
-Error during turn processing.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/error'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `error` | `IErrorInfo` | Error details |
-
-### `session/titleChanged`
-
-Session title updated (typically auto-generated from conversation).
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/titleChanged'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `title` | `string` | New title |
-
-### `session/usage`
-
-Token usage report for a turn.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/usage'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `usage` | `IUsageInfo` | Token usage data |
-
-### `session/reasoning`
-
-Reasoning/thinking text from the model.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/reasoning'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `turnId` | `string` | Turn identifier |
-| `content` | `string` | Reasoning text chunk |
-
-### `session/modelChanged`
-
-**Client-dispatchable.** Model changed for this session.
-
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/modelChanged'` | Discriminant |
-| `session` | `URI` | Session URI |
-| `model` | `string` | New model ID |
+The `data` field is OPTIONAL and MAY contain additional structured information about the error. Its shape is not defined by the protocol.
 
 ## Version Introduction
 
-All actions listed above were introduced in protocol version **1**.
-
-| Action Type | Version |
-|---|---|
-| `root/agentsChanged` | 1 |
-| `session/ready` | 1 |
-| `session/creationFailed` | 1 |
-| `session/turnStarted` | 1 |
-| `session/delta` | 1 |
-| `session/responsePart` | 1 |
-| `session/toolStart` | 1 |
-| `session/toolComplete` | 1 |
-| `session/permissionRequest` | 1 |
-| `session/permissionResolved` | 1 |
-| `session/turnComplete` | 1 |
-| `session/turnCancelled` | 1 |
-| `session/error` | 1 |
-| `session/titleChanged` | 1 |
-| `session/usage` | 1 |
-| `session/reasoning` | 1 |
-| `session/modelChanged` | 1 |
+All error codes listed above were introduced in protocol version **1**.

--- a/docs/reference/messages.md
+++ b/docs/reference/messages.md
@@ -1,254 +1,40 @@
-# State Types
+# Messages Reference
 
-Complete reference for all state types in the Agent Host Protocol.
+Complete reference of all JSON-RPC methods in the Agent Host Protocol, organized by direction and type.
 
-## Root State
+## Client → Server Requests
 
-### `IRootState`
+These methods have an `id` and expect a response.
 
-Global state shared with every client subscribed to `agenthost:/root`.
-
-| Field | Type | Description |
+| Method | Description | Reference |
 |---|---|---|
-| `agents` | `IAgentInfo[]` | Available agent backends and their models |
+| `initialize` | Handshake — establishes the connection and protocol version | [Lifecycle](/specification/lifecycle) |
+| `reconnect` | Re-establishes a dropped connection with replay or snapshot | [Lifecycle](/specification/lifecycle) |
+| `subscribe` | Subscribe to a URI-identified state resource | [Subscriptions](/specification/subscriptions) |
+| `createSession` | Create a new agent session | [Commands](/reference/commands) |
+| `disposeSession` | Dispose a session and clean up resources | [Commands](/reference/commands) |
+| `listSessions` | Fetch session summaries | [Commands](/reference/commands) |
+| `fetchTurns` | Fetch historical turns for a session | [Commands](/reference/commands) |
+| `fetchContent` | Fetch large content by reference | [Commands](/reference/commands) |
 
-### `IAgentInfo`
+## Client → Server Notifications
 
-| Field | Type | Description |
+These methods have no `id` and expect no response.
+
+| Method | Description | Reference |
 |---|---|---|
-| `provider` | `string` | Agent provider ID (e.g. `'copilot'`) |
-| `displayName` | `string` | Human-readable name |
-| `description` | `string` | Description string |
-| `models` | `ISessionModelInfo[]` | Available models for this agent |
+| `unsubscribe` | Stop receiving updates for a URI | [Subscriptions](/specification/subscriptions) |
+| `dispatchAction` | Fire-and-forget action dispatch (write-ahead) | [Actions](/guide/actions) |
 
-### `ISessionModelInfo`
+## Server → Client Notifications
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `id` | `string` | Yes | Model identifier |
-| `provider` | `string` | Yes | Provider this model belongs to |
-| `name` | `string` | Yes | Human-readable model name |
-| `maxContextWindow` | `number` | No | Maximum context window size |
-| `supportsVision` | `boolean` | No | Whether the model supports vision |
-| `policyState` | `'enabled' \| 'disabled' \| 'unconfigured'` | No | Policy configuration state |
+These are pushed by the server without a preceding request.
 
-## Session State
-
-### `ISessionState`
-
-Full state for a single session, loaded when a client subscribes to the session's URI.
-
-| Field | Type | Description |
+| Method | Description | Reference |
 |---|---|---|
-| `summary` | `ISessionSummary` | Lightweight session metadata |
-| `lifecycle` | `'creating' \| 'ready' \| 'creationFailed'` | Session initialization state |
-| `creationError` | `IErrorInfo?` | Error details if creation failed |
-| `turns` | `ITurn[]` | Completed turns |
-| `activeTurn` | `IActiveTurn \| undefined` | Currently in-progress turn |
+| `action` | Delivers an `ActionEnvelope` to subscribed clients | [Actions](/reference/actions) |
+| `notification` | Ephemeral protocol notification (e.g. session added/removed) | [Notifications](/reference/notifications) |
 
-### `ISessionSummary`
+## Version Introduction
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `resource` | `URI` | Yes | Session URI |
-| `provider` | `string` | Yes | Agent provider ID |
-| `title` | `string` | Yes | Session title |
-| `status` | `'idle' \| 'in-progress' \| 'error'` | Yes | Current session status |
-| `createdAt` | `number` | Yes | Creation timestamp |
-| `modifiedAt` | `number` | Yes | Last modification timestamp |
-| `model` | `string` | No | Currently selected model |
-
-## Turn Types
-
-### `ITurn`
-
-A completed request/response cycle.
-
-| Field | Type | Description |
-|---|---|---|
-| `id` | `string` | Turn identifier |
-| `userMessage` | `IUserMessage` | The user's input |
-| `responseText` | `string` | Final response text (captured from streaming) |
-| `responseParts` | `IResponsePart[]` | Structured response content |
-| `toolCalls` | `ICompletedToolCall[]` | Completed tool invocations |
-| `usage` | `IUsageInfo \| undefined` | Token usage info |
-| `state` | `'complete' \| 'cancelled' \| 'error'` | How the turn ended |
-| `error` | `IErrorInfo?` | Error details if state is `'error'` |
-
-### `IActiveTurn`
-
-An in-progress turn — the assistant is actively streaming.
-
-| Field | Type | Description |
-|---|---|---|
-| `id` | `string` | Turn identifier |
-| `userMessage` | `IUserMessage` | The user's input |
-| `streamingText` | `string` | Accumulated streaming response text |
-| `responseParts` | `IResponsePart[]` | Structured response content so far |
-| `toolCalls` | `Map<string, IToolCallState>` | Active tool invocations by tool call ID |
-| `pendingPermissions` | `Map<string, IPermissionRequest>` | Pending permission requests by request ID |
-| `reasoning` | `string` | Accumulated reasoning/thinking text |
-| `usage` | `IUsageInfo \| undefined` | Token usage info |
-
-### `IUserMessage`
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `text` | `string` | Yes | Message text |
-| `attachments` | `IMessageAttachment[]` | No | File/selection attachments |
-
-### `IMessageAttachment`
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `type` | `'file' \| 'directory' \| 'selection'` | Yes | Attachment type |
-| `path` | `string` | Yes | File/directory path |
-| `displayName` | `string` | No | Display name |
-
-## Response Parts
-
-### `IMarkdownResponsePart`
-
-| Field | Type | Description |
-|---|---|---|
-| `kind` | `'markdown'` | Discriminant |
-| `content` | `string` | Markdown content |
-
-### `IContentRef`
-
-A reference to large content stored outside the state tree.
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `kind` | `'contentRef'` | Yes | Discriminant |
-| `uri` | `string` | Yes | Content URI |
-| `sizeHint` | `number` | No | Approximate size in bytes |
-| `mimeType` | `string` | No | Content MIME type |
-
-`IResponsePart = IMarkdownResponsePart | IContentRef`
-
-## Tool Call Types
-
-### `IToolCallState`
-
-Full lifecycle state of a tool invocation within an active turn.
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `toolCallId` | `string` | Yes | Unique tool call identifier |
-| `toolName` | `string` | Yes | Internal tool name |
-| `displayName` | `string` | Yes | Human-readable tool name |
-| `invocationMessage` | `string` | Yes | Message shown while running |
-| `toolInput` | `string` | No | Raw tool input |
-| `toolKind` | `'terminal'` | No | Rendering hint |
-| `language` | `string` | No | Language for syntax highlighting |
-| `toolArguments` | `string` | No | Serialized tool arguments |
-| `status` | `ToolCallStatus` | Yes | Current status |
-| `parameters` | `unknown` | No | Parsed tool parameters |
-| `confirmed` | `ConfirmationState` | No | How the tool was confirmed |
-| `pastTenseMessage` | `string` | No | Message shown after completion |
-| `toolOutput` | `string` | No | Tool output text |
-| `error` | `{ message: string; code?: string }` | No | Error details |
-| `cancellationReason` | `'denied' \| 'skipped'` | No | Why the tool was cancelled |
-
-**`ToolCallStatus`**: `'running' | 'pending-permission' | 'completed' | 'failed' | 'cancelled'`
-
-**`ConfirmationState`**: `'not-needed' | 'user-action' | 'setting' | 'denied' | 'skipped'`
-
-### `ICompletedToolCall`
-
-| Field | Type | Description |
-|---|---|---|
-| `toolCallId` | `string` | Unique tool call identifier |
-| `toolName` | `string` | Internal tool name |
-| `displayName` | `string` | Human-readable tool name |
-| `invocationMessage` | `string` | Message shown during invocation |
-| `success` | `boolean` | Whether the tool succeeded |
-| `pastTenseMessage` | `string` | Message shown after completion |
-| `toolInput` | `string?` | Raw tool input |
-| `toolKind` | `'terminal'?` | Rendering hint |
-| `language` | `string?` | Language for syntax highlighting |
-| `toolOutput` | `string?` | Tool output text |
-| `error` | `{ message: string; code?: string }?` | Error details |
-
-## Permission Types
-
-### `IPermissionRequest`
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `requestId` | `string` | Yes | Unique request identifier |
-| `permissionKind` | `'shell' \| 'write' \| 'mcp' \| 'read' \| 'url'` | Yes | Type of permission |
-| `toolCallId` | `string` | No | Associated tool call |
-| `path` | `string` | No | File/directory path |
-| `fullCommandText` | `string` | No | Full command to execute |
-| `intention` | `string` | No | What the tool intends to do |
-| `serverName` | `string` | No | MCP server name |
-| `toolName` | `string` | No | Tool requesting permission |
-| `rawRequest` | `string` | No | Raw request data |
-
-## Common Types
-
-### `IUsageInfo`
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `inputTokens` | `number` | No | Input tokens consumed |
-| `outputTokens` | `number` | No | Output tokens generated |
-| `model` | `string` | No | Model used |
-| `cacheReadTokens` | `number` | No | Tokens read from cache |
-
-### `IErrorInfo`
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `errorType` | `string` | Yes | Error type identifier |
-| `message` | `string` | Yes | Human-readable error message |
-| `stack` | `string` | No | Stack trace |
-
----
-
-## Tool Messages
-
-### `tool/invoke`
-
-| Property  | Value           |
-| --------- | --------------- |
-| Direction | Agent → Host    |
-| Type      | Request         |
-
-Requests the host to invoke a tool on the agent's behalf.
-
-**Parameters:**
-
-| Field    | Type     | Required | Description                    |
-| -------- | -------- | -------- | ------------------------------ |
-| `tool`   | `string` | Yes      | The tool to invoke.             |
-| `params` | `object` | No       | Parameters for the tool.        |
-
-**Result:**
-
-| Field    | Type  | Description          |
-| -------- | ----- | -------------------- |
-| `result` | `any` | The tool result.      |
-
----
-
-## UI Messages
-
-### `ui/progress`
-
-| Property  | Value           |
-| --------- | --------------- |
-| Direction | Agent → Host    |
-| Type      | Notification    |
-
-Reports progress on a task.
-
-**Parameters:**
-
-| Field      | Type     | Required | Description                          |
-| ---------- | -------- | -------- | ------------------------------------ |
-| `taskId`   | `string` | Yes      | The task being reported on.           |
-| `progress` | `number` | No       | Progress fraction (0.0 to 1.0).      |
-| `message`  | `string` | No       | Human-readable progress message.      |
+All messages listed above were introduced in protocol version **1**.

--- a/docs/reference/notifications.md
+++ b/docs/reference/notifications.md
@@ -76,27 +76,7 @@ Clients use notifications to maintain a local session list cache:
 
 ## Server Notifications
 
-In addition to protocol notifications, the server sends these notifications during connection lifecycle:
-
-### `serverHello`
-
-Sent in response to the client's `initialize` message.
-
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "serverHello",
-  "params": {
-    "protocolVersion": 1,
-    "serverSeq": 42,
-    "snapshots": [{ "resource": "...", "state": { ... }, "fromSeq": 42 }]
-  }
-}
-```
-
-### `reconnectResponse`
-
-Sent in response to a `reconnect` message when the server cannot replay from the requested sequence number and must send fresh snapshots instead.
+In addition to protocol notifications, the server pushes action envelopes to subscribed clients:
 
 ### `action`
 

--- a/docs/reference/state-types.md
+++ b/docs/reference/state-types.md
@@ -85,8 +85,8 @@ An in-progress turn — the assistant is actively streaming.
 | `userMessage` | `IUserMessage` | The user's input |
 | `streamingText` | `string` | Accumulated streaming response text |
 | `responseParts` | `IResponsePart[]` | Structured response content so far |
-| `toolCalls` | `Map<string, IToolCallState>` | Active tool invocations by tool call ID |
-| `pendingPermissions` | `Map<string, IPermissionRequest>` | Pending permission requests by request ID |
+| `toolCalls` | `Record<string, IToolCallState>` | Active tool invocations keyed by tool call ID |
+| `pendingPermissions` | `Record<string, IPermissionRequest>` | Pending permission requests keyed by request ID |
 | `reasoning` | `string` | Accumulated reasoning/thinking text |
 | `usage` | `IUsageInfo \| undefined` | Token usage info |
 
@@ -132,6 +132,10 @@ A reference to large content stored outside the state tree.
 ### `IToolCallState`
 
 Full lifecycle state of a tool invocation within an active turn.
+
+::: tip FUTURE WORK
+Fields like `toolName` in `IToolCallState` and `serverName`/`toolName`/`rawRequest` in `IPermissionRequest` carry agent-specific identifiers on the wire despite the agent-agnostic design principle. These exist for debugging and logging purposes. A future version may move these to a separate diagnostic channel or namespace them more clearly.
+:::
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -205,3 +209,13 @@ Full lifecycle state of a tool invocation within an active turn.
 | `errorType` | `string` | Yes | Error type identifier |
 | `message` | `string` | Yes | Human-readable error message |
 | `stack` | `string` | No | Stack trace |
+
+### `ISnapshot`
+
+A point-in-time snapshot of a subscribed resource's state, returned by `initialize`, `reconnect`, and `subscribe`.
+
+| Field | Type | Description |
+|---|---|---|
+| `resource` | `URI` | The subscribed resource URI (e.g. `agenthost:/root` or `copilot:/<uuid>`) |
+| `state` | `IRootState \| ISessionState` | The current state of the resource |
+| `fromSeq` | `number` | The `serverSeq` at which this snapshot was taken. Subsequent actions will have `serverSeq > fromSeq`. |

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -4,18 +4,21 @@ The lifecycle defines how AHP connections are established, sessions are created 
 
 ## Connection Handshake
 
-The client initiates the connection with an `initialize` notification. The server responds with a `serverHello` notification:
+The client initiates the connection with an `initialize` **request**. The server responds with the protocol version and initial state snapshots:
 
 ```
 1. Client → Server:  initialize(protocolVersion, clientId, initialSubscriptions?)
-2. Server → Client:  serverHello(protocolVersion, serverSeq, snapshots[])
+2. Server → Client:  { protocolVersion, serverSeq, snapshots[] }
 ```
 
 ### Initialize (Client → Server)
 
+`initialize` is a JSON-RPC **request** — the server MUST respond with a result or error.
+
 ```json
 {
   "jsonrpc": "2.0",
+  "id": 1,
   "method": "initialize",
   "params": {
     "protocolVersion": 1,
@@ -27,13 +30,13 @@ The client initiates the connection with an `initialize` notification. The serve
 
 `initialSubscriptions` allows the client to subscribe to root state (and any previously-open sessions) in the same round-trip as the handshake.
 
-### ServerHello (Server → Client)
+### Initialize Response (Server → Client)
 
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "serverHello",
-  "params": {
+  "id": 1,
+  "result": {
     "protocolVersion": 1,
     "serverSeq": 42,
     "snapshots": [
@@ -48,6 +51,8 @@ The client initiates the connection with an `initialize` notification. The serve
 ```
 
 The `protocolVersion` in the response tells the client what version the server speaks. The client derives `ProtocolCapabilities` from this and gates feature usage accordingly.
+
+If the server cannot accept the connection (e.g. unsupported protocol version), it MUST return a JSON-RPC error. See [Error Codes](/reference/error-codes) for defined codes.
 
 ## Session Creation
 
@@ -75,6 +80,21 @@ Once a session reaches `lifecycle: 'ready'`, the session is active:
 
 All actions MUST be scoped to the session URI and reference a valid turn ID when applicable.
 
+## Server Validation of Client Actions
+
+When the server receives a client-dispatched action, it MUST validate it before applying. Invalid actions MUST be echoed back with a `rejectionReason`. The following validation rules apply:
+
+| Action | Condition | Server Behavior |
+|---|---|---|
+| Any action referencing a non-existent session | Session URI not found | Server MUST silently ignore the action (no echo) |
+| `session/permissionResolved` | `requestId` not in `pendingPermissions` | Server MUST reject the action |
+| `session/turnCancelled` | No active turn | Server MUST reject the action |
+| `session/modelChanged` | A turn is currently active | Server MUST defer the model change until the active turn completes, then apply it for the next turn |
+
+::: tip FUTURE WORK
+`session/turnStarted` dispatched while a turn is already active will eventually support queuing and steering. See the protocol roadmap for details.
+:::
+
 ## Session Disposal
 
 ```jsonc
@@ -91,11 +111,12 @@ The server disposes the session and broadcasts a `notify/sessionRemoved` notific
 
 ## Reconnection
 
-If the transport connection drops, the client reconnects and sends:
+If the transport connection drops, the client reconnects and sends a `reconnect` **request**:
 
 ```json
 {
   "jsonrpc": "2.0",
+  "id": 2,
   "method": "reconnect",
   "params": {
     "clientId": "client-abc",
@@ -105,9 +126,39 @@ If the transport connection drops, the client reconnects and sends:
 }
 ```
 
-The server replays actions since `lastSeenServerSeq` from a bounded replay buffer. If the gap exceeds the buffer, the server sends fresh snapshots via a `reconnectResponse` notification.
+The server MUST include all replayed data in the response before returning. If the server can replay from the requested sequence, it returns the missed action envelopes:
 
-Notifications are **not** replayed — the client SHOULD re-fetch the session list via `listSessions()`.
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "type": "replay",
+    "actions": [
+      { "action": { "type": "session/delta", ... }, "serverSeq": 43 },
+      { "action": { "type": "session/delta", ... }, "serverSeq": 44 }
+    ]
+  }
+}
+```
+
+If the gap exceeds the replay buffer, the server sends fresh snapshots instead:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "type": "snapshot",
+    "snapshots": [
+      { "resource": "agenthost:/root", "state": { ... }, "fromSeq": 50 },
+      { "resource": "copilot:/<uuid>", "state": { ... }, "fromSeq": 50 }
+    ]
+  }
+}
+```
+
+Protocol notifications are **not** replayed — the client SHOULD re-fetch the session list via `listSessions()`.
 
 ## Unexpected Disconnection
 

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -31,9 +31,9 @@ AHP uses [JSON-RPC 2.0](https://www.jsonrpc.org/specification) as its message fr
 
 | Direction | Type | Examples |
 |---|---|---|
-| Client → Server (notification) | Fire-and-forget | `initialize`, `reconnect`, `unsubscribe`, `dispatchAction` |
-| Client → Server (request) | Expects a response | `subscribe`, `createSession`, `disposeSession`, `listSessions`, `fetchTurns`, `fetchContent` |
-| Server → Client (notification) | Pushed | `serverHello`, `reconnectResponse`, `action`, `notification` |
+| Client → Server (notification) | Fire-and-forget | `unsubscribe`, `dispatchAction` |
+| Client → Server (request) | Expects a response | `initialize`, `reconnect`, `subscribe`, `createSession`, `disposeSession`, `listSessions`, `fetchTurns`, `fetchContent` |
+| Server → Client (notification) | Pushed | `action`, `notification` |
 | Server → Client (response) | Correlated by `id` | Success result or JSON-RPC error |
 
 ### Requests
@@ -77,4 +77,6 @@ The specification is organized into the following sections:
 - **[State Types](/reference/state-types)** — Complete state type definitions.
 - **[Actions](/reference/actions)** — Complete action type definitions.
 - **[Commands](/reference/commands)** — Available RPC commands.
+- **[Messages](/reference/messages)** — Complete list of JSON-RPC methods.
 - **[Notifications](/reference/notifications)** — Ephemeral event broadcasts.
+- **[Error Codes](/reference/error-codes)** — Application-specific error codes.

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -78,11 +78,12 @@ The server broadcasts action envelopes as JSON-RPC notifications to subscribed c
 
 ## Initial Subscriptions
 
-During the connection handshake, clients MAY include `initialSubscriptions` in the `initialize` message to subscribe to URIs in the same round-trip:
+During the connection handshake, clients MAY include `initialSubscriptions` in the `initialize` request to subscribe to URIs in the same round-trip:
 
 ```json
 {
   "jsonrpc": "2.0",
+  "id": 1,
   "method": "initialize",
   "params": {
     "protocolVersion": 1,
@@ -92,7 +93,7 @@ During the connection handshake, clients MAY include `initialSubscriptions` in t
 }
 ```
 
-The server includes snapshots for each in the `serverHello` response.
+The server includes snapshots for each in the `initialize` response.
 
 ## Protocol Notifications
 

--- a/docs/specification/transport.md
+++ b/docs/specification/transport.md
@@ -40,3 +40,11 @@ For desktop (Electron) deployments, the renderer connects directly to the agent 
 ## Custom Transports
 
 Implementations MAY define custom transports as long as they meet the requirements above. Any mechanism that delivers complete, ordered, bidirectional messages is acceptable.
+
+## Keep-Alive
+
+AHP does not define a protocol-level heartbeat. For WebSocket transports, implementations SHOULD use WebSocket protocol-level ping/pong frames to detect dead connections. The ping interval and timeout are implementation-specific.
+
+## Authentication
+
+Authentication is a transport-layer concern and is outside the scope of the AHP wire protocol. For WebSocket transports, implementations SHOULD authenticate during the WebSocket handshake (e.g. via query parameters, headers, or the HTTP upgrade request) before the AHP `initialize` request is sent.

--- a/docs/specification/versioning.md
+++ b/docs/specification/versioning.md
@@ -101,7 +101,7 @@ function capabilitiesForVersion(version: number): ProtocolCapabilities {
 
 A newer client connecting to an older server:
 
-1. During handshake, the client learns the server's protocol version from `serverHello`.
+1. During handshake, the client learns the server's protocol version from the `initialize` response.
 2. The client derives `ProtocolCapabilities` from the server version.
 3. Command factories check capabilities before dispatching; if unsupported, the client degrades gracefully.
 4. The server only sends action types known to the client's declared version (via `isActionKnownToVersion`).


### PR DESCRIPTION
- initialize is now a method, not a notification
- hardening around reconnection and initial subscriptions
- clarify rejection behavior behavior
- represent tool calls with Records instead of Maps for agnosticism
- better error codes
- note future todos