### PR TITLE
clean up tool invocation states

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -43,8 +43,8 @@ When a client dispatches an action, the server applies it to the state and also 
 | Type | Client-dispatchable? | When |
 |---|---|---|
 | `session/turnStarted` | **Yes** | User sent a message; server starts processing |
-| `session/delta` | No | Streaming text chunk from assistant |
-| `session/responsePart` | No | Structured content appended |
+| `session/delta` | No | Streaming text chunk appended to a response part by `partId` |
+| `session/responsePart` | No | New response part created (markdown, reasoning, content ref) |
 | `session/turnComplete` | No | Turn finished (assistant idle) |
 | `session/turnCancelled` | **Yes** | Turn was aborted; server stops processing |
 | `session/error` | No | Error during turn processing |
@@ -58,22 +58,13 @@ When a client dispatches an action, the server applies it to the state and also 
 
 ::: tip FUTURE WORK
 A `session/toolUpdate` action for streaming incremental tool output (e.g. terminal output during a shell command) is planned for a future protocol version.
-:::
-
-### Permissions
-
-| Type | Client-dispatchable? | When |
-|---|---|---|
-| `session/permissionRequest` | No | Permission needed from user |
-| `session/permissionResolved` | **Yes** | Permission granted or denied |
-
-### Metadata & Informational
+:::\n\n### Metadata & Informational
 
 | Type | Client-dispatchable? | When |
 |---|---|---|
 | `session/titleChanged` | No | Session title updated |
 | `session/usage` | No | Token usage report |
-| `session/reasoning` | No | Reasoning/thinking text |
+| `session/reasoning` | No | Reasoning/thinking text appended to a reasoning part by `partId` |
 | `session/modelChanged` | **Yes** | Model changed for this session |
 
 ## Client-Dispatched Actions
@@ -97,7 +88,7 @@ The client applies the action **optimistically** to its local state before sendi
 | Action | Server-side effect |
 |---|---|
 | `session/turnStarted` | Begins agent processing for the new turn |
-| `session/permissionResolved` | Unblocks the pending tool execution |
+| `session/toolCallConfirmed` | Approves or denies a pending tool call; unblocks or cancels tool execution |
 | `session/turnCancelled` | Aborts the in-progress turn |
 | `session/modelChanged` | Changes the model for subsequent turns |
 

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -80,9 +80,7 @@ A turn represents one request/response cycle between user and agent.
 Turn {
   id: string
   userMessage: UserMessage
-  responseText: string              // captured from streamingText on completion
-  responseParts: ResponsePart[]
-  toolCalls: CompletedToolCall[]
+  responseParts: ResponsePart[]     // all content in stream order
   usage: UsageInfo | undefined
   state: 'complete' | 'cancelled' | 'error'
   error?: ErrorInfo
@@ -97,11 +95,7 @@ An in-progress turn where the assistant is actively streaming:
 ActiveTurn {
   id: string
   userMessage: UserMessage
-  streamingText: string
-  responseParts: ResponsePart[]
-  toolCalls: Record<toolCallId, ToolCallState>
-  pendingPermissions: Record<requestId, PermissionRequest>
-  reasoning: string
+  responseParts: ResponsePart[]     // all content in stream order
   usage: UsageInfo | undefined
 }
 ```
@@ -123,13 +117,27 @@ MessageAttachment {
 
 ## Response Parts
 
-Response content comes in two forms:
+All response content — text, tool calls, reasoning, and content references — lives in a single `responseParts` array in stream order. This mirrors how LLM APIs (e.g. OpenAI) represent responses as a unified list of typed items.
 
 ```typescript
 // Inline markdown content
 MarkdownResponsePart {
   kind: 'markdown'
+  id: string               // targeted by session/delta for text appends
   content: string
+}
+
+// Reasoning/thinking content from the model
+ReasoningResponsePart {
+  kind: 'reasoning'
+  id: string               // targeted by session/reasoning for text appends
+  content: string
+}
+
+// Tool call (see Tool Call Lifecycle below)
+ToolCallResponsePart {
+  kind: 'toolCall'
+  toolCall: ToolCallState   // full lifecycle state
 }
 
 // Reference to large content stored outside the state tree
@@ -141,7 +149,11 @@ ContentRef {
 }
 ```
 
+Text content uses a **create-then-append** pattern: the server first emits a `session/responsePart` action to create a new markdown (or reasoning) part with an `id`, then streams text into it via `session/delta` (or `session/reasoning`) actions targeting that `partId`. This pattern is extensible to future streaming content types.
+
 Clients fetch `ContentRef` content separately via the `fetchContent(uri)` command. This keeps the state tree small and serializable.
+
+Consumers can derive display text by concatenating all `markdown` parts, find tool calls by filtering for `toolCall` parts, and access reasoning by filtering for `reasoning` parts.
 
 ## Tool Call Lifecycle
 
@@ -157,6 +169,7 @@ stateDiagram-v2
   pending_confirmation --> running : toolCallConfirmed (approved)
   pending_confirmation --> cancelled : toolCallConfirmed (denied/skipped)
 
+  running --> pending_confirmation : toolCallReady (re‑confirmation)
   running --> completed : toolCallComplete
   running --> pending_result_confirmation : toolCallComplete (requiresResultConfirmation)
 
@@ -172,31 +185,17 @@ stateDiagram-v2
 | Status | Key Fields | Description |
 |---|---|---|
 | `streaming` | `partialInput?` | LM is streaming tool call parameters. `partialInput` accumulates via `toolCallDelta`. |
-| `pending-confirmation` | `invocationMessage`, `toolInput?` | Parameters complete, waiting for client to confirm execution. |
+| `pending-confirmation` | `invocationMessage`, `toolInput?` | Parameters complete or mid-execution confirmation needed. Uses `_meta` for context (e.g. permission kind, command text). |
 | `running` | `confirmed` | Tool is executing. `confirmed` records how it was approved. |
 | `pending-result-confirmation` | `success`, `pastTenseMessage`, `content?` | Execution finished, waiting for client to approve the result. |
 | `completed` | `success`, `pastTenseMessage`, `content?` | Terminal state. Tool finished. |
 | `cancelled` | `reason`, `reasonMessage?`, `userSuggestion?` | Terminal state. `reason` is `'denied'`, `'skipped'`, or `'result-denied'`. |
 
-When a turn completes, only terminal-state tool calls (`completed` or `cancelled`) are preserved in the finalized `Turn.toolCalls` array.
+### Mid-execution Re-confirmation
 
-## Permission Requests
+When a running tool needs additional user approval (e.g. a shell permission), the server dispatches `session/toolCallReady` again without `confirmed`. This transitions the tool call from `running` back to `pending-confirmation`, updating `invocationMessage` and `_meta` with context about what needs approval. The client uses the standard `session/toolCallConfirmed` flow to approve or deny.
 
-Tools that require user approval generate permission requests:
-
-```typescript
-PermissionRequest {
-  requestId: string
-  permissionKind: 'shell' | 'write' | 'mcp' | 'read' | 'url'
-  toolCallId?: string
-  path?: string
-  fullCommandText?: string
-  intention?: string
-  serverName?: string
-  toolName?: string
-  rawRequest?: string
-}
-```
+When a turn completes, non-terminal tool calls in `responseParts` are force-cancelled with reason `'skipped'`.
 
 ## Usage Info
 

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -98,7 +98,7 @@ When the server receives a client-dispatched action, it MUST validate it before 
 | Action | Condition | Server Behavior |
 |---|---|---|
 | Any action referencing a non-existent session | Session URI not found | Server MUST silently ignore the action (no echo) |
-| `session/permissionResolved` | `requestId` not in `pendingPermissions` | Server MUST reject the action |
+| `session/toolCallConfirmed` | Tool call not in `pending-confirmation` state | Server MUST reject the action |
 | `session/turnCancelled` | No active turn | Server MUST reject the action |
 | `session/modelChanged` | A turn is currently active | Server MUST defer the model change until the active turn completes, then apply it for the next turn |
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -177,7 +177,7 @@
     },
     "ISessionDeltaAction": {
       "type": "object",
-      "description": "Streaming text chunk from the assistant.",
+      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `session/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionDelta"
@@ -190,6 +190,10 @@
           "type": "string",
           "description": "Turn identifier"
         },
+        "partId": {
+          "type": "string",
+          "description": "Identifier of the response part to append to"
+        },
         "content": {
           "type": "string",
           "description": "Text chunk"
@@ -199,6 +203,7 @@
         "type",
         "session",
         "turnId",
+        "partId",
         "content"
       ]
     },
@@ -278,18 +283,22 @@
     },
     "ISessionToolCallReadyAction": {
       "type": "object",
-      "description": "Tool call parameters are complete. Transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.\n\nFor client-provided tools, the server typically sets `confirmed` to\n`'not-needed'` so the tool transitions directly to `running`, where the\nowning client can begin execution immediately.",
+      "description": "Tool call parameters are complete, or a running tool requires re-confirmation.\n\nWhen dispatched for a `streaming` tool call, transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.\n\nWhen dispatched for a `running` tool call (e.g. mid-execution permission needed),\ntransitions back to `pending-confirmation`. The `invocationMessage` and `_meta`\nSHOULD be updated to describe the specific confirmation needed. Clients use the\nstandard `session/toolCallConfirmed` flow to approve or deny.\n\nFor client-provided tools, the server typically sets `confirmed` to\n`'not-needed'` so the tool transitions directly to `running`, where the\nowning client can begin execution immediately.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionToolCallReady"
         },
         "invocationMessage": {
           "$ref": "#/$defs/StringOrMarkdown",
-          "description": "Message describing what the tool will do"
+          "description": "Message describing what the tool will do or what confirmation is needed"
         },
         "toolInput": {
           "type": "string",
           "description": "Raw tool input"
+        },
+        "confirmationTitle": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -393,65 +402,6 @@
       },
       "required": [
         "type",
-        "approved"
-      ]
-    },
-    "ISessionPermissionRequestAction": {
-      "type": "object",
-      "description": "Permission needed from the user to proceed.",
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/ActionType.SessionPermissionRequest"
-        },
-        "session": {
-          "$ref": "#/$defs/URI",
-          "description": "Session URI"
-        },
-        "turnId": {
-          "type": "string",
-          "description": "Turn identifier"
-        },
-        "request": {
-          "$ref": "#/$defs/IPermissionRequest",
-          "description": "Permission request details"
-        }
-      },
-      "required": [
-        "type",
-        "session",
-        "turnId",
-        "request"
-      ]
-    },
-    "ISessionPermissionResolvedAction": {
-      "type": "object",
-      "description": "Permission granted or denied.",
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/ActionType.SessionPermissionResolved"
-        },
-        "session": {
-          "$ref": "#/$defs/URI",
-          "description": "Session URI"
-        },
-        "turnId": {
-          "type": "string",
-          "description": "Turn identifier"
-        },
-        "requestId": {
-          "type": "string",
-          "description": "Permission request ID"
-        },
-        "approved": {
-          "type": "boolean",
-          "description": "Whether permission was granted"
-        }
-      },
-      "required": [
-        "type",
-        "session",
-        "turnId",
-        "requestId",
         "approved"
       ]
     },
@@ -577,7 +527,7 @@
     },
     "ISessionReasoningAction": {
       "type": "object",
-      "description": "Reasoning/thinking text from the model.",
+      "description": "Reasoning/thinking text from the model, appended to a specific reasoning response part.\n\nThe server MUST first emit a `session/responsePart` to create the target\nreasoning part, then use this action to append text to it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionReasoning"
@@ -590,6 +540,10 @@
           "type": "string",
           "description": "Turn identifier"
         },
+        "partId": {
+          "type": "string",
+          "description": "Identifier of the reasoning response part to append to"
+        },
         "content": {
           "type": "string",
           "description": "Reasoning text chunk"
@@ -599,6 +553,7 @@
         "type",
         "session",
         "turnId",
+        "partId",
         "content"
       ]
     },
@@ -1014,30 +969,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "responseText": {
-          "type": "string",
-          "description": "Final response text (captured from streaming)"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content"
-        },
-        "toolCalls": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/$defs/IToolCallCompletedState"
-              },
-              {
-                "$ref": "#/$defs/IToolCallCancelledState"
-              }
-            ]
-          },
-          "description": "Tool invocations in terminal states (completed or cancelled)"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nConsumers should derive display text by concatenating markdown parts,\nand find tool calls by filtering for `ToolCall` parts."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -1055,9 +992,7 @@
       "required": [
         "id",
         "userMessage",
-        "responseText",
         "responseParts",
-        "toolCalls",
         "usage",
         "state"
       ]
@@ -1074,34 +1009,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "streamingText": {
-          "type": "string",
-          "description": "Accumulated streaming response text"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content so far"
-        },
-        "toolCalls": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IToolCallState"
-          },
-          "description": "Active tool invocations keyed by tool call ID"
-        },
-        "pendingPermissions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IPermissionRequest"
-          },
-          "description": "Pending permission requests keyed by request ID"
-        },
-        "reasoning": {
-          "type": "string",
-          "description": "Accumulated reasoning/thinking text"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nTool call parts include `pendingPermissions` when permissions are awaiting user approval."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -1111,11 +1024,7 @@
       "required": [
         "id",
         "userMessage",
-        "streamingText",
         "responseParts",
-        "toolCalls",
-        "pendingPermissions",
-        "reasoning",
         "usage"
       ]
     },
@@ -1166,6 +1075,10 @@
           "$ref": "#/$defs/ResponsePartKind.Markdown",
           "description": "Discriminant"
         },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/delta` to target this part for content appends"
+        },
         "content": {
           "type": "string",
           "description": "Markdown content"
@@ -1173,6 +1086,7 @@
       },
       "required": [
         "kind",
+        "id",
         "content"
       ]
     },
@@ -1200,6 +1114,47 @@
       "required": [
         "kind",
         "uri"
+      ]
+    },
+    "IToolCallResponsePart": {
+      "type": "object",
+      "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "description": "Discriminant"
+        },
+        "toolCall": {
+          "$ref": "#/$defs/IToolCallState",
+          "description": "Full tool call lifecycle state"
+        }
+      },
+      "required": [
+        "kind",
+        "toolCall"
+      ]
+    },
+    "IReasoningResponsePart": {
+      "type": "object",
+      "description": "Reasoning/thinking content from the model.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "description": "Discriminant"
+        },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/reasoning` to target this part for content appends"
+        },
+        "content": {
+          "type": "string",
+          "description": "Accumulated reasoning text"
+        }
+      },
+      "required": [
+        "kind",
+        "id",
+        "content"
       ]
     },
     "IToolCallBase": {
@@ -1318,10 +1273,14 @@
     },
     "IToolCallPendingConfirmationState": {
       "type": "object",
-      "description": "Parameters are complete, waiting for client to confirm execution.",
+      "description": "Parameters are complete, or a running tool requires re-confirmation\n(e.g. a mid-execution permission check).",
       "properties": {
         "status": {
           "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+        },
+        "confirmationTitle": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         }
       },
       "required": [
@@ -1569,51 +1528,6 @@
         "afterURI"
       ]
     },
-    "IPermissionRequest": {
-      "type": "object",
-      "properties": {
-        "requestId": {
-          "type": "string",
-          "description": "Unique request identifier"
-        },
-        "permissionKind": {
-          "$ref": "#/$defs/PermissionKind",
-          "description": "Type of permission"
-        },
-        "toolCallId": {
-          "type": "string",
-          "description": "Associated tool call"
-        },
-        "path": {
-          "type": "string",
-          "description": "File/directory path"
-        },
-        "fullCommandText": {
-          "type": "string",
-          "description": "Full command to execute"
-        },
-        "intention": {
-          "type": "string",
-          "description": "What the tool intends to do"
-        },
-        "serverName": {
-          "type": "string",
-          "description": "MCP server name"
-        },
-        "toolName": {
-          "type": "string",
-          "description": "Tool requesting permission"
-        },
-        "rawRequest": {
-          "type": "string",
-          "description": "Raw request data"
-        }
-      },
-      "required": [
-        "requestId",
-        "permissionKind"
-      ]
-    },
     "IUsageInfo": {
       "type": "object",
       "properties": {
@@ -1712,6 +1626,12 @@
         },
         {
           "$ref": "#/$defs/IContentRef"
+        },
+        {
+          "$ref": "#/$defs/IToolCallResponsePart"
+        },
+        {
+          "$ref": "#/$defs/IReasoningResponsePart"
         }
       ]
     },
@@ -1801,12 +1721,6 @@
         },
         {
           "$ref": "#/$defs/ISessionToolCallResultConfirmedAction"
-        },
-        {
-          "$ref": "#/$defs/ISessionPermissionRequestAction"
-        },
-        {
-          "$ref": "#/$defs/ISessionPermissionResolvedAction"
         },
         {
           "$ref": "#/$defs/ISessionTurnCompleteAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -720,30 +720,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "responseText": {
-          "type": "string",
-          "description": "Final response text (captured from streaming)"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content"
-        },
-        "toolCalls": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/$defs/IToolCallCompletedState"
-              },
-              {
-                "$ref": "#/$defs/IToolCallCancelledState"
-              }
-            ]
-          },
-          "description": "Tool invocations in terminal states (completed or cancelled)"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nConsumers should derive display text by concatenating markdown parts,\nand find tool calls by filtering for `ToolCall` parts."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -761,9 +743,7 @@
       "required": [
         "id",
         "userMessage",
-        "responseText",
         "responseParts",
-        "toolCalls",
         "usage",
         "state"
       ]
@@ -780,34 +760,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "streamingText": {
-          "type": "string",
-          "description": "Accumulated streaming response text"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content so far"
-        },
-        "toolCalls": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IToolCallState"
-          },
-          "description": "Active tool invocations keyed by tool call ID"
-        },
-        "pendingPermissions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IPermissionRequest"
-          },
-          "description": "Pending permission requests keyed by request ID"
-        },
-        "reasoning": {
-          "type": "string",
-          "description": "Accumulated reasoning/thinking text"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nTool call parts include `pendingPermissions` when permissions are awaiting user approval."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -817,11 +775,7 @@
       "required": [
         "id",
         "userMessage",
-        "streamingText",
         "responseParts",
-        "toolCalls",
-        "pendingPermissions",
-        "reasoning",
         "usage"
       ]
     },
@@ -872,6 +826,10 @@
           "$ref": "#/$defs/ResponsePartKind.Markdown",
           "description": "Discriminant"
         },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/delta` to target this part for content appends"
+        },
         "content": {
           "type": "string",
           "description": "Markdown content"
@@ -879,6 +837,7 @@
       },
       "required": [
         "kind",
+        "id",
         "content"
       ]
     },
@@ -906,6 +865,47 @@
       "required": [
         "kind",
         "uri"
+      ]
+    },
+    "IToolCallResponsePart": {
+      "type": "object",
+      "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "description": "Discriminant"
+        },
+        "toolCall": {
+          "$ref": "#/$defs/IToolCallState",
+          "description": "Full tool call lifecycle state"
+        }
+      },
+      "required": [
+        "kind",
+        "toolCall"
+      ]
+    },
+    "IReasoningResponsePart": {
+      "type": "object",
+      "description": "Reasoning/thinking content from the model.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "description": "Discriminant"
+        },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/reasoning` to target this part for content appends"
+        },
+        "content": {
+          "type": "string",
+          "description": "Accumulated reasoning text"
+        }
+      },
+      "required": [
+        "kind",
+        "id",
+        "content"
       ]
     },
     "IToolCallBase": {
@@ -1024,10 +1024,14 @@
     },
     "IToolCallPendingConfirmationState": {
       "type": "object",
-      "description": "Parameters are complete, waiting for client to confirm execution.",
+      "description": "Parameters are complete, or a running tool requires re-confirmation\n(e.g. a mid-execution permission check).",
       "properties": {
         "status": {
           "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+        },
+        "confirmationTitle": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         }
       },
       "required": [
@@ -1275,51 +1279,6 @@
         "afterURI"
       ]
     },
-    "IPermissionRequest": {
-      "type": "object",
-      "properties": {
-        "requestId": {
-          "type": "string",
-          "description": "Unique request identifier"
-        },
-        "permissionKind": {
-          "$ref": "#/$defs/PermissionKind",
-          "description": "Type of permission"
-        },
-        "toolCallId": {
-          "type": "string",
-          "description": "Associated tool call"
-        },
-        "path": {
-          "type": "string",
-          "description": "File/directory path"
-        },
-        "fullCommandText": {
-          "type": "string",
-          "description": "Full command to execute"
-        },
-        "intention": {
-          "type": "string",
-          "description": "What the tool intends to do"
-        },
-        "serverName": {
-          "type": "string",
-          "description": "MCP server name"
-        },
-        "toolName": {
-          "type": "string",
-          "description": "Tool requesting permission"
-        },
-        "rawRequest": {
-          "type": "string",
-          "description": "Raw request data"
-        }
-      },
-      "required": [
-        "requestId",
-        "permissionKind"
-      ]
-    },
     "IUsageInfo": {
       "type": "object",
       "properties": {
@@ -1564,7 +1523,7 @@
     },
     "ISessionDeltaAction": {
       "type": "object",
-      "description": "Streaming text chunk from the assistant.",
+      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `session/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionDelta"
@@ -1577,6 +1536,10 @@
           "type": "string",
           "description": "Turn identifier"
         },
+        "partId": {
+          "type": "string",
+          "description": "Identifier of the response part to append to"
+        },
         "content": {
           "type": "string",
           "description": "Text chunk"
@@ -1586,6 +1549,7 @@
         "type",
         "session",
         "turnId",
+        "partId",
         "content"
       ]
     },
@@ -1665,18 +1629,22 @@
     },
     "ISessionToolCallReadyAction": {
       "type": "object",
-      "description": "Tool call parameters are complete. Transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.\n\nFor client-provided tools, the server typically sets `confirmed` to\n`'not-needed'` so the tool transitions directly to `running`, where the\nowning client can begin execution immediately.",
+      "description": "Tool call parameters are complete, or a running tool requires re-confirmation.\n\nWhen dispatched for a `streaming` tool call, transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.\n\nWhen dispatched for a `running` tool call (e.g. mid-execution permission needed),\ntransitions back to `pending-confirmation`. The `invocationMessage` and `_meta`\nSHOULD be updated to describe the specific confirmation needed. Clients use the\nstandard `session/toolCallConfirmed` flow to approve or deny.\n\nFor client-provided tools, the server typically sets `confirmed` to\n`'not-needed'` so the tool transitions directly to `running`, where the\nowning client can begin execution immediately.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionToolCallReady"
         },
         "invocationMessage": {
           "$ref": "#/$defs/StringOrMarkdown",
-          "description": "Message describing what the tool will do"
+          "description": "Message describing what the tool will do or what confirmation is needed"
         },
         "toolInput": {
           "type": "string",
           "description": "Raw tool input"
+        },
+        "confirmationTitle": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -1780,65 +1748,6 @@
       },
       "required": [
         "type",
-        "approved"
-      ]
-    },
-    "ISessionPermissionRequestAction": {
-      "type": "object",
-      "description": "Permission needed from the user to proceed.",
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/ActionType.SessionPermissionRequest"
-        },
-        "session": {
-          "$ref": "#/$defs/URI",
-          "description": "Session URI"
-        },
-        "turnId": {
-          "type": "string",
-          "description": "Turn identifier"
-        },
-        "request": {
-          "$ref": "#/$defs/IPermissionRequest",
-          "description": "Permission request details"
-        }
-      },
-      "required": [
-        "type",
-        "session",
-        "turnId",
-        "request"
-      ]
-    },
-    "ISessionPermissionResolvedAction": {
-      "type": "object",
-      "description": "Permission granted or denied.",
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/ActionType.SessionPermissionResolved"
-        },
-        "session": {
-          "$ref": "#/$defs/URI",
-          "description": "Session URI"
-        },
-        "turnId": {
-          "type": "string",
-          "description": "Turn identifier"
-        },
-        "requestId": {
-          "type": "string",
-          "description": "Permission request ID"
-        },
-        "approved": {
-          "type": "boolean",
-          "description": "Whether permission was granted"
-        }
-      },
-      "required": [
-        "type",
-        "session",
-        "turnId",
-        "requestId",
         "approved"
       ]
     },
@@ -1964,7 +1873,7 @@
     },
     "ISessionReasoningAction": {
       "type": "object",
-      "description": "Reasoning/thinking text from the model.",
+      "description": "Reasoning/thinking text from the model, appended to a specific reasoning response part.\n\nThe server MUST first emit a `session/responsePart` to create the target\nreasoning part, then use this action to append text to it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionReasoning"
@@ -1977,6 +1886,10 @@
           "type": "string",
           "description": "Turn identifier"
         },
+        "partId": {
+          "type": "string",
+          "description": "Identifier of the reasoning response part to append to"
+        },
         "content": {
           "type": "string",
           "description": "Reasoning text chunk"
@@ -1986,6 +1899,7 @@
         "type",
         "session",
         "turnId",
+        "partId",
         "content"
       ]
     },

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -375,30 +375,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "responseText": {
-          "type": "string",
-          "description": "Final response text (captured from streaming)"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content"
-        },
-        "toolCalls": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/$defs/IToolCallCompletedState"
-              },
-              {
-                "$ref": "#/$defs/IToolCallCancelledState"
-              }
-            ]
-          },
-          "description": "Tool invocations in terminal states (completed or cancelled)"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nConsumers should derive display text by concatenating markdown parts,\nand find tool calls by filtering for `ToolCall` parts."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -416,9 +398,7 @@
       "required": [
         "id",
         "userMessage",
-        "responseText",
         "responseParts",
-        "toolCalls",
         "usage",
         "state"
       ]
@@ -435,34 +415,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "streamingText": {
-          "type": "string",
-          "description": "Accumulated streaming response text"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content so far"
-        },
-        "toolCalls": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IToolCallState"
-          },
-          "description": "Active tool invocations keyed by tool call ID"
-        },
-        "pendingPermissions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IPermissionRequest"
-          },
-          "description": "Pending permission requests keyed by request ID"
-        },
-        "reasoning": {
-          "type": "string",
-          "description": "Accumulated reasoning/thinking text"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nTool call parts include `pendingPermissions` when permissions are awaiting user approval."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -472,11 +430,7 @@
       "required": [
         "id",
         "userMessage",
-        "streamingText",
         "responseParts",
-        "toolCalls",
-        "pendingPermissions",
-        "reasoning",
         "usage"
       ]
     },
@@ -527,6 +481,10 @@
           "$ref": "#/$defs/ResponsePartKind.Markdown",
           "description": "Discriminant"
         },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/delta` to target this part for content appends"
+        },
         "content": {
           "type": "string",
           "description": "Markdown content"
@@ -534,6 +492,7 @@
       },
       "required": [
         "kind",
+        "id",
         "content"
       ]
     },
@@ -561,6 +520,47 @@
       "required": [
         "kind",
         "uri"
+      ]
+    },
+    "IToolCallResponsePart": {
+      "type": "object",
+      "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "description": "Discriminant"
+        },
+        "toolCall": {
+          "$ref": "#/$defs/IToolCallState",
+          "description": "Full tool call lifecycle state"
+        }
+      },
+      "required": [
+        "kind",
+        "toolCall"
+      ]
+    },
+    "IReasoningResponsePart": {
+      "type": "object",
+      "description": "Reasoning/thinking content from the model.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "description": "Discriminant"
+        },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/reasoning` to target this part for content appends"
+        },
+        "content": {
+          "type": "string",
+          "description": "Accumulated reasoning text"
+        }
+      },
+      "required": [
+        "kind",
+        "id",
+        "content"
       ]
     },
     "IToolCallBase": {
@@ -679,10 +679,14 @@
     },
     "IToolCallPendingConfirmationState": {
       "type": "object",
-      "description": "Parameters are complete, waiting for client to confirm execution.",
+      "description": "Parameters are complete, or a running tool requires re-confirmation\n(e.g. a mid-execution permission check).",
       "properties": {
         "status": {
           "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+        },
+        "confirmationTitle": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         }
       },
       "required": [
@@ -928,51 +932,6 @@
         "type",
         "beforeURI",
         "afterURI"
-      ]
-    },
-    "IPermissionRequest": {
-      "type": "object",
-      "properties": {
-        "requestId": {
-          "type": "string",
-          "description": "Unique request identifier"
-        },
-        "permissionKind": {
-          "$ref": "#/$defs/PermissionKind",
-          "description": "Type of permission"
-        },
-        "toolCallId": {
-          "type": "string",
-          "description": "Associated tool call"
-        },
-        "path": {
-          "type": "string",
-          "description": "File/directory path"
-        },
-        "fullCommandText": {
-          "type": "string",
-          "description": "Full command to execute"
-        },
-        "intention": {
-          "type": "string",
-          "description": "What the tool intends to do"
-        },
-        "serverName": {
-          "type": "string",
-          "description": "MCP server name"
-        },
-        "toolName": {
-          "type": "string",
-          "description": "Tool requesting permission"
-        },
-        "rawRequest": {
-          "type": "string",
-          "description": "Raw request data"
-        }
-      },
-      "required": [
-        "requestId",
-        "permissionKind"
       ]
     },
     "IUsageInfo": {

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -306,30 +306,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "responseText": {
-          "type": "string",
-          "description": "Final response text (captured from streaming)"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content"
-        },
-        "toolCalls": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/$defs/IToolCallCompletedState"
-              },
-              {
-                "$ref": "#/$defs/IToolCallCancelledState"
-              }
-            ]
-          },
-          "description": "Tool invocations in terminal states (completed or cancelled)"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nConsumers should derive display text by concatenating markdown parts,\nand find tool calls by filtering for `ToolCall` parts."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -347,9 +329,7 @@
       "required": [
         "id",
         "userMessage",
-        "responseText",
         "responseParts",
-        "toolCalls",
         "usage",
         "state"
       ]
@@ -366,34 +346,12 @@
           "$ref": "#/$defs/IUserMessage",
           "description": "The user's input"
         },
-        "streamingText": {
-          "type": "string",
-          "description": "Accumulated streaming response text"
-        },
         "responseParts": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/IResponsePart"
           },
-          "description": "Structured response content so far"
-        },
-        "toolCalls": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IToolCallState"
-          },
-          "description": "Active tool invocations keyed by tool call ID"
-        },
-        "pendingPermissions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/IPermissionRequest"
-          },
-          "description": "Pending permission requests keyed by request ID"
-        },
-        "reasoning": {
-          "type": "string",
-          "description": "Accumulated reasoning/thinking text"
+          "description": "All response content in stream order: text, tool calls, reasoning, and content refs.\n\nTool call parts include `pendingPermissions` when permissions are awaiting user approval."
         },
         "usage": {
           "$ref": "#/$defs/IUsageInfo",
@@ -403,11 +361,7 @@
       "required": [
         "id",
         "userMessage",
-        "streamingText",
         "responseParts",
-        "toolCalls",
-        "pendingPermissions",
-        "reasoning",
         "usage"
       ]
     },
@@ -458,6 +412,10 @@
           "$ref": "#/$defs/ResponsePartKind.Markdown",
           "description": "Discriminant"
         },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/delta` to target this part for content appends"
+        },
         "content": {
           "type": "string",
           "description": "Markdown content"
@@ -465,6 +423,7 @@
       },
       "required": [
         "kind",
+        "id",
         "content"
       ]
     },
@@ -492,6 +451,47 @@
       "required": [
         "kind",
         "uri"
+      ]
+    },
+    "IToolCallResponsePart": {
+      "type": "object",
+      "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "description": "Discriminant"
+        },
+        "toolCall": {
+          "$ref": "#/$defs/IToolCallState",
+          "description": "Full tool call lifecycle state"
+        }
+      },
+      "required": [
+        "kind",
+        "toolCall"
+      ]
+    },
+    "IReasoningResponsePart": {
+      "type": "object",
+      "description": "Reasoning/thinking content from the model.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "description": "Discriminant"
+        },
+        "id": {
+          "type": "string",
+          "description": "Part identifier, used by `session/reasoning` to target this part for content appends"
+        },
+        "content": {
+          "type": "string",
+          "description": "Accumulated reasoning text"
+        }
+      },
+      "required": [
+        "kind",
+        "id",
+        "content"
       ]
     },
     "IToolCallBase": {
@@ -610,10 +610,14 @@
     },
     "IToolCallPendingConfirmationState": {
       "type": "object",
-      "description": "Parameters are complete, waiting for client to confirm execution.",
+      "description": "Parameters are complete, or a running tool requires re-confirmation\n(e.g. a mid-execution permission check).",
       "properties": {
         "status": {
           "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+        },
+        "confirmationTitle": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         }
       },
       "required": [
@@ -861,51 +865,6 @@
         "afterURI"
       ]
     },
-    "IPermissionRequest": {
-      "type": "object",
-      "properties": {
-        "requestId": {
-          "type": "string",
-          "description": "Unique request identifier"
-        },
-        "permissionKind": {
-          "$ref": "#/$defs/PermissionKind",
-          "description": "Type of permission"
-        },
-        "toolCallId": {
-          "type": "string",
-          "description": "Associated tool call"
-        },
-        "path": {
-          "type": "string",
-          "description": "File/directory path"
-        },
-        "fullCommandText": {
-          "type": "string",
-          "description": "Full command to execute"
-        },
-        "intention": {
-          "type": "string",
-          "description": "What the tool intends to do"
-        },
-        "serverName": {
-          "type": "string",
-          "description": "MCP server name"
-        },
-        "toolName": {
-          "type": "string",
-          "description": "Tool requesting permission"
-        },
-        "rawRequest": {
-          "type": "string",
-          "description": "Raw request data"
-        }
-      },
-      "required": [
-        "requestId",
-        "permissionKind"
-      ]
-    },
     "IUsageInfo": {
       "type": "object",
       "properties": {
@@ -1004,6 +963,12 @@
         },
         {
           "$ref": "#/$defs/IContentRef"
+        },
+        {
+          "$ref": "#/$defs/IToolCallResponsePart"
+        },
+        {
+          "$ref": "#/$defs/IReasoningResponsePart"
         }
       ]
     },

--- a/scripts/generate-markdown.ts
+++ b/scripts/generate-markdown.ts
@@ -455,12 +455,6 @@ function generateStateTypesPage(project: Project): string {
     lines.push(renderInterfaceTable(iface) + '\n');
   }
 
-  // Permission Types
-  lines.push('## Permission Types\n');
-  const permReq = getInterface(project, 'IPermissionRequest');
-  lines.push(renderHeading('IPermissionRequest', permReq));
-  lines.push(renderInterfaceTable(permReq) + '\n');
-
   // Common Types
   lines.push('## Common Types\n');
 
@@ -501,13 +495,11 @@ const ACTION_ORDER: ActionMeta[] = [
   { interfaceName: 'ISessionResponsePartAction', typeValue: 'session/responsePart', description: 'Structured content appended to the response.', clientDispatchable: false, version: 1 },
   { interfaceName: 'ISessionToolCallStartAction', typeValue: 'session/toolCallStart', description: 'A tool call begins — parameters are streaming from the LM.', clientDispatchable: false, version: 1 },
   { interfaceName: 'ISessionToolCallDeltaAction', typeValue: 'session/toolCallDelta', description: 'Streaming partial parameters for a tool call.', clientDispatchable: false, version: 1 },
-  { interfaceName: 'ISessionToolCallReadyAction', typeValue: 'session/toolCallReady', description: 'Tool call parameters are complete.', clientDispatchable: false, version: 1 },
+  { interfaceName: 'ISessionToolCallReadyAction', typeValue: 'session/toolCallReady', description: 'Tool call parameters are complete, or a running tool requires re-confirmation.', clientDispatchable: false, version: 1 },
   { interfaceName: 'ISessionToolCallApprovedAction', typeValue: 'session/toolCallConfirmed (approved)', description: 'Client approves a pending tool call.', clientDispatchable: true, version: 1 },
   { interfaceName: 'ISessionToolCallDeniedAction', typeValue: 'session/toolCallConfirmed (denied)', description: 'Client denies a pending tool call.', clientDispatchable: true, version: 1 },
   { interfaceName: 'ISessionToolCallCompleteAction', typeValue: 'session/toolCallComplete', description: 'Tool execution finished.', clientDispatchable: false, version: 1 },
   { interfaceName: 'ISessionToolCallResultConfirmedAction', typeValue: 'session/toolCallResultConfirmed', description: 'Client approves or denies a tool result.', clientDispatchable: true, version: 1 },
-  { interfaceName: 'ISessionPermissionRequestAction', typeValue: 'session/permissionRequest', description: 'Permission needed from the user to proceed.', clientDispatchable: false, version: 1 },
-  { interfaceName: 'ISessionPermissionResolvedAction', typeValue: 'session/permissionResolved', description: 'Permission granted or denied.', clientDispatchable: true, version: 1 },
   { interfaceName: 'ISessionTurnCompleteAction', typeValue: 'session/turnComplete', description: 'Turn finished — the assistant is idle.', clientDispatchable: false, version: 1 },
   { interfaceName: 'ISessionTurnCancelledAction', typeValue: 'session/turnCancelled', description: 'Turn was aborted; server stops processing.', clientDispatchable: true, version: 1 },
   { interfaceName: 'ISessionErrorAction', typeValue: 'session/error', description: 'Error during turn processing.', clientDispatchable: false, version: 1 },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -16,8 +16,6 @@ import type {
   ISessionToolCallConfirmedAction,
   ISessionToolCallCompleteAction,
   ISessionToolCallResultConfirmedAction,
-  ISessionPermissionRequestAction,
-  ISessionPermissionResolvedAction,
   ISessionTurnCompleteAction,
   ISessionTurnCancelledAction,
   ISessionErrorAction,
@@ -53,8 +51,6 @@ export type ISessionAction =
   | ISessionToolCallConfirmedAction
   | ISessionToolCallCompleteAction
   | ISessionToolCallResultConfirmedAction
-  | ISessionPermissionRequestAction
-  | ISessionPermissionResolvedAction
   | ISessionTurnCompleteAction
   | ISessionTurnCancelledAction
   | ISessionErrorAction
@@ -73,7 +69,6 @@ export type IClientSessionAction =
   | ISessionToolCallConfirmedAction
   | ISessionToolCallCompleteAction
   | ISessionToolCallResultConfirmedAction
-  | ISessionPermissionResolvedAction
   | ISessionTurnCancelledAction
   | ISessionModelChangedAction
   | ISessionActiveClientChangedAction
@@ -89,7 +84,6 @@ export type IServerSessionAction =
   | ISessionToolCallStartAction
   | ISessionToolCallDeltaAction
   | ISessionToolCallReadyAction
-  | ISessionPermissionRequestAction
   | ISessionTurnCompleteAction
   | ISessionErrorAction
   | ISessionTitleChangedAction
@@ -118,8 +112,6 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in IStateAction['type']]: boo
   [ActionType.SessionToolCallConfirmed]: true,
   [ActionType.SessionToolCallComplete]: true,
   [ActionType.SessionToolCallResultConfirmed]: true,
-  [ActionType.SessionPermissionRequest]: false,
-  [ActionType.SessionPermissionResolved]: true,
   [ActionType.SessionTurnComplete]: false,
   [ActionType.SessionTurnCancelled]: true,
   [ActionType.SessionError]: false,

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -17,7 +17,6 @@ import type {
   IToolDefinition,
   ISessionActiveClient,
   IUsageInfo,
-  IPermissionRequest,
 } from './state.js';
 
 import { ToolCallConfirmationReason, ToolCallCancellationReason } from './state.js';
@@ -43,8 +42,6 @@ export const enum ActionType {
   SessionToolCallConfirmed = 'session/toolCallConfirmed',
   SessionToolCallComplete = 'session/toolCallComplete',
   SessionToolCallResultConfirmed = 'session/toolCallResultConfirmed',
-  SessionPermissionRequest = 'session/permissionRequest',
-  SessionPermissionResolved = 'session/permissionResolved',
   SessionTurnComplete = 'session/turnComplete',
   SessionTurnCancelled = 'session/turnCancelled',
   SessionError = 'session/error',
@@ -173,7 +170,10 @@ export interface ISessionTurnStartedAction {
 }
 
 /**
- * Streaming text chunk from the assistant.
+ * Streaming text chunk from the assistant, appended to a specific response part.
+ *
+ * The server MUST first emit a `session/responsePart` to create the target
+ * part (markdown or reasoning), then use this action to append text to it.
  *
  * @category Session Actions
  * @version 1
@@ -184,6 +184,8 @@ export interface ISessionDeltaAction {
   session: URI;
   /** Turn identifier */
   turnId: string;
+  /** Identifier of the response part to append to */
+  partId: string;
   /** Text chunk */
   content: string;
 }
@@ -242,8 +244,15 @@ export interface ISessionToolCallDeltaAction extends IToolCallActionBase {
 }
 
 /**
- * Tool call parameters are complete. Transitions to `pending-confirmation`
+ * Tool call parameters are complete, or a running tool requires re-confirmation.
+ *
+ * When dispatched for a `streaming` tool call, transitions to `pending-confirmation`
  * or directly to `running` if `confirmed` is set.
+ *
+ * When dispatched for a `running` tool call (e.g. mid-execution permission needed),
+ * transitions back to `pending-confirmation`. The `invocationMessage` and `_meta`
+ * SHOULD be updated to describe the specific confirmation needed. Clients use the
+ * standard `session/toolCallConfirmed` flow to approve or deny.
  *
  * For client-provided tools, the server typically sets `confirmed` to
  * `'not-needed'` so the tool transitions directly to `running`, where the
@@ -254,10 +263,12 @@ export interface ISessionToolCallDeltaAction extends IToolCallActionBase {
  */
 export interface ISessionToolCallReadyAction extends IToolCallActionBase {
   type: ActionType.SessionToolCallReady;
-  /** Message describing what the tool will do */
+  /** Message describing what the tool will do or what confirmation is needed */
   invocationMessage: StringOrMarkdown;
   /** Raw tool input */
   toolInput?: string;
+  /** Short title for the confirmation prompt (e.g. `"Run in terminal"`, `"Write file"`) */
+  confirmationTitle?: StringOrMarkdown;
   /** If set, the tool was auto-confirmed and transitions directly to `running` */
   confirmed?: ToolCallConfirmationReason;
 }
@@ -350,41 +361,6 @@ export interface ISessionToolCallResultConfirmedAction extends IToolCallActionBa
 }
 
 /**
- * Permission needed from the user to proceed.
- *
- * @category Session Actions
- * @version 1
- */
-export interface ISessionPermissionRequestAction {
-  type: ActionType.SessionPermissionRequest;
-  /** Session URI */
-  session: URI;
-  /** Turn identifier */
-  turnId: string;
-  /** Permission request details */
-  request: IPermissionRequest;
-}
-
-/**
- * Permission granted or denied.
- *
- * @category Session Actions
- * @version 1
- * @clientDispatchable
- */
-export interface ISessionPermissionResolvedAction {
-  type: ActionType.SessionPermissionResolved;
-  /** Session URI */
-  session: URI;
-  /** Turn identifier */
-  turnId: string;
-  /** Permission request ID */
-  requestId: string;
-  /** Whether permission was granted */
-  approved: boolean;
-}
-
-/**
  * Turn finished — the assistant is idle.
  *
  * @category Session Actions
@@ -460,7 +436,10 @@ export interface ISessionUsageAction {
 }
 
 /**
- * Reasoning/thinking text from the model.
+ * Reasoning/thinking text from the model, appended to a specific reasoning response part.
+ *
+ * The server MUST first emit a `session/responsePart` to create the target
+ * reasoning part, then use this action to append text to it.
  *
  * @category Session Actions
  * @version 1
@@ -471,6 +450,8 @@ export interface ISessionReasoningAction {
   session: URI;
   /** Turn identifier */
   turnId: string;
+  /** Identifier of the reasoning response part to append to */
+  partId: string;
   /** Reasoning text chunk */
   content: string;
 }
@@ -564,8 +545,6 @@ export type IStateAction =
   | ISessionToolCallConfirmedAction
   | ISessionToolCallCompleteAction
   | ISessionToolCallResultConfirmedAction
-  | ISessionPermissionRequestAction
-  | ISessionPermissionResolvedAction
   | ISessionTurnCompleteAction
   | ISessionTurnCancelledAction
   | ISessionErrorAction

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,6 +23,8 @@ export type {
   IMessageAttachment,
   IMarkdownResponsePart,
   IContentRef,
+  IToolCallResponsePart,
+  IReasoningResponsePart,
   IResponsePart,
   IToolCallResult,
   IToolCallStreamingState,
@@ -39,7 +41,6 @@ export type {
   IToolResultContent,
   IToolResultFileEditContent,
   ISessionActiveClient,
-  IPermissionRequest,
   IUsageInfo,
   IErrorInfo,
   ISnapshot,
@@ -56,7 +57,6 @@ export {
   ToolCallConfirmationReason,
   ToolCallCancellationReason,
   ToolResultContentType,
-  PermissionKind,
 } from './state.js';
 
 // Action types
@@ -78,8 +78,6 @@ export type {
   ISessionToolCallConfirmedAction,
   ISessionToolCallCompleteAction,
   ISessionToolCallResultConfirmedAction,
-  ISessionPermissionRequestAction,
-  ISessionPermissionResolvedAction,
   ISessionTurnCompleteAction,
   ISessionTurnCancelledAction,
   ISessionErrorAction,

--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -17,7 +17,7 @@ import {
 } from './reducers.js';
 import { IS_CLIENT_DISPATCHABLE } from './action-origin.generated.js';
 import { ActionType } from './actions.js';
-import type { IRootState, ISessionState } from './state.js';
+import type { IRootState, ISessionState, IToolCallResponsePart } from './state.js';
 import {
   SessionLifecycle,
   SessionStatus,
@@ -26,7 +26,6 @@ import {
   ToolCallConfirmationReason,
   ToolCallCancellationReason,
   ResponsePartKind,
-  PermissionKind,
 } from './state.js';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)));
@@ -78,11 +77,7 @@ function makeSessionStateWithActiveTurn(overrides?: Partial<ISessionState>): ISe
     activeTurn: {
       id: T,
       userMessage: { text: 'Hello' },
-      streamingText: '',
       responseParts: [],
-      toolCalls: {},
-      pendingPermissions: {},
-      reasoning: '',
       usage: undefined,
     },
     ...overrides,
@@ -95,6 +90,46 @@ function startToolCall(state: ISessionState, toolCallId = TC): ISessionState {
     type: ActionType.SessionToolCallStart,
     session: S, turnId: T, toolCallId,
     toolName: 'bash', displayName: 'Run Command',
+  });
+}
+
+/** Gets tool call response parts from responseParts. */
+function getToolCallParts(state: ISessionState): IToolCallResponsePart[] {
+  const parts = state.activeTurn?.responseParts ?? [];
+  return parts.filter((p): p is IToolCallResponsePart => p.kind === ResponsePartKind.ToolCall);
+}
+
+/** Gets a tool call part by toolCallId. */
+function getToolCallPart(state: ISessionState, toolCallId = TC): IToolCallResponsePart | undefined {
+  return getToolCallParts(state).find(p => p.toolCall.toolCallId === toolCallId);
+}
+
+/** Gets markdown text from responseParts by concatenating all markdown parts. */
+function getMarkdownText(state: ISessionState): string {
+  const parts = state.activeTurn?.responseParts ?? [];
+  return parts
+    .filter(p => p.kind === ResponsePartKind.Markdown)
+    .map(p => (p as { content: string }).content)
+    .join('');
+}
+
+/** Creates a markdown response part and returns updated state. */
+function createMarkdownPart(state: ISessionState, partId: string, turnId = T): ISessionState {
+  return sessionReducer(state, {
+    type: ActionType.SessionResponsePart,
+    session: S,
+    turnId,
+    part: { kind: ResponsePartKind.Markdown, id: partId, content: '' },
+  });
+}
+
+/** Creates a reasoning response part and returns updated state. */
+function createReasoningPart(state: ISessionState, partId: string, turnId = T): ISessionState {
+  return sessionReducer(state, {
+    type: ActionType.SessionResponsePart,
+    session: S,
+    turnId,
+    part: { kind: ResponsePartKind.Reasoning, id: partId, content: '' },
   });
 }
 
@@ -222,48 +257,48 @@ describe('sessionReducer — turn lifecycle', () => {
     assert.ok(next.activeTurn);
     assert.equal(next.activeTurn!.id, T);
     assert.equal(next.activeTurn!.userMessage.text, 'Hello');
-    assert.equal(next.activeTurn!.streamingText, '');
     assert.deepStrictEqual(next.activeTurn!.responseParts, []);
-    assert.deepStrictEqual(next.activeTurn!.toolCalls, {});
-    assert.deepStrictEqual(next.activeTurn!.pendingPermissions, {});
   });
 
   it('handles session/delta', () => {
-    const state = makeSessionStateWithActiveTurn();
-    let next = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, content: 'Hello ' });
-    next = sessionReducer(next, { type: ActionType.SessionDelta, session: S, turnId: T, content: 'world' });
-    assert.equal(next.activeTurn!.streamingText, 'Hello world');
+    let state = createMarkdownPart(makeSessionStateWithActiveTurn(), 'md-1');
+    state = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'Hello ' });
+    state = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'world' });
+    assert.equal(getMarkdownText(state), 'Hello world');
   });
 
   it('ignores session/delta with wrong turnId', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const next = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: 'wrong-turn', content: 'orphan' });
+    let state = createMarkdownPart(makeSessionStateWithActiveTurn(), 'md-1');
+    const next = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: 'wrong-turn', partId: 'md-1', content: 'orphan' });
     assert.equal(next, state);
   });
 
   it('ignores session/delta without activeTurn', () => {
     const state = makeSessionState();
-    const next = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, content: 'orphan' });
+    const next = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'orphan' });
     assert.equal(next, state);
   });
 
   it('handles session/responsePart', () => {
     const state = makeSessionStateWithActiveTurn();
-    const part = { kind: ResponsePartKind.Markdown as const, content: '# Title' };
+    const part = { kind: ResponsePartKind.Markdown as const, id: 'md-1', content: '# Title' };
     const next = sessionReducer(state, { type: ActionType.SessionResponsePart, session: S, turnId: T, part });
     assert.equal(next.activeTurn!.responseParts.length, 1);
     assert.deepStrictEqual(next.activeTurn!.responseParts[0], part);
   });
 
   it('handles session/turnComplete — finalizes turn', () => {
-    const state = makeSessionStateWithActiveTurn();
-    let s = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, content: 'Response text' });
+    let s = createMarkdownPart(makeSessionStateWithActiveTurn(), 'md-1');
+    s = sessionReducer(s, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'Response text' });
     s = sessionReducer(s, { type: ActionType.SessionTurnComplete, session: S, turnId: T });
 
     assert.equal(s.activeTurn, undefined);
     assert.equal(s.turns.length, 1);
     assert.equal(s.turns[0].id, T);
-    assert.equal(s.turns[0].responseText, 'Response text');
+    // responseText is derived from markdown parts
+    const markdownParts = s.turns[0].responseParts.filter(p => p.kind === ResponsePartKind.Markdown);
+    assert.equal(markdownParts.length, 1);
+    assert.equal((markdownParts[0] as { content: string }).content, 'Response text');
     assert.equal(s.turns[0].state, TurnState.Complete);
     assert.equal(s.summary.status, SessionStatus.Idle);
   });
@@ -291,10 +326,12 @@ describe('sessionReducer — turn lifecycle', () => {
   it('force-cancels in-progress tool calls on turn completion with skipped reason', () => {
     let state = startToolCall(makeSessionStateWithActiveTurn());
     const next = sessionReducer(state, { type: ActionType.SessionTurnComplete, session: S, turnId: T });
-    assert.equal(next.turns[0].toolCalls.length, 1);
-    assert.equal(next.turns[0].toolCalls[0].status, ToolCallStatus.Cancelled);
-    if (next.turns[0].toolCalls[0].status === ToolCallStatus.Cancelled) {
-      assert.equal(next.turns[0].toolCalls[0].reason, ToolCallCancellationReason.Skipped);
+    const toolCallParts = next.turns[0].responseParts.filter(p => p.kind === ResponsePartKind.ToolCall);
+    assert.equal(toolCallParts.length, 1);
+    const tc = (toolCallParts[0] as IToolCallResponsePart).toolCall;
+    assert.equal(tc.status, ToolCallStatus.Cancelled);
+    if (tc.status === ToolCallStatus.Cancelled) {
+      assert.equal(tc.reason, ToolCallCancellationReason.Skipped);
     }
   });
 
@@ -311,14 +348,14 @@ describe('sessionReducer — turn lifecycle', () => {
 describe('sessionReducer — tool calls', () => {
   it('handles full tool call lifecycle: start → delta → ready → confirmed → complete', () => {
     let state = startToolCall(makeSessionStateWithActiveTurn());
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.Streaming);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Streaming);
 
     // Delta
     state = sessionReducer(state, {
       type: ActionType.SessionToolCallDelta, session: S, turnId: T, toolCallId: TC,
       content: 'ls -la', invocationMessage: 'Listing files',
     });
-    const streaming = state.activeTurn!.toolCalls[TC];
+    const streaming = getToolCallPart(state)!.toolCall;
     assert.equal(streaming.status, ToolCallStatus.Streaming);
     if (streaming.status === ToolCallStatus.Streaming) {
       assert.equal(streaming.partialInput, 'ls -la');
@@ -330,28 +367,26 @@ describe('sessionReducer — tool calls', () => {
       type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
       invocationMessage: 'Run: ls -la', toolInput: 'ls -la',
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.PendingConfirmation);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
 
     // Confirmed (approved)
     state = sessionReducer(state, {
       type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
       approved: true, confirmed: ToolCallConfirmationReason.UserAction,
     });
-    //@ts-ignore
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.Running);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Running);
 
     // Complete
     state = sessionReducer(state, {
       type: ActionType.SessionToolCallComplete, session: S, turnId: T, toolCallId: TC,
       result: { success: true, pastTenseMessage: 'Ran command' },
     });
-    //@ts-ignore
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.Completed);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Completed);
   });
 
   it('handles tool call ready with auto-confirm → running', () => {
     let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    const tc = state.activeTurn!.toolCalls[TC];
+    const tc = getToolCallPart(state)!.toolCall;
     assert.equal(tc.status, ToolCallStatus.Running);
     if (tc.status === ToolCallStatus.Running) {
       assert.equal(tc.confirmed, ToolCallConfirmationReason.NotNeeded);
@@ -368,7 +403,7 @@ describe('sessionReducer — tool calls', () => {
       type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
       approved: false, reason: ToolCallCancellationReason.Denied,
     });
-    const tc = state.activeTurn!.toolCalls[TC];
+    const tc = getToolCallPart(state)!.toolCall;
     assert.equal(tc.status, ToolCallStatus.Cancelled);
     if (tc.status === ToolCallStatus.Cancelled) {
       assert.equal(tc.reason, ToolCallCancellationReason.Denied);
@@ -381,13 +416,13 @@ describe('sessionReducer — tool calls', () => {
       type: ActionType.SessionToolCallComplete, session: S, turnId: T, toolCallId: TC,
       result: { success: true, pastTenseMessage: 'Done' }, requiresResultConfirmation: true,
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.PendingResultConfirmation);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingResultConfirmation);
 
     state = sessionReducer(state, {
       type: ActionType.SessionToolCallResultConfirmed, session: S, turnId: T, toolCallId: TC,
       approved: true,
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.Completed);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Completed);
   });
 
   it('handles tool call result denied → cancelled with result-denied reason', () => {
@@ -400,7 +435,7 @@ describe('sessionReducer — tool calls', () => {
       type: ActionType.SessionToolCallResultConfirmed, session: S, turnId: T, toolCallId: TC,
       approved: false,
     });
-    const tc = state.activeTurn!.toolCalls[TC];
+    const tc = getToolCallPart(state)!.toolCall;
     assert.equal(tc.status, ToolCallStatus.Cancelled);
     if (tc.status === ToolCallStatus.Cancelled) {
       assert.equal(tc.reason, ToolCallCancellationReason.ResultDenied);
@@ -413,12 +448,12 @@ describe('sessionReducer — tool calls', () => {
       type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
       invocationMessage: 'Run',
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.PendingConfirmation);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
     state = sessionReducer(state, {
       type: ActionType.SessionToolCallComplete, session: S, turnId: T, toolCallId: TC,
       result: { success: true, pastTenseMessage: 'Done' },
     });
-    const tc = state.activeTurn!.toolCalls[TC];
+    const tc = getToolCallPart(state)!.toolCall;
     assert.equal(tc.status, ToolCallStatus.Completed);
     if (tc.status === ToolCallStatus.Completed) {
       //@ts-ignore
@@ -436,58 +471,71 @@ describe('sessionReducer — tool calls', () => {
   });
 });
 
-// ─── Session Reducer: Permissions ────────────────────────────────────────────
+// ─── Session Reducer: Running → Re-confirmation ─────────────────────────────
 
-describe('sessionReducer — permissions', () => {
-  it('handles session/permissionRequest and session/permissionResolved', () => {
-    let state = makeSessionStateWithActiveTurn();
-    const request = { requestId: 'perm-1', permissionKind: PermissionKind.Shell, fullCommandText: 'rm -rf /tmp/test' };
+describe('sessionReducer — running tool re-confirmation', () => {
+  it('toolCallReady transitions running tool call back to pending-confirmation', () => {
+    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Running);
 
-    state = sessionReducer(state, { type: ActionType.SessionPermissionRequest, session: S, turnId: T, request });
-    assert.ok(state.activeTurn!.pendingPermissions['perm-1']);
-    assert.equal(state.activeTurn!.pendingPermissions['perm-1'].requestId, 'perm-1');
+    // Server re-sends toolCallReady without confirmed, e.g. for a permission check
+    state = sessionReducer(state, {
+      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
+      invocationMessage: 'Run: rm -rf /tmp/test',
+      _meta: { permissionKind: 'shell', fullCommandText: 'rm -rf /tmp/test' },
+    });
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
 
-    state = sessionReducer(state, { type: ActionType.SessionPermissionResolved, session: S, turnId: T, requestId: 'perm-1', approved: true });
-    assert.equal(state.activeTurn!.pendingPermissions['perm-1'], undefined);
+    // Verify updated invocation message
+    const tc = getToolCallPart(state)!.toolCall;
+    if (tc.status === ToolCallStatus.PendingConfirmation) {
+      assert.equal(tc.invocationMessage, 'Run: rm -rf /tmp/test');
+    }
   });
 
-  it('permissionRequest transitions associated tool call to pending-confirmation', () => {
+  it('toolCallReady re-confirmation approved transitions back to running', () => {
     let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.Running);
+    state = sessionReducer(state, {
+      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
+      invocationMessage: 'Permission needed',
+    });
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
 
     state = sessionReducer(state, {
-      type: ActionType.SessionPermissionRequest, session: S, turnId: T,
-      request: { requestId: 'perm-1', permissionKind: PermissionKind.Shell, toolCallId: TC },
+      type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
+      approved: true, confirmed: ToolCallConfirmationReason.UserAction,
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.PendingConfirmation);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Running);
   });
 
-  it('permissionResolved (approved) transitions associated tool call back to running', () => {
+  it('toolCallReady re-confirmation denied transitions to cancelled', () => {
     let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
     state = sessionReducer(state, {
-      type: ActionType.SessionPermissionRequest, session: S, turnId: T,
-      request: { requestId: 'perm-1', permissionKind: PermissionKind.Shell, toolCallId: TC },
+      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
+      invocationMessage: 'Permission needed',
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.PendingConfirmation);
-
     state = sessionReducer(state, {
-      type: ActionType.SessionPermissionResolved, session: S, turnId: T,
-      requestId: 'perm-1', approved: true,
+      type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
+      approved: false, reason: ToolCallCancellationReason.Denied,
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.Running);
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Cancelled);
   });
 
-  it('permissionResolved (denied) transitions associated tool call to cancelled', () => {
-    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
+  it('toolCallReady ignores non-streaming/non-running tool calls', () => {
+    let state = startToolCall(makeSessionStateWithActiveTurn());
+    // Move to pending-confirmation first
     state = sessionReducer(state, {
-      type: ActionType.SessionPermissionRequest, session: S, turnId: T,
-      request: { requestId: 'perm-1', permissionKind: PermissionKind.Shell, toolCallId: TC },
+      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
+      invocationMessage: 'Run',
     });
-    state = sessionReducer(state, {
-      type: ActionType.SessionPermissionResolved, session: S, turnId: T,
-      requestId: 'perm-1', approved: false,
+    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
+
+    // Sending toolCallReady again while already pending-confirmation should be ignored
+    const next = sessionReducer(state, {
+      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
+      invocationMessage: 'Run again',
     });
-    assert.equal(state.activeTurn!.toolCalls[TC].status, ToolCallStatus.Cancelled);
+    assert.equal(next, state);
   });
 });
 
@@ -509,10 +557,12 @@ describe('sessionReducer — metadata', () => {
   });
 
   it('handles session/reasoning', () => {
-    const state = makeSessionStateWithActiveTurn();
-    let next = sessionReducer(state, { type: ActionType.SessionReasoning, session: S, turnId: T, content: 'Thinking about ' });
-    next = sessionReducer(next, { type: ActionType.SessionReasoning, session: S, turnId: T, content: 'the answer' });
-    assert.equal(next.activeTurn!.reasoning, 'Thinking about the answer');
+    let state = createReasoningPart(makeSessionStateWithActiveTurn(), 'r-1');
+    state = sessionReducer(state, { type: ActionType.SessionReasoning, session: S, turnId: T, partId: 'r-1', content: 'Thinking about ' });
+    state = sessionReducer(state, { type: ActionType.SessionReasoning, session: S, turnId: T, partId: 'r-1', content: 'the answer' });
+    const reasoningParts = state.activeTurn!.responseParts.filter(p => p.kind === ResponsePartKind.Reasoning);
+    assert.equal(reasoningParts.length, 1);
+    assert.equal((reasoningParts[0] as { content: string }).content, 'Thinking about the answer');
   });
 
   it('handles session/modelChanged and bumps modifiedAt', () => {
@@ -573,7 +623,7 @@ describe('isClientDispatchable', () => {
 // ─── Full Turn Flow Integration Test ─────────────────────────────────────────
 
 describe('sessionReducer — full turn flow', () => {
-  it('processes a complete turn with tool calls and permissions', () => {
+  it('processes a complete turn with tool calls and re-confirmation', () => {
     let state = makeSessionState({ lifecycle: SessionLifecycle.Ready });
 
     // Turn started
@@ -584,12 +634,16 @@ describe('sessionReducer — full turn flow', () => {
       userMessage: { text: 'Fix the bug' },
     });
 
-    // Streaming delta
+    // Create markdown part, then stream delta into it
     state = sessionReducer(state, {
-      type: ActionType.SessionDelta, session: 's', turnId: 't1', content: 'I will ',
+      type: ActionType.SessionResponsePart, session: 's', turnId: 't1',
+      part: { kind: ResponsePartKind.Markdown, id: 'md-1', content: '' },
     });
     state = sessionReducer(state, {
-      type: ActionType.SessionDelta, session: 's', turnId: 't1', content: 'fix it.',
+      type: ActionType.SessionDelta, session: 's', turnId: 't1', partId: 'md-1', content: 'I will ',
+    });
+    state = sessionReducer(state, {
+      type: ActionType.SessionDelta, session: 's', turnId: 't1', partId: 'md-1', content: 'fix it.',
     });
 
     // Tool call lifecycle
@@ -609,15 +663,33 @@ describe('sessionReducer — full turn flow', () => {
       result: { success: true, pastTenseMessage: 'Edited main.ts' },
     });
 
-    // Permission
+    // Tool call with mid-execution re-confirmation (e.g. permission check)
     state = sessionReducer(state, {
-      type: ActionType.SessionPermissionRequest,
-      session: 's', turnId: 't1',
-      request: { requestId: 'p1', permissionKind: PermissionKind.Write, path: '/tmp/out' },
+      type: ActionType.SessionToolCallStart,
+      session: 's', turnId: 't1', toolCallId: 'tc2',
+      toolName: 'write', displayName: 'Write File',
     });
     state = sessionReducer(state, {
-      type: ActionType.SessionPermissionResolved,
-      session: 's', turnId: 't1', requestId: 'p1', approved: true,
+      type: ActionType.SessionToolCallReady,
+      session: 's', turnId: 't1', toolCallId: 'tc2',
+      invocationMessage: 'Write /tmp/out', confirmed: ToolCallConfirmationReason.NotNeeded,
+    });
+    // Running tool needs re-confirmation (e.g. permission)
+    state = sessionReducer(state, {
+      type: ActionType.SessionToolCallReady,
+      session: 's', turnId: 't1', toolCallId: 'tc2',
+      invocationMessage: 'Write to /tmp/out',
+      _meta: { permissionKind: 'write', path: '/tmp/out' },
+    });
+    state = sessionReducer(state, {
+      type: ActionType.SessionToolCallConfirmed,
+      session: 's', turnId: 't1', toolCallId: 'tc2',
+      approved: true, confirmed: ToolCallConfirmationReason.UserAction,
+    });
+    state = sessionReducer(state, {
+      type: ActionType.SessionToolCallComplete,
+      session: 's', turnId: 't1', toolCallId: 'tc2',
+      result: { success: true, pastTenseMessage: 'Wrote file' },
     });
 
     // Usage + reasoning
@@ -627,15 +699,20 @@ describe('sessionReducer — full turn flow', () => {
       usage: { inputTokens: 200, outputTokens: 100 },
     });
     state = sessionReducer(state, {
+      type: ActionType.SessionResponsePart,
+      session: 's', turnId: 't1',
+      part: { kind: ResponsePartKind.Reasoning, id: 'r-1', content: '' },
+    });
+    state = sessionReducer(state, {
       type: ActionType.SessionReasoning,
-      session: 's', turnId: 't1', content: 'The bug was in line 42',
+      session: 's', turnId: 't1', partId: 'r-1', content: 'The bug was in line 42',
     });
 
-    // Response part
+    // Another markdown response part
     state = sessionReducer(state, {
       type: ActionType.SessionResponsePart,
       session: 's', turnId: 't1',
-      part: { kind: ResponsePartKind.Markdown, content: '## Fix applied' },
+      part: { kind: ResponsePartKind.Markdown, id: 'md-2', content: '## Fix applied' },
     });
 
     // Turn complete
@@ -648,11 +725,22 @@ describe('sessionReducer — full turn flow', () => {
     assert.equal(state.turns.length, 1);
     const turn = state.turns[0];
     assert.equal(turn.id, 't1');
-    assert.equal(turn.responseText, 'I will fix it.');
     assert.equal(turn.state, TurnState.Complete);
-    assert.equal(turn.toolCalls.length, 1);
-    assert.equal(turn.toolCalls[0].status, ToolCallStatus.Completed);
-    assert.equal(turn.responseParts.length, 1);
+
+    // Check response parts ordering and content
+    const markdownParts = turn.responseParts.filter(p => p.kind === ResponsePartKind.Markdown);
+    assert.equal(markdownParts.length, 2);
+    assert.equal((markdownParts[0] as { content: string }).content, 'I will fix it.');
+
+    const toolCallParts = turn.responseParts.filter(p => p.kind === ResponsePartKind.ToolCall) as IToolCallResponsePart[];
+    assert.equal(toolCallParts.length, 2);
+    assert.equal(toolCallParts[0].toolCall.status, ToolCallStatus.Completed);
+    assert.equal(toolCallParts[1].toolCall.status, ToolCallStatus.Completed);
+
+    const reasoningParts = turn.responseParts.filter(p => p.kind === ResponsePartKind.Reasoning);
+    assert.equal(reasoningParts.length, 1);
+    assert.equal((reasoningParts[0] as { content: string }).content, 'The bug was in line 42');
+
     assert.deepStrictEqual(turn.usage, { inputTokens: 200, outputTokens: 100 });
     assert.equal(state.summary.status, SessionStatus.Idle);
   });

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -5,8 +5,8 @@
  */
 
 import { ActionType } from './actions.js';
-import type { IRootState, ISessionState, IToolCallState, IToolCallCompletedState, IToolCallCancelledState, ITurn } from './state.js';
-import { SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallCancellationReason } from './state.js';
+import type { IRootState, ISessionState, IToolCallState, IResponsePart, IToolCallResponsePart, ITurn } from './state.js';
+import { SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallCancellationReason, ResponsePartKind } from './state.js';
 import type { IRootAction, ISessionAction, IClientSessionAction } from './action-origin.generated.js';
 import { IS_CLIENT_DISPATCHABLE } from './action-origin.generated.js';
 
@@ -38,6 +38,9 @@ function tcBase(tc: IToolCallState) {
 
 /**
  * Ends the active turn, finalizing it into a completed turn record.
+ *
+ * Tool call parts with non-terminal states are forced to cancelled.
+ * Pending permissions are stripped from tool call parts.
  */
 function endTurn(
   state: ISessionState,
@@ -51,28 +54,31 @@ function endTurn(
   }
   const active = state.activeTurn;
 
-  const toolCalls: (IToolCallCompletedState | IToolCallCancelledState)[] = [];
-  for (const tc of Object.values(active.toolCalls)) {
+  const responseParts: IResponsePart[] = active.responseParts.map(part => {
+    if (part.kind !== ResponsePartKind.ToolCall) {
+      return part;
+    }
+    const tc = part.toolCall;
     if (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) {
-      toolCalls.push(tc);
-    } else {
-      // Force non-terminal tool calls into cancelled state.
-      toolCalls.push({
-        status: ToolCallStatus.Cancelled,
+      return part;
+    }
+    // Force non-terminal tool calls into cancelled state
+    return {
+      kind: ResponsePartKind.ToolCall,
+      toolCall: {
+        status: ToolCallStatus.Cancelled as const,
         ...tcBase(tc),
         invocationMessage: tc.status === ToolCallStatus.Streaming ? (tc.invocationMessage ?? '') : tc.invocationMessage,
         toolInput: tc.status === ToolCallStatus.Streaming ? undefined : tc.toolInput,
         reason: ToolCallCancellationReason.Skipped,
-      });
-    }
-  }
+      },
+    };
+  });
 
   const turn: ITurn = {
     id: active.id,
     userMessage: active.userMessage,
-    responseText: active.streamingText,
-    responseParts: active.responseParts,
-    toolCalls,
+    responseParts,
     usage: active.usage,
     state: turnState,
     error,
@@ -87,10 +93,11 @@ function endTurn(
 }
 
 /**
- * Immutably updates a single tool call in the active turn's toolCalls map.
- * Returns `state` unchanged if the active turn or tool call doesn't match.
+ * Immutably updates the tool call inside a `ToolCall` response part in the
+ * active turn's `responseParts` array. Returns `state` unchanged if the
+ * active turn or tool call doesn't match.
  */
-function updateToolCall(
+function updateToolCallInParts(
   state: ISessionState,
   turnId: string,
   toolCallId: string,
@@ -101,20 +108,66 @@ function updateToolCall(
     return state;
   }
 
-  const existing = activeTurn.toolCalls[toolCallId];
-  if (!existing) {
+  let found = false;
+  const responseParts = activeTurn.responseParts.map(part => {
+    if (part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === toolCallId) {
+      const updated = updater(part.toolCall);
+      if (updated === part.toolCall) {
+        return part;
+      }
+      found = true;
+      return { ...part, toolCall: updated };
+    }
+    return part;
+  });
+
+  if (!found) {
     return state;
   }
 
   return {
     ...state,
-    activeTurn: {
-      ...activeTurn,
-      toolCalls: {
-        ...activeTurn.toolCalls,
-        [toolCallId]: updater(existing),
-      },
-    },
+    activeTurn: { ...activeTurn, responseParts },
+  };
+}
+
+/**
+ * Immutably updates a response part by `partId` in the active turn.
+ * For markdown/reasoning parts, matches on `id`. For tool call parts,
+ * matches on `toolCall.toolCallId`.
+ */
+function updateResponsePart(
+  state: ISessionState,
+  turnId: string,
+  partId: string,
+  updater: (part: IResponsePart) => IResponsePart,
+): ISessionState {
+  const activeTurn = state.activeTurn;
+  if (!activeTurn || activeTurn.id !== turnId) {
+    return state;
+  }
+
+  let found = false;
+  const responseParts = activeTurn.responseParts.map(part => {
+    if (!found) {
+      const id = part.kind === ResponsePartKind.ToolCall
+        ? part.toolCall.toolCallId
+        : 'id' in part ? part.id : undefined;
+      if (id === partId) {
+        found = true;
+        return updater(part);
+      }
+    }
+    return part;
+  });
+
+  if (!found) {
+    return state;
+  }
+
+  return {
+    ...state,
+    activeTurn: { ...activeTurn, responseParts },
   };
 }
 
@@ -169,26 +222,18 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
         activeTurn: {
           id: action.turnId,
           userMessage: action.userMessage,
-          streamingText: '',
           responseParts: [],
-          toolCalls: {},
-          pendingPermissions: {},
-          reasoning: '',
           usage: undefined,
         },
       };
 
     case ActionType.SessionDelta:
-      if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
-        return state;
-      }
-      return {
-        ...state,
-        activeTurn: {
-          ...state.activeTurn,
-          streamingText: state.activeTurn.streamingText + action.content,
-        },
-      };
+      return updateResponsePart(state, action.turnId, action.partId, part => {
+        if (part.kind === ResponsePartKind.Markdown) {
+          return { ...part, content: part.content + action.content };
+        }
+        return part;
+      });
 
     case ActionType.SessionResponsePart:
       if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
@@ -221,22 +266,25 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
         ...state,
         activeTurn: {
           ...state.activeTurn,
-          toolCalls: {
-            ...state.activeTurn.toolCalls,
-            [action.toolCallId]: {
-              toolCallId: action.toolCallId,
-              toolName: action.toolName,
-              displayName: action.displayName,
-              toolClientId: action.toolClientId,
-              _meta: action._meta,
-              status: ToolCallStatus.Streaming,
-            },
-          },
+          responseParts: [
+            ...state.activeTurn.responseParts,
+            {
+              kind: ResponsePartKind.ToolCall,
+              toolCall: {
+                toolCallId: action.toolCallId,
+                toolName: action.toolName,
+                displayName: action.displayName,
+                toolClientId: action.toolClientId,
+                _meta: action._meta,
+                status: ToolCallStatus.Streaming,
+              },
+            } satisfies IToolCallResponsePart,
+          ],
         },
       };
 
     case ActionType.SessionToolCallDelta:
-      return updateToolCall(state, action.turnId, action.toolCallId, tc => {
+      return updateToolCallInParts(state, action.turnId, action.toolCallId, tc => {
         if (tc.status !== ToolCallStatus.Streaming) {
           return tc;
         }
@@ -248,7 +296,10 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
       });
 
     case ActionType.SessionToolCallReady:
-      return updateToolCall(state, action.turnId, action.toolCallId, tc => {
+      return updateToolCallInParts(state, action.turnId, action.toolCallId, tc => {
+        if (tc.status !== ToolCallStatus.Streaming && tc.status !== ToolCallStatus.Running) {
+          return tc;
+        }
         const base = tcBase(tc);
         if (action.confirmed) {
           return {
@@ -264,11 +315,12 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
           ...base,
           invocationMessage: action.invocationMessage,
           toolInput: action.toolInput,
+          confirmationTitle: action.confirmationTitle,
         };
       });
 
     case ActionType.SessionToolCallConfirmed:
-      return updateToolCall(state, action.turnId, action.toolCallId, tc => {
+      return updateToolCallInParts(state, action.turnId, action.toolCallId, tc => {
         if (tc.status !== ToolCallStatus.PendingConfirmation) {
           return tc;
         }
@@ -294,7 +346,7 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
       });
 
     case ActionType.SessionToolCallComplete:
-      return updateToolCall(state, action.turnId, action.toolCallId, tc => {
+      return updateToolCallInParts(state, action.turnId, action.toolCallId, tc => {
         if (tc.status !== ToolCallStatus.Running && tc.status !== ToolCallStatus.PendingConfirmation) {
           return tc;
         }
@@ -323,7 +375,7 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
       });
 
     case ActionType.SessionToolCallResultConfirmed:
-      return updateToolCall(state, action.turnId, action.toolCallId, tc => {
+      return updateToolCallInParts(state, action.turnId, action.toolCallId, tc => {
         if (tc.status !== ToolCallStatus.PendingResultConfirmation) {
           return tc;
         }
@@ -351,73 +403,6 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
         };
       });
 
-    // ── Permissions ───────────────────────────────────────────────────────
-
-    case ActionType.SessionPermissionRequest: {
-      if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
-        return state;
-      }
-      const pendingPermissions = {
-        ...state.activeTurn.pendingPermissions,
-        [action.request.requestId]: action.request,
-      };
-      // If the permission is tied to a tool call, transition it to pending-confirmation
-      let toolCalls = state.activeTurn.toolCalls;
-      if (action.request.toolCallId) {
-        const tc = toolCalls[action.request.toolCallId];
-        if (tc && (tc.status === ToolCallStatus.Running || tc.status === ToolCallStatus.Streaming)) {
-          toolCalls = {
-            ...toolCalls,
-            [action.request.toolCallId]: {
-              ...tc,
-              status: ToolCallStatus.PendingConfirmation,
-              invocationMessage: tc.invocationMessage ?? '',
-            },
-          };
-        }
-      }
-      return {
-        ...state,
-        activeTurn: { ...state.activeTurn, pendingPermissions, toolCalls },
-      };
-    }
-
-    case ActionType.SessionPermissionResolved: {
-      if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
-        return state;
-      }
-      const resolved = state.activeTurn.pendingPermissions[action.requestId];
-      const { [action.requestId]: _, ...pendingPermissions } = state.activeTurn.pendingPermissions;
-      // If the permission was tied to a tool call, transition it based on approval
-      let toolCalls = state.activeTurn.toolCalls;
-      if (resolved?.toolCallId) {
-        const tc = toolCalls[resolved.toolCallId];
-        if (tc && tc.status === ToolCallStatus.PendingConfirmation) {
-          const base = tcBase(tc);
-          const updated: IToolCallState = action.approved
-            ? {
-              status: ToolCallStatus.Running,
-              ...base,
-              invocationMessage: tc.invocationMessage,
-              toolInput: tc.toolInput,
-              confirmed: ToolCallConfirmationReason.UserAction,
-            }
-            : {
-              status: ToolCallStatus.Cancelled,
-              ...base,
-              invocationMessage: tc.invocationMessage,
-              toolInput: tc.toolInput,
-              reason: ToolCallCancellationReason.Denied,
-            };
-          toolCalls = { ...toolCalls, [resolved.toolCallId]: updated };
-        }
-      }
-      return {
-        ...state,
-        activeTurn: { ...state.activeTurn, pendingPermissions, toolCalls },
-      };
-    }
-
     // ── Metadata ──────────────────────────────────────────────────────────
 
     case ActionType.SessionTitleChanged:
@@ -436,16 +421,12 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
       };
 
     case ActionType.SessionReasoning:
-      if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
-        return state;
-      }
-      return {
-        ...state,
-        activeTurn: {
-          ...state.activeTurn,
-          reasoning: state.activeTurn.reasoning + action.content,
-        },
-      };
+      return updateResponsePart(state, action.turnId, action.partId, part => {
+        if (part.kind === ResponsePartKind.Reasoning) {
+          return { ...part, content: part.content + action.content };
+        }
+        return part;
+      });
 
     case ActionType.SessionModelChanged:
       return {

--- a/types/state.ts
+++ b/types/state.ts
@@ -274,12 +274,13 @@ export interface ITurn {
   id: string;
   /** The user's input */
   userMessage: IUserMessage;
-  /** Final response text (captured from streaming) */
-  responseText: string;
-  /** Structured response content */
+  /**
+   * All response content in stream order: text, tool calls, reasoning, and content refs.
+   *
+   * Consumers should derive display text by concatenating markdown parts,
+   * and find tool calls by filtering for `ToolCall` parts.
+   */
   responseParts: IResponsePart[];
-  /** Tool invocations in terminal states (completed or cancelled) */
-  toolCalls: (IToolCallCompletedState | IToolCallCancelledState)[];
   /** Token usage info */
   usage: IUsageInfo | undefined;
   /** How the turn ended */
@@ -298,16 +299,12 @@ export interface IActiveTurn {
   id: string;
   /** The user's input */
   userMessage: IUserMessage;
-  /** Accumulated streaming response text */
-  streamingText: string;
-  /** Structured response content so far */
+  /**
+   * All response content in stream order: text, tool calls, reasoning, and content refs.
+   *
+   * Tool call parts include `pendingPermissions` when permissions are awaiting user approval.
+   */
   responseParts: IResponsePart[];
-  /** Active tool invocations keyed by tool call ID */
-  toolCalls: Record<string, IToolCallState>;
-  /** Pending permission requests keyed by request ID */
-  pendingPermissions: Record<string, IPermissionRequest>;
-  /** Accumulated reasoning/thinking text */
-  reasoning: string;
   /** Token usage info */
   usage: IUsageInfo | undefined;
 }
@@ -344,6 +341,8 @@ export interface IMessageAttachment {
 export const enum ResponsePartKind {
   Markdown = 'markdown',
   ContentRef = 'contentRef',
+  ToolCall = 'toolCall',
+  Reasoning = 'reasoning',
 }
 
 /**
@@ -352,6 +351,8 @@ export const enum ResponsePartKind {
 export interface IMarkdownResponsePart {
   /** Discriminant */
   kind: ResponsePartKind.Markdown;
+  /** Part identifier, used by `session/delta` to target this part for content appends */
+  id: string;
   /** Markdown content */
   content: string;
 }
@@ -373,9 +374,39 @@ export interface IContentRef {
 }
 
 /**
+ * A tool call represented as a response part.
+ *
+ * Tool calls are part of the response stream, interleaved with text and
+ * reasoning. The `toolCall.toolCallId` serves as the part identifier for
+ * actions that target this part.
+ *
  * @category Response Parts
  */
-export type IResponsePart = IMarkdownResponsePart | IContentRef;
+export interface IToolCallResponsePart {
+  /** Discriminant */
+  kind: ResponsePartKind.ToolCall;
+  /** Full tool call lifecycle state */
+  toolCall: IToolCallState;
+}
+
+/**
+ * Reasoning/thinking content from the model.
+ *
+ * @category Response Parts
+ */
+export interface IReasoningResponsePart {
+  /** Discriminant */
+  kind: ResponsePartKind.Reasoning;
+  /** Part identifier, used by `session/reasoning` to target this part for content appends */
+  id: string;
+  /** Accumulated reasoning text */
+  content: string;
+}
+
+/**
+ * @category Response Parts
+ */
+export type IResponsePart = IMarkdownResponsePart | IContentRef | IToolCallResponsePart | IReasoningResponsePart;
 
 // ─── Tool Call Types ─────────────────────────────────────────────────────────
 
@@ -507,12 +538,15 @@ export interface IToolCallStreamingState extends IToolCallBase {
 }
 
 /**
- * Parameters are complete, waiting for client to confirm execution.
+ * Parameters are complete, or a running tool requires re-confirmation
+ * (e.g. a mid-execution permission check).
  *
  * @category Tool Call Types
  */
 export interface IToolCallPendingConfirmationState extends IToolCallBase, IToolCallParameterFields {
   status: ToolCallStatus.PendingConfirmation;
+  /** Short title for the confirmation prompt (e.g. `"Run in terminal"`, `"Write file"`) */
+  confirmationTitle?: StringOrMarkdown;
 }
 
 /**
@@ -725,50 +759,6 @@ export type IToolResultContent =
   | IToolResultBinaryContent
   | IToolResultFileEditContent
   | IContentRef;
-
-// ─── Permission Types ────────────────────────────────────────────────────────
-
-/**
- * Type of permission requested.
- *
- * @category Permission Types
- */
-export const enum PermissionKind {
-  Shell = 'shell',
-  Write = 'write',
-  Mcp = 'mcp',
-  Read = 'read',
-  Url = 'url',
-}
-
-/**
- * @category Permission Types
- * @remarks
- * Fields like `serverName`, `toolName`, and `rawRequest` carry agent-specific
- * identifiers on the wire despite the agent-agnostic design principle. These exist
- * for debugging and logging purposes.
- * @todo @connor4312, split this up into well-separated union types
- */
-export interface IPermissionRequest {
-  /** Unique request identifier */
-  requestId: string;
-  /** Type of permission */
-  permissionKind: PermissionKind;
-  /** Associated tool call */
-  toolCallId?: string;
-  /** File/directory path */
-  path?: string;
-  /** Full command to execute */
-  fullCommandText?: string;
-  /** What the tool intends to do */
-  intention?: string;
-  /** MCP server name */
-  serverName?: string;
-  /** Tool requesting permission */
-  toolName?: string;
-  /** Raw request data */
-  rawRequest?: string;
-}
 
 // ─── Common Types ────────────────────────────────────────────────────────────
 

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -37,8 +37,6 @@ export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: numbe
   [ActionType.SessionToolCallConfirmed]: 1,
   [ActionType.SessionToolCallComplete]: 1,
   [ActionType.SessionToolCallResultConfirmed]: 1,
-  [ActionType.SessionPermissionRequest]: 1,
-  [ActionType.SessionPermissionResolved]: 1,
   [ActionType.SessionTurnComplete]: 1,
   [ActionType.SessionTurnCancelled]: 1,
   [ActionType.SessionError]: 1,

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -24,6 +24,8 @@ import type {
   IMessageAttachment,
   IMarkdownResponsePart,
   IContentRef,
+  IToolCallResponsePart,
+  IReasoningResponsePart,
   IToolCallResult,
   IToolCallStreamingState,
   IToolCallPendingConfirmationState,
@@ -37,7 +39,6 @@ import type {
   IToolResultTextContent,
   IToolResultBinaryContent,
   IToolResultFileEditContent,
-  IPermissionRequest,
   IUsageInfo,
   IErrorInfo,
   ISnapshot,
@@ -105,6 +106,8 @@ type V1_IUserMessage = IUserMessage;
 type V1_IMessageAttachment = IMessageAttachment;
 type V1_IMarkdownResponsePart = IMarkdownResponsePart;
 type V1_IContentRef = IContentRef;
+type V1_IToolCallResponsePart = IToolCallResponsePart;
+type V1_IReasoningResponsePart = IReasoningResponsePart;
 type V1_IToolCallResult = IToolCallResult;
 type V1_IToolCallStreamingState = IToolCallStreamingState;
 type V1_IToolCallPendingConfirmationState = IToolCallPendingConfirmationState;
@@ -118,7 +121,6 @@ type V1_IToolAnnotations = IToolAnnotations;
 type V1_IToolResultTextContent = IToolResultTextContent;
 type V1_IToolResultBinaryContent = IToolResultBinaryContent;
 type V1_IToolResultFileEditContent = IToolResultFileEditContent;
-type V1_IPermissionRequest = IPermissionRequest;
 type V1_IUsageInfo = IUsageInfo;
 type V1_IErrorInfo = IErrorInfo;
 type V1_ISnapshot = ISnapshot;
@@ -171,6 +173,10 @@ type _CheckMarkdownResponsePart = AssertCompatible<V1_IMarkdownResponsePart, IMa
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckContentRef = AssertCompatible<V1_IContentRef, IContentRef>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckToolCallResponsePart = AssertCompatible<V1_IToolCallResponsePart, IToolCallResponsePart>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckReasoningResponsePart = AssertCompatible<V1_IReasoningResponsePart, IReasoningResponsePart>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallResult = AssertCompatible<V1_IToolCallResult, IToolCallResult>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallStreamingState = AssertCompatible<V1_IToolCallStreamingState, IToolCallStreamingState>;
@@ -186,8 +192,6 @@ type _CheckToolCallCompletedState = AssertCompatible<V1_IToolCallCompletedState,
 type _CheckToolCallCancelledState = AssertCompatible<V1_IToolCallCancelledState, IToolCallCancelledState>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallState = AssertCompatible<V1_IToolCallState, IToolCallState>;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _CheckPermissionRequest = AssertCompatible<V1_IPermissionRequest, IPermissionRequest>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckUsageInfo = AssertCompatible<V1_IUsageInfo, IUsageInfo>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
We'd just migrated the vibe-coded tool invocation states previously. The main issue was that these weren't ordered in this response. So this fixes that.

Restructure ITurn and IActiveTurn so tool calls, reasoning, and text are all ResponsePart variants in a single responseParts array.

- Add ResponsePartKind.ToolCall and .Reasoning with IToolCallResponsePart and IReasoningResponsePart
- Add id to IMarkdownResponsePart for targeted delta appends. Usually delta will always be the last item, but in a multi-client world there could be some ordering surprises, so explicit is good
- Add partId to SessionDelta and SessionReasoning actions
- Remove responseText, streamingText, reasoning, toolCalls, and pendingPermissions as separate fields on ITurn/IActiveTurn
- Remove IPermissionRequest, PermissionKind, and permission actions; unify into toolCallReady re-confirmation (Running → PendingConfirmation)
- Add confirmationTitle to IToolCallPendingConfirmationState