### PR TITLE
add methods for truncation and forking sessions

### DIFF
--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -277,6 +277,51 @@ sequenceDiagram
 
 Clients can **set** or **remove** both steering and queued messages at any time using the `session/pendingMessageSet` (upsert) and `session/pendingMessageRemoved` actions with a `kind` discriminant (`'steering'` or `'queued'`).
 
+## Session Truncation
+
+The `session/truncated` action removes turn history from a session. It is **client-dispatchable** — either side can truncate. If the session has an active turn it is silently dropped and the session status returns to `idle`.
+
+- **With `turnId`** — keeps all turns up to and including the specified turn; removes everything after it.
+- **Without `turnId`** — removes all turns (empties the session).
+
+A common pattern is to truncate and then immediately start a new turn with an edited message:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client: User edits message from turn t-2
+
+    Client->>Server: dispatchAction (session/truncated, turnId: t-1)
+    Note over Server: Drops turns after t-1, drops active turn
+
+    Server->>Client: action (session/truncated)
+
+    Client->>Server: dispatchAction (session/turnStarted, edited message)
+    Server->>Client: action (session/turnStarted)
+    Note over Server: New turn begins with edited message
+```
+
+If the `turnId` is not found in the completed turns array, the action is a no-op.
+
+## Session Forking
+
+A new session can be created as a **fork** of an existing session by providing the optional `fork` field in `createSession`. The server populates the new session with content from the source session up to and including the response of the specified turn.
+
+```typescript
+createSession({
+  session: 'copilot:/<new-uuid>',
+  provider: 'copilot',
+  fork: {
+    session: 'copilot:/<source-uuid>',
+    turnId: 't-3',     // copy turns through t-3
+  },
+})
+```
+
+The forked session is an independent copy — subsequent changes to either session do not affect the other. The server broadcasts `notify/sessionAdded` for the new session as usual.
+
 ## Next Steps
 
 - [Actions](/guide/actions) — How state is mutated.

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -712,6 +712,27 @@
         "enabled"
       ]
     },
+    "ISessionTruncatedAction": {
+      "type": "object",
+      "description": "Truncates a session's history. If `turnId` is provided, all turns after that\nturn are removed and the specified turn is kept. If `turnId` is omitted, all\nturns are removed.\n\nIf there is an active turn it is silently dropped and the session status\nreturns to `idle`.\n\nCommon use-case: truncate old data then dispatch a new\n`session/turnStarted` with an edited message.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionTruncated"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Keep turns up to and including this turn. Omit to clear all turns."
+        }
+      },
+      "required": [
+        "type",
+        "session"
+      ]
+    },
     "ISessionPendingMessageSetAction": {
       "type": "object",
       "description": "A pending message was set (upsert semantics: creates or replaces).\n\nFor steering messages, this always replaces the single steering message.\nFor queued messages, if a message with the given `id` already exists it is\nupdated in place; otherwise it is appended to the queue. If the session is\nidle when a queued message is set, the server SHOULD immediately consume it\nand start a new turn.",
@@ -2047,6 +2068,9 @@
         },
         {
           "$ref": "#/$defs/ISessionCustomizationToggledAction"
+        },
+        {
+          "$ref": "#/$defs/ISessionTruncatedAction"
         }
       ]
     }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -154,9 +154,26 @@
         "snapshot"
       ]
     },
-    "ICreateSessionParams": {
+    "ISessionForkSource": {
       "type": "object",
       "description": "Creates a new session with the specified agent provider.\n\nIf the session URI already exists, the server MUST return an error with code\n`-32003` (`SessionAlreadyExists`).\n\nAfter creation, the client should subscribe to the session URI to receive state\nupdates. The server also broadcasts a `notify/sessionAdded` notification to all\nclients.",
+      "properties": {
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the existing session to fork from"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn ID in the source session; content up to and including this turn's response is copied"
+        }
+      },
+      "required": [
+        "session",
+        "turnId"
+      ]
+    },
+    "ICreateSessionParams": {
+      "type": "object",
       "properties": {
         "session": {
           "$ref": "#/$defs/URI",
@@ -173,6 +190,10 @@
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Working directory for the session"
+        },
+        "fork": {
+          "$ref": "#/$defs/ISessionForkSource",
+          "description": "Fork from an existing session. The new session is populated with content\nfrom the source session up to and including the specified turn's response."
         }
       },
       "required": [
@@ -2233,6 +2254,27 @@
         "session",
         "uri",
         "enabled"
+      ]
+    },
+    "ISessionTruncatedAction": {
+      "type": "object",
+      "description": "Truncates a session's history. If `turnId` is provided, all turns after that\nturn are removed and the specified turn is kept. If `turnId` is omitted, all\nturns are removed.\n\nIf there is an active turn it is silently dropped and the session status\nreturns to `idle`.\n\nCommon use-case: truncate old data then dispatch a new\n`session/turnStarted` with an edited message.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionTruncated"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Keep turns up to and including this turn. Omit to clear all turns."
+        }
+      },
+      "required": [
+        "type",
+        "session"
       ]
     },
     "ISessionPendingMessageSetAction": {

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -31,6 +31,7 @@ import type {
   ISessionQueuedMessagesReorderedAction,
   ISessionCustomizationsChangedAction,
   ISessionCustomizationToggledAction,
+  ISessionTruncatedAction,
 } from './actions.js';
 
 import { ActionType } from './actions.js';
@@ -71,6 +72,7 @@ export type ISessionAction =
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationsChangedAction
   | ISessionCustomizationToggledAction
+  | ISessionTruncatedAction
 ;
 
 /** Union of session actions that clients may dispatch. */
@@ -88,6 +90,7 @@ export type IClientSessionAction =
   | ISessionPendingMessageRemovedAction
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationToggledAction
+  | ISessionTruncatedAction
 ;
 
 /** Union of session actions that only the server may produce. */
@@ -142,4 +145,5 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in IStateAction['type']]: boo
   [ActionType.SessionQueuedMessagesReordered]: true,
   [ActionType.SessionCustomizationsChanged]: false,
   [ActionType.SessionCustomizationToggled]: true,
+  [ActionType.SessionTruncated]: true,
 };

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -58,6 +58,7 @@ export const enum ActionType {
   SessionQueuedMessagesReordered = 'session/queuedMessagesReordered',
   SessionCustomizationsChanged = 'session/customizationsChanged',
   SessionCustomizationToggled = 'session/customizationToggled',
+  SessionTruncated = 'session/truncated',
 }
 
 // ─── Action Envelope ─────────────────────────────────────────────────────────
@@ -575,6 +576,31 @@ export interface ISessionCustomizationToggledAction {
   enabled: boolean;
 }
 
+// ─── Truncation ──────────────────────────────────────────────────────────────
+
+/**
+ * Truncates a session's history. If `turnId` is provided, all turns after that
+ * turn are removed and the specified turn is kept. If `turnId` is omitted, all
+ * turns are removed.
+ *
+ * If there is an active turn it is silently dropped and the session status
+ * returns to `idle`.
+ *
+ * Common use-case: truncate old data then dispatch a new
+ * `session/turnStarted` with an edited message.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ISessionTruncatedAction {
+  type: ActionType.SessionTruncated;
+  /** Session URI */
+  session: URI;
+  /** Keep turns up to and including this turn. Omit to clear all turns. */
+  turnId?: string;
+}
+
 // ─── Pending Message Actions ─────────────────────────────────────────────────
 
 /**
@@ -677,4 +703,5 @@ export type IStateAction =
   | ISessionPendingMessageRemovedAction
   | ISessionQueuedMessagesReorderedAction
   | ISessionCustomizationsChangedAction
-  | ISessionCustomizationToggledAction;
+  | ISessionCustomizationToggledAction
+  | ISessionTruncatedAction;

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -163,6 +163,20 @@ export interface ISubscribeResult {
  * { "jsonrpc": "2.0", "id": 2, "error": { "code": -32003, "message": "Session already exists" } }
  * ```
  */
+/**
+ * Identifies a source session and turn to fork from.
+ *
+ * When provided in `createSession`, the server populates the new session with
+ * content from the source session up to and including the response of the
+ * specified turn.
+ */
+export interface ISessionForkSource {
+  /** URI of the existing session to fork from */
+  session: URI;
+  /** Turn ID in the source session; content up to and including this turn's response is copied */
+  turnId: string;
+}
+
 export interface ICreateSessionParams {
   /** Session URI (client-chosen, e.g. `copilot:/<uuid>`) */
   session: URI;
@@ -172,6 +186,11 @@ export interface ICreateSessionParams {
   model?: string;
   /** Working directory for the session */
   workingDirectory?: URI;
+  /**
+   * Fork from an existing session. The new session is populated with content
+   * from the source session up to and including the specified turn's response.
+   */
+  fork?: ISessionForkSource;
 }
 
 // ─── disposeSession ──────────────────────────────────────────────────────────

--- a/types/index.ts
+++ b/types/index.ts
@@ -93,6 +93,7 @@ export type {
   ISessionPendingMessageSetAction,
   ISessionPendingMessageRemovedAction,
   ISessionQueuedMessagesReorderedAction,
+  ISessionTruncatedAction,
   IStateAction,
 } from './actions.js';
 
@@ -126,6 +127,7 @@ export type {
   ISubscribeParams,
   ISubscribeResult,
   ICreateSessionParams,
+  ISessionForkSource,
   IDisposeSessionParams,
   IListSessionsParams,
   IListSessionsResult,

--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -1138,3 +1138,123 @@ describe('sessionReducer — customizations', () => {
     });
   });
 });
+
+// ─── Truncation Tests ────────────────────────────────────────────────────────
+
+describe('sessionReducer — session/truncated', () => {
+  const turn1 = { id: 't1', userMessage: { text: 'First' }, responseParts: [], usage: undefined, state: TurnState.Complete as const };
+  const turn2 = { id: 't2', userMessage: { text: 'Second' }, responseParts: [], usage: undefined, state: TurnState.Complete as const };
+  const turn3 = { id: 't3', userMessage: { text: 'Third' }, responseParts: [], usage: undefined, state: TurnState.Complete as const };
+
+  it('truncates turns after turnId, keeping the specified turn', () => {
+    const state = makeSessionState({
+      lifecycle: SessionLifecycle.Ready,
+      turns: [turn1, turn2, turn3],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+      turnId: 't2',
+    });
+    assert.equal(result.turns.length, 2);
+    assert.equal(result.turns[0].id, 't1');
+    assert.equal(result.turns[1].id, 't2');
+    assert.equal(result.summary.status, SessionStatus.Idle);
+  });
+
+  it('keeps all turns when turnId is the last turn', () => {
+    const state = makeSessionState({
+      lifecycle: SessionLifecycle.Ready,
+      turns: [turn1, turn2],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+      turnId: 't2',
+    });
+    assert.equal(result.turns.length, 2);
+  });
+
+  it('keeps only the first turn when turnId is the first turn', () => {
+    const state = makeSessionState({
+      lifecycle: SessionLifecycle.Ready,
+      turns: [turn1, turn2, turn3],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+      turnId: 't1',
+    });
+    assert.equal(result.turns.length, 1);
+    assert.equal(result.turns[0].id, 't1');
+  });
+
+  it('clears all turns when turnId is omitted', () => {
+    const state = makeSessionState({
+      lifecycle: SessionLifecycle.Ready,
+      turns: [turn1, turn2, turn3],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+    });
+    assert.equal(result.turns.length, 0);
+    assert.equal(result.summary.status, SessionStatus.Idle);
+  });
+
+  it('drops the active turn and sets status to idle', () => {
+    const state = makeSessionStateWithActiveTurn({
+      turns: [turn1, turn2],
+    });
+    assert.ok(state.activeTurn);
+    assert.equal(state.summary.status, SessionStatus.InProgress);
+
+    const result = sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+      turnId: 't1',
+    });
+    assert.equal(result.activeTurn, undefined);
+    assert.equal(result.turns.length, 1);
+    assert.equal(result.turns[0].id, 't1');
+    assert.equal(result.summary.status, SessionStatus.Idle);
+  });
+
+  it('drops active turn even when clearing all turns', () => {
+    const state = makeSessionStateWithActiveTurn();
+    const result = sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+    });
+    assert.equal(result.activeTurn, undefined);
+    assert.equal(result.turns.length, 0);
+    assert.equal(result.summary.status, SessionStatus.Idle);
+  });
+
+  it('is no-op for unknown turnId', () => {
+    const state = makeSessionState({
+      lifecycle: SessionLifecycle.Ready,
+      turns: [turn1, turn2],
+    });
+    const result = sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+      turnId: 'unknown',
+    });
+    assert.strictEqual(result, state);
+  });
+
+  it('does not mutate the original state', () => {
+    const state = makeSessionState({
+      lifecycle: SessionLifecycle.Ready,
+      turns: [turn1, turn2, turn3],
+    });
+    const original = { ...state, turns: [...state.turns] };
+    sessionReducer(state, {
+      type: ActionType.SessionTruncated,
+      session: S,
+      turnId: 't1',
+    });
+    assert.deepStrictEqual(state.turns, original.turns);
+  });
+});

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -485,6 +485,27 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
       return { ...state, customizations: updated };
     }
 
+    // ── Truncation ────────────────────────────────────────────────────────
+
+    case ActionType.SessionTruncated: {
+      let turns: typeof state.turns;
+      if (action.turnId === undefined) {
+        turns = [];
+      } else {
+        const idx = state.turns.findIndex(t => t.id === action.turnId);
+        if (idx < 0) {
+          return state;
+        }
+        turns = state.turns.slice(0, idx + 1);
+      }
+      return {
+        ...state,
+        turns,
+        activeTurn: undefined,
+        summary: { ...state.summary, status: SessionStatus.Idle, modifiedAt: Date.now() },
+      };
+    }
+
     // ── Pending Messages ──────────────────────────────────────────────────
 
     case ActionType.SessionPendingMessageSet: {

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -52,6 +52,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: numbe
   [ActionType.SessionQueuedMessagesReordered]: 1,
   [ActionType.SessionCustomizationsChanged]: 1,
   [ActionType.SessionCustomizationToggled]: 1,
+  [ActionType.SessionTruncated]: 1,
 };
 
 /**

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -63,6 +63,7 @@ import type {
   ISessionQueuedMessagesReorderedAction,
   ISessionCustomizationsChangedAction,
   ISessionCustomizationToggledAction,
+  ISessionTruncatedAction,
 } from '../actions.js';
 
 import type {
@@ -76,6 +77,7 @@ import type {
   IAuthenticateResult,
   IWriteFileParams,
   IWriteFileResult,
+  ISessionForkSource,
 } from '../commands.js';
 
 import type {
@@ -153,6 +155,8 @@ type V1_ISessionPendingMessageRemovedAction = ISessionPendingMessageRemovedActio
 type V1_ISessionQueuedMessagesReorderedAction = ISessionQueuedMessagesReorderedAction;
 type V1_ISessionCustomizationsChangedAction = ISessionCustomizationsChangedAction;
 type V1_ISessionCustomizationToggledAction = ISessionCustomizationToggledAction;
+type V1_ISessionTruncatedAction = ISessionTruncatedAction;
+type V1_ISessionForkSource = ISessionForkSource;
 type V1_IProtocolNotification = IProtocolNotification;
 type V1_IAuthRequiredNotification = IAuthRequiredNotification;
 type V1_IListSessionsResult = IListSessionsResult;
@@ -268,6 +272,10 @@ type _CheckSessionCustomization = AssertCompatible<V1_ISessionCustomization, ISe
 type _CheckCustomizationsChangedAction = AssertCompatible<V1_ISessionCustomizationsChangedAction, ISessionCustomizationsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckCustomizationToggledAction = AssertCompatible<V1_ISessionCustomizationToggledAction, ISessionCustomizationToggledAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckTruncatedAction = AssertCompatible<V1_ISessionTruncatedAction, ISessionTruncatedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSessionForkSource = AssertCompatible<V1_ISessionForkSource, ISessionForkSource>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
This is also==message editing, since a message edit is just a truncation operation followed by a new turn with the edited message.