### PR TITLE
Add editAutoApprovePatterns to session state

### DIFF
--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -712,6 +712,31 @@
         "enabled"
       ]
     },
+    "ISessionEditAutoApprovePatternsChangedAction": {
+      "type": "object",
+      "description": "The session's edit auto-approve patterns have changed.\n\nDispatched by clients to inform the server which file edits may be\nauto-approved. Full-replacement semantics: the `patterns` object\nreplaces the previous `editAutoApprovePatterns` entirely.\n\nThe server enforces these patterns when handling file-edit permission\nrequests: matching writes are auto-approved instead of transitioning\nto `PendingConfirmation`.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionEditAutoApprovePatternsChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "patterns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Glob patterns for edit auto-approval (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "patterns"
+      ]
+    },
     "ISessionPendingMessageSetAction": {
       "type": "object",
       "description": "A pending message was set (upsert semantics: creates or replaces).\n\nFor steering messages, this always replaces the single steering message.\nFor queued messages, if a message with the given `id` already exists it is\nupdated in place; otherwise it is appended to the queue. If the session is\nidle when a queued message is set, the server SHOULD immediately consume it\nand start a new turn.",
@@ -1094,6 +1119,13 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "editAutoApprovePatterns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Client-provided glob patterns that the server uses to decide which\nfile-edit permission requests to auto-approve.\n\nKeys are glob patterns and values are booleans:\n`true` means edits matching the pattern are auto-approved by the server,\n`false` means the server MUST request explicit user confirmation via\n`PendingConfirmation`. The last matching pattern wins.\nEdits not matching any pattern are auto-approved.\n\nClients set this via `editAutoApprovePatterns` on `createSession` or\nby dispatching `session/editAutoApprovePatternsChanged`.\n\nWhen absent, the server SHOULD apply reasonable defaults (e.g. auto-approve\nall edits except known sensitive files like lock files)."
         }
       },
       "required": [
@@ -1772,6 +1804,10 @@
             "$ref": "#/$defs/Icon"
           },
           "description": "Icons for the plugin"
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Opaque version token for this customization.\n\nClients SHOULD include a nonce with every customization they provide.\nConsumers can compare nonces to detect whether a customization has\nchanged since it was last seen, avoiding redundant reloads or copies."
         }
       },
       "required": [
@@ -2043,6 +2079,9 @@
         },
         {
           "$ref": "#/$defs/ISessionCustomizationToggledAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionEditAutoApprovePatternsChangedAction"
         }
       ]
     }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -173,6 +173,13 @@
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Working directory for the session"
+        },
+        "editAutoApprovePatterns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Initial edit auto-approve patterns for the session.\n\nIf provided, the server applies these patterns to the session state\nimmediately at creation time, avoiding a race between session creation\nand the first `session/editAutoApprovePatternsChanged` action."
         }
       },
       "required": [
@@ -705,6 +712,13 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "editAutoApprovePatterns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Client-provided glob patterns that the server uses to decide which\nfile-edit permission requests to auto-approve.\n\nKeys are glob patterns and values are booleans:\n`true` means edits matching the pattern are auto-approved by the server,\n`false` means the server MUST request explicit user confirmation via\n`PendingConfirmation`. The last matching pattern wins.\nEdits not matching any pattern are auto-approved.\n\nClients set this via `editAutoApprovePatterns` on `createSession` or\nby dispatching `session/editAutoApprovePatternsChanged`.\n\nWhen absent, the server SHOULD apply reasonable defaults (e.g. auto-approve\nall edits except known sensitive files like lock files)."
         }
       },
       "required": [
@@ -1383,6 +1397,10 @@
             "$ref": "#/$defs/Icon"
           },
           "description": "Icons for the plugin"
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Opaque version token for this customization.\n\nClients SHOULD include a nonce with every customization they provide.\nConsumers can compare nonces to detect whether a customization has\nchanged since it was last seen, avoiding redundant reloads or copies."
         }
       },
       "required": [
@@ -2193,6 +2211,31 @@
         "session",
         "uri",
         "enabled"
+      ]
+    },
+    "ISessionEditAutoApprovePatternsChangedAction": {
+      "type": "object",
+      "description": "The session's edit auto-approve patterns have changed.\n\nDispatched by clients to inform the server which file edits may be\nauto-approved. Full-replacement semantics: the `patterns` object\nreplaces the previous `editAutoApprovePatterns` entirely.\n\nThe server enforces these patterns when handling file-edit permission\nrequests: matching writes are auto-approved instead of transitioning\nto `PendingConfirmation`.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionEditAutoApprovePatternsChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "patterns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Glob patterns for edit auto-approval (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "patterns"
       ]
     },
     "ISessionPendingMessageSetAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -360,6 +360,13 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "editAutoApprovePatterns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Client-provided glob patterns that the server uses to decide which\nfile-edit permission requests to auto-approve.\n\nKeys are glob patterns and values are booleans:\n`true` means edits matching the pattern are auto-approved by the server,\n`false` means the server MUST request explicit user confirmation via\n`PendingConfirmation`. The last matching pattern wins.\nEdits not matching any pattern are auto-approved.\n\nClients set this via `editAutoApprovePatterns` on `createSession` or\nby dispatching `session/editAutoApprovePatternsChanged`.\n\nWhen absent, the server SHOULD apply reasonable defaults (e.g. auto-approve\nall edits except known sensitive files like lock files)."
         }
       },
       "required": [
@@ -1038,6 +1045,10 @@
             "$ref": "#/$defs/Icon"
           },
           "description": "Icons for the plugin"
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Opaque version token for this customization.\n\nClients SHOULD include a nonce with every customization they provide.\nConsumers can compare nonces to detect whether a customization has\nchanged since it was last seen, avoiding redundant reloads or copies."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -291,6 +291,13 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "editAutoApprovePatterns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Client-provided glob patterns that the server uses to decide which\nfile-edit permission requests to auto-approve.\n\nKeys are glob patterns and values are booleans:\n`true` means edits matching the pattern are auto-approved by the server,\n`false` means the server MUST request explicit user confirmation via\n`PendingConfirmation`. The last matching pattern wins.\nEdits not matching any pattern are auto-approved.\n\nClients set this via `editAutoApprovePatterns` on `createSession` or\nby dispatching `session/editAutoApprovePatternsChanged`.\n\nWhen absent, the server SHOULD apply reasonable defaults (e.g. auto-approve\nall edits except known sensitive files like lock files)."
         }
       },
       "required": [
@@ -969,6 +976,10 @@
             "$ref": "#/$defs/Icon"
           },
           "description": "Icons for the plugin"
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Opaque version token for this customization.\n\nClients SHOULD include a nonce with every customization they provide.\nConsumers can compare nonces to detect whether a customization has\nchanged since it was last seen, avoiding redundant reloads or copies."
         }
       },
       "required": [

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -31,6 +31,7 @@ import type {
   ISessionQueuedMessagesReorderedAction,
   ISessionCustomizationsChangedAction,
   ISessionCustomizationToggledAction,
+  ISessionEditAutoApprovePatternsChangedAction,
 } from './actions.js';
 
 import { ActionType } from './actions.js';
@@ -71,6 +72,7 @@ export type ISessionAction =
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationsChangedAction
   | ISessionCustomizationToggledAction
+  | ISessionEditAutoApprovePatternsChangedAction
 ;
 
 /** Union of session actions that clients may dispatch. */
@@ -87,6 +89,7 @@ export type IClientSessionAction =
   | ISessionPendingMessageRemovedAction
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationToggledAction
+  | ISessionEditAutoApprovePatternsChangedAction
 ;
 
 /** Union of session actions that only the server may produce. */
@@ -142,4 +145,5 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in IStateAction['type']]: boo
   [ActionType.SessionQueuedMessagesReordered]: true,
   [ActionType.SessionCustomizationsChanged]: false,
   [ActionType.SessionCustomizationToggled]: true,
+  [ActionType.SessionEditAutoApprovePatternsChanged]: true,
 };

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -58,6 +58,7 @@ export const enum ActionType {
   SessionQueuedMessagesReordered = 'session/queuedMessagesReordered',
   SessionCustomizationsChanged = 'session/customizationsChanged',
   SessionCustomizationToggled = 'session/customizationToggled',
+  SessionEditAutoApprovePatternsChanged = 'session/editAutoApprovePatternsChanged',
 }
 
 // ─── Action Envelope ─────────────────────────────────────────────────────────
@@ -573,6 +574,29 @@ export interface ISessionCustomizationToggledAction {
   enabled: boolean;
 }
 
+/**
+ * The session's edit auto-approve patterns have changed.
+ *
+ * Dispatched by clients to inform the server which file edits may be
+ * auto-approved. Full-replacement semantics: the `patterns` object
+ * replaces the previous `editAutoApprovePatterns` entirely.
+ *
+ * The server enforces these patterns when handling file-edit permission
+ * requests: matching writes are auto-approved instead of transitioning
+ * to `PendingConfirmation`.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionEditAutoApprovePatternsChangedAction {
+  type: ActionType.SessionEditAutoApprovePatternsChanged;
+  /** Session URI */
+  session: URI;
+  /** Glob patterns for edit auto-approval (full replacement) */
+  patterns: Record<string, boolean>;
+}
+
 // ─── Pending Message Actions ─────────────────────────────────────────────────
 
 /**
@@ -675,4 +699,5 @@ export type IStateAction =
   | ISessionPendingMessageRemovedAction
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationsChangedAction
-  | ISessionCustomizationToggledAction;
+  | ISessionCustomizationToggledAction
+  | ISessionEditAutoApprovePatternsChangedAction;

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -172,6 +172,16 @@ export interface ICreateSessionParams {
   model?: string;
   /** Working directory for the session */
   workingDirectory?: URI;
+  /**
+   * Initial edit auto-approve patterns for the session.
+   *
+   * If provided, the server applies these patterns to the session state
+   * immediately at creation time, avoiding a race between session creation
+   * and the first `session/editAutoApprovePatternsChanged` action.
+   *
+   * @see {@link ISessionState.editAutoApprovePatterns} for semantics.
+   */
+  editAutoApprovePatterns?: Record<string, boolean>;
 }
 
 // ─── disposeSession ──────────────────────────────────────────────────────────

--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -1138,3 +1138,45 @@ describe('sessionReducer — customizations', () => {
     });
   });
 });
+
+// ─── Edit Auto-Approve Patterns Tests ────────────────────────────────────────
+
+describe('sessionReducer - editAutoApprovePatterns', () => {
+  it('sets editAutoApprovePatterns from undefined', () => {
+    const state = makeSessionState();
+    assert.equal(state.editAutoApprovePatterns, undefined);
+
+    const patterns = { '**/*': true, '**/.vscode/*.json': false };
+    const result = sessionReducer(state, {
+      type: ActionType.SessionEditAutoApprovePatternsChanged,
+      session: S,
+      patterns,
+    });
+    assert.deepStrictEqual(result.editAutoApprovePatterns, patterns);
+  });
+
+  it('replaces existing editAutoApprovePatterns', () => {
+    const state = makeSessionState({
+      editAutoApprovePatterns: { '**/*': true },
+    });
+    const newPatterns = { '**/*.ts': true, '**/*.lock': false };
+    const result = sessionReducer(state, {
+      type: ActionType.SessionEditAutoApprovePatternsChanged,
+      session: S,
+      patterns: newPatterns,
+    });
+    assert.deepStrictEqual(result.editAutoApprovePatterns, newPatterns);
+  });
+
+  it('can set empty patterns object', () => {
+    const state = makeSessionState({
+      editAutoApprovePatterns: { '**/*': true },
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionEditAutoApprovePatternsChanged,
+      session: S,
+      patterns: {},
+    });
+    assert.deepStrictEqual(result.editAutoApprovePatterns, {});
+  });
+});

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -485,6 +485,11 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
       return { ...state, customizations: updated };
     }
 
+    // ── Edit Auto-Approve Patterns ────────────────────────────────────────
+
+    case ActionType.SessionEditAutoApprovePatternsChanged:
+      return { ...state, editAutoApprovePatterns: action.patterns };
+
     // ── Pending Messages ──────────────────────────────────────────────────
 
     case ActionType.SessionPendingMessageSet: {

--- a/types/state.ts
+++ b/types/state.ts
@@ -291,6 +291,23 @@ export interface ISessionState {
    * {@link ISessionActiveClient.customizations | activeClient.customizations}.
    */
   customizations?: ISessionCustomization[];
+  /**
+   * Client-provided glob patterns that the server uses to decide which
+   * file-edit permission requests to auto-approve.
+   *
+   * Keys are glob patterns and values are booleans:
+   * `true` means edits matching the pattern are auto-approved by the server,
+   * `false` means the server MUST request explicit user confirmation via
+   * `PendingConfirmation`. The last matching pattern wins.
+   * Edits not matching any pattern are auto-approved.
+   *
+   * Clients set this via `editAutoApprovePatterns` on `createSession` or
+   * by dispatching `session/editAutoApprovePatternsChanged`.
+   *
+   * When absent, the server SHOULD apply reasonable defaults (e.g. auto-approve
+   * all edits except known sensitive files like lock files).
+   */
+  editAutoApprovePatterns?: Record<string, boolean>;
 }
 
 /**

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -52,6 +52,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: numbe
   [ActionType.SessionQueuedMessagesReordered]: 1,
   [ActionType.SessionCustomizationsChanged]: 1,
   [ActionType.SessionCustomizationToggled]: 1,
+  [ActionType.SessionEditAutoApprovePatternsChanged]: 1,
 };
 
 /**

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -63,6 +63,7 @@ import type {
   ISessionQueuedMessagesReorderedAction,
   ISessionCustomizationsChangedAction,
   ISessionCustomizationToggledAction,
+  ISessionEditAutoApprovePatternsChangedAction,
 } from '../actions.js';
 
 import type {
@@ -151,6 +152,7 @@ type V1_ISessionPendingMessageRemovedAction = ISessionPendingMessageRemovedActio
 type V1_ISessionQueuedMessagesReorderedAction = ISessionQueuedMessagesReorderedAction;
 type V1_ISessionCustomizationsChangedAction = ISessionCustomizationsChangedAction;
 type V1_ISessionCustomizationToggledAction = ISessionCustomizationToggledAction;
+type V1_ISessionEditAutoApprovePatternsChangedAction = ISessionEditAutoApprovePatternsChangedAction;
 type V1_IProtocolNotification = IProtocolNotification;
 type V1_IAuthRequiredNotification = IAuthRequiredNotification;
 type V1_IListSessionsResult = IListSessionsResult;
@@ -264,6 +266,8 @@ type _CheckSessionCustomization = AssertCompatible<V1_ISessionCustomization, ISe
 type _CheckCustomizationsChangedAction = AssertCompatible<V1_ISessionCustomizationsChangedAction, ISessionCustomizationsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckCustomizationToggledAction = AssertCompatible<V1_ISessionCustomizationToggledAction, ISessionCustomizationToggledAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckEditAutoApprovePatternsChangedAction = AssertCompatible<V1_ISessionEditAutoApprovePatternsChangedAction, ISessionEditAutoApprovePatternsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Add a new optional field `editAutoApprovePatterns` (`Record<string, boolean>`) to `ISessionState` and `ICreateSessionParams`, plus a new client-dispatchable action `session/editAutoApprovePatternsChanged` for updating patterns mid-session.

## What

Keys are glob patterns, values indicate whether edits matching the pattern should be auto-approved (`true`) or require user confirmation (`false`). The last matching pattern wins. When absent, the server SHOULD apply reasonable defaults (matching the VS Code `chat.tools.edits.autoApprove` setting defaults).

## Changes

- **`types/state.ts`** — Added `editAutoApprovePatterns?: Record<string, boolean>` to `ISessionState`
- **`types/commands.ts`** — Added `editAutoApprovePatterns?: Record<string, boolean>` to `ICreateSessionParams` for race-free initialization
- **`types/actions.ts`** — New `SessionEditAutoApprovePatternsChanged` action type + `ISessionEditAutoApprovePatternsChangedAction` interface (client-dispatchable, full-replacement semantics)
- **`types/reducers.ts`** — Reducer case for the new action
- **`types/reducers.test.ts`** — 3 unit tests for the reducer
- **`types/version/registry.ts`** — Added to `ACTION_INTRODUCED_IN` map
- **`types/version/v1.ts`** — V1 alias + bidirectional compatibility check
- **`types/action-origin.generated.ts`** — Regenerated

No protocol version bump needed per versioning rules (optional field + new action type).

(Written by Copilot)