### PR TITLE
add types for rpc and protocol messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/node": "^25.5.0",
         "mermaid": "^11.13.0",
         "ts-morph": "^24.0.0",
         "tsx": "^4.19.0",
@@ -1745,6 +1746,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -4269,6 +4280,13 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "npm run generate && vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "typecheck": "tsc --noEmit -p types/tsconfig.json"
+    "typecheck": "tsc --noEmit -p types/tsconfig.json",
+    "test": "npm run typecheck && tsx --test types/*.test.ts"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   },
   "homepage": "https://github.com/microsoft/agent-host-protocol#readme",
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "mermaid": "^11.13.0",
     "ts-morph": "^24.0.0",
     "tsx": "^4.19.0",

--- a/types/index.ts
+++ b/types/index.ts
@@ -130,6 +130,27 @@ export type {
 
 export { NotificationType } from './notifications.js';
 
+// Message types (JSON-RPC wire format)
+export type {
+  IJsonRpcRequest,
+  IJsonRpcSuccessResponse,
+  IJsonRpcErrorResponse,
+  IJsonRpcResponse,
+  IJsonRpcNotification,
+  ICommandMap,
+  INotificationMethodParams,
+  IClientNotificationMap,
+  IServerNotificationMap,
+  INotificationMap,
+  IAhpRequest,
+  IAhpSuccessResponse,
+  IAhpResponse,
+  IAhpNotification,
+  IAhpClientNotification,
+  IAhpServerNotification,
+  IProtocolMessage,
+} from './messages.js';
+
 // Error codes
 export {
   JsonRpcErrorCodes,

--- a/types/messages.test.ts
+++ b/types/messages.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Validates that every @method in commands.ts is registered in the message maps
+ * (messages.ts) and that no stale entries remain.
+ *
+ * Run: npx tsx --test types/messages.test.ts
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)));
+
+function readSource(file: string): string {
+  return readFileSync(resolve(root, file), 'utf-8');
+}
+
+// ─── Parse commands.ts ───────────────────────────────────────────────────────
+
+interface MethodInfo {
+  method: string;
+  messageType: 'Request' | 'Notification';
+}
+
+function parseCommandMethods(source: string): MethodInfo[] {
+  const results: MethodInfo[] = [];
+  // Match JSDoc blocks containing @method and @messageType
+  const jsdocRe = /\/\*\*[\s\S]*?\*\//g;
+  for (const match of source.matchAll(jsdocRe)) {
+    const block = match[0];
+    const methodMatch = block.match(/@method\s+(\w+)/);
+    const typeMatch = block.match(/@messageType\s+(Request|Notification)/);
+    if (methodMatch && typeMatch) {
+      results.push({
+        method: methodMatch[1],
+        messageType: typeMatch[1] as 'Request' | 'Notification',
+      });
+    }
+  }
+  return results;
+}
+
+// ─── Parse messages.ts maps ──────────────────────────────────────────────────
+
+function parseMapKeys(source: string, interfaceName: string): string[] {
+  // Find the interface opening brace, then count braces to find the matching close
+  const startRe = new RegExp(`interface\\s+${interfaceName}\\s*\\{`);
+  const startMatch = startRe.exec(source);
+  if (!startMatch) {
+    throw new Error(`Interface ${interfaceName} not found in messages.ts`);
+  }
+  let depth = 1;
+  let i = startMatch.index + startMatch[0].length;
+  while (i < source.length && depth > 0) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') depth--;
+    i++;
+  }
+  const body = source.slice(startMatch.index + startMatch[0].length, i - 1);
+  const keys: string[] = [];
+  // Match top-level keys only: 'methodName': at the start of a line (within body)
+  for (const line of body.split('\n')) {
+    const m = line.match(/^\s*'([^']+)'\s*:/);
+    if (m) keys.push(m[1]);
+  }
+  return keys;
+}
+
+function parseExpectedUnion(source: string, typeName: string): string[] {
+  // Match: type _TypeName = | 'a' | 'b' | 'c';
+  const re = new RegExp(`type\\s+${typeName}\\s*=[^;]+;`, 's');
+  const match = source.match(re);
+  if (!match) {
+    throw new Error(`Type ${typeName} not found in source`);
+  }
+  const values: string[] = [];
+  for (const m of match[0].matchAll(/'([^']+)'/g)) {
+    values.push(m[1]);
+  }
+  return values;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+const commandsSrc = readSource('commands.ts');
+const messagesSrc = readSource('messages.ts');
+const messageChecksSrc = readSource('version/message-checks.ts');
+
+const allMethods = parseCommandMethods(commandsSrc);
+// Deduplicate (browseDirectory appears twice in commands.ts)
+const requests = [...new Set(allMethods.filter(m => m.messageType === 'Request').map(m => m.method))];
+const clientNotifications = [...new Set(allMethods.filter(m => m.messageType === 'Notification').map(m => m.method))];
+
+describe('ICommandMap', () => {
+  const mapKeys = parseMapKeys(messagesSrc, 'ICommandMap');
+
+  it('contains every @messageType Request method from commands.ts', () => {
+    const missing = requests.filter(m => !mapKeys.includes(m));
+    assert.deepStrictEqual(missing, [], `Missing from ICommandMap: ${missing.join(', ')}`);
+  });
+
+  it('contains no extra methods beyond commands.ts', () => {
+    const extra = mapKeys.filter(m => !requests.includes(m));
+    assert.deepStrictEqual(extra, [], `Extra in ICommandMap: ${extra.join(', ')}`);
+  });
+});
+
+describe('IClientNotificationMap', () => {
+  const mapKeys = parseMapKeys(messagesSrc, 'IClientNotificationMap');
+
+  it('contains every @messageType Notification method from commands.ts', () => {
+    const missing = clientNotifications.filter(m => !mapKeys.includes(m));
+    assert.deepStrictEqual(missing, [], `Missing from IClientNotificationMap: ${missing.join(', ')}`);
+  });
+
+  it('contains no extra methods beyond commands.ts', () => {
+    const extra = mapKeys.filter(m => !clientNotifications.includes(m));
+    assert.deepStrictEqual(extra, [], `Extra in IClientNotificationMap: ${extra.join(', ')}`);
+  });
+});
+
+describe('_ExpectedCommands matches ICommandMap', () => {
+  const expectedCommands = parseExpectedUnion(messageChecksSrc, '_ExpectedCommands');
+  const mapKeys = parseMapKeys(messagesSrc, 'ICommandMap');
+
+  it('_ExpectedCommands lists exactly the ICommandMap keys', () => {
+    assert.deepStrictEqual(expectedCommands.sort(), mapKeys.sort());
+  });
+
+  it('_ExpectedCommands lists exactly the @method Request annotations', () => {
+    assert.deepStrictEqual(expectedCommands.sort(), [...requests].sort());
+  });
+});
+
+describe('_ExpectedClientNotifications matches IClientNotificationMap', () => {
+  const expected = parseExpectedUnion(messageChecksSrc, '_ExpectedClientNotifications');
+  const mapKeys = parseMapKeys(messagesSrc, 'IClientNotificationMap');
+
+  it('_ExpectedClientNotifications lists exactly the IClientNotificationMap keys', () => {
+    assert.deepStrictEqual(expected.sort(), mapKeys.sort());
+  });
+
+  it('_ExpectedClientNotifications lists exactly the @method Notification annotations', () => {
+    assert.deepStrictEqual(expected.sort(), [...clientNotifications].sort());
+  });
+});
+
+describe('_ExpectedServerNotifications matches IServerNotificationMap', () => {
+  const expected = parseExpectedUnion(messageChecksSrc, '_ExpectedServerNotifications');
+  const mapKeys = parseMapKeys(messagesSrc, 'IServerNotificationMap');
+
+  it('_ExpectedServerNotifications lists exactly the IServerNotificationMap keys', () => {
+    assert.deepStrictEqual(expected.sort(), mapKeys.sort());
+  });
+});
+
+describe('command params/result naming conventions', () => {
+  for (const method of requests) {
+    const pascal = method[0].toUpperCase() + method.slice(1);
+    const paramsName = `I${pascal}Params`;
+    const resultName = `I${pascal}Result`;
+
+    it(`${method}: ${paramsName} is exported from commands.ts`, () => {
+      assert.ok(
+        new RegExp(`export\\s+interface\\s+${paramsName}\\b`).test(commandsSrc),
+        `Expected ${paramsName} to be exported from commands.ts`,
+      );
+    });
+
+    it(`${method}: result is ${resultName} or null`, () => {
+      // Check that ICommandMap entry references the right result type (or null)
+      const entryRe = new RegExp(`'${method}'\\s*:\\s*\\{[^}]*result:\\s*(\\S+)`);
+      const match = messagesSrc.match(entryRe);
+      assert.ok(match, `Could not find ICommandMap entry for ${method}`);
+      const resultType = match[1].replace(/[;\s}]+$/, '');
+      assert.ok(
+        resultType === resultName || resultType === 'null',
+        `Expected result type ${resultName} or null, got ${resultType}`,
+      );
+    });
+  }
+});

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -1,0 +1,234 @@
+/**
+ * Message Types — Fully typed JSON-RPC message definitions for the AHP wire protocol.
+ *
+ * @module messages
+ * @description Typed JSON-RPC request, response, and notification types for all
+ * AHP methods. Narrowing on the `method` field gives fully typed `params` and
+ * result types.
+ */
+
+import type {
+  IInitializeParams,
+  IInitializeResult,
+  IReconnectParams,
+  IReconnectResult,
+  ISubscribeParams,
+  ISubscribeResult,
+  ICreateSessionParams,
+  IDisposeSessionParams,
+  IListSessionsParams,
+  IListSessionsResult,
+  IFetchContentParams,
+  IFetchContentResult,
+  IBrowseDirectoryParams,
+  IBrowseDirectoryResult,
+  IFetchTurnsParams,
+  IFetchTurnsResult,
+  IUnsubscribeParams,
+  IDispatchActionParams,
+} from './commands.js';
+
+import type { IActionEnvelope } from './actions.js';
+import type { IProtocolNotification } from './notifications.js';
+
+// ─── JSON-RPC Base Types ─────────────────────────────────────────────────────
+
+/** A JSON-RPC request: has both `method` and `id`. */
+export interface IJsonRpcRequest {
+  readonly jsonrpc: '2.0';
+  readonly id: number;
+  readonly method: string;
+  readonly params?: unknown;
+}
+
+/** A JSON-RPC success response. */
+export interface IJsonRpcSuccessResponse {
+  readonly jsonrpc: '2.0';
+  readonly id: number;
+  readonly result: unknown;
+}
+
+/** A JSON-RPC error response. */
+export interface IJsonRpcErrorResponse {
+  readonly jsonrpc: '2.0';
+  readonly id: number;
+  readonly error: {
+    readonly code: number;
+    readonly message: string;
+    readonly data?: unknown;
+  };
+}
+
+/** A JSON-RPC response (success or error). */
+export type IJsonRpcResponse = IJsonRpcSuccessResponse | IJsonRpcErrorResponse;
+
+/** A JSON-RPC notification: has `method` but no `id`. */
+export interface IJsonRpcNotification {
+  readonly jsonrpc: '2.0';
+  readonly method: string;
+  readonly params?: unknown;
+}
+
+// ─── Command Map ─────────────────────────────────────────────────────────────
+
+/**
+ * Registry mapping each command method name to its params and result types.
+ *
+ * @category Commands
+ */
+export interface ICommandMap {
+  'initialize': { params: IInitializeParams; result: IInitializeResult };
+  'reconnect': { params: IReconnectParams; result: IReconnectResult };
+  'subscribe': { params: ISubscribeParams; result: ISubscribeResult };
+  'createSession': { params: ICreateSessionParams; result: null };
+  'disposeSession': { params: IDisposeSessionParams; result: null };
+  'listSessions': { params: IListSessionsParams; result: IListSessionsResult };
+  'fetchContent': { params: IFetchContentParams; result: IFetchContentResult };
+  'browseDirectory': { params: IBrowseDirectoryParams; result: IBrowseDirectoryResult };
+  'fetchTurns': { params: IFetchTurnsParams; result: IFetchTurnsResult };
+}
+
+// ─── Notification Maps ───────────────────────────────────────────────────────
+
+/** Params for the server → client `notification` method. */
+export interface INotificationMethodParams {
+  notification: IProtocolNotification;
+}
+
+/**
+ * Registry mapping each client → server notification method to its params type.
+ *
+ * @category Notifications
+ */
+export interface IClientNotificationMap {
+  'unsubscribe': { params: IUnsubscribeParams };
+  'dispatchAction': { params: IDispatchActionParams };
+}
+
+/**
+ * Registry mapping each server → client notification method to its params type.
+ *
+ * @category Notifications
+ */
+export interface IServerNotificationMap {
+  'action': { params: IActionEnvelope };
+  'notification': { params: INotificationMethodParams };
+}
+
+/** Combined notification map for all directions. */
+export type INotificationMap = IClientNotificationMap & IServerNotificationMap;
+
+// ─── Typed Requests ──────────────────────────────────────────────────────────
+
+/**
+ * A fully typed JSON-RPC request for a specific AHP command.
+ *
+ * When used as a union (default generic), narrowing on `method` gives typed `params`:
+ *
+ * ```ts
+ * function handle(req: IAhpRequest) {
+ *   if (req.method === 'fetchTurns') {
+ *     req.params.session; // typed as URI
+ *   }
+ * }
+ * ```
+ */
+export type IAhpRequest<M extends keyof ICommandMap = keyof ICommandMap> =
+  M extends unknown ? {
+    readonly jsonrpc: '2.0';
+    readonly id: number;
+    readonly method: M;
+    readonly params: ICommandMap[M]['params'];
+  } : never;
+
+// ─── Typed Responses ─────────────────────────────────────────────────────────
+
+/**
+ * A fully typed JSON-RPC success response for a specific AHP command.
+ *
+ * Since JSON-RPC responses do not carry `method`, use this with an explicit
+ * generic parameter when you know the method from the associated request:
+ *
+ * ```ts
+ * const result: IAhpSuccessResponse<'fetchTurns'> = ...;
+ * result.result.turns; // typed as ITurn[]
+ * ```
+ */
+export type IAhpSuccessResponse<M extends keyof ICommandMap = keyof ICommandMap> =
+  M extends unknown ? {
+    readonly jsonrpc: '2.0';
+    readonly id: number;
+    readonly result: ICommandMap[M]['result'];
+  } : never;
+
+/** Typed JSON-RPC response (success with known result type, or error). */
+export type IAhpResponse<M extends keyof ICommandMap = keyof ICommandMap> =
+  | IAhpSuccessResponse<M>
+  | IJsonRpcErrorResponse;
+
+// ─── Typed Notifications ─────────────────────────────────────────────────────
+
+/**
+ * A fully typed JSON-RPC notification for a specific AHP notification method.
+ *
+ * When used as a union (default generic), narrowing on `method` gives typed `params`:
+ *
+ * ```ts
+ * function handle(notif: IAhpNotification) {
+ *   if (notif.method === 'action') {
+ *     notif.params.serverSeq; // typed as number
+ *   }
+ * }
+ * ```
+ */
+export type IAhpNotification<M extends keyof INotificationMap = keyof INotificationMap> =
+  M extends unknown ? {
+    readonly jsonrpc: '2.0';
+    readonly method: M;
+    readonly params: INotificationMap[M]['params'];
+  } : never;
+
+/** A client → server notification. */
+export type IAhpClientNotification<M extends keyof IClientNotificationMap = keyof IClientNotificationMap> =
+  M extends unknown ? {
+    readonly jsonrpc: '2.0';
+    readonly method: M;
+    readonly params: IClientNotificationMap[M]['params'];
+  } : never;
+
+/** A server → client notification. */
+export type IAhpServerNotification<M extends keyof IServerNotificationMap = keyof IServerNotificationMap> =
+  M extends unknown ? {
+    readonly jsonrpc: '2.0';
+    readonly method: M;
+    readonly params: IServerNotificationMap[M]['params'];
+  } : never;
+
+// ─── Protocol Message Union ──────────────────────────────────────────────────
+
+/**
+ * Discriminated union of all AHP protocol messages.
+ *
+ * Narrow using standard JSON-RPC structure:
+ * - Has `method` + `id` → request ({@link IAhpRequest})
+ * - Has `method`, no `id` → notification ({@link IAhpNotification})
+ * - Has `result` or `error` + `id` → response ({@link IAhpResponse})
+ *
+ * Then narrow on `method` for fully typed params:
+ *
+ * ```ts
+ * function dispatch(msg: IProtocolMessage) {
+ *   if ('method' in msg && 'id' in msg) {
+ *     // msg is IAhpRequest
+ *     if (msg.method === 'fetchTurns') {
+ *       msg.params.session; // URI
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type IProtocolMessage =
+  | IAhpRequest
+  | IAhpSuccessResponse
+  | IJsonRpcErrorResponse
+  | IAhpNotification;

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -16,5 +16,5 @@
     "isolatedModules": true
   },
   "include": ["./**/*.ts"],
-  "exclude": ["../dist"]
+  "exclude": ["../dist", "./**/*.test.ts"]
 }

--- a/types/version/message-checks.ts
+++ b/types/version/message-checks.ts
@@ -1,0 +1,53 @@
+/**
+ * Message Map Exhaustiveness Checks — Compile-time verification that the
+ * command and notification maps in messages.ts stay in sync with the actual
+ * method definitions.
+ *
+ * If a method is added to commands.ts but not registered in the maps (or
+ * vice versa), the compiler will surface an error here.
+ *
+ * @module version/message-checks
+ */
+
+import type {
+  ICommandMap,
+  IClientNotificationMap,
+  IServerNotificationMap,
+} from '../messages.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type _Exact<A, B> = [A] extends [B] ? [B] extends [A] ? true : never : never;
+
+// ─── Expected Method Names ───────────────────────────────────────────────────
+
+/** All methods annotated `@messageType Request` in commands.ts. */
+type _ExpectedCommands =
+  | 'initialize'
+  | 'reconnect'
+  | 'subscribe'
+  | 'createSession'
+  | 'disposeSession'
+  | 'listSessions'
+  | 'fetchContent'
+  | 'browseDirectory'
+  | 'fetchTurns';
+
+/** All methods annotated `@messageType Notification` (client → server) in commands.ts. */
+type _ExpectedClientNotifications =
+  | 'unsubscribe'
+  | 'dispatchAction';
+
+/** All server → client notification methods. */
+type _ExpectedServerNotifications =
+  | 'action'
+  | 'notification';
+
+// ─── Assertions ──────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckCommandMapKeys = _Exact<keyof ICommandMap, _ExpectedCommands>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckClientNotificationMapKeys = _Exact<keyof IClientNotificationMap, _ExpectedClientNotifications>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckServerNotificationMapKeys = _Exact<keyof IServerNotificationMap, _ExpectedServerNotifications>;

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -61,6 +61,13 @@ import type {
   IListSessionsResult,
 } from '../commands.js';
 
+import type {
+  ICommandMap,
+  IClientNotificationMap,
+  IServerNotificationMap,
+  INotificationMethodParams,
+} from '../messages.js';
+
 // ─── Bidirectional Assignability Check ───────────────────────────────────────
 
 /**
@@ -119,6 +126,10 @@ type V1_ISessionActiveClientChangedAction = ISessionActiveClientChangedAction;
 type V1_ISessionActiveClientToolsChangedAction = ISessionActiveClientToolsChangedAction;
 type V1_IProtocolNotification = IProtocolNotification;
 type V1_IListSessionsResult = IListSessionsResult;
+type V1_ICommandMap = ICommandMap;
+type V1_IClientNotificationMap = IClientNotificationMap;
+type V1_IServerNotificationMap = IServerNotificationMap;
+type V1_INotificationMethodParams = INotificationMethodParams;
 
 // ─── Compatibility Assertions ────────────────────────────────────────────────
 
@@ -205,3 +216,11 @@ type _CheckActiveClientToolsChangedAction = AssertCompatible<V1_ISessionActiveCl
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckListSessionsResult = AssertCompatible<V1_IListSessionsResult, IListSessionsResult>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckCommandMap = AssertCompatible<V1_ICommandMap, ICommandMap>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckClientNotificationMap = AssertCompatible<V1_IClientNotificationMap, IClientNotificationMap>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckServerNotificationMap = AssertCompatible<V1_IServerNotificationMap, IServerNotificationMap>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckNotificationMethodParams = AssertCompatible<V1_INotificationMethodParams, INotificationMethodParams>;


### PR DESCRIPTION
Allows type-safe handling by clients. Adds tests at a type level and unit test level to assure all notifications/methods are correctly assigned to RPC types.