### PR TITLE
Align for vscode usage

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -22,7 +22,7 @@ interface IActionEnvelope {
 
 Mutate `RootState`. All are server-only.
 
-### `root/agentsChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L59" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `root/agentsChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L76" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Fired when available agent backends or their models change.
 
@@ -35,7 +35,7 @@ Fired when available agent backends or their models change.
 
 Mutate `SessionState`. Scoped to a session URI.
 
-### `session/ready` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L73" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/ready` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L102" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Session backend initialized successfully.
 
@@ -44,7 +44,7 @@ Session backend initialized successfully.
 | `type` | `'session/ready'` | Discriminant |
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 
-### `session/creationFailed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L85" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/creationFailed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L114" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Session backend failed to initialize.
 
@@ -54,7 +54,7 @@ Session backend failed to initialize.
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `error` | [IErrorInfo](/reference/state-types#ierrorinfo) | Error details |
 
-### `session/turnStarted` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L100" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/turnStarted` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L129" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** User sent a message; server starts agent processing.
 
@@ -65,7 +65,7 @@ Session backend failed to initialize.
 | `turnId` | `string` | Turn identifier |
 | `userMessage` | [IUserMessage](/reference/state-types#iusermessage) | User's message |
 
-### `session/delta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L116" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/delta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L145" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Streaming text chunk from the assistant.
 
@@ -76,7 +76,7 @@ Streaming text chunk from the assistant.
 | `turnId` | `string` | Turn identifier |
 | `content` | `string` | Text chunk |
 
-### `session/responsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L132" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/responsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L161" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Structured content appended to the response.
 
@@ -87,7 +87,7 @@ Structured content appended to the response.
 | `turnId` | `string` | Turn identifier |
 | `part` | [IResponsePart](/reference/state-types#iresponsepart) | Response part (markdown or content ref) |
 
-### `session/toolCallStart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L152" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallStart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L181" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A tool call begins — parameters are streaming from the LM.
 
@@ -103,7 +103,7 @@ reaches the `running` state and dispatching `session/toolCallComplete`.
 | `toolClientId` | `string` | No | If this tool is provided by a client, the `clientId` of the owning client.
 Absent for server-side tools. |
 
-### `session/toolCallDelta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L171" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallDelta` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L200" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Streaming partial parameters for a tool call.
 
@@ -113,7 +113,7 @@ Streaming partial parameters for a tool call.
 | `content` | `string` | Yes | Partial parameter content to append |
 | `invocationMessage` | [StringOrMarkdown](/reference/state-types#stringormarkdown) | No | Updated progress message |
 
-### `session/toolCallReady` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L190" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallReady` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L219" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool call parameters are complete. Transitions to `pending-confirmation`
 or directly to `running` if `confirmed` is set.
@@ -129,7 +129,7 @@ owning client can begin execution immediately.
 | `toolInput` | `string` | No | Raw tool input |
 | `confirmed` | [ToolCallConfirmationReason](/reference/state-types#toolcallconfirmationreason) | No | If set, the tool was auto-confirmed and transitions directly to `running` |
 
-### `session/toolCallConfirmed (approved)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L207" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallConfirmed (approved)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L236" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Client approves a pending tool call. The tool transitions to `running`.
 
@@ -139,7 +139,7 @@ owning client can begin execution immediately.
 | `approved` | `true` | The tool call was approved |
 | `confirmed` | [ToolCallConfirmationReason](/reference/state-types#toolcallconfirmationreason) | How the tool was confirmed |
 
-### `session/toolCallConfirmed (denied)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L225" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallConfirmed (denied)` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L254" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Client denies a pending tool call. The tool transitions to `cancelled`.
 
@@ -154,7 +154,7 @@ not recognize the tool or cannot execute it.
 | `userSuggestion` | [IUserMessage](/reference/state-types#iusermessage) | No | What the user suggested doing instead |
 | `reasonMessage` | [StringOrMarkdown](/reference/state-types#stringormarkdown) | No | Optional explanation for the denial |
 
-### `session/toolCallComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L264" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L293" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool execution finished. Transitions to `completed` or `pending-result-confirmation`
 if `requiresResultConfirmation` is `true`.
@@ -173,7 +173,7 @@ this action with `result.success = false` and an appropriate error.
 | `result` | [IToolCallResult](/reference/state-types#itoolcallresult) | Yes | Execution result |
 | `requiresResultConfirmation` | `boolean` | No | If true, the result requires client approval before finalizing |
 
-#### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L296" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+#### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L307" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -187,7 +187,7 @@ This mirrors the `content` field of MCP `CallToolResult`. |
 This mirrors the `structuredContent` field of MCP `CallToolResult`. |
 | `error` | `{ message: string; code?: string }` | No | Error details if the tool failed |
 
-### `session/toolCallResultConfirmed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L281" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/toolCallResultConfirmed` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L310" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Client approves or denies a tool's result.
 
@@ -198,7 +198,7 @@ If `approved` is `false`, the tool transitions to `cancelled` with reason `resul
 | `type` | `'session/toolCallResultConfirmed'` | Discriminant |
 | `approved` | `boolean` | Whether the result was approved |
 
-### `session/permissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L293" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/permissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L322" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Permission needed from the user to proceed.
 
@@ -209,7 +209,7 @@ Permission needed from the user to proceed.
 | `turnId` | `string` | Turn identifier |
 | `request` | [IPermissionRequest](/reference/state-types#ipermissionrequest) | Permission request details |
 
-### `session/permissionResolved` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L310" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/permissionResolved` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L339" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Permission granted or denied.
 
@@ -221,7 +221,7 @@ Permission needed from the user to proceed.
 | `requestId` | `string` | Permission request ID |
 | `approved` | `boolean` | Whether permission was granted |
 
-### `session/turnComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L328" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/turnComplete` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L357" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Turn finished — the assistant is idle.
 
@@ -231,7 +231,7 @@ Turn finished — the assistant is idle.
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `turnId` | `string` | Turn identifier |
 
-### `session/turnCancelled` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L343" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/turnCancelled` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L372" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Turn was aborted; server stops processing.
 
@@ -241,7 +241,7 @@ Turn finished — the assistant is idle.
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `turnId` | `string` | Turn identifier |
 
-### `session/error` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L357" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/error` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L386" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Error during turn processing.
 
@@ -252,7 +252,7 @@ Error during turn processing.
 | `turnId` | `string` | Turn identifier |
 | `error` | [IErrorInfo](/reference/state-types#ierrorinfo) | Error details |
 
-### `session/titleChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L373" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/titleChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L402" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Session title updated (typically auto-generated from conversation).
 
@@ -262,7 +262,7 @@ Session title updated (typically auto-generated from conversation).
 | `session` | [URI](/reference/state-types#uri) | Session URI |
 | `title` | `string` | New title |
 
-### `session/usage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L387" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/usage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L416" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Token usage report for a turn.
 
@@ -273,7 +273,7 @@ Token usage report for a turn.
 | `turnId` | `string` | Turn identifier |
 | `usage` | [IUsageInfo](/reference/state-types#iusageinfo) | Token usage data |
 
-### `session/reasoning` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L403" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/reasoning` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L432" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Reasoning/thinking text from the model.
 
@@ -284,7 +284,7 @@ Reasoning/thinking text from the model.
 | `turnId` | `string` | Turn identifier |
 | `content` | `string` | Reasoning text chunk |
 
-### `session/modelChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L420" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `session/modelChanged` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/actions.ts#L449" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 **Client-dispatchable.** Model changed for this session.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,17 +25,18 @@ This MUST be the first message sent by the client.
 
 **Result:**
 
-| Field | Type | Description |
-|---|---|---|
-| `protocolVersion` | `number` | Protocol version the server speaks |
-| `serverSeq` | `number` | Current server sequence number |
-| `snapshots` | [ISnapshot](/reference/state-types#isnapshot)[] | Snapshots for each `initialSubscriptions` URI |
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `protocolVersion` | `number` | Yes | Protocol version the server speaks |
+| `serverSeq` | `number` | Yes | Current server sequence number |
+| `snapshots` | [ISnapshot](/reference/state-types#isnapshot)[] | Yes | Snapshots for each `initialSubscriptions` URI |
+| `defaultDirectory` | `string` | No | Default working directory for sessions, if the server has one |
 
 See [Lifecycle](/specification/lifecycle) for details.
 
 ---
 
-## `reconnect` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L62" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+## `reconnect` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L64" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Re-establishes a dropped connection. The server replays missed actions or
 provides fresh snapshots.
@@ -75,7 +76,7 @@ See [Lifecycle](/specification/lifecycle) for details.
 
 ---
 
-## `createSession` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L154" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+## `createSession` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L156" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Creates a new session with the specified agent provider.
 
@@ -98,6 +99,7 @@ clients.
 | `session` | [URI](/reference/state-types#uri) | Yes | Session URI (client-chosen, e.g. `copilot:/&lt;uuid&gt;`) |
 | `provider` | `string` | No | Agent provider ID |
 | `model` | `string` | No | Model ID to use |
+| `workingDirectory` | `string` | No | Working directory for the session |
 
 **Result:** `null` on success.
 
@@ -127,7 +129,7 @@ clients.
 
 ---
 
-## `disposeSession` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L176" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+## `disposeSession` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L180" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Disposes a session and cleans up server-side resources.
 
@@ -150,7 +152,7 @@ The server broadcasts a `notify/sessionRemoved` notification to all clients.
 
 ---
 
-## `listSessions` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L196" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+## `listSessions` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L200" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Returns a list of session summaries. Used to populate session lists and sidebars.
 
@@ -177,7 +179,7 @@ large. Clients fetch it imperatively and maintain a local cache updated by
 
 ---
 
-## `fetchContent` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L234" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+## `fetchContent` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L238" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Fetches large content referenced by a `ContentRef` in the state tree.
 
@@ -229,7 +231,7 @@ use `utf-8` encoding.
 
 ---
 
-## `fetchTurns` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L279" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+## `fetchTurns` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/commands.ts#L283" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Fetches historical turns for a session. Used for lazy loading of conversation
 history.

--- a/docs/reference/state-types.md
+++ b/docs/reference/state-types.md
@@ -11,11 +11,12 @@ Complete reference for all state types in the Agent Host Protocol.
 
 Global state shared with every client subscribed to `agenthost:/root`.
 
-| Field | Type | Description |
-|---|---|---|
-| `agents` | [IAgentInfo](#iagentinfo)[] | Available agent backends and their models |
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `agents` | [IAgentInfo](#iagentinfo)[] | Yes | Available agent backends and their models |
+| `activeSessions` | `number` | No | Number of active (non-disposed) sessions on the server |
 
-### `IAgentInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L36" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IAgentInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L38" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Description |
 |---|---|---|
@@ -24,7 +25,7 @@ Global state shared with every client subscribed to `agenthost:/root`.
 | `description` | `string` | Description string |
 | `models` | [ISessionModelInfo](#isessionmodelinfo)[] | Available models for this agent |
 
-### `ISessionModelInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L50" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ISessionModelInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L52" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -37,7 +38,7 @@ Global state shared with every client subscribed to `agenthost:/root`.
 
 ## Session State
 
-### `ISessionState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L72" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ISessionState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L74" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Full state for a single session, loaded when a client subscribes to the session's URI.
 
@@ -51,7 +52,7 @@ Full state for a single session, loaded when a client subscribes to the session'
 | `turns` | [ITurn](#iturn)[] | Yes | Completed turns |
 | `activeTurn` | [IActiveTurn](#iactiveturn) | No | Currently in-progress turn |
 
-### `ISessionSummary` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L109" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ISessionSummary` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L111" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -65,7 +66,7 @@ Full state for a single session, loaded when a client subscribes to the session'
 
 ## Turn Types
 
-### `ITurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L133" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ITurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L135" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A completed request/response cycle.
 
@@ -80,7 +81,7 @@ A completed request/response cycle.
 | `state` | `'complete' \| 'cancelled' \| 'error'` | Yes | How the turn ended |
 | `error` | [IErrorInfo](#ierrorinfo) | No | Error details if state is `'error'` |
 
-### `IActiveTurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L157" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IActiveTurn` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L159" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 An in-progress turn — the assistant is actively streaming.
 
@@ -95,14 +96,14 @@ An in-progress turn — the assistant is actively streaming.
 | `reasoning` | `string` | Accumulated reasoning/thinking text |
 | `usage` | [IUsageInfo](#iusageinfo) \| undefined | Token usage info |
 
-### `IUserMessage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L179" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IUserMessage` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L181" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `text` | `string` | Yes | Message text |
 | `attachments` | [IMessageAttachment](#imessageattachment)[] | No | File/selection attachments |
 
-### `IMessageAttachment` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L189" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IMessageAttachment` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L191" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -112,14 +113,14 @@ An in-progress turn — the assistant is actively streaming.
 
 ## Response Parts
 
-### `IMarkdownResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L203" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IMarkdownResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L205" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Description |
 |---|---|---|
 | `kind` | `'markdown'` | Discriminant |
 | `content` | `string` | Markdown content |
 
-### `IContentRef` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L215" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IContentRef` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L217" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A reference to large content stored outside the state tree.
 
@@ -128,16 +129,16 @@ A reference to large content stored outside the state tree.
 | `kind` | `'contentRef'` | Yes | Discriminant |
 | `uri` | `string` | Yes | Content URI |
 | `sizeHint` | `number` | No | Approximate size in bytes |
-| `mimeType` | `string` | No | Content MIME type |
+| `contentType` | `string` | No | Content MIME type |
 
-### `IResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L229" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IResponsePart` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L231" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 [IMarkdownResponsePart](#imarkdownresponsepart) | [IContentRef](#icontentref)
 
 
 ## Tool Call Types
 
-### `ToolCallStatus` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L239" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ToolCallStatus` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L241" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Derived status type for the tool call lifecycle. This is the discriminant
 field (`status`) across all tool call state interfaces.
@@ -145,7 +146,7 @@ field (`status`) across all tool call state interfaces.
 [IToolCallState](#itoolcallstate)['status']
 
 
-### `ToolCallConfirmationReason` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L250" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ToolCallConfirmationReason` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L252" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 How a tool call was confirmed for execution.
 
@@ -156,7 +157,7 @@ How a tool call was confirmed for execution.
 `'not-needed' | 'user-action' | 'setting'`
 
 
-### `IToolCallState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L395" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L406" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Discriminated union of all tool call lifecycle states.
 
@@ -166,7 +167,7 @@ for the full state machine diagram.
 | [IToolCallStreamingState](#itoolcallstreamingstate) | [IToolCallPendingConfirmationState](#itoolcallpendingconfirmationstate) | [IToolCallRunningState](#itoolcallrunningstate) | [IToolCallPendingResultConfirmationState](#itoolcallpendingresultconfirmationstate) | [IToolCallCompletedState](#itoolcallcompletedstate) | [IToolCallCancelledState](#itoolcallcancelledstate)
 
 
-### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L296" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallResult` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L307" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool execution result details, available after execution completes.
 
@@ -182,7 +183,7 @@ This mirrors the `content` field of MCP `CallToolResult`. |
 This mirrors the `structuredContent` field of MCP `CallToolResult`. |
 | `error` | `{ message: string; code?: string }` | No | Error details if the tool failed |
 
-### `IToolCallStreamingState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L322" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallStreamingState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L333" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 LM is streaming the tool call parameters.
 
@@ -192,7 +193,7 @@ LM is streaming the tool call parameters.
 | `partialInput` | `string` | No | Partial parameters accumulated so far |
 | `invocationMessage` | [StringOrMarkdown](#stringormarkdown) | No | Progress message shown while parameters are streaming |
 
-### `IToolCallPendingConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L335" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallPendingConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L346" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Parameters are complete, waiting for client to confirm execution.
 
@@ -200,7 +201,7 @@ Parameters are complete, waiting for client to confirm execution.
 |---|---|---|
 | `status` | `'pending-confirmation'` |  |
 
-### `IToolCallRunningState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L344" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallRunningState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L355" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool is actively executing.
 
@@ -209,7 +210,7 @@ Tool is actively executing.
 | `status` | `'running'` |  |
 | `confirmed` | [ToolCallConfirmationReason](#toolcallconfirmationreason) | How the tool was confirmed for execution |
 
-### `IToolCallPendingResultConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L355" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallPendingResultConfirmationState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L366" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool finished executing, waiting for client to approve the result.
 
@@ -218,7 +219,7 @@ Tool finished executing, waiting for client to approve the result.
 | `status` | `'pending-result-confirmation'` |  |
 | `confirmed` | [ToolCallConfirmationReason](#toolcallconfirmationreason) | How the tool was confirmed for execution |
 
-### `IToolCallCompletedState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L366" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallCompletedState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L377" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool completed successfully or with an error.
 
@@ -227,7 +228,7 @@ Tool completed successfully or with an error.
 | `status` | `'completed'` |  |
 | `confirmed` | [ToolCallConfirmationReason](#toolcallconfirmationreason) | How the tool was confirmed for execution |
 
-### `IToolCallCancelledState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L377" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IToolCallCancelledState` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L388" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 Tool call was cancelled before execution.
 
@@ -240,7 +241,7 @@ Tool call was cancelled before execution.
 
 ## Permission Types
 
-### `IPermissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L524" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IPermissionRequest` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L535" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -256,7 +257,7 @@ Tool call was cancelled before execution.
 
 ## Common Types
 
-### `IUsageInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L550" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IUsageInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L561" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -265,7 +266,7 @@ Tool call was cancelled before execution.
 | `model` | `string` | No | Model used |
 | `cacheReadTokens` | `number` | No | Tokens read from cache |
 
-### `IErrorInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L564" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `IErrorInfo` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L575" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -273,7 +274,7 @@ Tool call was cancelled before execution.
 | `message` | `string` | Yes | Human-readable error message |
 | `stack` | `string` | No | Stack trace |
 
-### `ISnapshot` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L579" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
+### `ISnapshot` <a href="https://github.com/microsoft/agent-host-protocol/blob/main/types/state.ts#L590" title="View source" style="float:right;font-size:0.75em;opacity:0.5;text-decoration:none">📄</a>
 
 A point-in-time snapshot of a subscribed resource's state, returned by
 `initialize`, `reconnect`, and `subscribe`.

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -5,6 +5,22 @@
   "title": "AHP Action Types",
   "description": "All action types in the Agent Host Protocol.",
   "$defs": {
+    "IActionOrigin": {
+      "type": "object",
+      "description": "Identifies the client that originally dispatched an action.",
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "clientSeq": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "clientId",
+        "clientSeq"
+      ]
+    },
     "IActionEnvelope": {
       "type": "object",
       "description": "Every action is wrapped in an `ActionEnvelope`.",
@@ -16,19 +32,7 @@
           "type": "number"
         },
         "origin": {
-          "type": "object",
-          "properties": {
-            "clientId": {
-              "type": "string"
-            },
-            "clientSeq": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "clientId",
-            "clientSeq"
-          ]
+          "$ref": "#/$defs/IActionOrigin"
         },
         "rejectionReason": {
           "type": "string"
@@ -55,6 +59,11 @@
         "toolCallId": {
           "type": "string",
           "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         }
       },
       "required": [
@@ -84,6 +93,26 @@
       "required": [
         "type",
         "agents"
+      ]
+    },
+    "IRootActiveSessionsChangedAction": {
+      "type": "object",
+      "description": "Fired when the number of active sessions changes.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "root/activeSessionsChanged"
+          ]
+        },
+        "activeSessions": {
+          "type": "number",
+          "description": "Current count of active sessions"
+        }
+      },
+      "required": [
+        "type",
+        "activeSessions"
       ]
     },
     "ISessionReadyAction": {
@@ -769,6 +798,10 @@
             "$ref": "#/$defs/IAgentInfo"
           },
           "description": "Available agent backends and their models"
+        },
+        "activeSessions": {
+          "type": "number",
+          "description": "Number of active (non-disposed) sessions on the server"
         }
       },
       "required": [
@@ -1171,7 +1204,7 @@
           "type": "number",
           "description": "Approximate size in bytes"
         },
-        "mimeType": {
+        "contentType": {
           "type": "string",
           "description": "Content MIME type"
         }
@@ -1200,6 +1233,11 @@
         "toolClientId": {
           "type": "string",
           "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         }
       },
       "required": [
@@ -1747,6 +1785,9 @@
         },
         {
           "$ref": "#/$defs/IRootAgentsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/IRootActiveSessionsChangedAction"
         },
         {
           "$ref": "#/$defs/ISessionReadyAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -48,6 +48,10 @@
             "$ref": "#/$defs/ISnapshot"
           },
           "description": "Snapshots for each `initialSubscriptions` URI"
+        },
+        "defaultDirectory": {
+          "type": "string",
+          "description": "Default working directory for sessions, if the server has one"
         }
       },
       "required": [
@@ -171,6 +175,10 @@
         "model": {
           "type": "string",
           "description": "Model ID to use"
+        },
+        "workingDirectory": {
+          "type": "string",
+          "description": "Working directory for the session"
         }
       },
       "required": [
@@ -312,6 +320,55 @@
         "action"
       ]
     },
+    "IBrowseDirectoryParams": {
+      "type": "object",
+      "description": "Lists the contents of a directory on the server. Used by clients to\npresent directory pickers or file browsers.",
+      "properties": {
+        "directory": {
+          "type": "string",
+          "description": "Directory path to browse. Omit to list the default/root directory."
+        }
+      }
+    },
+    "IBrowseDirectoryEntry": {
+      "type": "object",
+      "description": "A single entry in a directory listing.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Entry name (not a full path)"
+        },
+        "isDirectory": {
+          "type": "boolean",
+          "description": "Whether this entry is a directory"
+        }
+      },
+      "required": [
+        "name",
+        "isDirectory"
+      ]
+    },
+    "IBrowseDirectoryResult": {
+      "type": "object",
+      "description": "Result of the `browseDirectory` command.",
+      "properties": {
+        "directory": {
+          "type": "string",
+          "description": "Absolute path of the listed directory"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IBrowseDirectoryEntry"
+          },
+          "description": "Entries in the directory"
+        }
+      },
+      "required": [
+        "directory",
+        "entries"
+      ]
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -322,6 +379,10 @@
             "$ref": "#/$defs/IAgentInfo"
           },
           "description": "Available agent backends and their models"
+        },
+        "activeSessions": {
+          "type": "number",
+          "description": "Number of active (non-disposed) sessions on the server"
         }
       },
       "required": [
@@ -724,7 +785,7 @@
           "type": "number",
           "description": "Approximate size in bytes"
         },
-        "mimeType": {
+        "contentType": {
           "type": "string",
           "description": "Content MIME type"
         }
@@ -753,6 +814,11 @@
         "toolClientId": {
           "type": "string",
           "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         }
       },
       "required": [
@@ -1215,6 +1281,22 @@
         "fromSeq"
       ]
     },
+    "IActionOrigin": {
+      "type": "object",
+      "description": "Identifies the client that originally dispatched an action.",
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "clientSeq": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "clientId",
+        "clientSeq"
+      ]
+    },
     "IActionEnvelope": {
       "type": "object",
       "description": "Every action is wrapped in an `ActionEnvelope`.",
@@ -1226,19 +1308,7 @@
           "type": "number"
         },
         "origin": {
-          "type": "object",
-          "properties": {
-            "clientId": {
-              "type": "string"
-            },
-            "clientSeq": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "clientId",
-            "clientSeq"
-          ]
+          "$ref": "#/$defs/IActionOrigin"
         },
         "rejectionReason": {
           "type": "string"
@@ -1265,6 +1335,11 @@
         "toolCallId": {
           "type": "string",
           "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         }
       },
       "required": [
@@ -1294,6 +1369,26 @@
       "required": [
         "type",
         "agents"
+      ]
+    },
+    "IRootActiveSessionsChangedAction": {
+      "type": "object",
+      "description": "Fired when the number of active sessions changes.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "root/activeSessionsChanged"
+          ]
+        },
+        "activeSessions": {
+          "type": "number",
+          "description": "Current count of active sessions"
+        }
+      },
+      "required": [
+        "type",
+        "activeSessions"
       ]
     },
     "ISessionReadyAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -66,6 +66,10 @@
             "$ref": "#/$defs/IAgentInfo"
           },
           "description": "Available agent backends and their models"
+        },
+        "activeSessions": {
+          "type": "number",
+          "description": "Number of active (non-disposed) sessions on the server"
         }
       },
       "required": [
@@ -468,7 +472,7 @@
           "type": "number",
           "description": "Approximate size in bytes"
         },
-        "mimeType": {
+        "contentType": {
           "type": "string",
           "description": "Content MIME type"
         }
@@ -497,6 +501,11 @@
         "toolClientId": {
           "type": "string",
           "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -15,6 +15,10 @@
             "$ref": "#/$defs/IAgentInfo"
           },
           "description": "Available agent backends and their models"
+        },
+        "activeSessions": {
+          "type": "number",
+          "description": "Number of active (non-disposed) sessions on the server"
         }
       },
       "required": [
@@ -417,7 +421,7 @@
           "type": "number",
           "description": "Approximate size in bytes"
         },
-        "mimeType": {
+        "contentType": {
           "type": "string",
           "description": "Content MIME type"
         }
@@ -446,6 +450,11 @@
         "toolClientId": {
           "type": "string",
           "description": "If this tool is provided by a client, the `clientId` of the owning client.\nAbsent for server-side tools.\n\nWhen set, the identified client is responsible for executing the tool and\ndispatching `session/toolCallComplete` with the result."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         }
       },
       "required": [

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -16,12 +16,56 @@ import type {
   IToolCallResult,
   IToolDefinition,
   ISessionActiveClient,
-  ToolCallConfirmationReason,
   IUsageInfo,
   IPermissionRequest,
 } from './state.js';
 
+import { ToolCallConfirmationReason, ToolCallCancellationReason } from './state.js';
+
+// ─── Action Type Enum ────────────────────────────────────────────────────────
+
+/**
+ * Discriminant values for all state actions.
+ *
+ * @category Actions
+ */
+export const enum ActionType {
+  RootAgentsChanged = 'root/agentsChanged',
+  RootActiveSessionsChanged = 'root/activeSessionsChanged',
+  SessionReady = 'session/ready',
+  SessionCreationFailed = 'session/creationFailed',
+  SessionTurnStarted = 'session/turnStarted',
+  SessionDelta = 'session/delta',
+  SessionResponsePart = 'session/responsePart',
+  SessionToolCallStart = 'session/toolCallStart',
+  SessionToolCallDelta = 'session/toolCallDelta',
+  SessionToolCallReady = 'session/toolCallReady',
+  SessionToolCallConfirmed = 'session/toolCallConfirmed',
+  SessionToolCallComplete = 'session/toolCallComplete',
+  SessionToolCallResultConfirmed = 'session/toolCallResultConfirmed',
+  SessionPermissionRequest = 'session/permissionRequest',
+  SessionPermissionResolved = 'session/permissionResolved',
+  SessionTurnComplete = 'session/turnComplete',
+  SessionTurnCancelled = 'session/turnCancelled',
+  SessionError = 'session/error',
+  SessionTitleChanged = 'session/titleChanged',
+  SessionUsage = 'session/usage',
+  SessionReasoning = 'session/reasoning',
+  SessionModelChanged = 'session/modelChanged',
+  SessionServerToolsChanged = 'session/serverToolsChanged',
+  SessionActiveClientChanged = 'session/activeClientChanged',
+  SessionActiveClientToolsChanged = 'session/activeClientToolsChanged',
+}
+
 // ─── Action Envelope ─────────────────────────────────────────────────────────
+
+/**
+ * Identifies the client that originally dispatched an action.
+ */
+export interface IActionOrigin {
+  clientId: string;
+  clientSeq: number;
+}
 
 /**
  * Every action is wrapped in an `ActionEnvelope`.
@@ -29,7 +73,7 @@ import type {
 export interface IActionEnvelope {
   readonly action: IStateAction;
   readonly serverSeq: number;
-  readonly origin: { clientId: string; clientSeq: number } | undefined;
+  readonly origin: IActionOrigin | undefined;
   readonly rejectionReason?: string;
 }
 
@@ -48,6 +92,15 @@ interface IToolCallActionBase {
   turnId: string;
   /** Tool call identifier */
   toolCallId: string;
+  /**
+   * Additional provider-specific metadata for this tool call.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI.
+   * For example, a `ptyTerminal` key with `{ input: string; output: string }`
+   * indicates the tool operated on a terminal (both `input` and `output` may
+   * contain escape sequences).
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -57,9 +110,21 @@ interface IToolCallActionBase {
  * @version 1
  */
 export interface IRootAgentsChangedAction {
-  type: 'root/agentsChanged';
+  type: ActionType.RootAgentsChanged;
   /** Updated agent list */
   agents: IAgentInfo[];
+}
+
+/**
+ * Fired when the number of active sessions changes.
+ *
+ * @category Root Actions
+ * @version 1
+ */
+export interface IRootActiveSessionsChangedAction {
+  type: ActionType.RootActiveSessionsChanged;
+  /** Current count of active sessions */
+  activeSessions: number;
 }
 
 // ─── Session Actions ─────────────────────────────────────────────────────────
@@ -71,7 +136,7 @@ export interface IRootAgentsChangedAction {
  * @version 1
  */
 export interface ISessionReadyAction {
-  type: 'session/ready';
+  type: ActionType.SessionReady;
   /** Session URI */
   session: URI;
 }
@@ -83,7 +148,7 @@ export interface ISessionReadyAction {
  * @version 1
  */
 export interface ISessionCreationFailedAction {
-  type: 'session/creationFailed';
+  type: ActionType.SessionCreationFailed;
   /** Session URI */
   session: URI;
   /** Error details */
@@ -98,7 +163,7 @@ export interface ISessionCreationFailedAction {
  * @clientDispatchable
  */
 export interface ISessionTurnStartedAction {
-  type: 'session/turnStarted';
+  type: ActionType.SessionTurnStarted;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -114,7 +179,7 @@ export interface ISessionTurnStartedAction {
  * @version 1
  */
 export interface ISessionDeltaAction {
-  type: 'session/delta';
+  type: ActionType.SessionDelta;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -130,7 +195,7 @@ export interface ISessionDeltaAction {
  * @version 1
  */
 export interface ISessionResponsePartAction {
-  type: 'session/responsePart';
+  type: ActionType.SessionResponsePart;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -150,7 +215,7 @@ export interface ISessionResponsePartAction {
  * @version 1
  */
 export interface ISessionToolCallStartAction extends IToolCallActionBase {
-  type: 'session/toolCallStart';
+  type: ActionType.SessionToolCallStart;
   /** Internal tool name (for debugging/logging) */
   toolName: string;
   /** Human-readable tool name */
@@ -169,7 +234,7 @@ export interface ISessionToolCallStartAction extends IToolCallActionBase {
  * @version 1
  */
 export interface ISessionToolCallDeltaAction extends IToolCallActionBase {
-  type: 'session/toolCallDelta';
+  type: ActionType.SessionToolCallDelta;
   /** Partial parameter content to append */
   content: string;
   /** Updated progress message */
@@ -188,7 +253,7 @@ export interface ISessionToolCallDeltaAction extends IToolCallActionBase {
  * @version 1
  */
 export interface ISessionToolCallReadyAction extends IToolCallActionBase {
-  type: 'session/toolCallReady';
+  type: ActionType.SessionToolCallReady;
   /** Message describing what the tool will do */
   invocationMessage: StringOrMarkdown;
   /** Raw tool input */
@@ -205,7 +270,7 @@ export interface ISessionToolCallReadyAction extends IToolCallActionBase {
  * @clientDispatchable
  */
 export interface ISessionToolCallApprovedAction extends IToolCallActionBase {
-  type: 'session/toolCallConfirmed';
+  type: ActionType.SessionToolCallConfirmed;
   /** The tool call was approved */
   approved: true;
   /** How the tool was confirmed */
@@ -223,11 +288,11 @@ export interface ISessionToolCallApprovedAction extends IToolCallActionBase {
  * @clientDispatchable
  */
 export interface ISessionToolCallDeniedAction extends IToolCallActionBase {
-  type: 'session/toolCallConfirmed';
+  type: ActionType.SessionToolCallConfirmed;
   /** The tool call was denied */
   approved: false;
   /** Why the tool was cancelled */
-  reason: 'denied' | 'skipped';
+  reason: ToolCallCancellationReason.Denied | ToolCallCancellationReason.Skipped;
   /** What the user suggested doing instead */
   userSuggestion?: IUserMessage;
   /** Optional explanation for the denial */
@@ -262,7 +327,7 @@ export type ISessionToolCallConfirmedAction =
  * @clientDispatchable
  */
 export interface ISessionToolCallCompleteAction extends IToolCallActionBase {
-  type: 'session/toolCallComplete';
+  type: ActionType.SessionToolCallComplete;
   /** Execution result */
   result: IToolCallResult;
   /** If true, the result requires client approval before finalizing */
@@ -279,7 +344,7 @@ export interface ISessionToolCallCompleteAction extends IToolCallActionBase {
  * @clientDispatchable
  */
 export interface ISessionToolCallResultConfirmedAction extends IToolCallActionBase {
-  type: 'session/toolCallResultConfirmed';
+  type: ActionType.SessionToolCallResultConfirmed;
   /** Whether the result was approved */
   approved: boolean;
 }
@@ -291,7 +356,7 @@ export interface ISessionToolCallResultConfirmedAction extends IToolCallActionBa
  * @version 1
  */
 export interface ISessionPermissionRequestAction {
-  type: 'session/permissionRequest';
+  type: ActionType.SessionPermissionRequest;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -308,7 +373,7 @@ export interface ISessionPermissionRequestAction {
  * @clientDispatchable
  */
 export interface ISessionPermissionResolvedAction {
-  type: 'session/permissionResolved';
+  type: ActionType.SessionPermissionResolved;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -326,7 +391,7 @@ export interface ISessionPermissionResolvedAction {
  * @version 1
  */
 export interface ISessionTurnCompleteAction {
-  type: 'session/turnComplete';
+  type: ActionType.SessionTurnComplete;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -341,7 +406,7 @@ export interface ISessionTurnCompleteAction {
  * @clientDispatchable
  */
 export interface ISessionTurnCancelledAction {
-  type: 'session/turnCancelled';
+  type: ActionType.SessionTurnCancelled;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -355,7 +420,7 @@ export interface ISessionTurnCancelledAction {
  * @version 1
  */
 export interface ISessionErrorAction {
-  type: 'session/error';
+  type: ActionType.SessionError;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -371,7 +436,7 @@ export interface ISessionErrorAction {
  * @version 1
  */
 export interface ISessionTitleChangedAction {
-  type: 'session/titleChanged';
+  type: ActionType.SessionTitleChanged;
   /** Session URI */
   session: URI;
   /** New title */
@@ -385,7 +450,7 @@ export interface ISessionTitleChangedAction {
  * @version 1
  */
 export interface ISessionUsageAction {
-  type: 'session/usage';
+  type: ActionType.SessionUsage;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -401,7 +466,7 @@ export interface ISessionUsageAction {
  * @version 1
  */
 export interface ISessionReasoningAction {
-  type: 'session/reasoning';
+  type: ActionType.SessionReasoning;
   /** Session URI */
   session: URI;
   /** Turn identifier */
@@ -418,7 +483,7 @@ export interface ISessionReasoningAction {
  * @clientDispatchable
  */
 export interface ISessionModelChangedAction {
-  type: 'session/modelChanged';
+  type: ActionType.SessionModelChanged;
   /** Session URI */
   session: URI;
   /** New model ID */
@@ -434,7 +499,7 @@ export interface ISessionModelChangedAction {
  * @version 1
  */
 export interface ISessionServerToolsChangedAction {
-  type: 'session/serverToolsChanged';
+  type: ActionType.SessionServerToolsChanged;
   /** Session URI */
   session: URI;
   /** Updated server tools list (full replacement) */
@@ -454,7 +519,7 @@ export interface ISessionServerToolsChangedAction {
  * @clientDispatchable
  */
 export interface ISessionActiveClientChangedAction {
-  type: 'session/activeClientChanged';
+  type: ActionType.SessionActiveClientChanged;
   /** Session URI */
   session: URI;
   /** The new active client, or `null` to unset */
@@ -473,7 +538,7 @@ export interface ISessionActiveClientChangedAction {
  * @clientDispatchable
  */
 export interface ISessionActiveClientToolsChangedAction {
-  type: 'session/activeClientToolsChanged';
+  type: ActionType.SessionActiveClientToolsChanged;
   /** Session URI */
   session: URI;
   /** Updated client tools list (full replacement) */
@@ -487,6 +552,7 @@ export interface ISessionActiveClientToolsChangedAction {
  */
 export type IStateAction =
   | IRootAgentsChangedAction
+  | IRootActiveSessionsChangedAction
   | ISessionReadyAction
   | ISessionCreationFailedAction
   | ISessionTurnStartedAction

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -44,9 +44,21 @@ export interface IInitializeResult {
   serverSeq: number;
   /** Snapshots for each `initialSubscriptions` URI */
   snapshots: ISnapshot[];
+  /** Default working directory for sessions, if the server has one */
+  defaultDirectory?: string;
 }
 
 // ─── reconnect ───────────────────────────────────────────────────────────────
+
+/**
+ * Discriminant for reconnect result types.
+ *
+ * @category Commands
+ */
+export const enum ReconnectResultType {
+  Replay = 'replay',
+  Snapshot = 'snapshot',
+}
 
 /**
  * Re-establishes a dropped connection. The server replays missed actions or
@@ -75,7 +87,7 @@ export interface IReconnectParams {
  */
 export interface IReconnectReplayResult {
   /** Discriminant */
-  type: 'replay';
+  type: ReconnectResultType.Replay;
   /** Missed action envelopes since `lastSeenServerSeq` */
   actions: IActionEnvelope[];
 }
@@ -85,7 +97,7 @@ export interface IReconnectReplayResult {
  */
 export interface IReconnectSnapshotResult {
   /** Discriminant */
-  type: 'snapshot';
+  type: ReconnectResultType.Snapshot;
   /** Fresh snapshots for each subscription */
   snapshots: ISnapshot[];
 }
@@ -158,6 +170,8 @@ export interface ICreateSessionParams {
   provider?: string;
   /** Model ID to use */
   model?: string;
+  /** Working directory for the session */
+  workingDirectory?: string;
 }
 
 // ─── disposeSession ──────────────────────────────────────────────────────────
@@ -204,6 +218,16 @@ export type IListSessionsResult = ISessionSummary[];
 // ─── fetchContent ────────────────────────────────────────────────────────────
 
 /**
+ * Encoding of fetched content data.
+ *
+ * @category Commands
+ */
+export const enum ContentEncoding {
+  Base64 = 'base64',
+  Utf8 = 'utf-8',
+}
+
+/**
  * Fetches large content referenced by a `ContentRef` in the state tree.
  *
  * Content references keep the state tree small by storing large data (images,
@@ -243,7 +267,7 @@ export interface IFetchContentResult {
   /** Content encoded as a string */
   data: string;
   /** How `data` is encoded */
-  encoding: 'base64' | 'utf-8';
+  encoding: ContentEncoding;
   /** MIME type of the content */
   mimeType?: string;
 }
@@ -330,4 +354,41 @@ export interface IDispatchActionParams {
   clientSeq: number;
   /** The action to dispatch */
   action: IStateAction;
+}
+
+// ─── browseDirectory ────────────────────────────────────────────────────
+
+/**
+ * Lists the contents of a directory on the server. Used by clients to
+ * present directory pickers or file browsers.
+ *
+ * @category Commands
+ * @method browseDirectory
+ * @direction Client → Server
+ * @messageType Request
+ * @version 1
+ */
+export interface IBrowseDirectoryParams {
+  /** Directory path to browse. Omit to list the default/root directory. */
+  directory?: string;
+}
+
+/**
+ * A single entry in a directory listing.
+ */
+export interface IBrowseDirectoryEntry {
+  /** Entry name (not a full path) */
+  name: string;
+  /** Whether this entry is a directory */
+  isDirectory: boolean;
+}
+
+/**
+ * Result of the `browseDirectory` command.
+ */
+export interface IBrowseDirectoryResult {
+  /** Absolute path of the listed directory */
+  directory: string;
+  /** Entries in the directory */
+  entries: IBrowseDirectoryEntry[];
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,8 +23,6 @@ export type {
   IMarkdownResponsePart,
   IContentRef,
   IResponsePart,
-  ToolCallStatus,
-  ToolCallConfirmationReason,
   IToolCallResult,
   IToolCallStreamingState,
   IToolCallPendingConfirmationState,
@@ -45,10 +43,26 @@ export type {
   ISnapshot,
 } from './state.js';
 
+export {
+  PolicyState,
+  SessionLifecycle,
+  SessionStatus,
+  TurnState,
+  AttachmentType,
+  ResponsePartKind,
+  ToolCallStatus,
+  ToolCallConfirmationReason,
+  ToolCallCancellationReason,
+  ToolResultContentType,
+  PermissionKind,
+} from './state.js';
+
 // Action types
 export type {
   IActionEnvelope,
+  IActionOrigin,
   IRootAgentsChangedAction,
+  IRootActiveSessionsChangedAction,
   ISessionReadyAction,
   ISessionCreationFailedAction,
   ISessionTurnStartedAction,
@@ -77,6 +91,8 @@ export type {
   IStateAction,
 } from './actions.js';
 
+export { ActionType } from './actions.js';
+
 // Command types
 export type {
   IInitializeParams,
@@ -97,7 +113,12 @@ export type {
   IFetchTurnsResult,
   IUnsubscribeParams,
   IDispatchActionParams,
+  IBrowseDirectoryParams,
+  IBrowseDirectoryEntry,
+  IBrowseDirectoryResult,
 } from './commands.js';
+
+export { ReconnectResultType, ContentEncoding } from './commands.js';
 
 // Notification types
 export type {
@@ -105,6 +126,8 @@ export type {
   ISessionRemovedNotification,
   IProtocolNotification,
 } from './notifications.js';
+
+export { NotificationType } from './notifications.js';
 
 // Error codes
 export {
@@ -121,7 +144,9 @@ export {
   PROTOCOL_VERSION,
   MIN_PROTOCOL_VERSION,
   ACTION_INTRODUCED_IN,
+  NOTIFICATION_INTRODUCED_IN,
   isActionKnownToVersion,
+  isNotificationKnownToVersion,
   capabilitiesForVersion,
 } from './version/registry.js';
 export type { ProtocolCapabilities } from './version/registry.js';

--- a/types/notifications.ts
+++ b/types/notifications.ts
@@ -11,6 +11,16 @@ import type { URI, ISessionSummary } from './state.js';
 // ─── Protocol Notifications ──────────────────────────────────────────────────
 
 /**
+ * Discriminant values for all protocol notifications.
+ *
+ * @category Protocol Notifications
+ */
+export const enum NotificationType {
+  SessionAdded = 'notify/sessionAdded',
+  SessionRemoved = 'notify/sessionRemoved',
+}
+
+/**
  * Broadcast to all connected clients when a new session is created.
  *
  * @category Protocol Notifications
@@ -37,7 +47,7 @@ import type { URI, ISessionSummary } from './state.js';
  * ```
  */
 export interface ISessionAddedNotification {
-  type: 'notify/sessionAdded';
+  type: NotificationType.SessionAdded;
   /** Summary of the new session */
   summary: ISessionSummary;
 }
@@ -62,7 +72,7 @@ export interface ISessionAddedNotification {
  * ```
  */
 export interface ISessionRemovedNotification {
-  type: 'notify/sessionRemoved';
+  type: NotificationType.SessionRemoved;
   /** URI of the removed session */
   session: URI;
 }

--- a/types/state.ts
+++ b/types/state.ts
@@ -21,6 +21,17 @@ export type StringOrMarkdown = string | { markdown: string };
 // ─── Root State ──────────────────────────────────────────────────────────────
 
 /**
+ * Policy configuration state for a model.
+ *
+ * @category Root State
+ */
+export const enum PolicyState {
+  Enabled = 'enabled',
+  Disabled = 'disabled',
+  Unconfigured = 'unconfigured',
+}
+
+/**
  * Global state shared with every client subscribed to `agenthost:/root`.
  *
  * @category Root State
@@ -28,6 +39,8 @@ export type StringOrMarkdown = string | { markdown: string };
 export interface IRootState {
   /** Available agent backends and their models */
   agents: IAgentInfo[];
+  /** Number of active (non-disposed) sessions on the server */
+  activeSessions?: number;
 }
 
 /**
@@ -59,10 +72,32 @@ export interface ISessionModelInfo {
   /** Whether the model supports vision */
   supportsVision?: boolean;
   /** Policy configuration state */
-  policyState?: 'enabled' | 'disabled' | 'unconfigured';
+  policyState?: PolicyState;
 }
 
 // ─── Session State ───────────────────────────────────────────────────────────
+
+/**
+ * Session initialization state.
+ *
+ * @category Session State
+ */
+export const enum SessionLifecycle {
+  Creating = 'creating',
+  Ready = 'ready',
+  CreationFailed = 'creationFailed',
+}
+
+/**
+ * Current session status.
+ *
+ * @category Session State
+ */
+export const enum SessionStatus {
+  Idle = 'idle',
+  InProgress = 'in-progress',
+  Error = 'error',
+}
 
 /**
  * Full state for a single session, loaded when a client subscribes to the session's URI.
@@ -73,7 +108,7 @@ export interface ISessionState {
   /** Lightweight session metadata */
   summary: ISessionSummary;
   /** Session initialization state */
-  lifecycle: 'creating' | 'ready' | 'creationFailed';
+  lifecycle: SessionLifecycle;
   /** Error details if creation failed */
   creationError?: IErrorInfo;
   /** Tools provided by the server (agent host) for this session */
@@ -114,7 +149,7 @@ export interface ISessionSummary {
   /** Session title */
   title: string;
   /** Current session status */
-  status: 'idle' | 'in-progress' | 'error';
+  status: SessionStatus;
   /** Creation timestamp */
   createdAt: number;
   /** Last modification timestamp */
@@ -124,6 +159,28 @@ export interface ISessionSummary {
 }
 
 // ─── Turn Types ──────────────────────────────────────────────────────────────
+
+/**
+ * How a turn ended.
+ *
+ * @category Turn Types
+ */
+export const enum TurnState {
+  Complete = 'complete',
+  Cancelled = 'cancelled',
+  Error = 'error',
+}
+
+/**
+ * Type of a message attachment.
+ *
+ * @category Turn Types
+ */
+export const enum AttachmentType {
+  File = 'file',
+  Directory = 'directory',
+  Selection = 'selection',
+}
 
 /**
  * A completed request/response cycle.
@@ -144,7 +201,7 @@ export interface ITurn {
   /** Token usage info */
   usage: IUsageInfo | undefined;
   /** How the turn ended */
-  state: 'complete' | 'cancelled' | 'error';
+  state: TurnState;
   /** Error details if state is `'error'` */
   error?: IErrorInfo;
 }
@@ -188,7 +245,7 @@ export interface IUserMessage {
  */
 export interface IMessageAttachment {
   /** Attachment type */
-  type: 'file' | 'directory' | 'selection';
+  type: AttachmentType;
   /** File/directory path */
   path: string;
   /** Display name */
@@ -198,11 +255,21 @@ export interface IMessageAttachment {
 // ─── Response Parts ──────────────────────────────────────────────────────────
 
 /**
+ * Discriminant for response part types.
+ *
+ * @category Response Parts
+ */
+export const enum ResponsePartKind {
+  Markdown = 'markdown',
+  ContentRef = 'contentRef',
+}
+
+/**
  * @category Response Parts
  */
 export interface IMarkdownResponsePart {
   /** Discriminant */
-  kind: 'markdown';
+  kind: ResponsePartKind.Markdown;
   /** Markdown content */
   content: string;
 }
@@ -214,13 +281,13 @@ export interface IMarkdownResponsePart {
  */
 export interface IContentRef {
   /** Discriminant */
-  kind: 'contentRef';
+  kind: ResponsePartKind.ContentRef;
   /** Content URI */
   uri: string;
   /** Approximate size in bytes */
   sizeHint?: number;
   /** Content MIME type */
-  mimeType?: string;
+  contentType?: string;
 }
 
 /**
@@ -231,23 +298,44 @@ export type IResponsePart = IMarkdownResponsePart | IContentRef;
 // ─── Tool Call Types ─────────────────────────────────────────────────────────
 
 /**
- * Derived status type for the tool call lifecycle. This is the discriminant
- * field (`status`) across all tool call state interfaces.
+ * Status of a tool call in the lifecycle state machine.
  *
  * @category Tool Call Types
  */
-export type ToolCallStatus = IToolCallState['status'];
+export const enum ToolCallStatus {
+  Streaming = 'streaming',
+  PendingConfirmation = 'pending-confirmation',
+  Running = 'running',
+  PendingResultConfirmation = 'pending-result-confirmation',
+  Completed = 'completed',
+  Cancelled = 'cancelled',
+}
 
 /**
  * How a tool call was confirmed for execution.
  *
- * - `'not-needed'` — No confirmation required (auto-approved)
- * - `'user-action'` — User explicitly approved
- * - `'setting'` — Approved by a persistent user setting
+ * - `NotNeeded` — No confirmation required (auto-approved)
+ * - `UserAction` — User explicitly approved
+ * - `Setting` — Approved by a persistent user setting
  *
  * @category Tool Call Types
  */
-export type ToolCallConfirmationReason = 'not-needed' | 'user-action' | 'setting';
+export const enum ToolCallConfirmationReason {
+  NotNeeded = 'not-needed',
+  UserAction = 'user-action',
+  Setting = 'setting',
+}
+
+/**
+ * Why a tool call was cancelled.
+ *
+ * @category Tool Call Types
+ */
+export const enum ToolCallCancellationReason {
+  Denied = 'denied',
+  Skipped = 'skipped',
+  ResultDenied = 'result-denied',
+}
 
 /**
  * Metadata common to all tool call states.
@@ -274,6 +362,15 @@ interface IToolCallBase {
    * dispatching `session/toolCallComplete` with the result.
    */
   toolClientId?: string;
+  /**
+   * Additional provider-specific metadata for this tool call.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI.
+   * For example, a `ptyTerminal` key with `{ input: string; output: string }`
+   * indicates the tool operated on a terminal (both `input` and `output` may
+   * contain escape sequences).
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -320,7 +417,7 @@ export interface IToolCallResult {
  * @category Tool Call Types
  */
 export interface IToolCallStreamingState extends IToolCallBase {
-  status: 'streaming';
+  status: ToolCallStatus.Streaming;
   /** Partial parameters accumulated so far */
   partialInput?: string;
   /** Progress message shown while parameters are streaming */
@@ -333,7 +430,7 @@ export interface IToolCallStreamingState extends IToolCallBase {
  * @category Tool Call Types
  */
 export interface IToolCallPendingConfirmationState extends IToolCallBase, IToolCallParameterFields {
-  status: 'pending-confirmation';
+  status: ToolCallStatus.PendingConfirmation;
 }
 
 /**
@@ -342,7 +439,7 @@ export interface IToolCallPendingConfirmationState extends IToolCallBase, IToolC
  * @category Tool Call Types
  */
 export interface IToolCallRunningState extends IToolCallBase, IToolCallParameterFields {
-  status: 'running';
+  status: ToolCallStatus.Running;
   /** How the tool was confirmed for execution */
   confirmed: ToolCallConfirmationReason;
 }
@@ -353,7 +450,7 @@ export interface IToolCallRunningState extends IToolCallBase, IToolCallParameter
  * @category Tool Call Types
  */
 export interface IToolCallPendingResultConfirmationState extends IToolCallBase, IToolCallParameterFields, IToolCallResult {
-  status: 'pending-result-confirmation';
+  status: ToolCallStatus.PendingResultConfirmation;
   /** How the tool was confirmed for execution */
   confirmed: ToolCallConfirmationReason;
 }
@@ -364,7 +461,7 @@ export interface IToolCallPendingResultConfirmationState extends IToolCallBase, 
  * @category Tool Call Types
  */
 export interface IToolCallCompletedState extends IToolCallBase, IToolCallParameterFields, IToolCallResult {
-  status: 'completed';
+  status: ToolCallStatus.Completed;
   /** How the tool was confirmed for execution */
   confirmed: ToolCallConfirmationReason;
 }
@@ -375,9 +472,9 @@ export interface IToolCallCompletedState extends IToolCallBase, IToolCallParamet
  * @category Tool Call Types
  */
 export interface IToolCallCancelledState extends IToolCallBase, IToolCallParameterFields {
-  status: 'cancelled';
+  status: ToolCallStatus.Cancelled;
   /** Why the tool was cancelled */
-  reason: 'denied' | 'skipped' | 'result-denied';
+  reason: ToolCallCancellationReason;
   /** Optional message explaining the cancellation */
   reasonMessage?: StringOrMarkdown;
   /** What the user suggested doing instead */
@@ -472,6 +569,16 @@ export interface IToolAnnotations {
 // ─── Tool Result Content ─────────────────────────────────────────────────────
 
 /**
+ * Discriminant for tool result content types.
+ *
+ * @category Tool Result Content
+ */
+export const enum ToolResultContentType {
+  Text = 'text',
+  Binary = 'binary',
+}
+
+/**
  * Text content in a tool result.
  *
  * Mirrors MCP `TextContent`.
@@ -479,7 +586,7 @@ export interface IToolAnnotations {
  * @category Tool Result Content
  */
 export interface IToolResultTextContent {
-  type: 'text';
+  type: ToolResultContentType.Text;
   /** The text content */
   text: string;
 }
@@ -492,7 +599,7 @@ export interface IToolResultTextContent {
  * @category Tool Result Content
  */
 export interface IToolResultBinaryContent {
-  type: 'binary';
+  type: ToolResultContentType.Binary;
   /** Base64-encoded data */
   data: string;
   /** Content type (e.g. `"image/png"`, `"application/pdf"`) */
@@ -515,17 +622,31 @@ export type IToolResultContent =
 // ─── Permission Types ────────────────────────────────────────────────────────
 
 /**
+ * Type of permission requested.
+ *
+ * @category Permission Types
+ */
+export const enum PermissionKind {
+  Shell = 'shell',
+  Write = 'write',
+  Mcp = 'mcp',
+  Read = 'read',
+  Url = 'url',
+}
+
+/**
  * @category Permission Types
  * @remarks
  * Fields like `serverName`, `toolName`, and `rawRequest` carry agent-specific
  * identifiers on the wire despite the agent-agnostic design principle. These exist
  * for debugging and logging purposes.
+ * @todo @connor4312, split this up into well-separated union types
  */
 export interface IPermissionRequest {
   /** Unique request identifier */
   requestId: string;
   /** Type of permission */
-  permissionKind: 'shell' | 'write' | 'mcp' | 'read' | 'url';
+  permissionKind: PermissionKind;
   /** Associated tool call */
   toolCallId?: string;
   /** File/directory path */

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -5,6 +5,9 @@
  */
 
 import type { IStateAction } from '../actions.js';
+import { ActionType } from '../actions.js';
+import type { IProtocolNotification } from '../notifications.js';
+import { NotificationType } from '../notifications.js';
 
 // ─── Protocol Version Constants ──────────────────────────────────────────────
 
@@ -21,30 +24,31 @@ export const MIN_PROTOCOL_VERSION = 1;
  * Adding a new action to `IStateAction` without adding it here is a compile error.
  */
 export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: number } = {
-  'root/agentsChanged': 1,
-  'session/ready': 1,
-  'session/creationFailed': 1,
-  'session/turnStarted': 1,
-  'session/delta': 1,
-  'session/responsePart': 1,
-  'session/toolCallStart': 1,
-  'session/toolCallDelta': 1,
-  'session/toolCallReady': 1,
-  'session/toolCallConfirmed': 1,
-  'session/toolCallComplete': 1,
-  'session/toolCallResultConfirmed': 1,
-  'session/permissionRequest': 1,
-  'session/permissionResolved': 1,
-  'session/turnComplete': 1,
-  'session/turnCancelled': 1,
-  'session/error': 1,
-  'session/titleChanged': 1,
-  'session/usage': 1,
-  'session/reasoning': 1,
-  'session/modelChanged': 1,
-  'session/serverToolsChanged': 1,
-  'session/activeClientChanged': 1,
-  'session/activeClientToolsChanged': 1,
+  [ActionType.RootAgentsChanged]: 1,
+  [ActionType.RootActiveSessionsChanged]: 1,
+  [ActionType.SessionReady]: 1,
+  [ActionType.SessionCreationFailed]: 1,
+  [ActionType.SessionTurnStarted]: 1,
+  [ActionType.SessionDelta]: 1,
+  [ActionType.SessionResponsePart]: 1,
+  [ActionType.SessionToolCallStart]: 1,
+  [ActionType.SessionToolCallDelta]: 1,
+  [ActionType.SessionToolCallReady]: 1,
+  [ActionType.SessionToolCallConfirmed]: 1,
+  [ActionType.SessionToolCallComplete]: 1,
+  [ActionType.SessionToolCallResultConfirmed]: 1,
+  [ActionType.SessionPermissionRequest]: 1,
+  [ActionType.SessionPermissionResolved]: 1,
+  [ActionType.SessionTurnComplete]: 1,
+  [ActionType.SessionTurnCancelled]: 1,
+  [ActionType.SessionError]: 1,
+  [ActionType.SessionTitleChanged]: 1,
+  [ActionType.SessionUsage]: 1,
+  [ActionType.SessionReasoning]: 1,
+  [ActionType.SessionModelChanged]: 1,
+  [ActionType.SessionServerToolsChanged]: 1,
+  [ActionType.SessionActiveClientChanged]: 1,
+  [ActionType.SessionActiveClientToolsChanged]: 1,
 };
 
 /**
@@ -52,6 +56,25 @@ export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: numbe
  */
 export function isActionKnownToVersion(action: IStateAction, clientVersion: number): boolean {
   return ACTION_INTRODUCED_IN[action.type] <= clientVersion;
+}
+
+// ─── Exhaustive Notification → Version Map ─────────────────────────────────
+
+/**
+ * Maps every notification type to the protocol version that introduced it.
+ * Adding a new notification to `IProtocolNotification` without adding it here
+ * is a compile error.
+ */
+export const NOTIFICATION_INTRODUCED_IN: { readonly [K in IProtocolNotification['type']]: number } = {
+  [NotificationType.SessionAdded]: 1,
+  [NotificationType.SessionRemoved]: 1,
+};
+
+/**
+ * Returns whether the given notification type is known to the specified protocol version.
+ */
+export function isNotificationKnownToVersion(notification: IProtocolNotification, clientVersion: number): boolean {
+  return NOTIFICATION_INTRODUCED_IN[notification.type] <= clientVersion;
 }
 
 // ─── Capabilities ────────────────────────────────────────────────────────────

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -44,6 +44,8 @@ import type {
 import type {
   IStateAction,
   IActionEnvelope,
+  IActionOrigin,
+  IRootActiveSessionsChangedAction,
   ISessionToolCallApprovedAction,
   ISessionToolCallDeniedAction,
   ISessionServerToolsChangedAction,
@@ -104,6 +106,8 @@ type V1_IErrorInfo = IErrorInfo;
 type V1_ISnapshot = ISnapshot;
 type V1_IStateAction = IStateAction;
 type V1_IActionEnvelope = IActionEnvelope;
+type V1_IActionOrigin = IActionOrigin;
+type V1_IRootActiveSessionsChangedAction = IRootActiveSessionsChangedAction;
 type V1_ISessionToolCallApprovedAction = ISessionToolCallApprovedAction;
 type V1_ISessionToolCallDeniedAction = ISessionToolCallDeniedAction;
 type V1_ISessionServerToolsChangedAction = ISessionServerToolsChangedAction;
@@ -168,6 +172,10 @@ type _CheckSnapshot = AssertCompatible<V1_ISnapshot, ISnapshot>;
 type _CheckStateAction = AssertCompatible<V1_IStateAction, IStateAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckActionEnvelope = AssertCompatible<V1_IActionEnvelope, IActionEnvelope>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckActionOrigin = AssertCompatible<V1_IActionOrigin, IActionOrigin>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckActiveSessionsChangedAction = AssertCompatible<V1_IRootActiveSessionsChangedAction, IRootActiveSessionsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallApprovedAction = AssertCompatible<V1_ISessionToolCallApprovedAction, ISessionToolCallApprovedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Setting up to have VS Code just copy types from this repo. This is the initial manifest of things identified as missing from the protocol


| Extension | Where | What to do |
|---|---|---|
| `IRootState.activeSessions` | state.ts | Add `activeSessions: number` to protocol's `IRootState` |
| `IActiveSessionsChangedAction` | actions.ts | Add new action type + entry in `ACTION_INTRODUCED_IN` |
| `IToolCallBase.toolKind` | state.ts | Add `toolKind?: string` to protocol's `IToolCallBase` |
| `IToolCallBase.language` | state.ts | Add `language?: string` to protocol's `IToolCallBase` |
| `IToolCallStartAction.toolKind/language` | actions.ts | Add to protocol's `ISessionToolCallStartAction` |
| `ICreateSessionParams.workingDirectory` | commands.ts | Add to protocol's `ICreateSessionParams` |
| `IInitializeResult.defaultDirectory` | commands.ts | Add to protocol's `IInitializeResult` (as `string`) |
| `ISetAuthTokenParams` | commands.ts | Add new command to protocol |
| `IBrowseDirectory*` types | commands.ts | Add new command to protocol |
| `NOTIFICATION_INTRODUCED_IN` | version/registry.ts | Add to protocol's version registry |
| `isNotificationKnownToVersion()` | version/registry.ts | Add to protocol's version registry |
| `IActionOrigin` as named interface | actions.ts | Extract from inline in protocol's `IActionEnvelope` |

This is that with some tweaks. Also moved to const enums, since that's what we'd been using in VS Code and I prefer them (you get all the LS goodness as far as usages/references go)