### PR TITLE
implementation of an activeClient and client-provided tools

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -22,7 +22,7 @@ interface IActionEnvelope {
 
 Mutate `RootState`. All are server-only.
 
-### `root/agentsChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L57" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `root/agentsChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L59" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Fired when available agent backends or their models change.
 
@@ -35,7 +35,7 @@ Fired when available agent backends or their models change.
 
 Mutate `SessionState`. Scoped to a session URI.
 
-### `session/ready` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L71" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/ready` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L73" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Session backend initialized successfully.
 
@@ -44,7 +44,7 @@ Session backend initialized successfully.
 | `type` | `'session/ready'` | Discriminant |
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 
-### `session/creationFailed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L83" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/creationFailed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L85" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Session backend failed to initialize.
 
@@ -54,7 +54,7 @@ Session backend failed to initialize.
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `error` | [IErrorInfo](/reference/state-types#ierrorinfo) | Error details |
 
-### `session/turnStarted` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L98" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/turnStarted` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L100" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** User sent a message; server starts agent processing.
 
@@ -65,7 +65,7 @@ Session backend failed to initialize.
 | `turnId` | `string` | Turn identifier |
 | `userMessage` | [IUserMessage](/reference/state-types#iusermessage) | User's message |
 
-### `session/delta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L114" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/delta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L116" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Streaming text chunk from the assistant.
 
@@ -76,7 +76,7 @@ Streaming text chunk from the assistant.
 | `turnId` | `string` | Turn identifier |
 | `content` | `string` | Text chunk |
 
-### `session/responsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L130" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/responsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L132" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Structured content appended to the response.
 
@@ -87,17 +87,23 @@ Structured content appended to the response.
 | `turnId` | `string` | Turn identifier |
 | `part` | [IResponsePart](/reference/state-types#iresponsepart) | Response part (markdown or content ref) |
 
-### `session/toolCallStart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L146" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallStart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L152" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A tool call begins — parameters are streaming from the LM.
 
-| Field | Type | Description |
-|---|---|---|
-| `type` | `'session/toolCallStart'` | Discriminant |
-| `toolName` | `string` | Internal tool name (for debugging/logging) |
-| `displayName` | `string` | Human-readable tool name |
+For client-provided tools, the server sets `toolClientId` to identify the
+owning client. That client is responsible for executing the tool once it
+reaches the `running` state and dispatching `session/toolCallComplete`.
 
-### `session/toolCallDelta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L160" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | `'session/toolCallStart'` | Yes | Discriminant |
+| `toolName` | `string` | Yes | Internal tool name (for debugging/logging) |
+| `displayName` | `string` | Yes | Human-readable tool name |
+| `toolClientId` | `string` | No | If this tool is provided by a client, the `clientId` of the owning client.
+Absent for server-side tools. |
+
+### `session/toolCallDelta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L171" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Streaming partial parameters for a tool call.
 
@@ -107,10 +113,14 @@ Streaming partial parameters for a tool call.
 | `content` | `string` | Yes | Partial parameter content to append |
 | `invocationMessage` | [StringOrMarkdown](/reference/state-types#stringormarkdown) | No | Updated progress message |
 
-### `session/toolCallReady` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L175" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallReady` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L190" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool call parameters are complete. Transitions to `pending-confirmation`
 or directly to `running` if `confirmed` is set.
+
+For client-provided tools, the server typically sets `confirmed` to
+`'not-needed'` so the tool transitions directly to `running`, where the
+owning client can begin execution immediately.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -119,7 +129,7 @@ or directly to `running` if `confirmed` is set.
 | `toolInput` | `string` | No | Raw tool input |
 | `confirmed` | [ToolCallConfirmationReason](/reference/state-types#toolcallconfirmationreason) | No | If set, the tool was auto-confirmed and transitions directly to `running` |
 
-### `session/toolCallConfirmed (approved)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L192" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallConfirmed (approved)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L207" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Client approves a pending tool call. The tool transitions to `running`.
 
@@ -129,9 +139,12 @@ or directly to `running` if `confirmed` is set.
 | `approved` | `true` | The tool call was approved |
 | `confirmed` | [ToolCallConfirmationReason](/reference/state-types#toolcallconfirmationreason) | How the tool was confirmed |
 
-### `session/toolCallConfirmed (denied)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L207" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallConfirmed (denied)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L225" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Client denies a pending tool call. The tool transitions to `cancelled`.
+
+For client-provided tools, the owning client MUST dispatch this if it does
+not recognize the tool or cannot execute it.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -141,10 +154,18 @@ or directly to `running` if `confirmed` is set.
 | `userSuggestion` | [IUserMessage](/reference/state-types#iusermessage) | No | What the user suggested doing instead |
 | `reasonMessage` | [StringOrMarkdown](/reference/state-types#stringormarkdown) | No | Optional explanation for the denial |
 
-### `session/toolCallComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L237" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L264" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool execution finished. Transitions to `completed` or `pending-result-confirmation`
 if `requiresResultConfirmation` is `true`.
+
+For client-provided tools (where `toolClientId` is set on the tool call state),
+the owning client dispatches this action with the execution result. The server
+SHOULD reject this action if the dispatching client does not match `toolClientId`.
+
+Servers waiting on a client tool call MAY time out after a reasonable duration
+if the implementing client disconnects or becomes unresponsive, and dispatch
+this action with `result.success = false` and an appropriate error.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -152,16 +173,21 @@ if `requiresResultConfirmation` is `true`.
 | `result` | [IToolCallResult](/reference/state-types#itoolcallresult) | Yes | Execution result |
 | `requiresResultConfirmation` | `boolean` | No | If true, the result requires client approval before finalizing |
 
-#### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L267" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+#### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L296" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `success` | `boolean` | Yes | Whether the tool succeeded |
 | `pastTenseMessage` | [StringOrMarkdown](/reference/state-types#stringormarkdown) | Yes | Past-tense description of what the tool did |
-| `toolOutput` | `string` | No | Tool output text |
+| `content` | [IToolResultContent](/reference/state-types#itoolresultcontent)[] | No | Unstructured result content blocks.
+
+This mirrors the `content` field of MCP `CallToolResult`. |
+| `structuredContent` | `Record<string, unknown>` | No | Optional structured result object.
+
+This mirrors the `structuredContent` field of MCP `CallToolResult`. |
 | `error` | `{ message: string; code?: string }` | No | Error details if the tool failed |
 
-### `session/toolCallResultConfirmed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L254" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallResultConfirmed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L281" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Client approves or denies a tool's result.
 
@@ -172,7 +198,7 @@ If `approved` is `false`, the tool transitions to `cancelled` with reason `resul
 | `type` | `'session/toolCallResultConfirmed'` | Discriminant |
 | `approved` | `boolean` | Whether the result was approved |
 
-### `session/permissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L266" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/permissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L293" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Permission needed from the user to proceed.
 
@@ -183,7 +209,7 @@ Permission needed from the user to proceed.
 | `turnId` | `string` | Turn identifier |
 | `request` | [IPermissionRequest](/reference/state-types#ipermissionrequest) | Permission request details |
 
-### `session/permissionResolved` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L283" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/permissionResolved` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L310" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Permission granted or denied.
 
@@ -195,7 +221,7 @@ Permission needed from the user to proceed.
 | `requestId` | `string` | Permission request ID |
 | `approved` | `boolean` | Whether permission was granted |
 
-### `session/turnComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L301" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/turnComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L328" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Turn finished — the assistant is idle.
 
@@ -205,7 +231,7 @@ Turn finished — the assistant is idle.
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `turnId` | `string` | Turn identifier |
 
-### `session/turnCancelled` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L316" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/turnCancelled` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L343" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Turn was aborted; server stops processing.
 
@@ -215,7 +241,7 @@ Turn finished — the assistant is idle.
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `turnId` | `string` | Turn identifier |
 
-### `session/error` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L330" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/error` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L357" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Error during turn processing.
 
@@ -226,7 +252,7 @@ Error during turn processing.
 | `turnId` | `string` | Turn identifier |
 | `error` | [IErrorInfo](/reference/state-types#ierrorinfo) | Error details |
 
-### `session/titleChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L346" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/titleChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L373" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Session title updated (typically auto-generated from conversation).
 
@@ -236,7 +262,7 @@ Session title updated (typically auto-generated from conversation).
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `title` | `string` | New title |
 
-### `session/usage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L360" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/usage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L387" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Token usage report for a turn.
 
@@ -247,7 +273,7 @@ Token usage report for a turn.
 | `turnId` | `string` | Turn identifier |
 | `usage` | [IUsageInfo](/reference/state-types#iusageinfo) | Token usage data |
 
-### `session/reasoning` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L376" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/reasoning` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L403" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Reasoning/thinking text from the model.
 
@@ -258,7 +284,7 @@ Reasoning/thinking text from the model.
 | `turnId` | `string` | Turn identifier |
 | `content` | `string` | Reasoning text chunk |
 
-### `session/modelChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L393" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/modelChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L420" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Model changed for this session.
 

--- a/docs/reference/state-types.md
+++ b/docs/reference/state-types.md
@@ -46,10 +46,12 @@ Full state for a single session, loaded when a client subscribes to the session'
 | `summary` | [ISessionSummary](#isessionsummary) | Yes | Lightweight session metadata |
 | `lifecycle` | `'creating' \| 'ready' \| 'creationFailed'` | Yes | Session initialization state |
 | `creationError` | [IErrorInfo](#ierrorinfo) | No | Error details if creation failed |
+| `serverTools` | [IToolDefinition](#itooldefinition)[] | No | Tools provided by the server (agent host) for this session |
+| `activeClient` | [ISessionActiveClient](#isessionactiveclient) | No | The client currently providing tools and interactive capabilities to this session |
 | `turns` | [ITurn](#iturn)[] | Yes | Completed turns |
 | `activeTurn` | [IActiveTurn](#iactiveturn) | No | Currently in-progress turn |
 
-### `ISessionSummary` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L88" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ISessionSummary` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L109" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -63,7 +65,7 @@ Full state for a single session, loaded when a client subscribes to the session'
 
 ## Turn Types
 
-### `ITurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L112" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ITurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L133" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A completed request/response cycle.
 
@@ -78,7 +80,7 @@ A completed request/response cycle.
 | `state` | `'complete' \| 'cancelled' \| 'error'` | Yes | How the turn ended |
 | `error` | [IErrorInfo](#ierrorinfo) | No | Error details if state is `'error'` |
 
-### `IActiveTurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L136" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IActiveTurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L157" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 An in-progress turn — the assistant is actively streaming.
 
@@ -93,14 +95,14 @@ An in-progress turn — the assistant is actively streaming.
 | `reasoning` | `string` | Accumulated reasoning/thinking text |
 | `usage` | [IUsageInfo](#iusageinfo) \| undefined | Token usage info |
 
-### `IUserMessage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L158" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IUserMessage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L179" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `text` | `string` | Yes | Message text |
 | `attachments` | [IMessageAttachment](#imessageattachment)[] | No | File/selection attachments |
 
-### `IMessageAttachment` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L168" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IMessageAttachment` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L189" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -110,14 +112,14 @@ An in-progress turn — the assistant is actively streaming.
 
 ## Response Parts
 
-### `IMarkdownResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L182" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IMarkdownResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L203" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Description |
 |---|---|---|
 | `kind` | `'markdown'` | Discriminant |
 | `content` | `string` | Markdown content |
 
-### `IContentRef` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L194" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IContentRef` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L215" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A reference to large content stored outside the state tree.
 
@@ -128,14 +130,14 @@ A reference to large content stored outside the state tree.
 | `sizeHint` | `number` | No | Approximate size in bytes |
 | `mimeType` | `string` | No | Content MIME type |
 
-### `IResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L208" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L229" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 [IMarkdownResponsePart](#imarkdownresponsepart) | [IContentRef](#icontentref)
 
 
 ## Tool Call Types
 
-### `ToolCallStatus` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L218" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ToolCallStatus` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L239" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Derived status type for the tool call lifecycle. This is the discriminant
 field (`status`) across all tool call state interfaces.
@@ -143,7 +145,7 @@ field (`status`) across all tool call state interfaces.
 [IToolCallState](#itoolcallstate)['status']
 
 
-### `ToolCallConfirmationReason` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L229" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ToolCallConfirmationReason` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L250" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 How a tool call was confirmed for execution.
 
@@ -154,7 +156,7 @@ How a tool call was confirmed for execution.
 `'not-needed' | 'user-action' | 'setting'`
 
 
-### `IToolCallState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L356" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L395" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Discriminated union of all tool call lifecycle states.
 
@@ -164,7 +166,7 @@ for the full state machine diagram.
 | [IToolCallStreamingState](#itoolcallstreamingstate) | [IToolCallPendingConfirmationState](#itoolcallpendingconfirmationstate) | [IToolCallRunningState](#itoolcallrunningstate) | [IToolCallPendingResultConfirmationState](#itoolcallpendingresultconfirmationstate) | [IToolCallCompletedState](#itoolcallcompletedstate) | [IToolCallCancelledState](#itoolcallcancelledstate)
 
 
-### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L267" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L296" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool execution result details, available after execution completes.
 
@@ -172,10 +174,15 @@ Tool execution result details, available after execution completes.
 |---|---|---|---|
 | `success` | `boolean` | Yes | Whether the tool succeeded |
 | `pastTenseMessage` | [StringOrMarkdown](#stringormarkdown) | Yes | Past-tense description of what the tool did |
-| `toolOutput` | `string` | No | Tool output text |
+| `content` | [IToolResultContent](#itoolresultcontent)[] | No | Unstructured result content blocks.
+
+This mirrors the `content` field of MCP `CallToolResult`. |
+| `structuredContent` | `Record<string, unknown>` | No | Optional structured result object.
+
+This mirrors the `structuredContent` field of MCP `CallToolResult`. |
 | `error` | `{ message: string; code?: string }` | No | Error details if the tool failed |
 
-### `IToolCallStreamingState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L283" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallStreamingState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L322" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 LM is streaming the tool call parameters.
 
@@ -185,7 +192,7 @@ LM is streaming the tool call parameters.
 | `partialInput` | `string` | No | Partial parameters accumulated so far |
 | `invocationMessage` | [StringOrMarkdown](#stringormarkdown) | No | Progress message shown while parameters are streaming |
 
-### `IToolCallPendingConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L296" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallPendingConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L335" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Parameters are complete, waiting for client to confirm execution.
 
@@ -193,7 +200,7 @@ Parameters are complete, waiting for client to confirm execution.
 |---|---|---|
 | `status` | `'pending-confirmation'` |  |
 
-### `IToolCallRunningState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L305" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallRunningState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L344" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool is actively executing.
 
@@ -202,7 +209,7 @@ Tool is actively executing.
 | `status` | `'running'` |  |
 | `confirmed` | [ToolCallConfirmationReason](#toolcallconfirmationreason) | How the tool was confirmed for execution |
 
-### `IToolCallPendingResultConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L316" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallPendingResultConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L355" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool finished executing, waiting for client to approve the result.
 
@@ -211,7 +218,7 @@ Tool finished executing, waiting for client to approve the result.
 | `status` | `'pending-result-confirmation'` |  |
 | `confirmed` | [ToolCallConfirmationReason](#toolcallconfirmationreason) | How the tool was confirmed for execution |
 
-### `IToolCallCompletedState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L327" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallCompletedState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L366" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool completed successfully or with an error.
 
@@ -220,7 +227,7 @@ Tool completed successfully or with an error.
 | `status` | `'completed'` |  |
 | `confirmed` | [ToolCallConfirmationReason](#toolcallconfirmationreason) | How the tool was confirmed for execution |
 
-### `IToolCallCancelledState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L338" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallCancelledState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L377" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool call was cancelled before execution.
 
@@ -233,7 +240,7 @@ Tool call was cancelled before execution.
 
 ## Permission Types
 
-### `IPermissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L373" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IPermissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L524" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -249,7 +256,7 @@ Tool call was cancelled before execution.
 
 ## Common Types
 
-### `IUsageInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L399" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IUsageInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L550" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -258,7 +265,7 @@ Tool call was cancelled before execution.
 | `model` | `string` | No | Model used |
 | `cacheReadTokens` | `number` | No | Tokens read from cache |
 
-### `IErrorInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L413" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IErrorInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L564" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -266,7 +273,7 @@ Tool call was cancelled before execution.
 | `message` | `string` | Yes | Human-readable error message |
 | `stack` | `string` | No | Stack trace |
 
-### `ISnapshot` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L428" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ISnapshot` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L579" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A point-in-time snapshot of a subscribed resource's state, returned by
 `initialize`, `reconnect`, and `subscribe`.

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -223,7 +223,7 @@
     },
     "ISessionToolCallStartAction": {
       "type": "object",
-      "description": "A tool call begins — parameters are streaming from the LM.",
+      "description": "A tool call begins — parameters are streaming from the LM.\n\nFor client-provided tools, the server sets `toolClientId` to identify the\nowning client. That client is responsible for executing the tool once it\nreaches the `running` state and dispatching `session/toolCallComplete`.",
       "properties": {
         "type": {
           "type": "string",
@@ -238,6 +238,10 @@
         "displayName": {
           "type": "string",
           "description": "Human-readable tool name"
+        },
+        "toolClientId": {
+          "type": "string",
+          "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools."
         }
       },
       "required": [
@@ -272,7 +276,7 @@
     },
     "ISessionToolCallReadyAction": {
       "type": "object",
-      "description": "Tool call parameters are complete. Transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.",
+      "description": "Tool call parameters are complete. Transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.\n\nFor client-provided tools, the server typically sets `confirmed` to\n`'not-needed'` so the tool transitions directly to `running`, where the\nowning client can begin execution immediately.",
       "properties": {
         "type": {
           "type": "string",
@@ -324,7 +328,7 @@
     },
     "ISessionToolCallDeniedAction": {
       "type": "object",
-      "description": "Client denies a pending tool call. The tool transitions to `cancelled`.",
+      "description": "Client denies a pending tool call. The tool transitions to `cancelled`.\n\nFor client-provided tools, the owning client MUST dispatch this if it does\nnot recognize the tool or cannot execute it.",
       "properties": {
         "type": {
           "type": "string",
@@ -360,7 +364,7 @@
     },
     "ISessionToolCallCompleteAction": {
       "type": "object",
-      "description": "Tool execution finished. Transitions to `completed` or `pending-result-confirmation`\nif `requiresResultConfirmation` is `true`.",
+      "description": "Tool execution finished. Transitions to `completed` or `pending-result-confirmation`\nif `requiresResultConfirmation` is `true`.\n\nFor client-provided tools (where `toolClientId` is set on the tool call state),\nthe owning client dispatches this action with the execution result. The server\nSHOULD reject this action if the dispatching client does not match `toolClientId`.\n\nServers waiting on a client tool call MAY time out after a reasonable duration\nif the implementing client disconnects or becomes unresponsive, and dispatch\nthis action with `result.success = false` and an appropriate error.",
       "properties": {
         "type": {
           "type": "string",
@@ -657,6 +661,92 @@
         "model"
       ]
     },
+    "ISessionServerToolsChangedAction": {
+      "type": "object",
+      "description": "Server tools for this session have changed.\n\nFull-replacement semantics: the `tools` array replaces the previous `serverTools` entirely.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session/serverToolsChanged"
+          ]
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Updated server tools list (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "tools"
+      ]
+    },
+    "ISessionActiveClientChangedAction": {
+      "type": "object",
+      "description": "The active client for this session has changed.\n\nA client dispatches this action with its own `ISessionActiveClient` to claim\nthe active role, or with `null` to release it. The server SHOULD reject if\nanother client is already active. The server SHOULD automatically dispatch\nthis action with `activeClient: null` when the active client disconnects.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session/activeClientChanged"
+          ]
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "activeClient": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ISessionActiveClient"
+            },
+            {}
+          ],
+          "description": "The new active client, or `null` to unset"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "activeClient"
+      ]
+    },
+    "ISessionActiveClientToolsChangedAction": {
+      "type": "object",
+      "description": "The active client's tool list has changed.\n\nFull-replacement semantics: the `tools` array replaces the active client's\nprevious tools entirely. The server SHOULD reject if the dispatching client\nis not the current active client.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session/activeClientToolsChanged"
+          ]
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Updated client tools list (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "tools"
+      ]
+    },
     "ISessionToolCallConfirmedAction": {
       "oneOf": [
         {},
@@ -775,6 +865,17 @@
           "$ref": "#/$defs/IErrorInfo",
           "description": "Error details if creation failed"
         },
+        "serverTools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools provided by the server (agent host) for this session"
+        },
+        "activeClient": {
+          "$ref": "#/$defs/ISessionActiveClient",
+          "description": "The client currently providing tools and interactive capabilities to this session"
+        },
         "turns": {
           "type": "array",
           "items": {
@@ -791,6 +892,31 @@
         "summary",
         "lifecycle",
         "turns"
+      ]
+    },
+    "ISessionActiveClient": {
+      "type": "object",
+      "description": "The client currently providing tools and interactive capabilities to a session.\n\nOnly one client may be active per session at a time. The server SHOULD\nautomatically unset the active client if that client disconnects.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "Client identifier (matches `clientId` from `initialize`)"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable client name (e.g. `\"VS Code\"`)"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools this client provides to the session"
+        }
+      },
+      "required": [
+        "clientId",
+        "tools"
       ]
     },
     "ISessionSummary": {
@@ -1070,6 +1196,10 @@
         "displayName": {
           "type": "string",
           "description": "Human-readable tool name"
+        },
+        "toolClientId": {
+          "type": "string",
+          "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
         }
       },
       "required": [
@@ -1107,9 +1237,17 @@
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Past-tense description of what the tool did"
         },
-        "toolOutput": {
-          "type": "string",
-          "description": "Tool output text"
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolResultContent"
+          },
+          "description": "Unstructured result content blocks.\n\nThis mirrors the `content` field of MCP `CallToolResult`."
+        },
+        "structuredContent": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional structured result object.\n\nThis mirrors the `structuredContent` field of MCP `CallToolResult`."
         },
         "error": {
           "type": "object",
@@ -1261,6 +1399,143 @@
       "required": [
         "status",
         "reason"
+      ]
+    },
+    "IToolDefinition": {
+      "type": "object",
+      "description": "Describes a tool available in a session, provided by either the server or the active client.\n\nThis type mirrors the MCP `Tool` type from the Model Context Protocol specification\n(2025-11-25 draft) and will continue to track it.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique tool identifier"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable display name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what the tool does"
+        },
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the expected input parameters.\n\nOptional because client-provided tools may not have formal schemas.\nMirrors MCP `Tool.inputSchema`."
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the structure of the tool's output.\n\nMirrors MCP `Tool.outputSchema`."
+        },
+        "annotations": {
+          "$ref": "#/$defs/IToolAnnotations",
+          "description": "Behavioral hints about the tool. All properties are advisory."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata.\n\nMirrors the MCP `_meta` convention."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "IToolAnnotations": {
+      "type": "object",
+      "description": "Behavioral hints about a tool. All properties are advisory and not\nguaranteed to faithfully describe tool behavior.\n\nMirrors MCP `ToolAnnotations` from the Model Context Protocol specification.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Alternate human-readable title"
+        },
+        "readOnlyHint": {
+          "type": "boolean",
+          "description": "Tool does not modify its environment (default: false)"
+        },
+        "destructiveHint": {
+          "type": "boolean",
+          "description": "Tool may perform destructive updates (default: true)"
+        },
+        "idempotentHint": {
+          "type": "boolean",
+          "description": "Repeated calls with the same arguments have no additional effect (default: false)"
+        },
+        "openWorldHint": {
+          "type": "boolean",
+          "description": "Tool may interact with external entities (default: true)"
+        }
+      }
+    },
+    "IToolResultTextContent": {
+      "type": "object",
+      "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        "text": {
+          "type": "string",
+          "description": "The text content"
+        }
+      },
+      "required": [
+        "type",
+        "text"
+      ]
+    },
+    "IToolResultBinaryContent": {
+      "type": "object",
+      "description": "Base64-encoded binary content in a tool result.\n\nMirrors MCP `ImageContent` but generalized to any binary content type.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "binary"
+          ]
+        },
+        "data": {
+          "type": "string",
+          "description": "Base64-encoded data"
+        },
+        "contentType": {
+          "type": "string",
+          "description": "Content type (e.g. `\"image/png\"`, `\"application/pdf\"`)"
+        }
+      },
+      "required": [
+        "type",
+        "data",
+        "contentType"
       ]
     },
     "IPermissionRequest": {
@@ -1449,6 +1724,21 @@
       ],
       "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
     },
+    "IToolResultContent": {
+      "oneOf": [
+        {},
+        {
+          "$ref": "#/$defs/IToolResultTextContent"
+        },
+        {
+          "$ref": "#/$defs/IToolResultBinaryContent"
+        },
+        {
+          "$ref": "#/$defs/IContentRef"
+        }
+      ],
+      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus `IContentRef`\nfor lazy-loading large results (an AHP extension)."
+    },
     "IStateAction": {
       "description": "Discriminated union of all state actions.",
       "oneOf": [
@@ -1517,6 +1807,15 @@
         },
         {
           "$ref": "#/$defs/ISessionModelChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionServerToolsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionActiveClientChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionActiveClientToolsChangedAction"
         }
       ]
     }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -418,6 +418,17 @@
           "$ref": "#/$defs/IErrorInfo",
           "description": "Error details if creation failed"
         },
+        "serverTools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools provided by the server (agent host) for this session"
+        },
+        "activeClient": {
+          "$ref": "#/$defs/ISessionActiveClient",
+          "description": "The client currently providing tools and interactive capabilities to this session"
+        },
         "turns": {
           "type": "array",
           "items": {
@@ -434,6 +445,31 @@
         "summary",
         "lifecycle",
         "turns"
+      ]
+    },
+    "ISessionActiveClient": {
+      "type": "object",
+      "description": "The client currently providing tools and interactive capabilities to a session.\n\nOnly one client may be active per session at a time. The server SHOULD\nautomatically unset the active client if that client disconnects.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "Client identifier (matches `clientId` from `initialize`)"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable client name (e.g. `\"VS Code\"`)"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools this client provides to the session"
+        }
+      },
+      "required": [
+        "clientId",
+        "tools"
       ]
     },
     "ISessionSummary": {
@@ -713,6 +749,10 @@
         "displayName": {
           "type": "string",
           "description": "Human-readable tool name"
+        },
+        "toolClientId": {
+          "type": "string",
+          "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
         }
       },
       "required": [
@@ -750,9 +790,17 @@
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Past-tense description of what the tool did"
         },
-        "toolOutput": {
-          "type": "string",
-          "description": "Tool output text"
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolResultContent"
+          },
+          "description": "Unstructured result content blocks.\n\nThis mirrors the `content` field of MCP `CallToolResult`."
+        },
+        "structuredContent": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional structured result object.\n\nThis mirrors the `structuredContent` field of MCP `CallToolResult`."
         },
         "error": {
           "type": "object",
@@ -904,6 +952,143 @@
       "required": [
         "status",
         "reason"
+      ]
+    },
+    "IToolDefinition": {
+      "type": "object",
+      "description": "Describes a tool available in a session, provided by either the server or the active client.\n\nThis type mirrors the MCP `Tool` type from the Model Context Protocol specification\n(2025-11-25 draft) and will continue to track it.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique tool identifier"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable display name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what the tool does"
+        },
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the expected input parameters.\n\nOptional because client-provided tools may not have formal schemas.\nMirrors MCP `Tool.inputSchema`."
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the structure of the tool's output.\n\nMirrors MCP `Tool.outputSchema`."
+        },
+        "annotations": {
+          "$ref": "#/$defs/IToolAnnotations",
+          "description": "Behavioral hints about the tool. All properties are advisory."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata.\n\nMirrors the MCP `_meta` convention."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "IToolAnnotations": {
+      "type": "object",
+      "description": "Behavioral hints about a tool. All properties are advisory and not\nguaranteed to faithfully describe tool behavior.\n\nMirrors MCP `ToolAnnotations` from the Model Context Protocol specification.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Alternate human-readable title"
+        },
+        "readOnlyHint": {
+          "type": "boolean",
+          "description": "Tool does not modify its environment (default: false)"
+        },
+        "destructiveHint": {
+          "type": "boolean",
+          "description": "Tool may perform destructive updates (default: true)"
+        },
+        "idempotentHint": {
+          "type": "boolean",
+          "description": "Repeated calls with the same arguments have no additional effect (default: false)"
+        },
+        "openWorldHint": {
+          "type": "boolean",
+          "description": "Tool may interact with external entities (default: true)"
+        }
+      }
+    },
+    "IToolResultTextContent": {
+      "type": "object",
+      "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        "text": {
+          "type": "string",
+          "description": "The text content"
+        }
+      },
+      "required": [
+        "type",
+        "text"
+      ]
+    },
+    "IToolResultBinaryContent": {
+      "type": "object",
+      "description": "Base64-encoded binary content in a tool result.\n\nMirrors MCP `ImageContent` but generalized to any binary content type.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "binary"
+          ]
+        },
+        "data": {
+          "type": "string",
+          "description": "Base64-encoded data"
+        },
+        "contentType": {
+          "type": "string",
+          "description": "Content type (e.g. `\"image/png\"`, `\"application/pdf\"`)"
+        }
+      },
+      "required": [
+        "type",
+        "data",
+        "contentType"
       ]
     },
     "IPermissionRequest": {
@@ -1248,7 +1433,7 @@
     },
     "ISessionToolCallStartAction": {
       "type": "object",
-      "description": "A tool call begins — parameters are streaming from the LM.",
+      "description": "A tool call begins — parameters are streaming from the LM.\n\nFor client-provided tools, the server sets `toolClientId` to identify the\nowning client. That client is responsible for executing the tool once it\nreaches the `running` state and dispatching `session/toolCallComplete`.",
       "properties": {
         "type": {
           "type": "string",
@@ -1263,6 +1448,10 @@
         "displayName": {
           "type": "string",
           "description": "Human-readable tool name"
+        },
+        "toolClientId": {
+          "type": "string",
+          "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools."
         }
       },
       "required": [
@@ -1297,7 +1486,7 @@
     },
     "ISessionToolCallReadyAction": {
       "type": "object",
-      "description": "Tool call parameters are complete. Transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.",
+      "description": "Tool call parameters are complete. Transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.\n\nFor client-provided tools, the server typically sets `confirmed` to\n`'not-needed'` so the tool transitions directly to `running`, where the\nowning client can begin execution immediately.",
       "properties": {
         "type": {
           "type": "string",
@@ -1349,7 +1538,7 @@
     },
     "ISessionToolCallDeniedAction": {
       "type": "object",
-      "description": "Client denies a pending tool call. The tool transitions to `cancelled`.",
+      "description": "Client denies a pending tool call. The tool transitions to `cancelled`.\n\nFor client-provided tools, the owning client MUST dispatch this if it does\nnot recognize the tool or cannot execute it.",
       "properties": {
         "type": {
           "type": "string",
@@ -1385,7 +1574,7 @@
     },
     "ISessionToolCallCompleteAction": {
       "type": "object",
-      "description": "Tool execution finished. Transitions to `completed` or `pending-result-confirmation`\nif `requiresResultConfirmation` is `true`.",
+      "description": "Tool execution finished. Transitions to `completed` or `pending-result-confirmation`\nif `requiresResultConfirmation` is `true`.\n\nFor client-provided tools (where `toolClientId` is set on the tool call state),\nthe owning client dispatches this action with the execution result. The server\nSHOULD reject this action if the dispatching client does not match `toolClientId`.\n\nServers waiting on a client tool call MAY time out after a reasonable duration\nif the implementing client disconnects or becomes unresponsive, and dispatch\nthis action with `result.success = false` and an appropriate error.",
       "properties": {
         "type": {
           "type": "string",
@@ -1680,6 +1869,92 @@
         "type",
         "session",
         "model"
+      ]
+    },
+    "ISessionServerToolsChangedAction": {
+      "type": "object",
+      "description": "Server tools for this session have changed.\n\nFull-replacement semantics: the `tools` array replaces the previous `serverTools` entirely.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session/serverToolsChanged"
+          ]
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Updated server tools list (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "tools"
+      ]
+    },
+    "ISessionActiveClientChangedAction": {
+      "type": "object",
+      "description": "The active client for this session has changed.\n\nA client dispatches this action with its own `ISessionActiveClient` to claim\nthe active role, or with `null` to release it. The server SHOULD reject if\nanother client is already active. The server SHOULD automatically dispatch\nthis action with `activeClient: null` when the active client disconnects.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session/activeClientChanged"
+          ]
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "activeClient": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ISessionActiveClient"
+            },
+            {}
+          ],
+          "description": "The new active client, or `null` to unset"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "activeClient"
+      ]
+    },
+    "ISessionActiveClientToolsChangedAction": {
+      "type": "object",
+      "description": "The active client's tool list has changed.\n\nFull-replacement semantics: the `tools` array replaces the active client's\nprevious tools entirely. The server SHOULD reject if the dispatching client\nis not the current active client.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session/activeClientToolsChanged"
+          ]
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Updated client tools list (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "tools"
       ]
     }
   }

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -162,6 +162,17 @@
           "$ref": "#/$defs/IErrorInfo",
           "description": "Error details if creation failed"
         },
+        "serverTools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools provided by the server (agent host) for this session"
+        },
+        "activeClient": {
+          "$ref": "#/$defs/ISessionActiveClient",
+          "description": "The client currently providing tools and interactive capabilities to this session"
+        },
         "turns": {
           "type": "array",
           "items": {
@@ -178,6 +189,31 @@
         "summary",
         "lifecycle",
         "turns"
+      ]
+    },
+    "ISessionActiveClient": {
+      "type": "object",
+      "description": "The client currently providing tools and interactive capabilities to a session.\n\nOnly one client may be active per session at a time. The server SHOULD\nautomatically unset the active client if that client disconnects.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "Client identifier (matches `clientId` from `initialize`)"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable client name (e.g. `\"VS Code\"`)"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools this client provides to the session"
+        }
+      },
+      "required": [
+        "clientId",
+        "tools"
       ]
     },
     "ISessionSummary": {
@@ -457,6 +493,10 @@
         "displayName": {
           "type": "string",
           "description": "Human-readable tool name"
+        },
+        "toolClientId": {
+          "type": "string",
+          "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
         }
       },
       "required": [
@@ -494,9 +534,17 @@
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Past-tense description of what the tool did"
         },
-        "toolOutput": {
-          "type": "string",
-          "description": "Tool output text"
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolResultContent"
+          },
+          "description": "Unstructured result content blocks.\n\nThis mirrors the `content` field of MCP `CallToolResult`."
+        },
+        "structuredContent": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional structured result object.\n\nThis mirrors the `structuredContent` field of MCP `CallToolResult`."
         },
         "error": {
           "type": "object",
@@ -648,6 +696,143 @@
       "required": [
         "status",
         "reason"
+      ]
+    },
+    "IToolDefinition": {
+      "type": "object",
+      "description": "Describes a tool available in a session, provided by either the server or the active client.\n\nThis type mirrors the MCP `Tool` type from the Model Context Protocol specification\n(2025-11-25 draft) and will continue to track it.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique tool identifier"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable display name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what the tool does"
+        },
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the expected input parameters.\n\nOptional because client-provided tools may not have formal schemas.\nMirrors MCP `Tool.inputSchema`."
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the structure of the tool's output.\n\nMirrors MCP `Tool.outputSchema`."
+        },
+        "annotations": {
+          "$ref": "#/$defs/IToolAnnotations",
+          "description": "Behavioral hints about the tool. All properties are advisory."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata.\n\nMirrors the MCP `_meta` convention."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "IToolAnnotations": {
+      "type": "object",
+      "description": "Behavioral hints about a tool. All properties are advisory and not\nguaranteed to faithfully describe tool behavior.\n\nMirrors MCP `ToolAnnotations` from the Model Context Protocol specification.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Alternate human-readable title"
+        },
+        "readOnlyHint": {
+          "type": "boolean",
+          "description": "Tool does not modify its environment (default: false)"
+        },
+        "destructiveHint": {
+          "type": "boolean",
+          "description": "Tool may perform destructive updates (default: true)"
+        },
+        "idempotentHint": {
+          "type": "boolean",
+          "description": "Repeated calls with the same arguments have no additional effect (default: false)"
+        },
+        "openWorldHint": {
+          "type": "boolean",
+          "description": "Tool may interact with external entities (default: true)"
+        }
+      }
+    },
+    "IToolResultTextContent": {
+      "type": "object",
+      "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        "text": {
+          "type": "string",
+          "description": "The text content"
+        }
+      },
+      "required": [
+        "type",
+        "text"
+      ]
+    },
+    "IToolResultBinaryContent": {
+      "type": "object",
+      "description": "Base64-encoded binary content in a tool result.\n\nMirrors MCP `ImageContent` but generalized to any binary content type.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "binary"
+          ]
+        },
+        "data": {
+          "type": "string",
+          "description": "Base64-encoded data"
+        },
+        "contentType": {
+          "type": "string",
+          "description": "Content type (e.g. `\"image/png\"`, `\"application/pdf\"`)"
+        }
+      },
+      "required": [
+        "type",
+        "data",
+        "contentType"
       ]
     },
     "IPermissionRequest": {

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -111,6 +111,17 @@
           "$ref": "#/$defs/IErrorInfo",
           "description": "Error details if creation failed"
         },
+        "serverTools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools provided by the server (agent host) for this session"
+        },
+        "activeClient": {
+          "$ref": "#/$defs/ISessionActiveClient",
+          "description": "The client currently providing tools and interactive capabilities to this session"
+        },
         "turns": {
           "type": "array",
           "items": {
@@ -127,6 +138,31 @@
         "summary",
         "lifecycle",
         "turns"
+      ]
+    },
+    "ISessionActiveClient": {
+      "type": "object",
+      "description": "The client currently providing tools and interactive capabilities to a session.\n\nOnly one client may be active per session at a time. The server SHOULD\nautomatically unset the active client if that client disconnects.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "Client identifier (matches `clientId` from `initialize`)"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable client name (e.g. `\"VS Code\"`)"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolDefinition"
+          },
+          "description": "Tools this client provides to the session"
+        }
+      },
+      "required": [
+        "clientId",
+        "tools"
       ]
     },
     "ISessionSummary": {
@@ -406,6 +442,10 @@
         "displayName": {
           "type": "string",
           "description": "Human-readable tool name"
+        },
+        "toolClientId": {
+          "type": "string",
+          "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
         }
       },
       "required": [
@@ -443,9 +483,17 @@
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Past-tense description of what the tool did"
         },
-        "toolOutput": {
-          "type": "string",
-          "description": "Tool output text"
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IToolResultContent"
+          },
+          "description": "Unstructured result content blocks.\n\nThis mirrors the `content` field of MCP `CallToolResult`."
+        },
+        "structuredContent": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional structured result object.\n\nThis mirrors the `structuredContent` field of MCP `CallToolResult`."
         },
         "error": {
           "type": "object",
@@ -597,6 +645,143 @@
       "required": [
         "status",
         "reason"
+      ]
+    },
+    "IToolDefinition": {
+      "type": "object",
+      "description": "Describes a tool available in a session, provided by either the server or the active client.\n\nThis type mirrors the MCP `Tool` type from the Model Context Protocol specification\n(2025-11-25 draft) and will continue to track it.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique tool identifier"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable display name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what the tool does"
+        },
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the expected input parameters.\n\nOptional because client-provided tools may not have formal schemas.\nMirrors MCP `Tool.inputSchema`."
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "string"
+            },
+            "required": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "JSON Schema defining the structure of the tool's output.\n\nMirrors MCP `Tool.outputSchema`."
+        },
+        "annotations": {
+          "$ref": "#/$defs/IToolAnnotations",
+          "description": "Behavioral hints about the tool. All properties are advisory."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata.\n\nMirrors the MCP `_meta` convention."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "IToolAnnotations": {
+      "type": "object",
+      "description": "Behavioral hints about a tool. All properties are advisory and not\nguaranteed to faithfully describe tool behavior.\n\nMirrors MCP `ToolAnnotations` from the Model Context Protocol specification.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Alternate human-readable title"
+        },
+        "readOnlyHint": {
+          "type": "boolean",
+          "description": "Tool does not modify its environment (default: false)"
+        },
+        "destructiveHint": {
+          "type": "boolean",
+          "description": "Tool may perform destructive updates (default: true)"
+        },
+        "idempotentHint": {
+          "type": "boolean",
+          "description": "Repeated calls with the same arguments have no additional effect (default: false)"
+        },
+        "openWorldHint": {
+          "type": "boolean",
+          "description": "Tool may interact with external entities (default: true)"
+        }
+      }
+    },
+    "IToolResultTextContent": {
+      "type": "object",
+      "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        "text": {
+          "type": "string",
+          "description": "The text content"
+        }
+      },
+      "required": [
+        "type",
+        "text"
+      ]
+    },
+    "IToolResultBinaryContent": {
+      "type": "object",
+      "description": "Base64-encoded binary content in a tool result.\n\nMirrors MCP `ImageContent` but generalized to any binary content type.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "binary"
+          ]
+        },
+        "data": {
+          "type": "string",
+          "description": "Base64-encoded data"
+        },
+        "contentType": {
+          "type": "string",
+          "description": "Content type (e.g. `\"image/png\"`, `\"application/pdf\"`)"
+        }
+      },
+      "required": [
+        "type",
+        "data",
+        "contentType"
       ]
     },
     "IPermissionRequest": {
@@ -784,6 +969,21 @@
         }
       ],
       "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
+    },
+    "IToolResultContent": {
+      "oneOf": [
+        {},
+        {
+          "$ref": "#/$defs/IToolResultTextContent"
+        },
+        {
+          "$ref": "#/$defs/IToolResultBinaryContent"
+        },
+        {
+          "$ref": "#/$defs/IContentRef"
+        }
+      ],
+      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus `IContentRef`\nfor lazy-loading large results (an AHP extension)."
     }
   }
 }

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -14,6 +14,8 @@ import type {
   IUserMessage,
   IResponsePart,
   IToolCallResult,
+  IToolDefinition,
+  ISessionActiveClient,
   ToolCallConfirmationReason,
   IUsageInfo,
   IPermissionRequest,
@@ -140,6 +142,10 @@ export interface ISessionResponsePartAction {
 /**
  * A tool call begins — parameters are streaming from the LM.
  *
+ * For client-provided tools, the server sets `toolClientId` to identify the
+ * owning client. That client is responsible for executing the tool once it
+ * reaches the `running` state and dispatching `session/toolCallComplete`.
+ *
  * @category Session Actions
  * @version 1
  */
@@ -149,6 +155,11 @@ export interface ISessionToolCallStartAction extends IToolCallActionBase {
   toolName: string;
   /** Human-readable tool name */
   displayName: string;
+  /**
+   * If this tool is provided by a client, the `clientId` of the owning client.
+   * Absent for server-side tools.
+   */
+  toolClientId?: string;
 }
 
 /**
@@ -168,6 +179,10 @@ export interface ISessionToolCallDeltaAction extends IToolCallActionBase {
 /**
  * Tool call parameters are complete. Transitions to `pending-confirmation`
  * or directly to `running` if `confirmed` is set.
+ *
+ * For client-provided tools, the server typically sets `confirmed` to
+ * `'not-needed'` so the tool transitions directly to `running`, where the
+ * owning client can begin execution immediately.
  *
  * @category Session Actions
  * @version 1
@@ -200,6 +215,9 @@ export interface ISessionToolCallApprovedAction extends IToolCallActionBase {
 /**
  * Client denies a pending tool call. The tool transitions to `cancelled`.
  *
+ * For client-provided tools, the owning client MUST dispatch this if it does
+ * not recognize the tool or cannot execute it.
+ *
  * @category Session Actions
  * @version 1
  * @clientDispatchable
@@ -231,8 +249,17 @@ export type ISessionToolCallConfirmedAction =
  * Tool execution finished. Transitions to `completed` or `pending-result-confirmation`
  * if `requiresResultConfirmation` is `true`.
  *
+ * For client-provided tools (where `toolClientId` is set on the tool call state),
+ * the owning client dispatches this action with the execution result. The server
+ * SHOULD reject this action if the dispatching client does not match `toolClientId`.
+ *
+ * Servers waiting on a client tool call MAY time out after a reasonable duration
+ * if the implementing client disconnects or becomes unresponsive, and dispatch
+ * this action with `result.success = false` and an appropriate error.
+ *
  * @category Session Actions
  * @version 1
+ * @clientDispatchable
  */
 export interface ISessionToolCallCompleteAction extends IToolCallActionBase {
   type: 'session/toolCallComplete';
@@ -398,6 +425,61 @@ export interface ISessionModelChangedAction {
   model: string;
 }
 
+/**
+ * Server tools for this session have changed.
+ *
+ * Full-replacement semantics: the `tools` array replaces the previous `serverTools` entirely.
+ *
+ * @category Session Actions
+ * @version 1
+ */
+export interface ISessionServerToolsChangedAction {
+  type: 'session/serverToolsChanged';
+  /** Session URI */
+  session: URI;
+  /** Updated server tools list (full replacement) */
+  tools: IToolDefinition[];
+}
+
+/**
+ * The active client for this session has changed.
+ *
+ * A client dispatches this action with its own `ISessionActiveClient` to claim
+ * the active role, or with `null` to release it. The server SHOULD reject if
+ * another client is already active. The server SHOULD automatically dispatch
+ * this action with `activeClient: null` when the active client disconnects.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionActiveClientChangedAction {
+  type: 'session/activeClientChanged';
+  /** Session URI */
+  session: URI;
+  /** The new active client, or `null` to unset */
+  activeClient: ISessionActiveClient | null;
+}
+
+/**
+ * The active client's tool list has changed.
+ *
+ * Full-replacement semantics: the `tools` array replaces the active client's
+ * previous tools entirely. The server SHOULD reject if the dispatching client
+ * is not the current active client.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionActiveClientToolsChangedAction {
+  type: 'session/activeClientToolsChanged';
+  /** Session URI */
+  session: URI;
+  /** Updated client tools list (full replacement) */
+  tools: IToolDefinition[];
+}
+
 // ─── Discriminated Union ─────────────────────────────────────────────────────
 
 /**
@@ -424,4 +506,7 @@ export type IStateAction =
   | ISessionTitleChangedAction
   | ISessionUsageAction
   | ISessionReasoningAction
-  | ISessionModelChangedAction;
+  | ISessionModelChangedAction
+  | ISessionServerToolsChangedAction
+  | ISessionActiveClientChangedAction
+  | ISessionActiveClientToolsChangedAction;

--- a/types/index.ts
+++ b/types/index.ts
@@ -33,6 +33,12 @@ export type {
   IToolCallCompletedState,
   IToolCallCancelledState,
   IToolCallState,
+  IToolDefinition,
+  IToolAnnotations,
+  IToolResultTextContent,
+  IToolResultBinaryContent,
+  IToolResultContent,
+  ISessionActiveClient,
   IPermissionRequest,
   IUsageInfo,
   IErrorInfo,
@@ -65,6 +71,9 @@ export type {
   ISessionUsageAction,
   ISessionReasoningAction,
   ISessionModelChangedAction,
+  ISessionServerToolsChangedAction,
+  ISessionActiveClientChangedAction,
+  ISessionActiveClientToolsChangedAction,
   IStateAction,
 } from './actions.js';
 

--- a/types/state.ts
+++ b/types/state.ts
@@ -76,10 +76,31 @@ export interface ISessionState {
   lifecycle: 'creating' | 'ready' | 'creationFailed';
   /** Error details if creation failed */
   creationError?: IErrorInfo;
+  /** Tools provided by the server (agent host) for this session */
+  serverTools?: IToolDefinition[];
+  /** The client currently providing tools and interactive capabilities to this session */
+  activeClient?: ISessionActiveClient;
   /** Completed turns */
   turns: ITurn[];
   /** Currently in-progress turn */
   activeTurn?: IActiveTurn;
+}
+
+/**
+ * The client currently providing tools and interactive capabilities to a session.
+ *
+ * Only one client may be active per session at a time. The server SHOULD
+ * automatically unset the active client if that client disconnects.
+ *
+ * @category Session State
+ */
+export interface ISessionActiveClient {
+  /** Client identifier (matches `clientId` from `initialize`) */
+  clientId: string;
+  /** Human-readable client name (e.g. `"VS Code"`) */
+  displayName?: string;
+  /** Tools this client provides to the session */
+  tools: IToolDefinition[];
 }
 
 /**
@@ -245,6 +266,14 @@ interface IToolCallBase {
   toolName: string;
   /** Human-readable tool name */
   displayName: string;
+  /**
+   * If this tool is provided by a client, the `clientId` of the owning client.
+   * Absent for server-side tools.
+   *
+   * When set, the identified client is responsible for executing the tool and
+   * dispatching `session/toolCallComplete` with the result.
+   */
+  toolClientId?: string;
 }
 
 /**
@@ -269,8 +298,18 @@ export interface IToolCallResult {
   success: boolean;
   /** Past-tense description of what the tool did */
   pastTenseMessage: StringOrMarkdown;
-  /** Tool output text */
-  toolOutput?: string;
+  /**
+   * Unstructured result content blocks.
+   *
+   * This mirrors the `content` field of MCP `CallToolResult`.
+   */
+  content?: IToolResultContent[];
+  /**
+   * Optional structured result object.
+   *
+   * This mirrors the `structuredContent` field of MCP `CallToolResult`.
+   */
+  structuredContent?: Record<string, unknown>;
   /** Error details if the tool failed */
   error?: { message: string; code?: string };
 }
@@ -360,6 +399,118 @@ export type IToolCallState =
   | IToolCallPendingResultConfirmationState
   | IToolCallCompletedState
   | IToolCallCancelledState;
+
+// ─── Tool Definition Types ───────────────────────────────────────────────────
+
+/**
+ * Describes a tool available in a session, provided by either the server or the active client.
+ *
+ * This type mirrors the MCP `Tool` type from the Model Context Protocol specification
+ * (2025-11-25 draft) and will continue to track it.
+ *
+ * @category Tool Definition Types
+ */
+export interface IToolDefinition {
+  /** Unique tool identifier */
+  name: string;
+  /** Human-readable display name */
+  title?: string;
+  /** Description of what the tool does */
+  description?: string;
+  /**
+   * JSON Schema defining the expected input parameters.
+   *
+   * Optional because client-provided tools may not have formal schemas.
+   * Mirrors MCP `Tool.inputSchema`.
+   */
+  inputSchema?: {
+    type: 'object';
+    properties?: Record<string, object>;
+    required?: string[];
+  };
+  /**
+   * JSON Schema defining the structure of the tool's output.
+   *
+   * Mirrors MCP `Tool.outputSchema`.
+   */
+  outputSchema?: {
+    type: 'object';
+    properties?: Record<string, object>;
+    required?: string[];
+  };
+  /** Behavioral hints about the tool. All properties are advisory. */
+  annotations?: IToolAnnotations;
+  /**
+   * Additional provider-specific metadata.
+   *
+   * Mirrors the MCP `_meta` convention.
+   */
+  _meta?: Record<string, unknown>;
+}
+
+/**
+ * Behavioral hints about a tool. All properties are advisory and not
+ * guaranteed to faithfully describe tool behavior.
+ *
+ * Mirrors MCP `ToolAnnotations` from the Model Context Protocol specification.
+ *
+ * @category Tool Definition Types
+ */
+export interface IToolAnnotations {
+  /** Alternate human-readable title */
+  title?: string;
+  /** Tool does not modify its environment (default: false) */
+  readOnlyHint?: boolean;
+  /** Tool may perform destructive updates (default: true) */
+  destructiveHint?: boolean;
+  /** Repeated calls with the same arguments have no additional effect (default: false) */
+  idempotentHint?: boolean;
+  /** Tool may interact with external entities (default: true) */
+  openWorldHint?: boolean;
+}
+
+// ─── Tool Result Content ─────────────────────────────────────────────────────
+
+/**
+ * Text content in a tool result.
+ *
+ * Mirrors MCP `TextContent`.
+ *
+ * @category Tool Result Content
+ */
+export interface IToolResultTextContent {
+  type: 'text';
+  /** The text content */
+  text: string;
+}
+
+/**
+ * Base64-encoded binary content in a tool result.
+ *
+ * Mirrors MCP `ImageContent` but generalized to any binary content type.
+ *
+ * @category Tool Result Content
+ */
+export interface IToolResultBinaryContent {
+  type: 'binary';
+  /** Base64-encoded data */
+  data: string;
+  /** Content type (e.g. `"image/png"`, `"application/pdf"`) */
+  contentType: string;
+}
+
+/**
+ * Content block in a tool result.
+ *
+ * Mirrors the content blocks in MCP `CallToolResult.content`, plus `IContentRef`
+ * for lazy-loading large results (an AHP extension).
+ *
+ * @category Tool Result Content
+ */
+export type IToolResultContent =
+  | IToolResultTextContent
+  | IToolResultBinaryContent
+  | IContentRef;
 
 // ─── Permission Types ────────────────────────────────────────────────────────
 

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -42,6 +42,9 @@ export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: numbe
   'session/usage': 1,
   'session/reasoning': 1,
   'session/modelChanged': 1,
+  'session/serverToolsChanged': 1,
+  'session/activeClientChanged': 1,
+  'session/activeClientToolsChanged': 1,
 };
 
 /**

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -16,6 +16,7 @@ import type {
   StringOrMarkdown,
   ISessionState,
   ISessionSummary,
+  ISessionActiveClient,
   ITurn,
   IActiveTurn,
   IUserMessage,
@@ -30,6 +31,10 @@ import type {
   IToolCallCompletedState,
   IToolCallCancelledState,
   IToolCallState,
+  IToolDefinition,
+  IToolAnnotations,
+  IToolResultTextContent,
+  IToolResultBinaryContent,
   IPermissionRequest,
   IUsageInfo,
   IErrorInfo,
@@ -41,6 +46,9 @@ import type {
   IActionEnvelope,
   ISessionToolCallApprovedAction,
   ISessionToolCallDeniedAction,
+  ISessionServerToolsChangedAction,
+  ISessionActiveClientChangedAction,
+  ISessionActiveClientToolsChangedAction,
 } from '../actions.js';
 
 import type {
@@ -71,6 +79,7 @@ type V1_IAgentInfo = IAgentInfo;
 type V1_ISessionModelInfo = ISessionModelInfo;
 type V1_ISessionState = ISessionState;
 type V1_ISessionSummary = ISessionSummary;
+type V1_ISessionActiveClient = ISessionActiveClient;
 type V1_ITurn = ITurn;
 type V1_IActiveTurn = IActiveTurn;
 type V1_IUserMessage = IUserMessage;
@@ -85,6 +94,10 @@ type V1_IToolCallPendingResultConfirmationState = IToolCallPendingResultConfirma
 type V1_IToolCallCompletedState = IToolCallCompletedState;
 type V1_IToolCallCancelledState = IToolCallCancelledState;
 type V1_IToolCallState = IToolCallState;
+type V1_IToolDefinition = IToolDefinition;
+type V1_IToolAnnotations = IToolAnnotations;
+type V1_IToolResultTextContent = IToolResultTextContent;
+type V1_IToolResultBinaryContent = IToolResultBinaryContent;
 type V1_IPermissionRequest = IPermissionRequest;
 type V1_IUsageInfo = IUsageInfo;
 type V1_IErrorInfo = IErrorInfo;
@@ -93,6 +106,9 @@ type V1_IStateAction = IStateAction;
 type V1_IActionEnvelope = IActionEnvelope;
 type V1_ISessionToolCallApprovedAction = ISessionToolCallApprovedAction;
 type V1_ISessionToolCallDeniedAction = ISessionToolCallDeniedAction;
+type V1_ISessionServerToolsChangedAction = ISessionServerToolsChangedAction;
+type V1_ISessionActiveClientChangedAction = ISessionActiveClientChangedAction;
+type V1_ISessionActiveClientToolsChangedAction = ISessionActiveClientToolsChangedAction;
 type V1_IProtocolNotification = IProtocolNotification;
 
 // ─── Compatibility Assertions ────────────────────────────────────────────────
@@ -156,5 +172,21 @@ type _CheckActionEnvelope = AssertCompatible<V1_IActionEnvelope, IActionEnvelope
 type _CheckToolCallApprovedAction = AssertCompatible<V1_ISessionToolCallApprovedAction, ISessionToolCallApprovedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallDeniedAction = AssertCompatible<V1_ISessionToolCallDeniedAction, ISessionToolCallDeniedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSessionActiveClient = AssertCompatible<V1_ISessionActiveClient, ISessionActiveClient>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckToolDefinition = AssertCompatible<V1_IToolDefinition, IToolDefinition>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckToolAnnotations = AssertCompatible<V1_IToolAnnotations, IToolAnnotations>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckToolResultTextContent = AssertCompatible<V1_IToolResultTextContent, IToolResultTextContent>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckToolResultBinaryContent = AssertCompatible<V1_IToolResultBinaryContent, IToolResultBinaryContent>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckServerToolsChangedAction = AssertCompatible<V1_ISessionServerToolsChangedAction, ISessionServerToolsChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckActiveClientChangedAction = AssertCompatible<V1_ISessionActiveClientChangedAction, ISessionActiveClientChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckActiveClientToolsChangedAction = AssertCompatible<V1_ISessionActiveClientToolsChangedAction, ISessionActiveClientToolsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;


### PR DESCRIPTION
I went back and forth a few times on this. Landed on this approach for now:

- Our tool and response structure mirrors MCP's tool structure
- We use content references instead of MCP resource reference, but for implementations this should be quite easy to map back and forth.
- Tool calling is now birdirectional in a nicely stateful way: we just let the client be the one to have side-effects from the tool call start action and let it dispatch a result -- with the additionl of a `toolClientId?: string` for bookkeeping.
- I thought about but intentionally opted not to bring in a mechanism like [tool resolution](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1862) because:

  1. It's something only the client needs to provide (server calling the client) and currently the only purpose of resolution is aiding in tool approvals.
  2. The client is _already_ the one controlling when tool approvals are shown and if it wants to auto-approve something, so there's no point in juggling the data back and forth.

- Streaming tool results are interesting and are what we should use for the terminal tool. I've not tackled that yet, I need to research what MCP folks have been trying to do first.

cc @roblourens 