### PR TITLE
Add settings support to the protocol

### DIFF
--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -109,6 +109,40 @@
         "activeSessions"
       ]
     },
+    "IRootSettingsChangedAction": {
+      "type": "object",
+      "description": "Fired when the client pushes updated settings to the agent host.\n\nThe settings object is applied as a full replacement (not a merge).\nValues should conform to the schema advertised in\n{@link IRootState.settingsSchema | settingsSchema}.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootSettingsChanged"
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "The complete settings values object"
+        }
+      },
+      "required": [
+        "type",
+        "settings"
+      ]
+    },
+    "IRootSettingsSchemaChangedAction": {
+      "type": "object",
+      "description": "Fired when the server updates the settings schema.\n\nThe schema describes which settings the agent host supports, their types,\ndescriptions, and defaults. Clients use this to render a generic settings\neditor.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootSettingsSchemaChanged"
+        },
+        "settingsSchema": {
+          "$ref": "#/$defs/ISettingsSchema",
+          "description": "JSON Schema describing supported settings"
+        }
+      },
+      "required": [
+        "type",
+        "settingsSchema"
+      ]
+    },
     "ISessionReadyAction": {
       "type": "object",
       "description": "Session backend initialized successfully.",
@@ -796,6 +830,28 @@
         "order"
       ]
     },
+    "ISessionSettingsChangedAction": {
+      "type": "object",
+      "description": "Session-level settings have changed.\n\nDispatched by clients to override settings for a specific session.\nOnly settings whose schema has `scope: 'session'` may be set here.\nSession values take precedence over root-level settings.\n\nFull-replacement semantics: the `settings` object replaces the\nprevious session settings entirely.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionSettingsChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Session-level settings overrides (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "settings"
+      ]
+    },
     "ISessionToolCallConfirmedAction": {
       "oneOf": [
         {},
@@ -919,6 +975,117 @@
         "resource"
       ]
     },
+    "ISettingPropertySchema": {
+      "type": "object",
+      "description": "JSON Schema for a single setting property.\n\nSupports standard JSON Schema draft-2020-12 keywords for use in\ngeneric schema-driven settings editors.",
+      "properties": {
+        "type": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "description": "JSON Schema type keyword (e.g. `'string'`, `'object'`, `'boolean'`)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this setting."
+        },
+        "markdownDescription": {
+          "type": "string",
+          "description": "Markdown-formatted description of this setting."
+        },
+        "default": {
+          "description": "Default value for this setting."
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values for this setting."
+        },
+        "enumDescriptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Human-readable descriptions for each enum value."
+        },
+        "items": {
+          "$ref": "#/$defs/ISettingPropertySchema",
+          "description": "Schema for array items."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingPropertySchema"
+          },
+          "description": "Schemas for object properties."
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ISettingPropertySchema"
+            }
+          ],
+          "description": "Schema for additional object properties, or `false` to disallow them."
+        }
+      }
+    },
+    "ISettingRegistration": {
+      "type": "object",
+      "description": "A top-level setting registration in the settings schema.\n\nExtends {@link ISettingPropertySchema} with protocol-specific metadata\nsuch as {@link scope} that only applies at the top level, not to nested\nsub-schemas within a setting's type definition.",
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/SettingScope",
+          "description": "The scope at which this setting can be configured.\n\n- `'root'` — host-wide only; applies to all sessions.\n- `'session'` — can be overridden per session. The session value takes\n  precedence when set; otherwise the root value applies.\n\nDefaults to `'root'` when not specified."
+        }
+      }
+    },
+    "ISettingsSchema": {
+      "type": "object",
+      "description": "JSON Schema describing the settings an agent host supports.\n\nThe top-level schema is always `type: 'object'` with flat dotted keys\nas properties (e.g. `'tools.edits.autoApprove'`). Clients can use this\nschema to render a generic settings editor.\n\nThe server advertises the schema via `root/settingsSchemaChanged`.\nClients push values (conforming to this schema) via `root/settingsChanged`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "object"
+          ],
+          "description": "Always `'object'` for the top-level settings schema."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingRegistration"
+          },
+          "description": "Each key is a flat dotted setting name, value is its registration."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "IAgentHostSettings": {
+      "type": "object",
+      "description": "Settings values for an agent host.\n\nWell-known settings are explicitly typed for compile-time safety.\nThe index signature allows additional dynamic settings that the server\nmay advertise at runtime via {@link ISettingsSchema}.",
+      "properties": {
+        "tools.edits.autoApprove": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Glob-pattern map controlling which file-edit tool calls are auto-approved.\n\nKeys are glob patterns, values are booleans: `true` means edits matching\nthe pattern are auto-approved, `false` means the server MUST request\nexplicit user confirmation. The last matching pattern wins.\n\nEquivalent to VS Code's `chat.tools.edits.autoApprove` setting."
+        }
+      }
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -933,6 +1100,14 @@
         "activeSessions": {
           "type": "number",
           "description": "Number of active (non-disposed) sessions on the server"
+        },
+        "settingsSchema": {
+          "$ref": "#/$defs/ISettingsSchema",
+          "description": "JSON Schema describing the settings this agent host supports.\n\nUpdated by the server via `root/settingsSchemaChanged`. Clients use\nthis to render a settings editor and to validate setting values."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Current settings values, conforming to {@link settingsSchema}.\n\nWell-known keys are typed (e.g. `'tools.edits.autoApprove'`).\nAdditional dynamic keys may appear based on the server's schema.\n\nClients push settings via `root/settingsChanged`. The server applies\nthe object as a whole (full replace, not a merge)."
         }
       },
       "required": [
@@ -1094,6 +1269,10 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Session-level settings overrides.\n\nOnly settings whose schema has `scope: 'session'` may be set here.\nSession values take precedence over the root-level\n{@link IRootState.settings | settings}.\n\nClients push session settings via `session/settingsChanged`."
         }
       },
       "required": [
@@ -1971,6 +2150,12 @@
           "$ref": "#/$defs/IRootActiveSessionsChangedAction"
         },
         {
+          "$ref": "#/$defs/IRootSettingsSchemaChangedAction"
+        },
+        {
+          "$ref": "#/$defs/IRootSettingsChangedAction"
+        },
+        {
           "$ref": "#/$defs/ISessionReadyAction"
         },
         {
@@ -2047,6 +2232,9 @@
         },
         {
           "$ref": "#/$defs/ISessionCustomizationToggledAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionSettingsChangedAction"
         }
       ]
     }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -566,6 +566,117 @@
         "resource"
       ]
     },
+    "ISettingPropertySchema": {
+      "type": "object",
+      "description": "JSON Schema for a single setting property.\n\nSupports standard JSON Schema draft-2020-12 keywords for use in\ngeneric schema-driven settings editors.",
+      "properties": {
+        "type": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "description": "JSON Schema type keyword (e.g. `'string'`, `'object'`, `'boolean'`)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this setting."
+        },
+        "markdownDescription": {
+          "type": "string",
+          "description": "Markdown-formatted description of this setting."
+        },
+        "default": {
+          "description": "Default value for this setting."
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values for this setting."
+        },
+        "enumDescriptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Human-readable descriptions for each enum value."
+        },
+        "items": {
+          "$ref": "#/$defs/ISettingPropertySchema",
+          "description": "Schema for array items."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingPropertySchema"
+          },
+          "description": "Schemas for object properties."
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ISettingPropertySchema"
+            }
+          ],
+          "description": "Schema for additional object properties, or `false` to disallow them."
+        }
+      }
+    },
+    "ISettingRegistration": {
+      "type": "object",
+      "description": "A top-level setting registration in the settings schema.\n\nExtends {@link ISettingPropertySchema} with protocol-specific metadata\nsuch as {@link scope} that only applies at the top level, not to nested\nsub-schemas within a setting's type definition.",
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/SettingScope",
+          "description": "The scope at which this setting can be configured.\n\n- `'root'` — host-wide only; applies to all sessions.\n- `'session'` — can be overridden per session. The session value takes\n  precedence when set; otherwise the root value applies.\n\nDefaults to `'root'` when not specified."
+        }
+      }
+    },
+    "ISettingsSchema": {
+      "type": "object",
+      "description": "JSON Schema describing the settings an agent host supports.\n\nThe top-level schema is always `type: 'object'` with flat dotted keys\nas properties (e.g. `'tools.edits.autoApprove'`). Clients can use this\nschema to render a generic settings editor.\n\nThe server advertises the schema via `root/settingsSchemaChanged`.\nClients push values (conforming to this schema) via `root/settingsChanged`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "object"
+          ],
+          "description": "Always `'object'` for the top-level settings schema."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingRegistration"
+          },
+          "description": "Each key is a flat dotted setting name, value is its registration."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "IAgentHostSettings": {
+      "type": "object",
+      "description": "Settings values for an agent host.\n\nWell-known settings are explicitly typed for compile-time safety.\nThe index signature allows additional dynamic settings that the server\nmay advertise at runtime via {@link ISettingsSchema}.",
+      "properties": {
+        "tools.edits.autoApprove": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Glob-pattern map controlling which file-edit tool calls are auto-approved.\n\nKeys are glob patterns, values are booleans: `true` means edits matching\nthe pattern are auto-approved, `false` means the server MUST request\nexplicit user confirmation. The last matching pattern wins.\n\nEquivalent to VS Code's `chat.tools.edits.autoApprove` setting."
+        }
+      }
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -580,6 +691,14 @@
         "activeSessions": {
           "type": "number",
           "description": "Number of active (non-disposed) sessions on the server"
+        },
+        "settingsSchema": {
+          "$ref": "#/$defs/ISettingsSchema",
+          "description": "JSON Schema describing the settings this agent host supports.\n\nUpdated by the server via `root/settingsSchemaChanged`. Clients use\nthis to render a settings editor and to validate setting values."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Current settings values, conforming to {@link settingsSchema}.\n\nWell-known keys are typed (e.g. `'tools.edits.autoApprove'`).\nAdditional dynamic keys may appear based on the server's schema.\n\nClients push settings via `root/settingsChanged`. The server applies\nthe object as a whole (full replace, not a merge)."
         }
       },
       "required": [
@@ -741,6 +860,10 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Session-level settings overrides.\n\nOnly settings whose schema has `scope: 'session'` may be set here.\nSession values take precedence over the root-level\n{@link IRootState.settings | settings}.\n\nClients push session settings via `session/settingsChanged`."
         }
       },
       "required": [
@@ -1632,6 +1755,40 @@
         "activeSessions"
       ]
     },
+    "IRootSettingsChangedAction": {
+      "type": "object",
+      "description": "Fired when the client pushes updated settings to the agent host.\n\nThe settings object is applied as a full replacement (not a merge).\nValues should conform to the schema advertised in\n{@link IRootState.settingsSchema | settingsSchema}.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootSettingsChanged"
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "The complete settings values object"
+        }
+      },
+      "required": [
+        "type",
+        "settings"
+      ]
+    },
+    "IRootSettingsSchemaChangedAction": {
+      "type": "object",
+      "description": "Fired when the server updates the settings schema.\n\nThe schema describes which settings the agent host supports, their types,\ndescriptions, and defaults. Clients use this to render a generic settings\neditor.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootSettingsSchemaChanged"
+        },
+        "settingsSchema": {
+          "$ref": "#/$defs/ISettingsSchema",
+          "description": "JSON Schema describing supported settings"
+        }
+      },
+      "required": [
+        "type",
+        "settingsSchema"
+      ]
+    },
     "ISessionReadyAction": {
       "type": "object",
       "description": "Session backend initialized successfully.",
@@ -2317,6 +2474,28 @@
         "type",
         "session",
         "order"
+      ]
+    },
+    "ISessionSettingsChangedAction": {
+      "type": "object",
+      "description": "Session-level settings have changed.\n\nDispatched by clients to override settings for a specific session.\nOnly settings whose schema has `scope: 'session'` may be set here.\nSession values take precedence over root-level settings.\n\nFull-replacement semantics: the `settings` object replaces the\nprevious session settings entirely.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionSettingsChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Session-level settings overrides (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "settings"
       ]
     }
   }

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -185,6 +185,117 @@
         "resource"
       ]
     },
+    "ISettingPropertySchema": {
+      "type": "object",
+      "description": "JSON Schema for a single setting property.\n\nSupports standard JSON Schema draft-2020-12 keywords for use in\ngeneric schema-driven settings editors.",
+      "properties": {
+        "type": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "description": "JSON Schema type keyword (e.g. `'string'`, `'object'`, `'boolean'`)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this setting."
+        },
+        "markdownDescription": {
+          "type": "string",
+          "description": "Markdown-formatted description of this setting."
+        },
+        "default": {
+          "description": "Default value for this setting."
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values for this setting."
+        },
+        "enumDescriptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Human-readable descriptions for each enum value."
+        },
+        "items": {
+          "$ref": "#/$defs/ISettingPropertySchema",
+          "description": "Schema for array items."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingPropertySchema"
+          },
+          "description": "Schemas for object properties."
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ISettingPropertySchema"
+            }
+          ],
+          "description": "Schema for additional object properties, or `false` to disallow them."
+        }
+      }
+    },
+    "ISettingRegistration": {
+      "type": "object",
+      "description": "A top-level setting registration in the settings schema.\n\nExtends {@link ISettingPropertySchema} with protocol-specific metadata\nsuch as {@link scope} that only applies at the top level, not to nested\nsub-schemas within a setting's type definition.",
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/SettingScope",
+          "description": "The scope at which this setting can be configured.\n\n- `'root'` — host-wide only; applies to all sessions.\n- `'session'` — can be overridden per session. The session value takes\n  precedence when set; otherwise the root value applies.\n\nDefaults to `'root'` when not specified."
+        }
+      }
+    },
+    "ISettingsSchema": {
+      "type": "object",
+      "description": "JSON Schema describing the settings an agent host supports.\n\nThe top-level schema is always `type: 'object'` with flat dotted keys\nas properties (e.g. `'tools.edits.autoApprove'`). Clients can use this\nschema to render a generic settings editor.\n\nThe server advertises the schema via `root/settingsSchemaChanged`.\nClients push values (conforming to this schema) via `root/settingsChanged`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "object"
+          ],
+          "description": "Always `'object'` for the top-level settings schema."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingRegistration"
+          },
+          "description": "Each key is a flat dotted setting name, value is its registration."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "IAgentHostSettings": {
+      "type": "object",
+      "description": "Settings values for an agent host.\n\nWell-known settings are explicitly typed for compile-time safety.\nThe index signature allows additional dynamic settings that the server\nmay advertise at runtime via {@link ISettingsSchema}.",
+      "properties": {
+        "tools.edits.autoApprove": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Glob-pattern map controlling which file-edit tool calls are auto-approved.\n\nKeys are glob patterns, values are booleans: `true` means edits matching\nthe pattern are auto-approved, `false` means the server MUST request\nexplicit user confirmation. The last matching pattern wins.\n\nEquivalent to VS Code's `chat.tools.edits.autoApprove` setting."
+        }
+      }
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -199,6 +310,14 @@
         "activeSessions": {
           "type": "number",
           "description": "Number of active (non-disposed) sessions on the server"
+        },
+        "settingsSchema": {
+          "$ref": "#/$defs/ISettingsSchema",
+          "description": "JSON Schema describing the settings this agent host supports.\n\nUpdated by the server via `root/settingsSchemaChanged`. Clients use\nthis to render a settings editor and to validate setting values."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Current settings values, conforming to {@link settingsSchema}.\n\nWell-known keys are typed (e.g. `'tools.edits.autoApprove'`).\nAdditional dynamic keys may appear based on the server's schema.\n\nClients push settings via `root/settingsChanged`. The server applies\nthe object as a whole (full replace, not a merge)."
         }
       },
       "required": [
@@ -360,6 +479,10 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Session-level settings overrides.\n\nOnly settings whose schema has `scope: 'session'` may be set here.\nSession values take precedence over the root-level\n{@link IRootState.settings | settings}.\n\nClients push session settings via `session/settingsChanged`."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -116,6 +116,117 @@
         "resource"
       ]
     },
+    "ISettingPropertySchema": {
+      "type": "object",
+      "description": "JSON Schema for a single setting property.\n\nSupports standard JSON Schema draft-2020-12 keywords for use in\ngeneric schema-driven settings editors.",
+      "properties": {
+        "type": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "description": "JSON Schema type keyword (e.g. `'string'`, `'object'`, `'boolean'`)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this setting."
+        },
+        "markdownDescription": {
+          "type": "string",
+          "description": "Markdown-formatted description of this setting."
+        },
+        "default": {
+          "description": "Default value for this setting."
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values for this setting."
+        },
+        "enumDescriptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Human-readable descriptions for each enum value."
+        },
+        "items": {
+          "$ref": "#/$defs/ISettingPropertySchema",
+          "description": "Schema for array items."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingPropertySchema"
+          },
+          "description": "Schemas for object properties."
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ISettingPropertySchema"
+            }
+          ],
+          "description": "Schema for additional object properties, or `false` to disallow them."
+        }
+      }
+    },
+    "ISettingRegistration": {
+      "type": "object",
+      "description": "A top-level setting registration in the settings schema.\n\nExtends {@link ISettingPropertySchema} with protocol-specific metadata\nsuch as {@link scope} that only applies at the top level, not to nested\nsub-schemas within a setting's type definition.",
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/SettingScope",
+          "description": "The scope at which this setting can be configured.\n\n- `'root'` — host-wide only; applies to all sessions.\n- `'session'` — can be overridden per session. The session value takes\n  precedence when set; otherwise the root value applies.\n\nDefaults to `'root'` when not specified."
+        }
+      }
+    },
+    "ISettingsSchema": {
+      "type": "object",
+      "description": "JSON Schema describing the settings an agent host supports.\n\nThe top-level schema is always `type: 'object'` with flat dotted keys\nas properties (e.g. `'tools.edits.autoApprove'`). Clients can use this\nschema to render a generic settings editor.\n\nThe server advertises the schema via `root/settingsSchemaChanged`.\nClients push values (conforming to this schema) via `root/settingsChanged`.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "object"
+          ],
+          "description": "Always `'object'` for the top-level settings schema."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ISettingRegistration"
+          },
+          "description": "Each key is a flat dotted setting name, value is its registration."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "IAgentHostSettings": {
+      "type": "object",
+      "description": "Settings values for an agent host.\n\nWell-known settings are explicitly typed for compile-time safety.\nThe index signature allows additional dynamic settings that the server\nmay advertise at runtime via {@link ISettingsSchema}.",
+      "properties": {
+        "tools.edits.autoApprove": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Glob-pattern map controlling which file-edit tool calls are auto-approved.\n\nKeys are glob patterns, values are booleans: `true` means edits matching\nthe pattern are auto-approved, `false` means the server MUST request\nexplicit user confirmation. The last matching pattern wins.\n\nEquivalent to VS Code's `chat.tools.edits.autoApprove` setting."
+        }
+      }
+    },
     "IRootState": {
       "type": "object",
       "description": "Global state shared with every client subscribed to `agenthost:/root`.",
@@ -130,6 +241,14 @@
         "activeSessions": {
           "type": "number",
           "description": "Number of active (non-disposed) sessions on the server"
+        },
+        "settingsSchema": {
+          "$ref": "#/$defs/ISettingsSchema",
+          "description": "JSON Schema describing the settings this agent host supports.\n\nUpdated by the server via `root/settingsSchemaChanged`. Clients use\nthis to render a settings editor and to validate setting values."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Current settings values, conforming to {@link settingsSchema}.\n\nWell-known keys are typed (e.g. `'tools.edits.autoApprove'`).\nAdditional dynamic keys may appear based on the server's schema.\n\nClients push settings via `root/settingsChanged`. The server applies\nthe object as a whole (full replace, not a merge)."
         }
       },
       "required": [
@@ -291,6 +410,10 @@
             "$ref": "#/$defs/ISessionCustomization"
           },
           "description": "Server-provided customizations active in this session.\n\nClient-provided customizations are available on\n{@link ISessionActiveClient.customizations | activeClient.customizations}."
+        },
+        "settings": {
+          "$ref": "#/$defs/IAgentHostSettings",
+          "description": "Session-level settings overrides.\n\nOnly settings whose schema has `scope: 'session'` may be set here.\nSession values take precedence over the root-level\n{@link IRootState.settings | settings}.\n\nClients push session settings via `session/settingsChanged`."
         }
       },
       "required": [

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -183,7 +183,9 @@ function interfaceToSchema(iface: InterfaceDeclaration, project: Project): JsonS
   };
 
   for (const prop of iface.getProperties()) {
-    const name = prop.getName();
+    const rawName = prop.getName();
+    // Strip surrounding quotes from string-literal property names (e.g. 'tools.edits.autoApprove')
+    const name = rawName.replace(/^['"]|['"]$/g, '');
     const typeText = getPropertyType(prop);
     const desc = getPropertyDescription(prop);
     const propSchema = typeTextToSchema(typeText, project);

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -5,6 +5,8 @@ import type {
   IStateAction,
   IRootAgentsChangedAction,
   IRootActiveSessionsChangedAction,
+  IRootSettingsSchemaChangedAction,
+  IRootSettingsChangedAction,
   ISessionReadyAction,
   ISessionCreationFailedAction,
   ISessionTurnStartedAction,
@@ -31,6 +33,7 @@ import type {
   ISessionQueuedMessagesReorderedAction,
   ISessionCustomizationsChangedAction,
   ISessionCustomizationToggledAction,
+  ISessionSettingsChangedAction,
 } from './actions.js';
 
 import { ActionType } from './actions.js';
@@ -41,6 +44,8 @@ import { ActionType } from './actions.js';
 export type IRootAction =
   | IRootAgentsChangedAction
   | IRootActiveSessionsChangedAction
+  | IRootSettingsSchemaChangedAction
+  | IRootSettingsChangedAction
 ;
 
 /** Union of all session-scoped actions. */
@@ -71,6 +76,7 @@ export type ISessionAction =
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationsChangedAction
   | ISessionCustomizationToggledAction
+  | ISessionSettingsChangedAction
 ;
 
 /** Union of session actions that clients may dispatch. */
@@ -88,6 +94,7 @@ export type IClientSessionAction =
   | ISessionPendingMessageRemovedAction
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationToggledAction
+  | ISessionSettingsChangedAction
 ;
 
 /** Union of session actions that only the server may produce. */
@@ -116,6 +123,8 @@ export type IServerSessionAction =
 export const IS_CLIENT_DISPATCHABLE: { readonly [K in IStateAction['type']]: boolean } = {
   [ActionType.RootAgentsChanged]: false,
   [ActionType.RootActiveSessionsChanged]: false,
+  [ActionType.RootSettingsSchemaChanged]: false,
+  [ActionType.RootSettingsChanged]: true,
   [ActionType.SessionReady]: false,
   [ActionType.SessionCreationFailed]: false,
   [ActionType.SessionTurnStarted]: true,
@@ -142,4 +151,5 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in IStateAction['type']]: boo
   [ActionType.SessionQueuedMessagesReordered]: true,
   [ActionType.SessionCustomizationsChanged]: false,
   [ActionType.SessionCustomizationToggled]: true,
+  [ActionType.SessionSettingsChanged]: true,
 };

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -10,6 +10,8 @@ import type {
   URI,
   StringOrMarkdown,
   IAgentInfo,
+  IAgentHostSettings,
+  ISettingsSchema,
   IErrorInfo,
   IUserMessage,
   IResponsePart,
@@ -32,6 +34,8 @@ import { ToolCallConfirmationReason, ToolCallCancellationReason, PendingMessageK
 export const enum ActionType {
   RootAgentsChanged = 'root/agentsChanged',
   RootActiveSessionsChanged = 'root/activeSessionsChanged',
+  RootSettingsSchemaChanged = 'root/settingsSchemaChanged',
+  RootSettingsChanged = 'root/settingsChanged',
   SessionReady = 'session/ready',
   SessionCreationFailed = 'session/creationFailed',
   SessionTurnStarted = 'session/turnStarted',
@@ -58,6 +62,7 @@ export const enum ActionType {
   SessionQueuedMessagesReordered = 'session/queuedMessagesReordered',
   SessionCustomizationsChanged = 'session/customizationsChanged',
   SessionCustomizationToggled = 'session/customizationToggled',
+  SessionSettingsChanged = 'session/settingsChanged',
 }
 
 // ─── Action Envelope ─────────────────────────────────────────────────────────
@@ -128,6 +133,39 @@ export interface IRootActiveSessionsChangedAction {
   type: ActionType.RootActiveSessionsChanged;
   /** Current count of active sessions */
   activeSessions: number;
+}
+
+/**
+ * Fired when the client pushes updated settings to the agent host.
+ *
+ * The settings object is applied as a full replacement (not a merge).
+ * Values should conform to the schema advertised in
+ * {@link IRootState.settingsSchema | settingsSchema}.
+ *
+ * @category Root Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface IRootSettingsChangedAction {
+  type: ActionType.RootSettingsChanged;
+  /** The complete settings values object */
+  settings: IAgentHostSettings;
+}
+
+/**
+ * Fired when the server updates the settings schema.
+ *
+ * The schema describes which settings the agent host supports, their types,
+ * descriptions, and defaults. Clients use this to render a generic settings
+ * editor.
+ *
+ * @category Root Actions
+ * @version 1
+ */
+export interface IRootSettingsSchemaChangedAction {
+  type: ActionType.RootSettingsSchemaChanged;
+  /** JSON Schema describing supported settings */
+  settingsSchema: ISettingsSchema;
 }
 
 // ─── Session Actions ─────────────────────────────────────────────────────────
@@ -644,6 +682,28 @@ export interface ISessionQueuedMessagesReorderedAction {
   order: string[];
 }
 
+/**
+ * Session-level settings have changed.
+ *
+ * Dispatched by clients to override settings for a specific session.
+ * Only settings whose schema has `scope: 'session'` may be set here.
+ * Session values take precedence over root-level settings.
+ *
+ * Full-replacement semantics: the `settings` object replaces the
+ * previous session settings entirely.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionSettingsChangedAction {
+  type: ActionType.SessionSettingsChanged;
+  /** Session URI */
+  session: URI;
+  /** Session-level settings overrides (full replacement) */
+  settings: IAgentHostSettings;
+}
+
 // ─── Discriminated Union ─────────────────────────────────────────────────────
 
 /**
@@ -652,6 +712,8 @@ export interface ISessionQueuedMessagesReorderedAction {
 export type IStateAction =
   | IRootAgentsChangedAction
   | IRootActiveSessionsChangedAction
+  | IRootSettingsSchemaChangedAction
+  | IRootSettingsChangedAction
   | ISessionReadyAction
   | ISessionCreationFailedAction
   | ISessionTurnStartedAction
@@ -677,4 +739,5 @@ export type IStateAction =
   | ISessionPendingMessageRemovedAction
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationsChangedAction
-  | ISessionCustomizationToggledAction;
+  | ISessionCustomizationToggledAction
+  | ISessionSettingsChangedAction;

--- a/types/index.ts
+++ b/types/index.ts
@@ -13,6 +13,10 @@ export type {
   StringOrMarkdown,
   IRootState,
   IAgentInfo,
+  ISettingsSchema,
+  ISettingPropertySchema,
+  ISettingRegistration,
+  IAgentHostSettings,
   IProtectedResourceMetadata,
   ISessionModelInfo,
   ISessionState,
@@ -59,6 +63,7 @@ export {
   ToolCallCancellationReason,
   ToolResultContentType,
   PendingMessageKind,
+  SettingScope,
 } from './state.js';
 
 // Action types
@@ -67,6 +72,8 @@ export type {
   IActionOrigin,
   IRootAgentsChangedAction,
   IRootActiveSessionsChangedAction,
+  IRootSettingsSchemaChangedAction,
+  IRootSettingsChangedAction,
   ISessionReadyAction,
   ISessionCreationFailedAction,
   ISessionTurnStartedAction,
@@ -93,6 +100,7 @@ export type {
   ISessionPendingMessageSetAction,
   ISessionPendingMessageRemovedAction,
   ISessionQueuedMessagesReorderedAction,
+  ISessionSettingsChangedAction,
   IStateAction,
 } from './actions.js';
 

--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -27,6 +27,7 @@ import {
   ToolCallCancellationReason,
   ResponsePartKind,
   PendingMessageKind,
+  SettingScope,
 } from './state.js';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)));
@@ -223,6 +224,72 @@ describe('rootReducer', () => {
     const agents = [{ provider: 'x', displayName: 'X', description: 'x', models: [] }];
     rootReducer(state, { type: ActionType.RootAgentsChanged, agents });
     assert.deepStrictEqual(state.agents, []);
+  });
+
+  it('handles root/settingsChanged from undefined', () => {
+    const state = makeRootState();
+    assert.equal(state.settings, undefined);
+    const settings = { 'tools.edits.autoApprove': { '**/*.lock': false } };
+    const next = rootReducer(state, { type: ActionType.RootSettingsChanged, settings });
+    assert.deepStrictEqual(next.settings, settings);
+    // Well-known key is typed
+    assert.deepStrictEqual(next.settings!['tools.edits.autoApprove'], { '**/*.lock': false });
+  });
+
+  it('handles root/settingsChanged replacing existing settings', () => {
+    const state = makeRootState({ settings: { 'tools.edits.autoApprove': { '**/*': true } } });
+    const settings = { 'tools.edits.autoApprove': { '**/*.lock': false } };
+    const next = rootReducer(state, { type: ActionType.RootSettingsChanged, settings });
+    assert.deepStrictEqual(next.settings, settings);
+  });
+
+  it('root/settingsChanged preserves other root state fields', () => {
+    const agents = [{ provider: 'copilot', displayName: 'Copilot', description: 'AI', models: [] }];
+    const state = makeRootState({ agents, activeSessions: 3 });
+    const settings = { 'tools.edits.autoApprove': { '**/*.env': false } };
+    const next = rootReducer(state, { type: ActionType.RootSettingsChanged, settings });
+    assert.deepStrictEqual(next.agents, agents);
+    assert.equal(next.activeSessions, 3);
+    assert.deepStrictEqual(next.settings, settings);
+  });
+
+  it('root/settingsChanged supports dynamic keys alongside well-known ones', () => {
+    const state = makeRootState();
+    const settings = {
+      'tools.edits.autoApprove': { '**/*': true },
+      'some.dynamic.setting': 42,
+    };
+    const next = rootReducer(state, { type: ActionType.RootSettingsChanged, settings });
+    assert.deepStrictEqual(next.settings!['tools.edits.autoApprove'], { '**/*': true });
+    assert.equal(next.settings!['some.dynamic.setting'], 42);
+  });
+
+  it('handles root/settingsSchemaChanged', () => {
+    const state = makeRootState();
+    assert.equal(state.settingsSchema, undefined);
+    const settingsSchema = {
+      type: 'object' as const,
+      properties: {
+        'tools.edits.autoApprove': {
+          type: 'object',
+          description: 'Glob patterns controlling edit auto-approval',
+          default: { '**/*': true, '**/.vscode/*.json': false },
+          additionalProperties: { type: 'boolean' },
+          scope: SettingScope.Session,
+        },
+      },
+    };
+    const next = rootReducer(state, { type: ActionType.RootSettingsSchemaChanged, settingsSchema });
+    assert.deepStrictEqual(next.settingsSchema, settingsSchema);
+  });
+
+  it('root/settingsSchemaChanged preserves settings values', () => {
+    const settings = { 'tools.edits.autoApprove': { '**/*': true } };
+    const state = makeRootState({ settings });
+    const settingsSchema = { type: 'object' as const, properties: {} };
+    const next = rootReducer(state, { type: ActionType.RootSettingsSchemaChanged, settingsSchema });
+    assert.deepStrictEqual(next.settings, settings);
+    assert.deepStrictEqual(next.settingsSchema, settingsSchema);
   });
 });
 
@@ -1136,5 +1203,46 @@ describe('sessionReducer — customizations', () => {
       });
       assert.strictEqual(result, state);
     });
+  });
+});
+
+// ─── Session Reducer: Settings ───────────────────────────────────────────────
+
+describe('sessionReducer — settings', () => {
+  it('handles session/settingsChanged from undefined', () => {
+    const state = makeSessionState();
+    assert.equal(state.settings, undefined);
+    const settings = { 'tools.edits.autoApprove': { '**/*.lock': false } };
+    const next = sessionReducer(state, {
+      type: ActionType.SessionSettingsChanged,
+      session: S,
+      settings,
+    });
+    assert.deepStrictEqual(next.settings, settings);
+  });
+
+  it('handles session/settingsChanged replacing existing', () => {
+    const state = makeSessionState({
+      settings: { 'tools.edits.autoApprove': { '**/*': true } },
+    });
+    const settings = { 'tools.edits.autoApprove': { '**/*.lock': false } };
+    const next = sessionReducer(state, {
+      type: ActionType.SessionSettingsChanged,
+      session: S,
+      settings,
+    });
+    assert.deepStrictEqual(next.settings, settings);
+  });
+
+  it('session/settingsChanged preserves other session state', () => {
+    const state = makeSessionState({ lifecycle: SessionLifecycle.Ready });
+    const settings = { 'tools.edits.autoApprove': { '**/*.env': false } };
+    const next = sessionReducer(state, {
+      type: ActionType.SessionSettingsChanged,
+      session: S,
+      settings,
+    });
+    assert.equal(next.lifecycle, SessionLifecycle.Ready);
+    assert.deepStrictEqual(next.settings, settings);
   });
 });

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -184,6 +184,12 @@ export function rootReducer(state: IRootState, action: IRootAction, log?: (msg: 
     case ActionType.RootActiveSessionsChanged:
       return { ...state, activeSessions: action.activeSessions };
 
+    case ActionType.RootSettingsSchemaChanged:
+      return { ...state, settingsSchema: action.settingsSchema };
+
+    case ActionType.RootSettingsChanged:
+      return { ...state, settings: action.settings };
+
     default:
       softAssertNever(action, log);
       return state;
@@ -543,6 +549,9 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
       }
       return { ...state, queuedMessages: reordered };
     }
+
+    case ActionType.SessionSettingsChanged:
+      return { ...state, settings: action.settings };
 
     default:
       softAssertNever(action, log);

--- a/types/state.ts
+++ b/types/state.ts
@@ -142,6 +142,119 @@ export const enum PolicyState {
 }
 
 /**
+ * Scope at which a setting can be configured.
+ *
+ * @category Root State
+ */
+export const enum SettingScope {
+  /**
+   * Setting can only be configured at the root (host-wide) level.
+   * It applies to all sessions uniformly.
+   */
+  Root = 'root',
+  /**
+   * Setting can be configured at the root level and overridden per session.
+   * The session value takes precedence when set; otherwise the root value applies.
+   */
+  Session = 'session',
+}
+
+/**
+ * JSON Schema for a single setting property.
+ *
+ * Supports standard JSON Schema draft-2020-12 keywords for use in
+ * generic schema-driven settings editors.
+ *
+ * @category Root State
+ */
+export interface ISettingPropertySchema {
+  /** JSON Schema type keyword (e.g. `'string'`, `'object'`, `'boolean'`). */
+  type?: string | string[];
+  /** Human-readable description of this setting. */
+  description?: string;
+  /** Markdown-formatted description of this setting. */
+  markdownDescription?: string;
+  /** Default value for this setting. */
+  default?: unknown;
+  /** Allowed values for this setting. */
+  enum?: unknown[];
+  /** Human-readable descriptions for each enum value. */
+  enumDescriptions?: string[];
+  /** Schema for array items. */
+  items?: ISettingPropertySchema;
+  /** Schemas for object properties. */
+  properties?: Record<string, ISettingPropertySchema>;
+  /** Schema for additional object properties, or `false` to disallow them. */
+  additionalProperties?: boolean | ISettingPropertySchema;
+}
+
+/**
+ * A top-level setting registration in the settings schema.
+ *
+ * Extends {@link ISettingPropertySchema} with protocol-specific metadata
+ * such as {@link scope} that only applies at the top level, not to nested
+ * sub-schemas within a setting's type definition.
+ *
+ * @category Root State
+ */
+export interface ISettingRegistration extends ISettingPropertySchema {
+  /**
+   * The scope at which this setting can be configured.
+   *
+   * - `'root'` — host-wide only; applies to all sessions.
+   * - `'session'` — can be overridden per session. The session value takes
+   *   precedence when set; otherwise the root value applies.
+   *
+   * Defaults to `'root'` when not specified.
+   */
+  scope?: SettingScope;
+}
+
+/**
+ * JSON Schema describing the settings an agent host supports.
+ *
+ * The top-level schema is always `type: 'object'` with flat dotted keys
+ * as properties (e.g. `'tools.edits.autoApprove'`). Clients can use this
+ * schema to render a generic settings editor.
+ *
+ * The server advertises the schema via `root/settingsSchemaChanged`.
+ * Clients push values (conforming to this schema) via `root/settingsChanged`.
+ *
+ * @category Root State
+ */
+export interface ISettingsSchema {
+  /** Always `'object'` for the top-level settings schema. */
+  type: 'object';
+  /** Each key is a flat dotted setting name, value is its registration. */
+  properties?: Record<string, ISettingRegistration>;
+}
+
+/**
+ * Settings values for an agent host.
+ *
+ * Well-known settings are explicitly typed for compile-time safety.
+ * The index signature allows additional dynamic settings that the server
+ * may advertise at runtime via {@link ISettingsSchema}.
+ *
+ * @category Root State
+ */
+export interface IAgentHostSettings {
+  /**
+   * Glob-pattern map controlling which file-edit tool calls are auto-approved.
+   *
+   * Keys are glob patterns, values are booleans: `true` means edits matching
+   * the pattern are auto-approved, `false` means the server MUST request
+   * explicit user confirmation. The last matching pattern wins.
+   *
+   * Equivalent to VS Code's `chat.tools.edits.autoApprove` setting.
+   */
+  'tools.edits.autoApprove'?: Record<string, boolean>;
+
+  /** Additional dynamic settings not known at compile time. */
+  [key: string]: unknown;
+}
+
+/**
  * Global state shared with every client subscribed to `agenthost:/root`.
  *
  * @category Root State
@@ -151,6 +264,23 @@ export interface IRootState {
   agents: IAgentInfo[];
   /** Number of active (non-disposed) sessions on the server */
   activeSessions?: number;
+  /**
+   * JSON Schema describing the settings this agent host supports.
+   *
+   * Updated by the server via `root/settingsSchemaChanged`. Clients use
+   * this to render a settings editor and to validate setting values.
+   */
+  settingsSchema?: ISettingsSchema;
+  /**
+   * Current settings values, conforming to {@link settingsSchema}.
+   *
+   * Well-known keys are typed (e.g. `'tools.edits.autoApprove'`).
+   * Additional dynamic keys may appear based on the server's schema.
+   *
+   * Clients push settings via `root/settingsChanged`. The server applies
+   * the object as a whole (full replace, not a merge).
+   */
+  settings?: IAgentHostSettings;
 }
 
 /**
@@ -291,6 +421,16 @@ export interface ISessionState {
    * {@link ISessionActiveClient.customizations | activeClient.customizations}.
    */
   customizations?: ISessionCustomization[];
+  /**
+   * Session-level settings overrides.
+   *
+   * Only settings whose schema has `scope: 'session'` may be set here.
+   * Session values take precedence over the root-level
+   * {@link IRootState.settings | settings}.
+   *
+   * Clients push session settings via `session/settingsChanged`.
+   */
+  settings?: IAgentHostSettings;
 }
 
 /**

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -26,6 +26,8 @@ export const MIN_PROTOCOL_VERSION = 1;
 export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: number } = {
   [ActionType.RootAgentsChanged]: 1,
   [ActionType.RootActiveSessionsChanged]: 1,
+  [ActionType.RootSettingsSchemaChanged]: 1,
+  [ActionType.RootSettingsChanged]: 1,
   [ActionType.SessionReady]: 1,
   [ActionType.SessionCreationFailed]: 1,
   [ActionType.SessionTurnStarted]: 1,
@@ -52,6 +54,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: numbe
   [ActionType.SessionQueuedMessagesReordered]: 1,
   [ActionType.SessionCustomizationsChanged]: 1,
   [ActionType.SessionCustomizationToggled]: 1,
+  [ActionType.SessionSettingsChanged]: 1,
 };
 
 /**

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -12,6 +12,10 @@
 import type {
   IRootState,
   IAgentInfo,
+  ISettingsSchema,
+  ISettingPropertySchema,
+  ISettingRegistration,
+  IAgentHostSettings,
   ISessionModelInfo,
   IProtectedResourceMetadata,
   StringOrMarkdown,
@@ -53,6 +57,8 @@ import type {
   IActionEnvelope,
   IActionOrigin,
   IRootActiveSessionsChangedAction,
+  IRootSettingsSchemaChangedAction,
+  IRootSettingsChangedAction,
   ISessionToolCallApprovedAction,
   ISessionToolCallDeniedAction,
   ISessionServerToolsChangedAction,
@@ -63,6 +69,7 @@ import type {
   ISessionQueuedMessagesReorderedAction,
   ISessionCustomizationsChangedAction,
   ISessionCustomizationToggledAction,
+  ISessionSettingsChangedAction,
 } from '../actions.js';
 
 import type {
@@ -106,6 +113,10 @@ type AssertCompatible<Frozen, _Current extends Frozen> =
 type V1_IRootState = IRootState;
 type V1_StringOrMarkdown = StringOrMarkdown;
 type V1_IAgentInfo = IAgentInfo;
+type V1_ISettingsSchema = ISettingsSchema;
+type V1_ISettingPropertySchema = ISettingPropertySchema;
+type V1_ISettingRegistration = ISettingRegistration;
+type V1_IAgentHostSettings = IAgentHostSettings;
 type V1_IProtectedResourceMetadata = IProtectedResourceMetadata;
 type V1_ISessionModelInfo = ISessionModelInfo;
 type V1_ISessionState = ISessionState;
@@ -153,6 +164,9 @@ type V1_ISessionPendingMessageRemovedAction = ISessionPendingMessageRemovedActio
 type V1_ISessionQueuedMessagesReorderedAction = ISessionQueuedMessagesReorderedAction;
 type V1_ISessionCustomizationsChangedAction = ISessionCustomizationsChangedAction;
 type V1_ISessionCustomizationToggledAction = ISessionCustomizationToggledAction;
+type V1_ISessionSettingsChangedAction = ISessionSettingsChangedAction;
+type V1_IRootSettingsChangedAction = IRootSettingsChangedAction;
+type V1_IRootSettingsSchemaChangedAction = IRootSettingsSchemaChangedAction;
 type V1_IProtocolNotification = IProtocolNotification;
 type V1_IAuthRequiredNotification = IAuthRequiredNotification;
 type V1_IListSessionsResult = IListSessionsResult;
@@ -176,6 +190,14 @@ type _CheckRootState = AssertCompatible<V1_IRootState, IRootState>;
 type _CheckStringOrMarkdown = AssertCompatible<V1_StringOrMarkdown, StringOrMarkdown>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckAgentInfo = AssertCompatible<V1_IAgentInfo, IAgentInfo>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSettingsSchema = AssertCompatible<V1_ISettingsSchema, ISettingsSchema>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSettingPropertySchema = AssertCompatible<V1_ISettingPropertySchema, ISettingPropertySchema>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSettingRegistration = AssertCompatible<V1_ISettingRegistration, ISettingRegistration>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckAgentHostSettings = AssertCompatible<V1_IAgentHostSettings, IAgentHostSettings>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckSessionModelInfo = AssertCompatible<V1_ISessionModelInfo, ISessionModelInfo>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -229,6 +251,10 @@ type _CheckActionOrigin = AssertCompatible<V1_IActionOrigin, IActionOrigin>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckActiveSessionsChangedAction = AssertCompatible<V1_IRootActiveSessionsChangedAction, IRootActiveSessionsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSettingsChangedAction = AssertCompatible<V1_IRootSettingsChangedAction, IRootSettingsChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSettingsSchemaChangedAction = AssertCompatible<V1_IRootSettingsSchemaChangedAction, IRootSettingsSchemaChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallApprovedAction = AssertCompatible<V1_ISessionToolCallApprovedAction, ISessionToolCallApprovedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallDeniedAction = AssertCompatible<V1_ISessionToolCallDeniedAction, ISessionToolCallDeniedAction>;
@@ -268,6 +294,8 @@ type _CheckSessionCustomization = AssertCompatible<V1_ISessionCustomization, ISe
 type _CheckCustomizationsChangedAction = AssertCompatible<V1_ISessionCustomizationsChangedAction, ISessionCustomizationsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckCustomizationToggledAction = AssertCompatible<V1_ISessionCustomizationToggledAction, ISessionCustomizationToggledAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSessionSettingsChangedAction = AssertCompatible<V1_ISessionSettingsChangedAction, ISessionSettingsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Introduce a settings system with server-advertised schema and typed client-pushed values.

## Design

Two complementary pieces on root state:

1. **`settingsSchema?: ISettingsSchema`** — server-advertised JSON Schema describing which settings the host supports, their types, defaults, and descriptions. Updated via `root/settingsSchemaChanged`. Clients use this to render a generic settings editor.

2. **`settings?: IAgentHostSettings`** — client-pushed setting values. Updated via `root/settingsChanged` (full-replace semantics). Well-known keys are explicitly typed for compile-time safety; an index signature allows dynamic settings the server may advertise at runtime.

Session-level overrides are supported: `ISessionState.settings` can override root settings for settings whose schema has `scope: 'session'`.

## New Types

- **`SettingScope`** enum (`'root'` | `'session'`) — declares where a setting can be configured
- **`ISettingPropertySchema`** — recursive JSON Schema subset for setting value types (no `scope`)
- **`ISettingRegistration extends ISettingPropertySchema`** — adds `scope` at the top level only
- **`ISettingsSchema`** — `type: 'object'` with `properties?: Record<string, ISettingRegistration>`
- **`IAgentHostSettings`** — typed well-known keys + `[key: string]: unknown` for dynamic ones

## New Actions

| Action | Direction | Description |
|--------|-----------|-------------|
| `root/settingsSchemaChanged` | Server → Client | Advertise supported settings schema |
| `root/settingsChanged` | Client → Server | Push root-level setting values |
| `session/settingsChanged` | Client → Server | Push per-session setting overrides |

## First Well-Known Setting

`tools.edits.autoApprove` (`Record<string, boolean>`) — glob-pattern map controlling which file-edit tool calls are auto-approved. Equivalent to VS Code's `chat.tools.edits.autoApprove`. Declared with `scope: 'session'` so it can be overridden per-session.

## Other

- Fix in `generate-json-schema.ts` to strip quotes from string-literal property names (e.g. `'tools.edits.autoApprove'` was being emitted as `"'tools.edits.autoApprove'"` in generated schemas)

(Written by Copilot)