### PR TITLE
feat: add steering message, queued messages

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -67,6 +67,16 @@ A `session/toolUpdate` action for streaming incremental tool output (e.g. termin
 | `session/reasoning` | No | Reasoning/thinking text appended to a reasoning part by `partId` |
 | `session/modelChanged` | **Yes** | Model changed for this session |
 
+### Pending Messages
+
+| Type | Client-dispatchable? | When |
+|---|---|---|
+| `session/pendingMessageSet` | **Yes** | A steering or queued message was set (upsert) |
+| `session/pendingMessageRemoved` | **Yes** | A pending message was cancelled (by client) or consumed (by server) |
+| `session/queuedMessagesReordered` | **Yes** | Queued messages were reordered |
+
+The `pendingMessageSet` and `pendingMessageRemoved` actions carry a `kind` discriminant (`'steering'` or `'queued'`). See the [State Model — Pending Messages](/guide/state-model#pending-messages) for semantics.
+
 ## Client-Dispatched Actions
 
 Clients interact with the server by dispatching actions as fire-and-forget notifications:
@@ -91,6 +101,9 @@ The client applies the action **optimistically** to its local state before sendi
 | `session/toolCallConfirmed` | Approves or denies a pending tool call; unblocks or cancels tool execution |
 | `session/turnCancelled` | Aborts the in-progress turn |
 | `session/modelChanged` | Changes the model for subsequent turns |
+| `session/pendingMessageSet` | Stores a steering or queued message (upsert); if queued and idle, auto-starts a turn |
+| `session/pendingMessageRemoved` | Cancels a pending message before it is consumed |
+| `session/queuedMessagesReordered` | Reorders queued messages; unknown IDs ignored, unmentioned messages kept at end |
 
 ## Reducers
 

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -219,6 +219,62 @@ The session list can be arbitrarily large and is **not** part of the state tree.
 
 Notifications are ephemeral — not processed by reducers, not stored in state, not replayed on reconnect. On reconnect, clients re-fetch the list.
 
+## Pending Messages
+
+Sessions maintain two optional arrays of **pending messages** — instructions queued for future delivery to the agent:
+
+```typescript
+SessionState {
+  // ...existing fields...
+  steeringMessage?: PendingMessage      // inject into current turn
+  queuedMessages?: PendingMessage[]     // start as new turns
+}
+
+PendingMessage {
+  id: string
+  userMessage: UserMessage
+}
+```
+
+### Steering Message
+
+The steering message is injected into the **current turn** at a convenient point. Clients set a steering message to guide the agent mid-flight — for example, telling it to focus on a specific file or change approach. Only one steering message exists at a time; adding a new one replaces any existing one.
+
+- When the session has an active turn, the server consumes the steering message at its discretion, dispatching `session/pendingMessageRemoved` when it does.
+- When set while idle, the steering message is silently stored until a turn starts.
+
+### Queued Messages
+
+Queued messages are automatically started as **new turns** after the current turn finishes. The server processes them FIFO (by arrival order).
+
+- When a turn completes and queued messages exist, the server removes the first queued message and starts a new turn from it.
+- When a queued message is added while the session is idle, the server SHOULD immediately consume it and start a turn.
+- The resulting `session/turnStarted` action includes a `queuedMessageId` field linking back to the source queued message.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: pendingMessageSet (kind: queued, id: q-1)
+    Note over Server: Turn in progress, message stored
+
+    Client->>Server: pendingMessageSet (kind: queued, id: q-2)
+
+    Server->>Client: turnComplete (current turn)
+    Server->>Client: pendingMessageRemoved (kind: queued, id: q-1)
+    Server->>Client: turnStarted (queuedMessageId: q-1)
+    Note over Server: Auto-started from queue
+
+    Server->>Client: turnComplete
+    Server->>Client: pendingMessageRemoved (kind: queued, id: q-2)
+    Server->>Client: turnStarted (queuedMessageId: q-2)
+```
+
+### Management
+
+Clients can **set** or **remove** both steering and queued messages at any time using the `session/pendingMessageSet` (upsert) and `session/pendingMessageRemoved` actions with a `kind` discriminant (`'steering'` or `'queued'`).
+
 ## Next Steps
 
 - [Actions](/guide/actions) — How state is mutated.

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -101,10 +101,29 @@ When the server receives a client-dispatched action, it MUST validate it before 
 | `session/toolCallConfirmed` | Tool call not in `pending-confirmation` state | Server MUST reject the action |
 | `session/turnCancelled` | No active turn | Server MUST reject the action |
 | `session/modelChanged` | A turn is currently active | Server MUST defer the model change until the active turn completes, then apply it for the next turn |
+| `session/pendingMessageRemoved` | No pending message with matching `id` and `kind` | Server SHOULD reject the action |
 
-::: tip FUTURE WORK
-`session/turnStarted` dispatched while a turn is already active will eventually support queuing and steering. See the protocol roadmap for details.
-:::
+## Pending Message Consumption
+
+The server consumes pending messages according to their kind:
+
+### Queued Messages
+
+When a turn completes and `queuedMessages` is non-empty, the server SHOULD:
+
+1. Dispatch `session/pendingMessageRemoved` with `kind: 'queued'` for the first queued message.
+2. Dispatch `session/turnStarted` with the queued message's `userMessage` and `queuedMessageId` set to the message's `id`.
+
+When a queued message is added while the session is idle (no active turn), the server SHOULD immediately consume it using the same two-step sequence.
+
+### Steering Messages
+
+When a turn is active and `steeringMessages` is non-empty, the server MAY consume steering messages at its discretion. To consume a steering message, the server:
+
+1. Dispatches `session/pendingMessageRemoved` with `kind: 'steering'`.
+2. Injects the message content into the model context (the injection mechanism is opaque to the protocol).
+
+Steering messages added while idle are silently stored and consumed when a turn becomes active.
 
 ## Session Disposal
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -166,6 +166,10 @@
         "userMessage": {
           "$ref": "#/$defs/IUserMessage",
           "description": "User's message"
+        },
+        "queuedMessageId": {
+          "type": "string",
+          "description": "If this turn was auto-started from a queued message, the ID of that message"
         }
       },
       "required": [
@@ -656,6 +660,90 @@
         "tools"
       ]
     },
+    "ISessionPendingMessageSetAction": {
+      "type": "object",
+      "description": "A pending message was set (upsert semantics: creates or replaces).\n\nFor steering messages, this always replaces the single steering message.\nFor queued messages, if a message with the given `id` already exists it is\nupdated in place; otherwise it is appended to the queue. If the session is\nidle when a queued message is set, the server SHOULD immediately consume it\nand start a new turn.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionPendingMessageSet"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "kind": {
+          "$ref": "#/$defs/PendingMessageKind",
+          "description": "Whether this is a steering or queued message"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this pending message"
+        },
+        "userMessage": {
+          "$ref": "#/$defs/IUserMessage",
+          "description": "The message content"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "kind",
+        "id",
+        "userMessage"
+      ]
+    },
+    "ISessionPendingMessageRemovedAction": {
+      "type": "object",
+      "description": "A pending message was removed (steering or queued).\n\nDispatched by clients to cancel a pending message, or by the server when\nit consumes a message (e.g. starting a turn from a queued message or\ninjecting a steering message into the current turn).",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionPendingMessageRemoved"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "kind": {
+          "$ref": "#/$defs/PendingMessageKind",
+          "description": "Whether this is a steering or queued message"
+        },
+        "id": {
+          "type": "string",
+          "description": "Identifier of the pending message to remove"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "kind",
+        "id"
+      ]
+    },
+    "ISessionQueuedMessagesReorderedAction": {
+      "type": "object",
+      "description": "Reorder the queued messages.\n\nThe `order` array contains the IDs of queued messages in their new\ndesired order. IDs not present in the current queue are ignored.\nQueued messages whose IDs are absent from `order` are appended at\nthe end in their original relative order (so a client with a stale\nview of the queue never silently drops messages).",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionQueuedMessagesReordered"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Queued message IDs in the desired order"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "order"
+      ]
+    },
     "ISessionToolCallConfirmedAction": {
       "oneOf": [
         {},
@@ -838,6 +926,24 @@
         "name"
       ]
     },
+    "IPendingMessage": {
+      "type": "object",
+      "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this pending message"
+        },
+        "userMessage": {
+          "$ref": "#/$defs/IUserMessage",
+          "description": "The message content"
+        }
+      },
+      "required": [
+        "id",
+        "userMessage"
+      ]
+    },
     "ISessionState": {
       "type": "object",
       "description": "Full state for a single session, loaded when a client subscribes to the session's URI.",
@@ -879,6 +985,17 @@
         "activeTurn": {
           "$ref": "#/$defs/IActiveTurn",
           "description": "Currently in-progress turn"
+        },
+        "steeringMessage": {
+          "$ref": "#/$defs/IPendingMessage",
+          "description": "Message to inject into the current turn at a convenient point"
+        },
+        "queuedMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IPendingMessage"
+          },
+          "description": "Messages to send automatically as new turns after the current turn finishes"
         }
       },
       "required": [
@@ -1751,6 +1868,15 @@
         },
         {
           "$ref": "#/$defs/ISessionActiveClientToolsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionPendingMessageSetAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionPendingMessageRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionQueuedMessagesReorderedAction"
         }
       ]
     }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -589,6 +589,24 @@
         "name"
       ]
     },
+    "IPendingMessage": {
+      "type": "object",
+      "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this pending message"
+        },
+        "userMessage": {
+          "$ref": "#/$defs/IUserMessage",
+          "description": "The message content"
+        }
+      },
+      "required": [
+        "id",
+        "userMessage"
+      ]
+    },
     "ISessionState": {
       "type": "object",
       "description": "Full state for a single session, loaded when a client subscribes to the session's URI.",
@@ -630,6 +648,17 @@
         "activeTurn": {
           "$ref": "#/$defs/IActiveTurn",
           "description": "Currently in-progress turn"
+        },
+        "steeringMessage": {
+          "$ref": "#/$defs/IPendingMessage",
+          "description": "Message to inject into the current turn at a convenient point"
+        },
+        "queuedMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IPendingMessage"
+          },
+          "description": "Messages to send automatically as new turns after the current turn finishes"
         }
       },
       "required": [
@@ -1512,6 +1541,10 @@
         "userMessage": {
           "$ref": "#/$defs/IUserMessage",
           "description": "User's message"
+        },
+        "queuedMessageId": {
+          "type": "string",
+          "description": "If this turn was auto-started from a queued message, the ID of that message"
         }
       },
       "required": [
@@ -2000,6 +2033,90 @@
         "type",
         "session",
         "tools"
+      ]
+    },
+    "ISessionPendingMessageSetAction": {
+      "type": "object",
+      "description": "A pending message was set (upsert semantics: creates or replaces).\n\nFor steering messages, this always replaces the single steering message.\nFor queued messages, if a message with the given `id` already exists it is\nupdated in place; otherwise it is appended to the queue. If the session is\nidle when a queued message is set, the server SHOULD immediately consume it\nand start a new turn.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionPendingMessageSet"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "kind": {
+          "$ref": "#/$defs/PendingMessageKind",
+          "description": "Whether this is a steering or queued message"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this pending message"
+        },
+        "userMessage": {
+          "$ref": "#/$defs/IUserMessage",
+          "description": "The message content"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "kind",
+        "id",
+        "userMessage"
+      ]
+    },
+    "ISessionPendingMessageRemovedAction": {
+      "type": "object",
+      "description": "A pending message was removed (steering or queued).\n\nDispatched by clients to cancel a pending message, or by the server when\nit consumes a message (e.g. starting a turn from a queued message or\ninjecting a steering message into the current turn).",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionPendingMessageRemoved"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "kind": {
+          "$ref": "#/$defs/PendingMessageKind",
+          "description": "Whether this is a steering or queued message"
+        },
+        "id": {
+          "type": "string",
+          "description": "Identifier of the pending message to remove"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "kind",
+        "id"
+      ]
+    },
+    "ISessionQueuedMessagesReorderedAction": {
+      "type": "object",
+      "description": "Reorder the queued messages.\n\nThe `order` array contains the IDs of queued messages in their new\ndesired order. IDs not present in the current queue are ignored.\nQueued messages whose IDs are absent from `order` are appended at\nthe end in their original relative order (so a client with a stale\nview of the queue never silently drops messages).",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionQueuedMessagesReordered"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Queued message IDs in the desired order"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "order"
       ]
     }
   }

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -244,6 +244,24 @@
         "name"
       ]
     },
+    "IPendingMessage": {
+      "type": "object",
+      "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this pending message"
+        },
+        "userMessage": {
+          "$ref": "#/$defs/IUserMessage",
+          "description": "The message content"
+        }
+      },
+      "required": [
+        "id",
+        "userMessage"
+      ]
+    },
     "ISessionState": {
       "type": "object",
       "description": "Full state for a single session, loaded when a client subscribes to the session's URI.",
@@ -285,6 +303,17 @@
         "activeTurn": {
           "$ref": "#/$defs/IActiveTurn",
           "description": "Currently in-progress turn"
+        },
+        "steeringMessage": {
+          "$ref": "#/$defs/IPendingMessage",
+          "description": "Message to inject into the current turn at a convenient point"
+        },
+        "queuedMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IPendingMessage"
+          },
+          "description": "Messages to send automatically as new turns after the current turn finishes"
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -175,6 +175,24 @@
         "name"
       ]
     },
+    "IPendingMessage": {
+      "type": "object",
+      "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this pending message"
+        },
+        "userMessage": {
+          "$ref": "#/$defs/IUserMessage",
+          "description": "The message content"
+        }
+      },
+      "required": [
+        "id",
+        "userMessage"
+      ]
+    },
     "ISessionState": {
       "type": "object",
       "description": "Full state for a single session, loaded when a client subscribes to the session's URI.",
@@ -216,6 +234,17 @@
         "activeTurn": {
           "$ref": "#/$defs/IActiveTurn",
           "description": "Currently in-progress turn"
+        },
+        "steeringMessage": {
+          "$ref": "#/$defs/IPendingMessage",
+          "description": "Message to inject into the current turn at a convenient point"
+        },
+        "queuedMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IPendingMessage"
+          },
+          "description": "Messages to send automatically as new turns after the current turn finishes"
         }
       },
       "required": [

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -26,6 +26,9 @@ import type {
   ISessionServerToolsChangedAction,
   ISessionActiveClientChangedAction,
   ISessionActiveClientToolsChangedAction,
+  ISessionPendingMessageSetAction,
+  ISessionPendingMessageRemovedAction,
+  ISessionQueuedMessagesReorderedAction,
 } from './actions.js';
 
 import { ActionType } from './actions.js';
@@ -61,6 +64,9 @@ export type ISessionAction =
   | ISessionServerToolsChangedAction
   | ISessionActiveClientChangedAction
   | ISessionActiveClientToolsChangedAction
+  | ISessionPendingMessageSetAction
+  | ISessionPendingMessageRemovedAction
+  | ISessionQueuedMessagesReorderedAction
 ;
 
 /** Union of session actions that clients may dispatch. */
@@ -73,6 +79,9 @@ export type IClientSessionAction =
   | ISessionModelChangedAction
   | ISessionActiveClientChangedAction
   | ISessionActiveClientToolsChangedAction
+  | ISessionPendingMessageSetAction
+  | ISessionPendingMessageRemovedAction
+  | ISessionQueuedMessagesReorderedAction
 ;
 
 /** Union of session actions that only the server may produce. */
@@ -122,4 +131,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in IStateAction['type']]: boo
   [ActionType.SessionServerToolsChanged]: false,
   [ActionType.SessionActiveClientChanged]: true,
   [ActionType.SessionActiveClientToolsChanged]: true,
+  [ActionType.SessionPendingMessageSet]: true,
+  [ActionType.SessionPendingMessageRemoved]: true,
+  [ActionType.SessionQueuedMessagesReordered]: true,
 };

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -19,7 +19,7 @@ import type {
   IUsageInfo,
 } from './state.js';
 
-import { ToolCallConfirmationReason, ToolCallCancellationReason } from './state.js';
+import { ToolCallConfirmationReason, ToolCallCancellationReason, PendingMessageKind } from './state.js';
 
 // ─── Action Type Enum ────────────────────────────────────────────────────────
 
@@ -52,6 +52,9 @@ export const enum ActionType {
   SessionServerToolsChanged = 'session/serverToolsChanged',
   SessionActiveClientChanged = 'session/activeClientChanged',
   SessionActiveClientToolsChanged = 'session/activeClientToolsChanged',
+  SessionPendingMessageSet = 'session/pendingMessageSet',
+  SessionPendingMessageRemoved = 'session/pendingMessageRemoved',
+  SessionQueuedMessagesReordered = 'session/queuedMessagesReordered',
 }
 
 // ─── Action Envelope ─────────────────────────────────────────────────────────
@@ -167,6 +170,8 @@ export interface ISessionTurnStartedAction {
   turnId: string;
   /** User's message */
   userMessage: IUserMessage;
+  /** If this turn was auto-started from a queued message, the ID of that message */
+  queuedMessageId?: string;
 }
 
 /**
@@ -526,6 +531,75 @@ export interface ISessionActiveClientToolsChangedAction {
   tools: IToolDefinition[];
 }
 
+// ─── Pending Message Actions ─────────────────────────────────────────────────
+
+/**
+ * A pending message was set (upsert semantics: creates or replaces).
+ *
+ * For steering messages, this always replaces the single steering message.
+ * For queued messages, if a message with the given `id` already exists it is
+ * updated in place; otherwise it is appended to the queue. If the session is
+ * idle when a queued message is set, the server SHOULD immediately consume it
+ * and start a new turn.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionPendingMessageSetAction {
+  type: ActionType.SessionPendingMessageSet;
+  /** Session URI */
+  session: URI;
+  /** Whether this is a steering or queued message */
+  kind: PendingMessageKind;
+  /** Unique identifier for this pending message */
+  id: string;
+  /** The message content */
+  userMessage: IUserMessage;
+}
+
+/**
+ * A pending message was removed (steering or queued).
+ *
+ * Dispatched by clients to cancel a pending message, or by the server when
+ * it consumes a message (e.g. starting a turn from a queued message or
+ * injecting a steering message into the current turn).
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionPendingMessageRemovedAction {
+  type: ActionType.SessionPendingMessageRemoved;
+  /** Session URI */
+  session: URI;
+  /** Whether this is a steering or queued message */
+  kind: PendingMessageKind;
+  /** Identifier of the pending message to remove */
+  id: string;
+}
+
+/**
+ * Reorder the queued messages.
+ *
+ * The `order` array contains the IDs of queued messages in their new
+ * desired order. IDs not present in the current queue are ignored.
+ * Queued messages whose IDs are absent from `order` are appended at
+ * the end in their original relative order (so a client with a stale
+ * view of the queue never silently drops messages).
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionQueuedMessagesReorderedAction {
+  type: ActionType.SessionQueuedMessagesReordered;
+  /** Session URI */
+  session: URI;
+  /** Queued message IDs in the desired order */
+  order: string[];
+}
+
 // ─── Discriminated Union ─────────────────────────────────────────────────────
 
 /**
@@ -554,4 +628,7 @@ export type IStateAction =
   | ISessionModelChangedAction
   | ISessionServerToolsChangedAction
   | ISessionActiveClientChangedAction
-  | ISessionActiveClientToolsChangedAction;
+  | ISessionActiveClientToolsChangedAction
+  | ISessionPendingMessageSetAction
+  | ISessionPendingMessageRemovedAction
+  | ISessionQueuedMessagesReorderedAction;

--- a/types/index.ts
+++ b/types/index.ts
@@ -41,6 +41,7 @@ export type {
   IToolResultContent,
   IToolResultFileEditContent,
   ISessionActiveClient,
+  IPendingMessage,
   IUsageInfo,
   IErrorInfo,
   ISnapshot,
@@ -57,6 +58,7 @@ export {
   ToolCallConfirmationReason,
   ToolCallCancellationReason,
   ToolResultContentType,
+  PendingMessageKind,
 } from './state.js';
 
 // Action types
@@ -88,6 +90,9 @@ export type {
   ISessionServerToolsChangedAction,
   ISessionActiveClientChangedAction,
   ISessionActiveClientToolsChangedAction,
+  ISessionPendingMessageSetAction,
+  ISessionPendingMessageRemovedAction,
+  ISessionQueuedMessagesReorderedAction,
   IStateAction,
 } from './actions.js';
 

--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -26,6 +26,7 @@ import {
   ToolCallConfirmationReason,
   ToolCallCancellationReason,
   ResponsePartKind,
+  PendingMessageKind,
 } from './state.js';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)));
@@ -743,5 +744,264 @@ describe('sessionReducer — full turn flow', () => {
 
     assert.deepStrictEqual(turn.usage, { inputTokens: 200, outputTokens: 100 });
     assert.equal(state.summary.status, SessionStatus.Idle);
+  });
+});
+
+// ─── Pending Message Tests ───────────────────────────────────────────────────
+
+describe('sessionReducer — pending messages', () => {
+  describe('steering message', () => {
+    it('sets a steering message', () => {
+      const state = makeSessionState();
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageSet,
+        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
+        userMessage: { text: 'Focus on tests' },
+      });
+      assert.deepStrictEqual(result.steeringMessage, {
+        id: 'sm-1', userMessage: { text: 'Focus on tests' },
+      });
+    });
+
+    it('replaces existing steering message', () => {
+      const state = makeSessionState({
+        steeringMessage: { id: 'sm-1', userMessage: { text: 'Old' } },
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageSet,
+        session: S, kind: PendingMessageKind.Steering, id: 'sm-2',
+        userMessage: { text: 'New' },
+      });
+      assert.equal(result.steeringMessage!.id, 'sm-2');
+      assert.equal(result.steeringMessage!.userMessage.text, 'New');
+    });
+
+    it('updates steering message content via set with same ID', () => {
+      const state = makeSessionState({
+        steeringMessage: { id: 'sm-1', userMessage: { text: 'Original' } },
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageSet,
+        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
+        userMessage: { text: 'Updated' },
+      });
+      assert.equal(result.steeringMessage!.id, 'sm-1');
+      assert.equal(result.steeringMessage!.userMessage.text, 'Updated');
+    });
+
+    it('removes steering message', () => {
+      const state = makeSessionState({
+        steeringMessage: { id: 'sm-1', userMessage: { text: 'Steer' } },
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageRemoved,
+        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
+      });
+      assert.strictEqual(result.steeringMessage, undefined);
+    });
+
+    it('remove is no-op for mismatched ID', () => {
+      const state = makeSessionState({
+        steeringMessage: { id: 'sm-1', userMessage: { text: 'Hello' } },
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageRemoved,
+        session: S, kind: PendingMessageKind.Steering, id: 'sm-unknown',
+      });
+      assert.strictEqual(result, state);
+    });
+
+    it('remove is no-op when no steering message exists', () => {
+      const state = makeSessionState();
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageRemoved,
+        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
+      });
+      assert.strictEqual(result, state);
+    });
+  });
+
+  describe('queued messages', () => {
+    it('sets a new queued message', () => {
+      const state = makeSessionState();
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageSet,
+        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
+        userMessage: { text: 'Do something' },
+      });
+      assert.deepStrictEqual(result.queuedMessages, [
+        { id: 'pm-1', userMessage: { text: 'Do something' } },
+      ]);
+    });
+
+    it('appends when ID is new', () => {
+      const state = makeSessionState({
+        queuedMessages: [{ id: 'pm-1', userMessage: { text: 'First' } }],
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageSet,
+        session: S, kind: PendingMessageKind.Queued, id: 'pm-2',
+        userMessage: { text: 'Second' },
+      });
+      assert.equal(result.queuedMessages!.length, 2);
+      assert.equal(result.queuedMessages![1].id, 'pm-2');
+    });
+
+    it('updates in place when ID already exists', () => {
+      const state = makeSessionState({
+        queuedMessages: [
+          { id: 'pm-1', userMessage: { text: 'First' } },
+          { id: 'pm-2', userMessage: { text: 'Second' } },
+        ],
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageSet,
+        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
+        userMessage: { text: 'Updated first' },
+      });
+      assert.equal(result.queuedMessages!.length, 2);
+      assert.equal(result.queuedMessages![0].userMessage.text, 'Updated first');
+      assert.equal(result.queuedMessages![1].id, 'pm-2');
+    });
+
+    it('removes a queued message', () => {
+      const state = makeSessionState({
+        queuedMessages: [
+          { id: 'pm-1', userMessage: { text: 'First' } },
+          { id: 'pm-2', userMessage: { text: 'Second' } },
+        ],
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageRemoved,
+        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
+      });
+      assert.equal(result.queuedMessages!.length, 1);
+      assert.equal(result.queuedMessages![0].id, 'pm-2');
+    });
+
+    it('removes last queued message and sets array to undefined', () => {
+      const state = makeSessionState({
+        queuedMessages: [{ id: 'pm-1', userMessage: { text: 'Only one' } }],
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageRemoved,
+        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
+      });
+      assert.strictEqual(result.queuedMessages, undefined);
+    });
+
+    it('remove is no-op for unknown ID', () => {
+      const state = makeSessionState({
+        queuedMessages: [{ id: 'pm-1', userMessage: { text: 'Hello' } }],
+      });
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageRemoved,
+        session: S, kind: PendingMessageKind.Queued, id: 'pm-unknown',
+      });
+      assert.strictEqual(result, state);
+    });
+
+    it('remove is no-op when array is empty', () => {
+      const state = makeSessionState();
+      const result = sessionReducer(state, {
+        type: ActionType.SessionPendingMessageRemoved,
+        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
+      });
+      assert.strictEqual(result, state);
+    });
+  });
+
+  it('steering message and queued messages are independent', () => {
+    let state = makeSessionState();
+    state = sessionReducer(state, {
+      type: ActionType.SessionPendingMessageSet,
+      session: S, kind: PendingMessageKind.Steering, id: 's-1',
+      userMessage: { text: 'Steer' },
+    });
+    state = sessionReducer(state, {
+      type: ActionType.SessionPendingMessageSet,
+      session: S, kind: PendingMessageKind.Queued, id: 'q-1',
+      userMessage: { text: 'Queue' },
+    });
+    assert.equal(state.steeringMessage!.userMessage.text, 'Steer');
+    assert.equal(state.queuedMessages!.length, 1);
+    assert.equal(state.queuedMessages![0].userMessage.text, 'Queue');
+  });
+});
+
+// ─── Queued Messages Reorder Tests ───────────────────────────────────────────
+
+describe('sessionReducer — queuedMessagesReordered', () => {
+  it('reorders queued messages', () => {
+    const state = makeSessionState({
+      queuedMessages: [
+        { id: 'a', userMessage: { text: 'A' } },
+        { id: 'b', userMessage: { text: 'B' } },
+        { id: 'c', userMessage: { text: 'C' } },
+      ],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionQueuedMessagesReordered,
+      session: S, order: ['c', 'a', 'b'],
+    });
+    assert.equal(result.queuedMessages!.length, 3);
+    assert.equal(result.queuedMessages![0].id, 'c');
+    assert.equal(result.queuedMessages![1].id, 'a');
+    assert.equal(result.queuedMessages![2].id, 'b');
+  });
+
+  it('keeps messages not in order at the end in original order', () => {
+    const state = makeSessionState({
+      queuedMessages: [
+        { id: 'a', userMessage: { text: 'A' } },
+        { id: 'b', userMessage: { text: 'B' } },
+        { id: 'c', userMessage: { text: 'C' } },
+      ],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionQueuedMessagesReordered,
+      session: S, order: ['c'],
+    });
+    assert.equal(result.queuedMessages!.length, 3);
+    assert.equal(result.queuedMessages![0].id, 'c');
+    assert.equal(result.queuedMessages![1].id, 'a');
+    assert.equal(result.queuedMessages![2].id, 'b');
+  });
+
+  it('ignores unknown IDs in order array', () => {
+    const state = makeSessionState({
+      queuedMessages: [
+        { id: 'a', userMessage: { text: 'A' } },
+        { id: 'b', userMessage: { text: 'B' } },
+      ],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionQueuedMessagesReordered,
+      session: S, order: ['unknown', 'b', 'a', 'also-unknown'],
+    });
+    assert.equal(result.queuedMessages!.length, 2);
+    assert.equal(result.queuedMessages![0].id, 'b');
+    assert.equal(result.queuedMessages![1].id, 'a');
+  });
+
+  it('empty order preserves all messages in original order', () => {
+    const state = makeSessionState({
+      queuedMessages: [{ id: 'a', userMessage: { text: 'A' } }],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionQueuedMessagesReordered,
+      session: S, order: [],
+    });
+    assert.equal(result.queuedMessages!.length, 1);
+    assert.equal(result.queuedMessages![0].id, 'a');
+  });
+
+  it('is no-op when no queued messages exist', () => {
+    const state = makeSessionState();
+    const result = sessionReducer(state, {
+      type: ActionType.SessionQueuedMessagesReordered,
+      session: S, order: ['a', 'b'],
+    });
+    assert.strictEqual(result, state);
   });
 });

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -5,8 +5,8 @@
  */
 
 import { ActionType } from './actions.js';
-import type { IRootState, ISessionState, IToolCallState, IResponsePart, IToolCallResponsePart, ITurn } from './state.js';
-import { SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallCancellationReason, ResponsePartKind } from './state.js';
+import type { IRootState, ISessionState, IToolCallState, IResponsePart, IToolCallResponsePart, ITurn, IPendingMessage } from './state.js';
+import { SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallCancellationReason, ResponsePartKind, PendingMessageKind } from './state.js';
 import type { IRootAction, ISessionAction, IClientSessionAction } from './action-origin.generated.js';
 import { IS_CLIENT_DISPATCHABLE } from './action-origin.generated.js';
 
@@ -451,6 +451,65 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
         ...state,
         activeClient: { ...state.activeClient, tools: action.tools },
       };
+
+    // ── Pending Messages ──────────────────────────────────────────────────
+
+    case ActionType.SessionPendingMessageSet: {
+      const entry: IPendingMessage = { id: action.id, userMessage: action.userMessage };
+      if (action.kind === PendingMessageKind.Steering) {
+        return { ...state, steeringMessage: entry };
+      }
+      const existing = state.queuedMessages ?? [];
+      const idx = existing.findIndex(m => m.id === action.id);
+      if (idx >= 0) {
+        const updated = [...existing];
+        updated[idx] = entry;
+        return { ...state, queuedMessages: updated };
+      }
+      return { ...state, queuedMessages: [...existing, entry] };
+    }
+
+    case ActionType.SessionPendingMessageRemoved: {
+      if (action.kind === PendingMessageKind.Steering) {
+        if (!state.steeringMessage || state.steeringMessage.id !== action.id) {
+          return state;
+        }
+        return { ...state, steeringMessage: undefined };
+      }
+      const existing = state.queuedMessages;
+      if (!existing) {
+        return state;
+      }
+      const filtered = existing.filter(m => m.id !== action.id);
+      return filtered.length === existing.length
+        ? state
+        : { ...state, queuedMessages: filtered.length > 0 ? filtered : undefined };
+    }
+
+    case ActionType.SessionQueuedMessagesReordered: {
+      const existing = state.queuedMessages;
+      if (!existing) {
+        return state;
+      }
+      const byId = new Map(existing.map(m => [m.id, m]));
+      const ordered = new Set<string>();
+      const reordered = action.order
+        .filter(id => {
+          if (byId.has(id) && !ordered.has(id)) {
+            ordered.add(id);
+            return true;
+          }
+          return false;
+        })
+        .map(id => byId.get(id)!);
+      // Append any messages not mentioned in order, preserving original order
+      for (const m of existing) {
+        if (!ordered.has(m.id)) {
+          reordered.push(m);
+        }
+      }
+      return { ...state, queuedMessages: reordered };
+    }
 
     default:
       softAssertNever(action, log);

--- a/types/state.ts
+++ b/types/state.ts
@@ -153,6 +153,36 @@ export interface ISessionModelInfo {
   policyState?: PolicyState;
 }
 
+// ─── Pending Message Types ───────────────────────────────────────────────────
+
+/**
+ * Discriminant for pending message kinds.
+ *
+ * @category Pending Message Types
+ */
+export const enum PendingMessageKind {
+  /** Injected into the current turn at a convenient point */
+  Steering = 'steering',
+  /** Sent automatically as a new turn after the current turn finishes */
+  Queued = 'queued',
+}
+
+/**
+ * A message queued for future delivery to the agent.
+ *
+ * Steering messages are injected into the current turn mid-flight.
+ * Queued messages are automatically started as new turns after the
+ * current turn naturally finishes.
+ *
+ * @category Pending Message Types
+ */
+export interface IPendingMessage {
+  /** Unique identifier for this pending message */
+  id: string;
+  /** The message content */
+  userMessage: IUserMessage;
+}
+
 // ─── Session State ───────────────────────────────────────────────────────────
 
 /**
@@ -199,6 +229,10 @@ export interface ISessionState {
   turns: ITurn[];
   /** Currently in-progress turn */
   activeTurn?: IActiveTurn;
+  /** Message to inject into the current turn at a convenient point */
+  steeringMessage?: IPendingMessage;
+  /** Messages to send automatically as new turns after the current turn finishes */
+  queuedMessages?: IPendingMessage[];
 }
 
 /**

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -47,6 +47,9 @@ export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: numbe
   [ActionType.SessionServerToolsChanged]: 1,
   [ActionType.SessionActiveClientChanged]: 1,
   [ActionType.SessionActiveClientToolsChanged]: 1,
+  [ActionType.SessionPendingMessageSet]: 1,
+  [ActionType.SessionPendingMessageRemoved]: 1,
+  [ActionType.SessionQueuedMessagesReordered]: 1,
 };
 
 /**

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -42,6 +42,7 @@ import type {
   IUsageInfo,
   IErrorInfo,
   ISnapshot,
+  IPendingMessage,
 } from '../state.js';
 
 import type {
@@ -54,6 +55,9 @@ import type {
   ISessionServerToolsChangedAction,
   ISessionActiveClientChangedAction,
   ISessionActiveClientToolsChangedAction,
+  ISessionPendingMessageSetAction,
+  ISessionPendingMessageRemovedAction,
+  ISessionQueuedMessagesReorderedAction,
 } from '../actions.js';
 
 import type {
@@ -124,6 +128,7 @@ type V1_IToolResultFileEditContent = IToolResultFileEditContent;
 type V1_IUsageInfo = IUsageInfo;
 type V1_IErrorInfo = IErrorInfo;
 type V1_ISnapshot = ISnapshot;
+type V1_IPendingMessage = IPendingMessage;
 type V1_IStateAction = IStateAction;
 type V1_IActionEnvelope = IActionEnvelope;
 type V1_IActionOrigin = IActionOrigin;
@@ -133,6 +138,9 @@ type V1_ISessionToolCallDeniedAction = ISessionToolCallDeniedAction;
 type V1_ISessionServerToolsChangedAction = ISessionServerToolsChangedAction;
 type V1_ISessionActiveClientChangedAction = ISessionActiveClientChangedAction;
 type V1_ISessionActiveClientToolsChangedAction = ISessionActiveClientToolsChangedAction;
+type V1_ISessionPendingMessageSetAction = ISessionPendingMessageSetAction;
+type V1_ISessionPendingMessageRemovedAction = ISessionPendingMessageRemovedAction;
+type V1_ISessionQueuedMessagesReorderedAction = ISessionQueuedMessagesReorderedAction;
 type V1_IProtocolNotification = IProtocolNotification;
 type V1_IAuthRequiredNotification = IAuthRequiredNotification;
 type V1_IListSessionsResult = IListSessionsResult;
@@ -228,6 +236,14 @@ type _CheckServerToolsChangedAction = AssertCompatible<V1_ISessionServerToolsCha
 type _CheckActiveClientChangedAction = AssertCompatible<V1_ISessionActiveClientChangedAction, ISessionActiveClientChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckActiveClientToolsChangedAction = AssertCompatible<V1_ISessionActiveClientToolsChangedAction, ISessionActiveClientToolsChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckPendingMessage = AssertCompatible<V1_IPendingMessage, IPendingMessage>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckPendingMessageSetAction = AssertCompatible<V1_ISessionPendingMessageSetAction, ISessionPendingMessageSetAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckPendingMessageRemovedAction = AssertCompatible<V1_ISessionPendingMessageRemovedAction, ISessionPendingMessageRemovedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckQueuedMessagesReorderedAction = AssertCompatible<V1_ISessionQueuedMessagesReorderedAction, ISessionQueuedMessagesReorderedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Add pending message primitives for client-to-agent communication:

- Steering message: single message injected into the current turn
- Queued messages: FIFO queue auto-started as new turns after completion

New actions:
- session/pendingMessageSet (upsert for both kinds)
- session/pendingMessageRemoved (cancel or consume)
- session/queuedMessagesReordered (reorder queue, unmentioned IDs preserved)

New state: ISessionState.steeringMessage, ISessionState.queuedMessages New field: ISessionTurnStartedAction.queuedMessageId for traceability