### PR TITLE
feat: add RFC 9728 authentication support

### DIFF
--- a/.github/instructions/general-instructions.instructions.md
+++ b/.github/instructions/general-instructions.instructions.md
@@ -36,3 +36,4 @@ applyTo: 'types/**/*.ts'
 
 - After making a change, always add compatibility checks to the resulting file (current tip: `types/version/v1.ts`) so that any future incompatible changes will be caught by the compiler. See [Versioning](../../docs/specification/versioning.md) for details.
 - For actions or commands that could be implemented by returning an array `T[]` directly, still prefer to wrap it in `{ items: T[] }` for forward compatibility. This allows adding additional fields later without breaking the shape.
+- After making your changes, check to make sure the documentation in `docs` is up to date. For significant new flows or features, consider adding new documentation for it. Note that Mermaid diagrams are allowed.

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ docs/.vitepress/cache
 # Generated files (npm run generate)
 docs/reference/
 docs/public/schema/
-schema/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,6 +51,7 @@ export default withMermaid(defineConfig({
             { text: 'Overview', link: '/specification/overview' },
             { text: 'Transport', link: '/specification/transport' },
             { text: 'Lifecycle', link: '/specification/lifecycle' },
+            { text: 'Authentication', link: '/specification/authentication' },
             { text: 'Subscriptions', link: '/specification/subscriptions' },
             { text: 'Versioning', link: '/specification/versioning' },
           ],

--- a/docs/specification/authentication.md
+++ b/docs/specification/authentication.md
@@ -19,7 +19,7 @@ sequenceDiagram
     AS-->>C: Token
 
     C->>S: authenticate({ resource, token })
-    S-->>C: { authenticated: true }
+    S-->>C: {}
 
     C->>S: createSession / other commands
 ```
@@ -101,15 +101,15 @@ Clients push Bearer tokens to the server using the [`authenticate`](/reference/c
   }
 }
 
-// Server → Client
+// Server → Client (success)
 {
   "jsonrpc": "2.0",
   "id": 3,
-  "result": { "authenticated": true }
+  "result": {}
 }
 ```
 
-The server SHOULD validate the token and return `{ "authenticated": false }` if the token is invalid or the resource is unrecognized.
+If the token is invalid or the resource is unrecognized, the server MUST return a JSON-RPC error (e.g. `AuthRequired` `-32007` or `InvalidParams` `-32602`).
 
 ### Why keyed by `resource`?
 

--- a/docs/specification/authentication.md
+++ b/docs/specification/authentication.md
@@ -1,0 +1,207 @@
+# Authentication
+
+AHP uses [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) (OAuth 2.0 Protected Resource Metadata) semantics for authentication discovery, and [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750) (Bearer Token Usage) semantics for token delivery. Communication is JSON-RPC, not HTTP, but the vocabulary and flow mirror the HTTP standards.
+
+## Overview
+
+Each agent declares the **protected resources** it requires authentication for via the `protectedResources` field on [`IAgentInfo`](/reference/state-types#iagentinfo) in root state. Clients discover these requirements by subscribing to `agenthost:/root`, obtain tokens from the declared authorization servers using standard OAuth 2.0 flows, and push them to the server via the [`authenticate`](/reference/commands#authenticate) command.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Agent Host (Server)
+    participant AS as Authorization Server
+
+    C->>S: subscribe("agenthost:/root")
+    S-->>C: snapshot: { agents: [{ protectedResources: [...] }] }
+
+    C->>AS: OAuth token request
+    AS-->>C: Token
+
+    C->>S: authenticate({ resource, token })
+    S-->>C: { authenticated: true }
+
+    C->>S: createSession / other commands
+```
+
+## Discovery
+
+Authentication requirements are declared **per-agent** on [`IAgentInfo.protectedResources`](/reference/state-types#iagentinfo). Each entry is an [`IProtectedResourceMetadata`](/reference/state-types#iprotectedresourcemetadata) object following the [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) shape:
+
+```json
+{
+  "agents": [
+    {
+      "provider": "copilot",
+      "displayName": "GitHub Copilot",
+      "description": "AI pair programmer",
+      "models": [...],
+      "protectedResources": [
+        {
+          "resource": "https://api.github.com",
+          "resource_name": "GitHub Copilot",
+          "authorization_servers": ["https://github.com/login/oauth"],
+          "scopes_supported": ["read:user", "user:email"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Clients receive this metadata automatically via the root state snapshot (when subscribing to `agenthost:/root`) and via `root/agentsChanged` actions when the agent list changes.
+
+An agent with no `protectedResources` (or an empty array) does not require authentication.
+
+### Required vs. optional authentication
+
+Each protected resource entry has a `required` field (defaults to `true`) that controls whether the agent can be used without a token:
+
+- **`required: true`** (default) — the agent cannot function without authentication. The server SHOULD return `AuthRequired` (`-32007`) if the client attempts to use the agent unauthenticated.
+- **`required: false`** — the agent works without authentication but MAY offer enhanced capabilities (e.g. higher rate limits, personalized results) when a token is provided.
+
+Clients SHOULD treat an absent `required` field the same as `true`.
+
+```json
+{
+  "protectedResources": [
+    {
+      "resource": "https://api.example.com",
+      "resource_name": "Example API",
+      "authorization_servers": ["https://login.example.com"],
+      "required": false
+    }
+  ]
+}
+```
+
+Clients MAY use the `required` field to decide whether to prompt users for authentication up front or defer it until the user explicitly requests a feature that benefits from auth.
+
+### Why per-agent metadata?
+
+Different agents MAY require authentication with different providers. For example, one agent might require a GitHub token while another requires an Azure AD token. Declaring requirements per-agent rather than server-wide allows:
+
+- A single server to host agents from different providers with different auth requirements
+- Clients to selectively authenticate only for agents they intend to use
+- Auth requirements to change as agents are added or removed
+
+## Token Delivery
+
+Clients push Bearer tokens to the server using the [`authenticate`](/reference/commands#authenticate) command. The `resource` field MUST match a `resource` value from the agent's `protectedResources` metadata:
+
+```jsonc
+// Client → Server
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "authenticate",
+  "params": {
+    "resource": "https://api.github.com",
+    "token": "gho_xxxxxxxxxxxx"
+  }
+}
+
+// Server → Client
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": { "authenticated": true }
+}
+```
+
+The server SHOULD validate the token and return `{ "authenticated": false }` if the token is invalid or the resource is unrecognized.
+
+### Why keyed by `resource`?
+
+The RFC 9728 `resource` field is already a unique identifier for the protected resource. Using it directly as the correlation key between discovery and token delivery avoids inventing a parallel ID scheme. Clients match tokens to resources using standard OAuth 2.0 semantics.
+
+## Error Handling
+
+### `AuthRequired` Error Code
+
+When a command fails because the client has not authenticated for a required protected resource, the server SHOULD return error code `-32007` (`AuthRequired`). This error MAY be returned from **any** command — not just `authenticate`.
+
+The `data` field of the JSON-RPC error SHOULD contain an `IProtectedResourceMetadata[]` array describing the resources that require authentication. This allows clients to handle authentication programmatically:
+
+```jsonc
+// Client → Server
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "createSession",
+  "params": { "session": "copilot:/<uuid>", "provider": "copilot" }
+}
+
+// Server → Client (auth required)
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "error": {
+    "code": -32007,
+    "message": "Authentication required for GitHub Copilot",
+    "data": [
+      {
+        "resource": "https://api.github.com",
+        "resource_name": "GitHub Copilot",
+        "authorization_servers": ["https://github.com/login/oauth"],
+        "scopes_supported": ["read:user", "user:email"]
+      }
+    ]
+  }
+}
+```
+
+Clients receiving an `AuthRequired` error SHOULD:
+
+1. Parse the `data` field to discover the required resources
+2. Obtain tokens from the declared authorization servers
+3. Push tokens via `authenticate`
+4. Retry the original command
+
+## Auth Expiry Notification
+
+The server MAY send a [`notify/authRequired`](/reference/notifications#notifyauthrequired) notification when a previously valid token expires or is revoked, or when new authentication requirements appear:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notification",
+  "params": {
+    "notification": {
+      "type": "notify/authRequired",
+      "resource": "https://api.github.com",
+      "reason": "expired"
+    }
+  }
+}
+```
+
+The `reason` field indicates why authentication is required:
+
+| Value | Description |
+|---|---|
+| `required` | The client has not yet authenticated for the resource |
+| `expired` | A previously valid token has expired or been revoked |
+
+Like all protocol notifications, `notify/authRequired` is ephemeral and is **not** replayed on reconnection. Clients SHOULD re-check authentication requirements after reconnecting.
+
+## Design Decisions
+
+### Why RFC 9728 instead of a custom type?
+
+Using the standard OAuth 2.0 Protected Resource Metadata format means:
+
+- Clients can resolve tokens using the same code path as other OAuth-based protocols (e.g. MCP)
+- Dynamic auth providers (for enterprise IdPs) work without hardcoded knowledge of specific providers
+- The `authorization_servers` field enables automatic provider matching in runtimes that support it
+
+### Why `authenticate` instead of including tokens in `initialize`?
+
+- Authentication is per-resource, not per-connection
+- Clients may authenticate for multiple resources independently
+- Tokens can be refreshed or rotated without re-initializing the connection
+- Not all clients need to authenticate (some agents may not require auth)
+
+### Why not store auth status in root state?
+
+Root state is global and visible to all subscribed clients. Authentication status is per-connection (each client authenticates independently), so it is kept imperative via commands and notifications rather than polluting the shared state tree.

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -57,6 +57,14 @@ If present, `defaultDirectory` provides a server-local starting location for rem
 
 If the server cannot accept the connection (e.g. unsupported protocol version), it MUST return a JSON-RPC error. See [Error Codes](/reference/error-codes) for defined codes.
 
+## Authentication
+
+Agents MAY declare `protectedResources` in their [`IAgentInfo`](/reference/state-types#iagentinfo). Before interacting with a session backed by such an agent, the client SHOULD authenticate by obtaining a Bearer token from the declared authorization server(s) and pushing it via the [`authenticate`](/reference/commands#authenticate) command.
+
+If a client attempts to create or use a session with an agent that requires authentication and has not yet provided a token, the server SHOULD return error code `-32007` (`AuthRequired`) with the required resource metadata in the error's `data` field.
+
+See [Authentication](/specification/authentication) for the full specification.
+
 ## Session Creation
 
 ```

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -713,6 +713,85 @@
       ],
       "description": "Client confirms or denies a pending tool call."
     },
+    "IProtectedResourceMetadata": {
+      "type": "object",
+      "description": "Describes a protected resource's authentication requirements using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) (OAuth 2.0\nProtected Resource Metadata) semantics.\n\nField names use snake_case to match the RFC 9728 JSON format.",
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "REQUIRED. The protected resource's resource identifier, a URL using the\n`https` scheme with no fragment component (e.g. `\"https://api.github.com\"`)."
+        },
+        "resource_name": {
+          "type": "string",
+          "description": "OPTIONAL. Human-readable name of the protected resource."
+        },
+        "authorization_servers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of OAuth authorization server identifier URLs."
+        },
+        "jwks_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the protected resource's JWK Set document."
+        },
+        "scopes_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "RECOMMENDED. JSON array of OAuth 2.0 scope values used in authorization requests."
+        },
+        "bearer_methods_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of Bearer Token presentation methods supported."
+        },
+        "resource_signing_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
+        },
+        "resource_encryption_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
+        },
+        "resource_encryption_enc_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
+        },
+        "resource_documentation": {
+          "type": "string",
+          "description": "OPTIONAL. URL of human-readable documentation for the resource."
+        },
+        "resource_policy_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's data-usage policy."
+        },
+        "resource_tos_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's terms of service."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "AHP extension. Whether authentication is required for this resource.\n\n- `true` (default) — the agent cannot be used without a valid token.\n  The server SHOULD return `AuthRequired` (`-32007`) if the client\n  attempts to use the agent without authenticating.\n- `false` — the agent works without authentication but MAY offer\n  enhanced capabilities when a token is provided.\n\nClients SHOULD treat an absent field the same as `true`."
+        }
+      },
+      "required": [
+        "resource"
+      ]
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -754,6 +833,13 @@
             "$ref": "#/$defs/ISessionModelInfo"
           },
           "description": "Available models for this agent"
+        },
+        "protectedResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IProtectedResourceMetadata"
+          },
+          "description": "Protected resources this agent requires authentication for.\n\nEach entry describes an OAuth 2.0 protected resource using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) semantics.\nClients should obtain tokens from the declared `authorization_servers`\nand push them via the `authenticate` command before creating sessions\nwith this agent."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -412,16 +412,8 @@
     },
     "IAuthenticateResult": {
       "type": "object",
-      "description": "Result of the `authenticate` command.",
-      "properties": {
-        "authenticated": {
-          "type": "boolean",
-          "description": "Whether the server accepted the token for the specified resource"
-        }
-      },
-      "required": [
-        "authenticated"
-      ]
+      "description": "Result of the `authenticate` command.\n\nAn empty object on success. If the token is invalid or the resource is\nunrecognized, the server MUST return a JSON-RPC error (e.g. `AuthRequired`\n`-32007` or `InvalidParams` `-32602`).",
+      "properties": {}
     },
     "IProtectedResourceMetadata": {
       "type": "object",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -392,6 +392,116 @@
         "isDirectory"
       ]
     },
+    "IAuthenticateParams": {
+      "type": "object",
+      "description": "Pushes a Bearer token for a protected resource. The `resource` field MUST\nmatch an `IProtectedResourceMetadata.resource` value declared by an agent\nin `IAgentInfo.protectedResources`.\n\nTokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)\n(Bearer Token Usage) semantics. The client obtains the token from the\nauthorization server(s) listed in the resource's metadata and pushes it\nto the server via this command.",
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "The protected resource identifier. MUST match a `resource` value from\n`IProtectedResourceMetadata` declared in `IAgentInfo.protectedResources`."
+        },
+        "token": {
+          "type": "string",
+          "description": "Bearer token obtained from the resource's authorization server"
+        }
+      },
+      "required": [
+        "resource",
+        "token"
+      ]
+    },
+    "IAuthenticateResult": {
+      "type": "object",
+      "description": "Result of the `authenticate` command.",
+      "properties": {
+        "authenticated": {
+          "type": "boolean",
+          "description": "Whether the server accepted the token for the specified resource"
+        }
+      },
+      "required": [
+        "authenticated"
+      ]
+    },
+    "IProtectedResourceMetadata": {
+      "type": "object",
+      "description": "Describes a protected resource's authentication requirements using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) (OAuth 2.0\nProtected Resource Metadata) semantics.\n\nField names use snake_case to match the RFC 9728 JSON format.",
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "REQUIRED. The protected resource's resource identifier, a URL using the\n`https` scheme with no fragment component (e.g. `\"https://api.github.com\"`)."
+        },
+        "resource_name": {
+          "type": "string",
+          "description": "OPTIONAL. Human-readable name of the protected resource."
+        },
+        "authorization_servers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of OAuth authorization server identifier URLs."
+        },
+        "jwks_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the protected resource's JWK Set document."
+        },
+        "scopes_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "RECOMMENDED. JSON array of OAuth 2.0 scope values used in authorization requests."
+        },
+        "bearer_methods_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of Bearer Token presentation methods supported."
+        },
+        "resource_signing_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
+        },
+        "resource_encryption_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
+        },
+        "resource_encryption_enc_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
+        },
+        "resource_documentation": {
+          "type": "string",
+          "description": "OPTIONAL. URL of human-readable documentation for the resource."
+        },
+        "resource_policy_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's data-usage policy."
+        },
+        "resource_tos_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's terms of service."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "AHP extension. Whether authentication is required for this resource.\n\n- `true` (default) — the agent cannot be used without a valid token.\n  The server SHOULD return `AuthRequired` (`-32007`) if the client\n  attempts to use the agent without authenticating.\n- `false` — the agent works without authentication but MAY offer\n  enhanced capabilities when a token is provided.\n\nClients SHOULD treat an absent field the same as `true`."
+        }
+      },
+      "required": [
+        "resource"
+      ]
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -433,6 +543,13 @@
             "$ref": "#/$defs/ISessionModelInfo"
           },
           "description": "Available models for this agent"
+        },
+        "protectedResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IProtectedResourceMetadata"
+          },
+          "description": "Protected resources this agent requires authentication for.\n\nEach entry describes an OAuth 2.0 protected resource using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) semantics.\nClients should obtain tokens from the declared `authorization_servers`\nand push them via the `authenticate` command before creating sessions\nwith this agent."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -39,6 +39,27 @@
         "session"
       ]
     },
+    "IAuthRequiredNotification": {
+      "type": "object",
+      "description": "Sent by the server when a protected resource requires (re-)authentication.\n\nThis notification is sent when a previously valid token expires or is\nrevoked, or when the server discovers a new authentication requirement.\nClients should obtain a fresh token and push it via the `authenticate`\ncommand.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/NotificationType.AuthRequired"
+        },
+        "resource": {
+          "type": "string",
+          "description": "The protected resource identifier that requires authentication"
+        },
+        "reason": {
+          "$ref": "#/$defs/AuthRequiredReason",
+          "description": "Why authentication is required"
+        }
+      },
+      "required": [
+        "type",
+        "resource"
+      ]
+    },
     "IProtocolNotification": {
       "description": "Discriminated union of all protocol notifications.",
       "oneOf": [
@@ -47,7 +68,89 @@
         },
         {
           "$ref": "#/$defs/ISessionRemovedNotification"
+        },
+        {
+          "$ref": "#/$defs/IAuthRequiredNotification"
         }
+      ]
+    },
+    "IProtectedResourceMetadata": {
+      "type": "object",
+      "description": "Describes a protected resource's authentication requirements using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) (OAuth 2.0\nProtected Resource Metadata) semantics.\n\nField names use snake_case to match the RFC 9728 JSON format.",
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "REQUIRED. The protected resource's resource identifier, a URL using the\n`https` scheme with no fragment component (e.g. `\"https://api.github.com\"`)."
+        },
+        "resource_name": {
+          "type": "string",
+          "description": "OPTIONAL. Human-readable name of the protected resource."
+        },
+        "authorization_servers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of OAuth authorization server identifier URLs."
+        },
+        "jwks_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the protected resource's JWK Set document."
+        },
+        "scopes_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "RECOMMENDED. JSON array of OAuth 2.0 scope values used in authorization requests."
+        },
+        "bearer_methods_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of Bearer Token presentation methods supported."
+        },
+        "resource_signing_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
+        },
+        "resource_encryption_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
+        },
+        "resource_encryption_enc_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
+        },
+        "resource_documentation": {
+          "type": "string",
+          "description": "OPTIONAL. URL of human-readable documentation for the resource."
+        },
+        "resource_policy_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's data-usage policy."
+        },
+        "resource_tos_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's terms of service."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "AHP extension. Whether authentication is required for this resource.\n\n- `true` (default) — the agent cannot be used without a valid token.\n  The server SHOULD return `AuthRequired` (`-32007`) if the client\n  attempts to use the agent without authenticating.\n- `false` — the agent works without authentication but MAY offer\n  enhanced capabilities when a token is provided.\n\nClients SHOULD treat an absent field the same as `true`."
+        }
+      },
+      "required": [
+        "resource"
       ]
     },
     "IRootState": {
@@ -91,6 +194,13 @@
             "$ref": "#/$defs/ISessionModelInfo"
           },
           "description": "Available models for this agent"
+        },
+        "protectedResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IProtectedResourceMetadata"
+          },
+          "description": "Protected resources this agent requires authentication for.\n\nEach entry describes an OAuth 2.0 protected resource using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) semantics.\nClients should obtain tokens from the declared `authorization_servers`\nand push them via the `authenticate` command before creating sessions\nwith this agent."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -5,6 +5,85 @@
   "title": "AHP State Types",
   "description": "All state types in the Agent Host Protocol.",
   "$defs": {
+    "IProtectedResourceMetadata": {
+      "type": "object",
+      "description": "Describes a protected resource's authentication requirements using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) (OAuth 2.0\nProtected Resource Metadata) semantics.\n\nField names use snake_case to match the RFC 9728 JSON format.",
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "REQUIRED. The protected resource's resource identifier, a URL using the\n`https` scheme with no fragment component (e.g. `\"https://api.github.com\"`)."
+        },
+        "resource_name": {
+          "type": "string",
+          "description": "OPTIONAL. Human-readable name of the protected resource."
+        },
+        "authorization_servers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of OAuth authorization server identifier URLs."
+        },
+        "jwks_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the protected resource's JWK Set document."
+        },
+        "scopes_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "RECOMMENDED. JSON array of OAuth 2.0 scope values used in authorization requests."
+        },
+        "bearer_methods_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of Bearer Token presentation methods supported."
+        },
+        "resource_signing_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
+        },
+        "resource_encryption_alg_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
+        },
+        "resource_encryption_enc_values_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
+        },
+        "resource_documentation": {
+          "type": "string",
+          "description": "OPTIONAL. URL of human-readable documentation for the resource."
+        },
+        "resource_policy_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's data-usage policy."
+        },
+        "resource_tos_uri": {
+          "type": "string",
+          "description": "OPTIONAL. URL of the resource's terms of service."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "AHP extension. Whether authentication is required for this resource.\n\n- `true` (default) — the agent cannot be used without a valid token.\n  The server SHOULD return `AuthRequired` (`-32007`) if the client\n  attempts to use the agent without authenticating.\n- `false` — the agent works without authentication but MAY offer\n  enhanced capabilities when a token is provided.\n\nClients SHOULD treat an absent field the same as `true`."
+        }
+      },
+      "required": [
+        "resource"
+      ]
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -46,6 +125,13 @@
             "$ref": "#/$defs/ISessionModelInfo"
           },
           "description": "Available models for this agent"
+        },
+        "protectedResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IProtectedResourceMetadata"
+          },
+          "description": "Protected resources this agent requires authentication for.\n\nEach entry describes an OAuth 2.0 protected resource using\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) semantics.\nClients should obtain tokens from the declared `authorization_servers`\nand push them via the `authenticate` command before creating sessions\nwith this agent."
         }
       },
       "required": [

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -452,10 +452,10 @@ export interface IBrowseDirectoryEntry {
  *   "params": { "resource": "https://api.github.com", "token": "gho_xxxx" } }
  *
  * // Server → Client (success)
- * { "jsonrpc": "2.0", "id": 3, "result": { "authenticated": true } }
+ * { "jsonrpc": "2.0", "id": 3, "result": {} }
  *
- * // Server → Client (failure — unknown resource)
- * { "jsonrpc": "2.0", "id": 3, "result": { "authenticated": false } }
+ * // Server → Client (failure — invalid token)
+ * { "jsonrpc": "2.0", "id": 3, "error": { "code": -32007, "message": "Invalid token" } }
  * ```
  */
 export interface IAuthenticateParams {
@@ -470,8 +470,10 @@ export interface IAuthenticateParams {
 
 /**
  * Result of the `authenticate` command.
+ *
+ * An empty object on success. If the token is invalid or the resource is
+ * unrecognized, the server MUST return a JSON-RPC error (e.g. `AuthRequired`
+ * `-32007` or `InvalidParams` `-32602`).
  */
 export interface IAuthenticateResult {
-  /** Whether the server accepted the token for the specified resource */
-  authenticated: boolean;
 }

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -426,3 +426,52 @@ export interface IBrowseDirectoryEntry {
   /** Whether this entry is a directory */
   isDirectory: boolean;
 }
+
+// ─── authenticate ────────────────────────────────────────────────────────────
+
+/**
+ * Pushes a Bearer token for a protected resource. The `resource` field MUST
+ * match an `IProtectedResourceMetadata.resource` value declared by an agent
+ * in `IAgentInfo.protectedResources`.
+ *
+ * Tokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)
+ * (Bearer Token Usage) semantics. The client obtains the token from the
+ * authorization server(s) listed in the resource's metadata and pushes it
+ * to the server via this command.
+ *
+ * @category Commands
+ * @method authenticate
+ * @direction Client → Server
+ * @messageType Request
+ * @version 1
+ * @see {@link /specification/authentication | Authentication}
+ * @example
+ * ```jsonc
+ * // Client → Server
+ * { "jsonrpc": "2.0", "id": 3, "method": "authenticate",
+ *   "params": { "resource": "https://api.github.com", "token": "gho_xxxx" } }
+ *
+ * // Server → Client (success)
+ * { "jsonrpc": "2.0", "id": 3, "result": { "authenticated": true } }
+ *
+ * // Server → Client (failure — unknown resource)
+ * { "jsonrpc": "2.0", "id": 3, "result": { "authenticated": false } }
+ * ```
+ */
+export interface IAuthenticateParams {
+  /**
+   * The protected resource identifier. MUST match a `resource` value from
+   * `IProtectedResourceMetadata` declared in `IAgentInfo.protectedResources`.
+   */
+  resource: string;
+  /** Bearer token obtained from the resource's authorization server */
+  token: string;
+}
+
+/**
+ * Result of the `authenticate` command.
+ */
+export interface IAuthenticateResult {
+  /** Whether the server accepted the token for the specified resource */
+  authenticated: boolean;
+}

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -48,6 +48,15 @@ export const AhpErrorCodes = {
   UnsupportedProtocolVersion: -32005,
   /** The requested content URI does not exist */
   ContentNotFound: -32006,
+  /**
+   * A command failed because the client has not authenticated for a required
+   * protected resource. The `data` field of the JSON-RPC error SHOULD contain
+   * an `IProtectedResourceMetadata[]` array describing the resources that
+   * require authentication.
+   *
+   * @see {@link /specification/authentication | Authentication}
+   */
+  AuthRequired: -32007,
 } as const;
 
 /** Union type of all AHP application error codes. */

--- a/types/index.ts
+++ b/types/index.ts
@@ -13,6 +13,7 @@ export type {
   StringOrMarkdown,
   IRootState,
   IAgentInfo,
+  IProtectedResourceMetadata,
   ISessionModelInfo,
   ISessionState,
   ISessionSummary,
@@ -133,6 +134,8 @@ export type {
   IFetchTurnsResult,
   IUnsubscribeParams,
   IDispatchActionParams,
+  IAuthenticateParams,
+  IAuthenticateResult,
   IBrowseDirectoryEntry,
 } from './commands.js';
 
@@ -142,10 +145,11 @@ export { ReconnectResultType, ContentEncoding } from './commands.js';
 export type {
   ISessionAddedNotification,
   ISessionRemovedNotification,
+  IAuthRequiredNotification,
   IProtocolNotification,
 } from './notifications.js';
 
-export { NotificationType } from './notifications.js';
+export { NotificationType, AuthRequiredReason } from './notifications.js';
 
 // Message types (JSON-RPC wire format)
 export type {

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -26,6 +26,8 @@ import type {
   IFetchTurnsResult,
   IUnsubscribeParams,
   IDispatchActionParams,
+  IAuthenticateParams,
+  IAuthenticateResult,
 } from './commands.js';
 
 import type { IActionEnvelope } from './actions.js';
@@ -86,6 +88,7 @@ export interface ICommandMap {
   'fetchContent': { params: IFetchContentParams; result: IFetchContentResult };
   'browseDirectory': { params: IBrowseDirectoryParams; result: IBrowseDirectoryResult };
   'fetchTurns': { params: IFetchTurnsParams; result: IFetchTurnsResult };
+  'authenticate': { params: IAuthenticateParams; result: IAuthenticateResult };
 }
 
 // ─── Notification Maps ───────────────────────────────────────────────────────

--- a/types/notifications.ts
+++ b/types/notifications.ts
@@ -8,6 +8,18 @@
 
 import type { URI, ISessionSummary } from './state.js';
 
+/**
+ * Reason why authentication is required.
+ *
+ * @category Protocol Notifications
+ */
+export const enum AuthRequiredReason {
+  /** The client has not yet authenticated for the resource */
+  Required = 'required',
+  /** A previously valid token has expired or been revoked */
+  Expired = 'expired',
+}
+
 // ─── Protocol Notifications ──────────────────────────────────────────────────
 
 /**
@@ -18,6 +30,7 @@ import type { URI, ISessionSummary } from './state.js';
 export const enum NotificationType {
   SessionAdded = 'notify/sessionAdded',
   SessionRemoved = 'notify/sessionRemoved',
+  AuthRequired = 'notify/authRequired',
 }
 
 /**
@@ -78,8 +91,43 @@ export interface ISessionRemovedNotification {
 }
 
 /**
+ * Sent by the server when a protected resource requires (re-)authentication.
+ *
+ * This notification is sent when a previously valid token expires or is
+ * revoked, or when the server discovers a new authentication requirement.
+ * Clients should obtain a fresh token and push it via the `authenticate`
+ * command.
+ *
+ * @category Protocol Notifications
+ * @version 1
+ * @see {@link /specification/authentication | Authentication}
+ * @example
+ * ```json
+ * {
+ *   "jsonrpc": "2.0",
+ *   "method": "notification",
+ *   "params": {
+ *     "notification": {
+ *       "type": "notify/authRequired",
+ *       "resource": "https://api.github.com",
+ *       "reason": "expired"
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export interface IAuthRequiredNotification {
+  type: NotificationType.AuthRequired;
+  /** The protected resource identifier that requires authentication */
+  resource: string;
+  /** Why authentication is required */
+  reason?: AuthRequiredReason;
+}
+
+/**
  * Discriminated union of all protocol notifications.
  */
 export type IProtocolNotification =
   | ISessionAddedNotification
-  | ISessionRemovedNotification;
+  | ISessionRemovedNotification
+  | IAuthRequiredNotification;

--- a/types/state.ts
+++ b/types/state.ts
@@ -18,6 +18,72 @@ export type URI = string;
  */
 export type StringOrMarkdown = string | { markdown: string };
 
+// ─── Protected Resource Metadata (RFC 9728) ─────────────────────────────────
+
+/**
+ * Describes a protected resource's authentication requirements using
+ * [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) (OAuth 2.0
+ * Protected Resource Metadata) semantics.
+ *
+ * Field names use snake_case to match the RFC 9728 JSON format.
+ *
+ * @category Authentication
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc9728 | RFC 9728}
+ */
+export interface IProtectedResourceMetadata {
+  /**
+   * REQUIRED. The protected resource's resource identifier, a URL using the
+   * `https` scheme with no fragment component (e.g. `"https://api.github.com"`).
+   */
+  resource: string;
+
+  /** OPTIONAL. Human-readable name of the protected resource. */
+  resource_name?: string;
+
+  /** OPTIONAL. JSON array of OAuth authorization server identifier URLs. */
+  authorization_servers?: string[];
+
+  /** OPTIONAL. URL of the protected resource's JWK Set document. */
+  jwks_uri?: string;
+
+  /** RECOMMENDED. JSON array of OAuth 2.0 scope values used in authorization requests. */
+  scopes_supported?: string[];
+
+  /** OPTIONAL. JSON array of Bearer Token presentation methods supported. */
+  bearer_methods_supported?: string[];
+
+  /** OPTIONAL. JSON array of JWS signing algorithms supported. */
+  resource_signing_alg_values_supported?: string[];
+
+  /** OPTIONAL. JSON array of JWE encryption algorithms (alg) supported. */
+  resource_encryption_alg_values_supported?: string[];
+
+  /** OPTIONAL. JSON array of JWE encryption algorithms (enc) supported. */
+  resource_encryption_enc_values_supported?: string[];
+
+  /** OPTIONAL. URL of human-readable documentation for the resource. */
+  resource_documentation?: string;
+
+  /** OPTIONAL. URL of the resource's data-usage policy. */
+  resource_policy_uri?: string;
+
+  /** OPTIONAL. URL of the resource's terms of service. */
+  resource_tos_uri?: string;
+
+  /**
+   * AHP extension. Whether authentication is required for this resource.
+   *
+   * - `true` (default) — the agent cannot be used without a valid token.
+   *   The server SHOULD return `AuthRequired` (`-32007`) if the client
+   *   attempts to use the agent without authenticating.
+   * - `false` — the agent works without authentication but MAY offer
+   *   enhanced capabilities when a token is provided.
+   *
+   * Clients SHOULD treat an absent field the same as `true`.
+   */
+  required?: boolean;
+}
+
 // ─── Root State ──────────────────────────────────────────────────────────────
 
 /**
@@ -55,6 +121,18 @@ export interface IAgentInfo {
   description: string;
   /** Available models for this agent */
   models: ISessionModelInfo[];
+  /**
+   * Protected resources this agent requires authentication for.
+   *
+   * Each entry describes an OAuth 2.0 protected resource using
+   * [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) semantics.
+   * Clients should obtain tokens from the declared `authorization_servers`
+   * and push them via the `authenticate` command before creating sessions
+   * with this agent.
+   *
+   * @see {@link /specification/authentication | Authentication}
+   */
+  protectedResources?: IProtectedResourceMetadata[];
 }
 
 /**

--- a/types/version/message-checks.ts
+++ b/types/version/message-checks.ts
@@ -31,7 +31,8 @@ type _ExpectedCommands =
   | 'listSessions'
   | 'fetchContent'
   | 'browseDirectory'
-  | 'fetchTurns';
+  | 'fetchTurns'
+  | 'authenticate';
 
 /** All methods annotated `@messageType Notification` (client → server) in commands.ts. */
 type _ExpectedClientNotifications =

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -68,6 +68,7 @@ export function isActionKnownToVersion(action: IStateAction, clientVersion: numb
 export const NOTIFICATION_INTRODUCED_IN: { readonly [K in IProtocolNotification['type']]: number } = {
   [NotificationType.SessionAdded]: 1,
   [NotificationType.SessionRemoved]: 1,
+  [NotificationType.AuthRequired]: 1,
 };
 
 /**

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -13,6 +13,7 @@ import type {
   IRootState,
   IAgentInfo,
   ISessionModelInfo,
+  IProtectedResourceMetadata,
   StringOrMarkdown,
   ISessionState,
   ISessionSummary,
@@ -55,10 +56,13 @@ import type {
 
 import type {
   IProtocolNotification,
+  IAuthRequiredNotification,
 } from '../notifications.js';
 
 import type {
   IListSessionsResult,
+  IAuthenticateParams,
+  IAuthenticateResult,
 } from '../commands.js';
 
 import type {
@@ -89,6 +93,7 @@ type AssertCompatible<Frozen, _Current extends Frozen> =
 type V1_IRootState = IRootState;
 type V1_StringOrMarkdown = StringOrMarkdown;
 type V1_IAgentInfo = IAgentInfo;
+type V1_IProtectedResourceMetadata = IProtectedResourceMetadata;
 type V1_ISessionModelInfo = ISessionModelInfo;
 type V1_ISessionState = ISessionState;
 type V1_ISessionSummary = ISessionSummary;
@@ -125,7 +130,10 @@ type V1_ISessionServerToolsChangedAction = ISessionServerToolsChangedAction;
 type V1_ISessionActiveClientChangedAction = ISessionActiveClientChangedAction;
 type V1_ISessionActiveClientToolsChangedAction = ISessionActiveClientToolsChangedAction;
 type V1_IProtocolNotification = IProtocolNotification;
+type V1_IAuthRequiredNotification = IAuthRequiredNotification;
 type V1_IListSessionsResult = IListSessionsResult;
+type V1_IAuthenticateParams = IAuthenticateParams;
+type V1_IAuthenticateResult = IAuthenticateResult;
 type V1_ICommandMap = ICommandMap;
 type V1_IClientNotificationMap = IClientNotificationMap;
 type V1_IServerNotificationMap = IServerNotificationMap;
@@ -216,6 +224,14 @@ type _CheckActiveClientToolsChangedAction = AssertCompatible<V1_ISessionActiveCl
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckListSessionsResult = AssertCompatible<V1_IListSessionsResult, IListSessionsResult>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckAuthenticateParams = AssertCompatible<V1_IAuthenticateParams, IAuthenticateParams>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckAuthenticateResult = AssertCompatible<V1_IAuthenticateResult, IAuthenticateResult>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckProtectedResourceMetadata = AssertCompatible<V1_IProtectedResourceMetadata, IProtectedResourceMetadata>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckAuthRequiredNotification = AssertCompatible<V1_IAuthRequiredNotification, IAuthRequiredNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckCommandMap = AssertCompatible<V1_ICommandMap, ICommandMap>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Add formal authentication to AHP using RFC 9728 (OAuth 2.0 Protected Resource Metadata) for discovery and RFC 6750 (Bearer Token Usage) for token delivery over JSON-RPC.

Types:
- IProtectedResourceMetadata: full RFC 9728 shape with `required` field
- IAgentInfo.protectedResources: per-agent auth requirements in root state
- authenticate command (IAuthenticateParams/IAuthenticateResult)
- AuthRequired (-32007) error code, usable on any command
- notify/authRequired notification for token expiry/invalidation
- AuthRequiredReason enum (required | expired)

Spec:
- New docs/specification/authentication.md covering discovery, token delivery, error handling, and auth expiry notifications
- Updated lifecycle.md with authentication section

All registered in ICommandMap, message-checks, version registry, v1 type snapshot, and index exports. Schemas and reference docs regenerated.