### PR TITLE
refactor: split out unit test to .json expectation files

### DIFF
--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -1,12 +1,19 @@
 /**
- * Reducer unit tests.
+ * Reducer unit tests — driven by JSON fixtures for cross-language parity.
+ *
+ * Fixture format: { description, reducer, initial, actions, expected }
+ * Fixtures live in types/test-cases/reducers/*.json and can be consumed by
+ * any language implementation to verify reducer parity.
+ *
+ * Tests that are inherently JS-specific (source-code parsing, identity checks)
+ * remain as manual test cases below the fixture-driven tests.
  *
  * Run: npx tsx --test types/reducers.test.ts
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,16 +24,11 @@ import {
 } from './reducers.js';
 import { IS_CLIENT_DISPATCHABLE } from './action-origin.generated.js';
 import { ActionType } from './actions.js';
-import type { IRootState, ISessionState, IToolCallResponsePart } from './state.js';
+import type { IRootState, ISessionState } from './state.js';
 import {
   SessionLifecycle,
   SessionStatus,
   TurnState,
-  ToolCallStatus,
-  ToolCallConfirmationReason,
-  ToolCallCancellationReason,
-  ResponsePartKind,
-  PendingMessageKind,
 } from './state.js';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)));
@@ -35,122 +37,84 @@ function readSource(file: string): string {
   return readFileSync(resolve(root, file), 'utf-8');
 }
 
-// ─── Test Fixtures ───────────────────────────────────────────────────────────
+// ─── Fixture Loading ─────────────────────────────────────────────────────────
 
-const S = 'copilot:/test-session';
-const T = 'turn-1';
-const TC = 'tc-1';
-
-function makeRootState(overrides?: Partial<IRootState>): IRootState {
-  return {
-    agents: [],
-    ...overrides,
-  };
+interface Fixture {
+  description: string;
+  reducer: 'root' | 'session';
+  initial: IRootState | ISessionState;
+  actions: unknown[];
+  expected: IRootState | ISessionState;
 }
 
-function makeSessionState(overrides?: Partial<ISessionState>): ISessionState {
-  return {
-    summary: {
-      resource: S,
-      provider: 'copilot',
-      title: 'Test Session',
-      status: SessionStatus.Idle,
-      createdAt: 1000,
-      modifiedAt: 1000,
-    },
-    lifecycle: SessionLifecycle.Creating,
-    turns: [],
-    ...overrides,
-  };
+/**
+ * Recursively replaces JSON `null` with `undefined` to match TypeScript
+ * reducer output, which uses `undefined` for absent optional fields.
+ */
+function nullToUndefined<T>(value: T): T {
+  if (value === null) return undefined as unknown as T;
+  if (Array.isArray(value)) return value.map(nullToUndefined) as unknown as T;
+  if (typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = nullToUndefined(v);
+    }
+    return result as T;
+  }
+  return value;
 }
 
-function makeSessionStateWithActiveTurn(overrides?: Partial<ISessionState>): ISessionState {
-  return makeSessionState({
-    lifecycle: SessionLifecycle.Ready,
-    summary: {
-      resource: S,
-      provider: 'copilot',
-      title: 'Test Session',
-      status: SessionStatus.InProgress,
-      createdAt: 1000,
-      modifiedAt: 2000,
-    },
-    activeTurn: {
-      id: T,
-      userMessage: { text: 'Hello' },
-      responseParts: [],
-      usage: undefined,
-    },
-    ...overrides,
+const fixtureDir = resolve(root, 'test-cases', 'reducers');
+const fixtureFiles = readdirSync(fixtureDir).filter(f => f.endsWith('.json')).sort();
+
+const fixtures: Fixture[] = fixtureFiles.map(f => {
+  const raw = JSON.parse(readFileSync(resolve(fixtureDir, f), 'utf-8'));
+  return nullToUndefined(raw) as Fixture;
+});
+
+// ─── Fixture-Driven Reducer Tests ────────────────────────────────────────────
+
+/**
+ * The reducers call Date.now() for modifiedAt timestamps.
+ * We mock it to a fixed value (9999) matching what was used during
+ * fixture generation, so expected values match exactly.
+ */
+const MOCK_NOW = 9999;
+let originalDateNow: typeof Date.now;
+
+describe('reducer fixtures', () => {
+  beforeEach(() => {
+    originalDateNow = Date.now;
+    Date.now = () => MOCK_NOW;
   });
-}
 
-/** Starts a tool call in streaming state. */
-function startToolCall(state: ISessionState, toolCallId = TC): ISessionState {
-  return sessionReducer(state, {
-    type: ActionType.SessionToolCallStart,
-    session: S, turnId: T, toolCallId,
-    toolName: 'bash', displayName: 'Run Command',
+  afterEach(() => {
+    Date.now = originalDateNow;
   });
-}
 
-/** Gets tool call response parts from responseParts. */
-function getToolCallParts(state: ISessionState): IToolCallResponsePart[] {
-  const parts = state.activeTurn?.responseParts ?? [];
-  return parts.filter((p): p is IToolCallResponsePart => p.kind === ResponsePartKind.ToolCall);
-}
-
-/** Gets a tool call part by toolCallId. */
-function getToolCallPart(state: ISessionState, toolCallId = TC): IToolCallResponsePart | undefined {
-  return getToolCallParts(state).find(p => p.toolCall.toolCallId === toolCallId);
-}
-
-/** Gets markdown text from responseParts by concatenating all markdown parts. */
-function getMarkdownText(state: ISessionState): string {
-  const parts = state.activeTurn?.responseParts ?? [];
-  return parts
-    .filter(p => p.kind === ResponsePartKind.Markdown)
-    .map(p => (p as { content: string }).content)
-    .join('');
-}
-
-/** Creates a markdown response part and returns updated state. */
-function createMarkdownPart(state: ISessionState, partId: string, turnId = T): ISessionState {
-  return sessionReducer(state, {
-    type: ActionType.SessionResponsePart,
-    session: S,
-    turnId,
-    part: { kind: ResponsePartKind.Markdown, id: partId, content: '' },
-  });
-}
-
-/** Creates a reasoning response part and returns updated state. */
-function createReasoningPart(state: ISessionState, partId: string, turnId = T): ISessionState {
-  return sessionReducer(state, {
-    type: ActionType.SessionResponsePart,
-    session: S,
-    turnId,
-    part: { kind: ResponsePartKind.Reasoning, id: partId, content: '' },
-  });
-}
-
-/** Advances a streaming tool call to running (auto-confirmed). */
-function readyToolCallAutoConfirm(state: ISessionState, toolCallId = TC): ISessionState {
-  return sessionReducer(state, {
-    type: ActionType.SessionToolCallReady,
-    session: S, turnId: T, toolCallId,
-    invocationMessage: 'Run',
-    confirmed: ToolCallConfirmationReason.NotNeeded,
-  });
-}
+  for (const fixture of fixtures) {
+    it(fixture.description, () => {
+      let state = fixture.initial;
+      for (const action of fixture.actions) {
+        if (fixture.reducer === 'root') {
+          state = rootReducer(state as IRootState, action as any);
+        } else {
+          state = sessionReducer(state as ISessionState, action as any);
+        }
+      }
+      assert.deepStrictEqual(state, fixture.expected);
+    });
+  }
+});
 
 // ─── IS_CLIENT_DISPATCHABLE validation ───────────────────────────────────────
+//
+// These tests parse TypeScript source, so they must remain JS-only.
 
 describe('IS_CLIENT_DISPATCHABLE', () => {
   it('matches @clientDispatchable annotations in actions.ts', () => {
     const source = readSource('actions.ts');
 
-    // Parse JSDoc blocks for @clientDispatchable and extract ActionType references
     const jsdocInterfaceRe = /\/\*\*([\s\S]*?)\*\/\s*export\s+(?:interface|type)\s+(\w+)/g;
     const clientDispatchableTypes = new Set<string>();
 
@@ -167,7 +131,6 @@ describe('IS_CLIENT_DISPATCHABLE', () => {
       }
     }
 
-    // Map ActionType enum members to their string values
     const enumValueRe = /(\w+)\s*=\s*'([^']+)'/g;
     const enumMap = new Map<string, string>();
     for (const match of source.matchAll(enumValueRe)) {
@@ -202,1059 +165,44 @@ describe('IS_CLIENT_DISPATCHABLE', () => {
   });
 });
 
-// ─── Root Reducer ────────────────────────────────────────────────────────────
-
-describe('rootReducer', () => {
-  it('handles root/agentsChanged', () => {
-    const state = makeRootState();
-    const agents = [{ provider: 'copilot', displayName: 'Copilot', description: 'AI', models: [] }];
-    const next = rootReducer(state, { type: ActionType.RootAgentsChanged, agents });
-    assert.deepStrictEqual(next.agents, agents);
-  });
-
-  it('handles root/activeSessionsChanged', () => {
-    const state = makeRootState();
-    const next = rootReducer(state, { type: ActionType.RootActiveSessionsChanged, activeSessions: 5 });
-    assert.equal(next.activeSessions, 5);
-  });
-
-  it('does not mutate original state', () => {
-    const state = makeRootState({ agents: [] });
-    const agents = [{ provider: 'x', displayName: 'X', description: 'x', models: [] }];
-    rootReducer(state, { type: ActionType.RootAgentsChanged, agents });
-    assert.deepStrictEqual(state.agents, []);
-  });
-});
-
-// ─── Session Reducer: Lifecycle ──────────────────────────────────────────────
-
-describe('sessionReducer — lifecycle', () => {
-  it('handles session/ready', () => {
-    const state = makeSessionState();
-    const next = sessionReducer(state, { type: ActionType.SessionReady, session: S });
-    assert.equal(next.lifecycle, SessionLifecycle.Ready);
-    assert.equal(next.summary.status, SessionStatus.Idle);
-  });
-
-  it('handles session/creationFailed', () => {
-    const state = makeSessionState();
-    const error = { errorType: 'init', message: 'Failed to start' };
-    const next = sessionReducer(state, { type: ActionType.SessionCreationFailed, session: S, error });
-    assert.equal(next.lifecycle, SessionLifecycle.CreationFailed);
-    assert.deepStrictEqual(next.creationError, error);
-  });
-});
-
-// ─── Session Reducer: Turn Lifecycle ─────────────────────────────────────────
-
-describe('sessionReducer — turn lifecycle', () => {
-  it('handles session/turnStarted', () => {
-    const state = makeSessionState({ lifecycle: SessionLifecycle.Ready });
-    const next = sessionReducer(state, {
-      type: ActionType.SessionTurnStarted, session: S, turnId: T,
-      userMessage: { text: 'Hello' },
-    });
-    assert.equal(next.summary.status, SessionStatus.InProgress);
-    assert.ok(next.activeTurn);
-    assert.equal(next.activeTurn!.id, T);
-    assert.equal(next.activeTurn!.userMessage.text, 'Hello');
-    assert.deepStrictEqual(next.activeTurn!.responseParts, []);
-  });
-
-  it('turnStarted with queuedMessageId removes from queuedMessages', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      queuedMessages: [
-        { id: 'q-1', userMessage: { text: 'First' } },
-        { id: 'q-2', userMessage: { text: 'Second' } },
-      ],
-    });
-    const next = sessionReducer(state, {
-      type: ActionType.SessionTurnStarted, session: S, turnId: T,
-      userMessage: { text: 'First' }, queuedMessageId: 'q-1',
-    });
-    assert.equal(next.queuedMessages!.length, 1);
-    assert.equal(next.queuedMessages![0].id, 'q-2');
-  });
-
-  it('turnStarted with queuedMessageId removes last queued message and sets undefined', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      queuedMessages: [{ id: 'q-1', userMessage: { text: 'Only' } }],
-    });
-    const next = sessionReducer(state, {
-      type: ActionType.SessionTurnStarted, session: S, turnId: T,
-      userMessage: { text: 'Only' }, queuedMessageId: 'q-1',
-    });
-    assert.strictEqual(next.queuedMessages, undefined);
-  });
-
-  it('turnStarted with queuedMessageId removes matching steering message', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      steeringMessage: { id: 's-1', userMessage: { text: 'Steer' } },
-    });
-    const next = sessionReducer(state, {
-      type: ActionType.SessionTurnStarted, session: S, turnId: T,
-      userMessage: { text: 'Steer' }, queuedMessageId: 's-1',
-    });
-    assert.strictEqual(next.steeringMessage, undefined);
-  });
-
-  it('turnStarted without queuedMessageId does not touch pending messages', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      steeringMessage: { id: 's-1', userMessage: { text: 'Steer' } },
-      queuedMessages: [{ id: 'q-1', userMessage: { text: 'Queued' } }],
-    });
-    const next = sessionReducer(state, {
-      type: ActionType.SessionTurnStarted, session: S, turnId: T,
-      userMessage: { text: 'Hello' },
-    });
-    assert.deepStrictEqual(next.steeringMessage, state.steeringMessage);
-    assert.deepStrictEqual(next.queuedMessages, state.queuedMessages);
-  });
-
-  it('handles session/delta', () => {
-    let state = createMarkdownPart(makeSessionStateWithActiveTurn(), 'md-1');
-    state = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'Hello ' });
-    state = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'world' });
-    assert.equal(getMarkdownText(state), 'Hello world');
-  });
-
-  it('ignores session/delta with wrong turnId', () => {
-    let state = createMarkdownPart(makeSessionStateWithActiveTurn(), 'md-1');
-    const next = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: 'wrong-turn', partId: 'md-1', content: 'orphan' });
-    assert.equal(next, state);
-  });
-
-  it('ignores session/delta without activeTurn', () => {
-    const state = makeSessionState();
-    const next = sessionReducer(state, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'orphan' });
-    assert.equal(next, state);
-  });
-
-  it('handles session/responsePart', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const part = { kind: ResponsePartKind.Markdown as const, id: 'md-1', content: '# Title' };
-    const next = sessionReducer(state, { type: ActionType.SessionResponsePart, session: S, turnId: T, part });
-    assert.equal(next.activeTurn!.responseParts.length, 1);
-    assert.deepStrictEqual(next.activeTurn!.responseParts[0], part);
-  });
-
-  it('handles session/turnComplete — finalizes turn', () => {
-    let s = createMarkdownPart(makeSessionStateWithActiveTurn(), 'md-1');
-    s = sessionReducer(s, { type: ActionType.SessionDelta, session: S, turnId: T, partId: 'md-1', content: 'Response text' });
-    s = sessionReducer(s, { type: ActionType.SessionTurnComplete, session: S, turnId: T });
-
-    assert.equal(s.activeTurn, undefined);
-    assert.equal(s.turns.length, 1);
-    assert.equal(s.turns[0].id, T);
-    // responseText is derived from markdown parts
-    const markdownParts = s.turns[0].responseParts.filter(p => p.kind === ResponsePartKind.Markdown);
-    assert.equal(markdownParts.length, 1);
-    assert.equal((markdownParts[0] as { content: string }).content, 'Response text');
-    assert.equal(s.turns[0].state, TurnState.Complete);
-    assert.equal(s.summary.status, SessionStatus.Idle);
-  });
-
-  it('handles session/turnCancelled — finalizes turn', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const next = sessionReducer(state, { type: ActionType.SessionTurnCancelled, session: S, turnId: T });
-    assert.equal(next.activeTurn, undefined);
-    assert.equal(next.turns.length, 1);
-    assert.equal(next.turns[0].state, TurnState.Cancelled);
-    assert.equal(next.summary.status, SessionStatus.Idle);
-  });
-
-  it('handles session/error — finalizes turn with error', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const error = { errorType: 'runtime', message: 'Something broke' };
-    const next = sessionReducer(state, { type: ActionType.SessionError, session: S, turnId: T, error });
-    assert.equal(next.activeTurn, undefined);
-    assert.equal(next.turns.length, 1);
-    assert.equal(next.turns[0].state, TurnState.Error);
-    assert.deepStrictEqual(next.turns[0].error, error);
-    assert.equal(next.summary.status, SessionStatus.Error);
-  });
-
-  it('force-cancels in-progress tool calls on turn completion with skipped reason', () => {
-    let state = startToolCall(makeSessionStateWithActiveTurn());
-    const next = sessionReducer(state, { type: ActionType.SessionTurnComplete, session: S, turnId: T });
-    const toolCallParts = next.turns[0].responseParts.filter(p => p.kind === ResponsePartKind.ToolCall);
-    assert.equal(toolCallParts.length, 1);
-    const tc = (toolCallParts[0] as IToolCallResponsePart).toolCall;
-    assert.equal(tc.status, ToolCallStatus.Cancelled);
-    if (tc.status === ToolCallStatus.Cancelled) {
-      assert.equal(tc.reason, ToolCallCancellationReason.Skipped);
-    }
-  });
-
-  it('ignores turn completion with wrong turnId', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const next = sessionReducer(state, { type: ActionType.SessionTurnComplete, session: S, turnId: 'wrong-turn' });
-    assert.ok(next.activeTurn);
-    assert.equal(next, state);
-  });
-});
-
-// ─── Session Reducer: Tool Call State Machine ────────────────────────────────
-
-describe('sessionReducer — tool calls', () => {
-  it('handles full tool call lifecycle: start → delta → ready → confirmed → complete', () => {
-    let state = startToolCall(makeSessionStateWithActiveTurn());
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Streaming);
-
-    // Delta
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallDelta, session: S, turnId: T, toolCallId: TC,
-      content: 'ls -la', invocationMessage: 'Listing files',
-    });
-    const streaming = getToolCallPart(state)!.toolCall;
-    assert.equal(streaming.status, ToolCallStatus.Streaming);
-    if (streaming.status === ToolCallStatus.Streaming) {
-      assert.equal(streaming.partialInput, 'ls -la');
-      assert.equal(streaming.invocationMessage, 'Listing files');
-    }
-
-    // Ready (no auto-confirm → pending confirmation)
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Run: ls -la', toolInput: 'ls -la',
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
-
-    // Confirmed (approved)
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
-      approved: true, confirmed: ToolCallConfirmationReason.UserAction,
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Running);
-
-    // Complete
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallComplete, session: S, turnId: T, toolCallId: TC,
-      result: { success: true, pastTenseMessage: 'Ran command' },
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Completed);
-  });
-
-  it('handles tool call ready with auto-confirm → running', () => {
-    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    const tc = getToolCallPart(state)!.toolCall;
-    assert.equal(tc.status, ToolCallStatus.Running);
-    if (tc.status === ToolCallStatus.Running) {
-      assert.equal(tc.confirmed, ToolCallConfirmationReason.NotNeeded);
-    }
-  });
-
-  it('handles tool call denied → cancelled', () => {
-    let state = startToolCall(makeSessionStateWithActiveTurn());
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Run: rm -rf /',
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
-      approved: false, reason: ToolCallCancellationReason.Denied,
-    });
-    const tc = getToolCallPart(state)!.toolCall;
-    assert.equal(tc.status, ToolCallStatus.Cancelled);
-    if (tc.status === ToolCallStatus.Cancelled) {
-      assert.equal(tc.reason, ToolCallCancellationReason.Denied);
-    }
-  });
-
-  it('handles tool call complete with result confirmation → pending → approved', () => {
-    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallComplete, session: S, turnId: T, toolCallId: TC,
-      result: { success: true, pastTenseMessage: 'Done' }, requiresResultConfirmation: true,
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingResultConfirmation);
-
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallResultConfirmed, session: S, turnId: T, toolCallId: TC,
-      approved: true,
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Completed);
-  });
-
-  it('handles tool call result denied → cancelled with result-denied reason', () => {
-    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallComplete, session: S, turnId: T, toolCallId: TC,
-      result: { success: true, pastTenseMessage: 'Done' }, requiresResultConfirmation: true,
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallResultConfirmed, session: S, turnId: T, toolCallId: TC,
-      approved: false,
-    });
-    const tc = getToolCallPart(state)!.toolCall;
-    assert.equal(tc.status, ToolCallStatus.Cancelled);
-    if (tc.status === ToolCallStatus.Cancelled) {
-      assert.equal(tc.reason, ToolCallCancellationReason.ResultDenied);
-    }
-  });
-
-  it('handles tool call complete from pending-confirmation with defaulted confirmed', () => {
-    let state = startToolCall(makeSessionStateWithActiveTurn());
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Run',
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallComplete, session: S, turnId: T, toolCallId: TC,
-      result: { success: true, pastTenseMessage: 'Done' },
-    });
-    const tc = getToolCallPart(state)!.toolCall;
-    assert.equal(tc.status, ToolCallStatus.Completed);
-    if (tc.status === ToolCallStatus.Completed) {
-      //@ts-ignore
-      assert.equal(tc.confirmed, ToolCallConfirmationReason.NotNeeded);
-    }
-  });
-
-  it('ignores tool call actions for unknown toolCallId', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const next = sessionReducer(state, {
-      type: ActionType.SessionToolCallDelta, session: S, turnId: T,
-      toolCallId: 'nonexistent', content: 'data',
-    });
-    assert.equal(next, state);
-  });
-});
-
-// ─── Session Reducer: Running → Re-confirmation ─────────────────────────────
-
-describe('sessionReducer — running tool re-confirmation', () => {
-  it('toolCallReady transitions running tool call back to pending-confirmation', () => {
-    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Running);
-
-    // Server re-sends toolCallReady without confirmed, e.g. for a permission check
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Run: rm -rf /tmp/test',
-      _meta: { permissionKind: 'shell', fullCommandText: 'rm -rf /tmp/test' },
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
-
-    // Verify updated invocation message
-    const tc = getToolCallPart(state)!.toolCall;
-    if (tc.status === ToolCallStatus.PendingConfirmation) {
-      assert.equal(tc.invocationMessage, 'Run: rm -rf /tmp/test');
-    }
-  });
-
-  it('toolCallReady re-confirmation approved transitions back to running', () => {
-    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Permission needed',
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
-
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
-      approved: true, confirmed: ToolCallConfirmationReason.UserAction,
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Running);
-  });
-
-  it('toolCallReady re-confirmation denied transitions to cancelled', () => {
-    let state = readyToolCallAutoConfirm(startToolCall(makeSessionStateWithActiveTurn()));
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Permission needed',
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallConfirmed, session: S, turnId: T, toolCallId: TC,
-      approved: false, reason: ToolCallCancellationReason.Denied,
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.Cancelled);
-  });
-
-  it('toolCallReady ignores non-streaming/non-running tool calls', () => {
-    let state = startToolCall(makeSessionStateWithActiveTurn());
-    // Move to pending-confirmation first
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Run',
-    });
-    assert.equal(getToolCallPart(state)!.toolCall.status, ToolCallStatus.PendingConfirmation);
-
-    // Sending toolCallReady again while already pending-confirmation should be ignored
-    const next = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady, session: S, turnId: T, toolCallId: TC,
-      invocationMessage: 'Run again',
-    });
-    assert.equal(next, state);
-  });
-});
-
-// ─── Session Reducer: Metadata ───────────────────────────────────────────────
-
-describe('sessionReducer — metadata', () => {
-  it('handles session/titleChanged and bumps modifiedAt', () => {
-    const state = makeSessionState();
-    const next = sessionReducer(state, { type: ActionType.SessionTitleChanged, session: S, title: 'New Title' });
-    assert.equal(next.summary.title, 'New Title');
-    assert.ok(next.summary.modifiedAt > state.summary.modifiedAt);
-  });
-
-  it('handles session/usage', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const usage = { inputTokens: 100, outputTokens: 50 };
-    const next = sessionReducer(state, { type: ActionType.SessionUsage, session: S, turnId: T, usage });
-    assert.deepStrictEqual(next.activeTurn!.usage, usage);
-  });
-
-  it('handles session/reasoning', () => {
-    let state = createReasoningPart(makeSessionStateWithActiveTurn(), 'r-1');
-    state = sessionReducer(state, { type: ActionType.SessionReasoning, session: S, turnId: T, partId: 'r-1', content: 'Thinking about ' });
-    state = sessionReducer(state, { type: ActionType.SessionReasoning, session: S, turnId: T, partId: 'r-1', content: 'the answer' });
-    const reasoningParts = state.activeTurn!.responseParts.filter(p => p.kind === ResponsePartKind.Reasoning);
-    assert.equal(reasoningParts.length, 1);
-    assert.equal((reasoningParts[0] as { content: string }).content, 'Thinking about the answer');
-  });
-
-  it('handles session/modelChanged and bumps modifiedAt', () => {
-    const state = makeSessionState();
-    const next = sessionReducer(state, { type: ActionType.SessionModelChanged, session: S, model: 'gpt-4' });
-    assert.equal(next.summary.model, 'gpt-4');
-    assert.ok(next.summary.modifiedAt > state.summary.modifiedAt);
-  });
-
-  it('handles session/serverToolsChanged', () => {
-    const state = makeSessionState();
-    const tools = [{ name: 'bash', description: 'Run shell commands' }];
-    const next = sessionReducer(state, { type: ActionType.SessionServerToolsChanged, session: S, tools });
-    assert.deepStrictEqual(next.serverTools, tools);
-  });
-
-  it('handles session/activeClientChanged — set client', () => {
-    const state = makeSessionState();
-    const activeClient = { clientId: 'vscode-1', displayName: 'VS Code', tools: [] };
-    const next = sessionReducer(state, { type: ActionType.SessionActiveClientChanged, session: S, activeClient });
-    assert.deepStrictEqual(next.activeClient, activeClient);
-  });
-
-  it('handles session/activeClientChanged — unset client', () => {
-    const state = makeSessionState({ activeClient: { clientId: 'vscode-1', tools: [] } });
-    const next = sessionReducer(state, { type: ActionType.SessionActiveClientChanged, session: S, activeClient: null });
-    assert.equal(next.activeClient, undefined);
-  });
-
-  it('handles session/activeClientToolsChanged', () => {
-    const state = makeSessionState({ activeClient: { clientId: 'vscode-1', tools: [] } });
-    const tools = [{ name: 'openFile', description: 'Open a file' }];
-    const next = sessionReducer(state, { type: ActionType.SessionActiveClientToolsChanged, session: S, tools });
-    assert.deepStrictEqual(next.activeClient!.tools, tools);
-  });
-
-  it('ignores session/activeClientToolsChanged without activeClient', () => {
-    const state = makeSessionState();
-    const next = sessionReducer(state, { type: ActionType.SessionActiveClientToolsChanged, session: S, tools: [{ name: 'openFile' }] });
-    assert.equal(next, state);
-  });
-});
-
 // ─── Dispatch Validation ─────────────────────────────────────────────────────
 
 describe('isClientDispatchable', () => {
   it('returns true for client-dispatchable actions', () => {
-    const action = { type: ActionType.SessionTurnStarted, session: S, turnId: T, userMessage: { text: 'Hello' } } as const;
+    const action = { type: ActionType.SessionTurnStarted, session: 'x', turnId: 't', userMessage: { text: 'Hello' } } as const;
     assert.equal(isClientDispatchable(action), true);
   });
 
   it('returns false for server-only actions', () => {
-    const action = { type: ActionType.SessionReady, session: S } as const;
+    const action = { type: ActionType.SessionReady, session: 'x' } as const;
     assert.equal(isClientDispatchable(action), false);
   });
 });
 
-// ─── Full Turn Flow Integration Test ─────────────────────────────────────────
+// ─── Immutability Checks ─────────────────────────────────────────────────────
+//
+// Verifying that the reducer does not mutate the input state requires
+// identity checks (===), which can't be expressed in JSON fixtures.
 
-describe('sessionReducer — full turn flow', () => {
-  it('processes a complete turn with tool calls and re-confirmation', () => {
-    let state = makeSessionState({ lifecycle: SessionLifecycle.Ready });
-
-    // Turn started
-    state = sessionReducer(state, {
-      type: ActionType.SessionTurnStarted,
-      session: 's',
-      turnId: 't1',
-      userMessage: { text: 'Fix the bug' },
-    });
-
-    // Create markdown part, then stream delta into it
-    state = sessionReducer(state, {
-      type: ActionType.SessionResponsePart, session: 's', turnId: 't1',
-      part: { kind: ResponsePartKind.Markdown, id: 'md-1', content: '' },
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionDelta, session: 's', turnId: 't1', partId: 'md-1', content: 'I will ',
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionDelta, session: 's', turnId: 't1', partId: 'md-1', content: 'fix it.',
-    });
-
-    // Tool call lifecycle
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallStart,
-      session: 's', turnId: 't1', toolCallId: 'tc1',
-      toolName: 'edit', displayName: 'Edit File',
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady,
-      session: 's', turnId: 't1', toolCallId: 'tc1',
-      invocationMessage: 'Edit main.ts', confirmed: ToolCallConfirmationReason.NotNeeded,
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallComplete,
-      session: 's', turnId: 't1', toolCallId: 'tc1',
-      result: { success: true, pastTenseMessage: 'Edited main.ts' },
-    });
-
-    // Tool call with mid-execution re-confirmation (e.g. permission check)
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallStart,
-      session: 's', turnId: 't1', toolCallId: 'tc2',
-      toolName: 'write', displayName: 'Write File',
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady,
-      session: 's', turnId: 't1', toolCallId: 'tc2',
-      invocationMessage: 'Write /tmp/out', confirmed: ToolCallConfirmationReason.NotNeeded,
-    });
-    // Running tool needs re-confirmation (e.g. permission)
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallReady,
-      session: 's', turnId: 't1', toolCallId: 'tc2',
-      invocationMessage: 'Write to /tmp/out',
-      _meta: { permissionKind: 'write', path: '/tmp/out' },
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallConfirmed,
-      session: 's', turnId: 't1', toolCallId: 'tc2',
-      approved: true, confirmed: ToolCallConfirmationReason.UserAction,
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionToolCallComplete,
-      session: 's', turnId: 't1', toolCallId: 'tc2',
-      result: { success: true, pastTenseMessage: 'Wrote file' },
-    });
-
-    // Usage + reasoning
-    state = sessionReducer(state, {
-      type: ActionType.SessionUsage,
-      session: 's', turnId: 't1',
-      usage: { inputTokens: 200, outputTokens: 100 },
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionResponsePart,
-      session: 's', turnId: 't1',
-      part: { kind: ResponsePartKind.Reasoning, id: 'r-1', content: '' },
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionReasoning,
-      session: 's', turnId: 't1', partId: 'r-1', content: 'The bug was in line 42',
-    });
-
-    // Another markdown response part
-    state = sessionReducer(state, {
-      type: ActionType.SessionResponsePart,
-      session: 's', turnId: 't1',
-      part: { kind: ResponsePartKind.Markdown, id: 'md-2', content: '## Fix applied' },
-    });
-
-    // Turn complete
-    state = sessionReducer(state, {
-      type: ActionType.SessionTurnComplete, session: 's', turnId: 't1',
-    });
-
-    // Verify final state
-    assert.equal(state.activeTurn, undefined);
-    assert.equal(state.turns.length, 1);
-    const turn = state.turns[0];
-    assert.equal(turn.id, 't1');
-    assert.equal(turn.state, TurnState.Complete);
-
-    // Check response parts ordering and content
-    const markdownParts = turn.responseParts.filter(p => p.kind === ResponsePartKind.Markdown);
-    assert.equal(markdownParts.length, 2);
-    assert.equal((markdownParts[0] as { content: string }).content, 'I will fix it.');
-
-    const toolCallParts = turn.responseParts.filter(p => p.kind === ResponsePartKind.ToolCall) as IToolCallResponsePart[];
-    assert.equal(toolCallParts.length, 2);
-    assert.equal(toolCallParts[0].toolCall.status, ToolCallStatus.Completed);
-    assert.equal(toolCallParts[1].toolCall.status, ToolCallStatus.Completed);
-
-    const reasoningParts = turn.responseParts.filter(p => p.kind === ResponsePartKind.Reasoning);
-    assert.equal(reasoningParts.length, 1);
-    assert.equal((reasoningParts[0] as { content: string }).content, 'The bug was in line 42');
-
-    assert.deepStrictEqual(turn.usage, { inputTokens: 200, outputTokens: 100 });
-    assert.equal(state.summary.status, SessionStatus.Idle);
-  });
-});
-
-// ─── Pending Message Tests ───────────────────────────────────────────────────
-
-describe('sessionReducer — pending messages', () => {
-  describe('steering message', () => {
-    it('sets a steering message', () => {
-      const state = makeSessionState();
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageSet,
-        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
-        userMessage: { text: 'Focus on tests' },
-      });
-      assert.deepStrictEqual(result.steeringMessage, {
-        id: 'sm-1', userMessage: { text: 'Focus on tests' },
-      });
-    });
-
-    it('replaces existing steering message', () => {
-      const state = makeSessionState({
-        steeringMessage: { id: 'sm-1', userMessage: { text: 'Old' } },
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageSet,
-        session: S, kind: PendingMessageKind.Steering, id: 'sm-2',
-        userMessage: { text: 'New' },
-      });
-      assert.equal(result.steeringMessage!.id, 'sm-2');
-      assert.equal(result.steeringMessage!.userMessage.text, 'New');
-    });
-
-    it('updates steering message content via set with same ID', () => {
-      const state = makeSessionState({
-        steeringMessage: { id: 'sm-1', userMessage: { text: 'Original' } },
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageSet,
-        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
-        userMessage: { text: 'Updated' },
-      });
-      assert.equal(result.steeringMessage!.id, 'sm-1');
-      assert.equal(result.steeringMessage!.userMessage.text, 'Updated');
-    });
-
-    it('removes steering message', () => {
-      const state = makeSessionState({
-        steeringMessage: { id: 'sm-1', userMessage: { text: 'Steer' } },
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageRemoved,
-        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
-      });
-      assert.strictEqual(result.steeringMessage, undefined);
-    });
-
-    it('remove is no-op for mismatched ID', () => {
-      const state = makeSessionState({
-        steeringMessage: { id: 'sm-1', userMessage: { text: 'Hello' } },
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageRemoved,
-        session: S, kind: PendingMessageKind.Steering, id: 'sm-unknown',
-      });
-      assert.strictEqual(result, state);
-    });
-
-    it('remove is no-op when no steering message exists', () => {
-      const state = makeSessionState();
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageRemoved,
-        session: S, kind: PendingMessageKind.Steering, id: 'sm-1',
-      });
-      assert.strictEqual(result, state);
-    });
+describe('reducer immutability', () => {
+  it('rootReducer does not mutate original state', () => {
+    const state: IRootState = { agents: [] };
+    const agents = [{ provider: 'x', displayName: 'X', description: 'x', models: [] }];
+    rootReducer(state, { type: ActionType.RootAgentsChanged, agents });
+    assert.deepStrictEqual(state.agents, []);
   });
 
-  describe('queued messages', () => {
-    it('sets a new queued message', () => {
-      const state = makeSessionState();
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageSet,
-        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
-        userMessage: { text: 'Do something' },
-      });
-      assert.deepStrictEqual(result.queuedMessages, [
-        { id: 'pm-1', userMessage: { text: 'Do something' } },
-      ]);
-    });
-
-    it('appends when ID is new', () => {
-      const state = makeSessionState({
-        queuedMessages: [{ id: 'pm-1', userMessage: { text: 'First' } }],
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageSet,
-        session: S, kind: PendingMessageKind.Queued, id: 'pm-2',
-        userMessage: { text: 'Second' },
-      });
-      assert.equal(result.queuedMessages!.length, 2);
-      assert.equal(result.queuedMessages![1].id, 'pm-2');
-    });
-
-    it('updates in place when ID already exists', () => {
-      const state = makeSessionState({
-        queuedMessages: [
-          { id: 'pm-1', userMessage: { text: 'First' } },
-          { id: 'pm-2', userMessage: { text: 'Second' } },
-        ],
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageSet,
-        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
-        userMessage: { text: 'Updated first' },
-      });
-      assert.equal(result.queuedMessages!.length, 2);
-      assert.equal(result.queuedMessages![0].userMessage.text, 'Updated first');
-      assert.equal(result.queuedMessages![1].id, 'pm-2');
-    });
-
-    it('removes a queued message', () => {
-      const state = makeSessionState({
-        queuedMessages: [
-          { id: 'pm-1', userMessage: { text: 'First' } },
-          { id: 'pm-2', userMessage: { text: 'Second' } },
-        ],
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageRemoved,
-        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
-      });
-      assert.equal(result.queuedMessages!.length, 1);
-      assert.equal(result.queuedMessages![0].id, 'pm-2');
-    });
-
-    it('removes last queued message and sets array to undefined', () => {
-      const state = makeSessionState({
-        queuedMessages: [{ id: 'pm-1', userMessage: { text: 'Only one' } }],
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageRemoved,
-        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
-      });
-      assert.strictEqual(result.queuedMessages, undefined);
-    });
-
-    it('remove is no-op for unknown ID', () => {
-      const state = makeSessionState({
-        queuedMessages: [{ id: 'pm-1', userMessage: { text: 'Hello' } }],
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageRemoved,
-        session: S, kind: PendingMessageKind.Queued, id: 'pm-unknown',
-      });
-      assert.strictEqual(result, state);
-    });
-
-    it('remove is no-op when array is empty', () => {
-      const state = makeSessionState();
-      const result = sessionReducer(state, {
-        type: ActionType.SessionPendingMessageRemoved,
-        session: S, kind: PendingMessageKind.Queued, id: 'pm-1',
-      });
-      assert.strictEqual(result, state);
-    });
-  });
-
-  it('steering message and queued messages are independent', () => {
-    let state = makeSessionState();
-    state = sessionReducer(state, {
-      type: ActionType.SessionPendingMessageSet,
-      session: S, kind: PendingMessageKind.Steering, id: 's-1',
-      userMessage: { text: 'Steer' },
-    });
-    state = sessionReducer(state, {
-      type: ActionType.SessionPendingMessageSet,
-      session: S, kind: PendingMessageKind.Queued, id: 'q-1',
-      userMessage: { text: 'Queue' },
-    });
-    assert.equal(state.steeringMessage!.userMessage.text, 'Steer');
-    assert.equal(state.queuedMessages!.length, 1);
-    assert.equal(state.queuedMessages![0].userMessage.text, 'Queue');
-  });
-});
-
-// ─── Queued Messages Reorder Tests ───────────────────────────────────────────
-
-describe('sessionReducer — queuedMessagesReordered', () => {
-  it('reorders queued messages', () => {
-    const state = makeSessionState({
-      queuedMessages: [
-        { id: 'a', userMessage: { text: 'A' } },
-        { id: 'b', userMessage: { text: 'B' } },
-        { id: 'c', userMessage: { text: 'C' } },
-      ],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionQueuedMessagesReordered,
-      session: S, order: ['c', 'a', 'b'],
-    });
-    assert.equal(result.queuedMessages!.length, 3);
-    assert.equal(result.queuedMessages![0].id, 'c');
-    assert.equal(result.queuedMessages![1].id, 'a');
-    assert.equal(result.queuedMessages![2].id, 'b');
-  });
-
-  it('keeps messages not in order at the end in original order', () => {
-    const state = makeSessionState({
-      queuedMessages: [
-        { id: 'a', userMessage: { text: 'A' } },
-        { id: 'b', userMessage: { text: 'B' } },
-        { id: 'c', userMessage: { text: 'C' } },
-      ],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionQueuedMessagesReordered,
-      session: S, order: ['c'],
-    });
-    assert.equal(result.queuedMessages!.length, 3);
-    assert.equal(result.queuedMessages![0].id, 'c');
-    assert.equal(result.queuedMessages![1].id, 'a');
-    assert.equal(result.queuedMessages![2].id, 'b');
-  });
-
-  it('ignores unknown IDs in order array', () => {
-    const state = makeSessionState({
-      queuedMessages: [
-        { id: 'a', userMessage: { text: 'A' } },
-        { id: 'b', userMessage: { text: 'B' } },
-      ],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionQueuedMessagesReordered,
-      session: S, order: ['unknown', 'b', 'a', 'also-unknown'],
-    });
-    assert.equal(result.queuedMessages!.length, 2);
-    assert.equal(result.queuedMessages![0].id, 'b');
-    assert.equal(result.queuedMessages![1].id, 'a');
-  });
-
-  it('empty order preserves all messages in original order', () => {
-    const state = makeSessionState({
-      queuedMessages: [{ id: 'a', userMessage: { text: 'A' } }],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionQueuedMessagesReordered,
-      session: S, order: [],
-    });
-    assert.equal(result.queuedMessages!.length, 1);
-    assert.equal(result.queuedMessages![0].id, 'a');
-  });
-
-  it('is no-op when no queued messages exist', () => {
-    const state = makeSessionState();
-    const result = sessionReducer(state, {
-      type: ActionType.SessionQueuedMessagesReordered,
-      session: S, order: ['a', 'b'],
-    });
-    assert.strictEqual(result, state);
-  });
-});
-
-// ─── Customization Tests ─────────────────────────────────────────────────────
-
-describe('sessionReducer — customizations', () => {
-  const cRef1 = { uri: 'https://plugins.example/a', displayName: 'Plugin A' };
-  const cRef2 = { uri: 'https://plugins.example/b', displayName: 'Plugin B' };
-
-  describe('session/customizationsChanged', () => {
-    it('replaces the entire customizations list', () => {
-      const state = makeSessionState();
-      const customizations = [
-        { customization: cRef1, enabled: true },
-        { customization: cRef2, enabled: false, clientId: 'client-1' },
-      ];
-      const result = sessionReducer(state, {
-        type: ActionType.SessionCustomizationsChanged,
-        session: S,
-        customizations,
-      });
-      assert.deepStrictEqual(result.customizations, customizations);
-    });
-
-    it('replaces existing customizations', () => {
-      const state = makeSessionState({
-        customizations: [{ customization: cRef1, enabled: true }],
-      });
-      const customizations = [{ customization: cRef2, enabled: false }];
-      const result = sessionReducer(state, {
-        type: ActionType.SessionCustomizationsChanged,
-        session: S,
-        customizations,
-      });
-      assert.deepStrictEqual(result.customizations, customizations);
-    });
-  });
-
-  describe('session/customizationToggled', () => {
-    it('toggles a customization by URI', () => {
-      const state = makeSessionState({
-        customizations: [
-          { customization: cRef1, enabled: true },
-          { customization: cRef2, enabled: true },
-        ],
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionCustomizationToggled,
-        session: S,
-        uri: cRef1.uri,
-        enabled: false,
-      });
-      assert.equal(result.customizations![0].enabled, false);
-      assert.equal(result.customizations![1].enabled, true);
-    });
-
-    it('is no-op for unknown URI', () => {
-      const state = makeSessionState({
-        customizations: [{ customization: cRef1, enabled: true }],
-      });
-      const result = sessionReducer(state, {
-        type: ActionType.SessionCustomizationToggled,
-        session: S,
-        uri: 'https://plugins.example/unknown',
-        enabled: false,
-      });
-      assert.strictEqual(result, state);
-    });
-
-    it('is no-op when customizations is undefined', () => {
-      const state = makeSessionState();
-      const result = sessionReducer(state, {
-        type: ActionType.SessionCustomizationToggled,
-        session: S,
-        uri: cRef1.uri,
-        enabled: false,
-      });
-      assert.strictEqual(result, state);
-    });
-  });
-});
-
-// ─── Truncation Tests ────────────────────────────────────────────────────────
-
-describe('sessionReducer — session/truncated', () => {
-  const turn1 = { id: 't1', userMessage: { text: 'First' }, responseParts: [], usage: undefined, state: TurnState.Complete as const };
-  const turn2 = { id: 't2', userMessage: { text: 'Second' }, responseParts: [], usage: undefined, state: TurnState.Complete as const };
-  const turn3 = { id: 't3', userMessage: { text: 'Third' }, responseParts: [], usage: undefined, state: TurnState.Complete as const };
-
-  it('truncates turns after turnId, keeping the specified turn', () => {
-    const state = makeSessionState({
+  it('sessionReducer does not mutate original turns array', () => {
+    const turn1 = { id: 't1', userMessage: { text: 'First' }, responseParts: [], usage: undefined, state: TurnState.Complete };
+    const turn2 = { id: 't2', userMessage: { text: 'Second' }, responseParts: [], usage: undefined, state: TurnState.Complete };
+    const turn3 = { id: 't3', userMessage: { text: 'Third' }, responseParts: [], usage: undefined, state: TurnState.Complete };
+    const state: ISessionState = {
+      summary: { resource: 'x', provider: 'copilot', title: 'T', status: SessionStatus.Idle, createdAt: 1000, modifiedAt: 1000 },
       lifecycle: SessionLifecycle.Ready,
       turns: [turn1, turn2, turn3],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-      turnId: 't2',
-    });
-    assert.equal(result.turns.length, 2);
-    assert.equal(result.turns[0].id, 't1');
-    assert.equal(result.turns[1].id, 't2');
-    assert.equal(result.summary.status, SessionStatus.Idle);
-  });
-
-  it('keeps all turns when turnId is the last turn', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      turns: [turn1, turn2],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-      turnId: 't2',
-    });
-    assert.equal(result.turns.length, 2);
-  });
-
-  it('keeps only the first turn when turnId is the first turn', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      turns: [turn1, turn2, turn3],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-      turnId: 't1',
-    });
-    assert.equal(result.turns.length, 1);
-    assert.equal(result.turns[0].id, 't1');
-  });
-
-  it('clears all turns when turnId is omitted', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      turns: [turn1, turn2, turn3],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-    });
-    assert.equal(result.turns.length, 0);
-    assert.equal(result.summary.status, SessionStatus.Idle);
-  });
-
-  it('drops the active turn and sets status to idle', () => {
-    const state = makeSessionStateWithActiveTurn({
-      turns: [turn1, turn2],
-    });
-    assert.ok(state.activeTurn);
-    assert.equal(state.summary.status, SessionStatus.InProgress);
-
-    const result = sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-      turnId: 't1',
-    });
-    assert.equal(result.activeTurn, undefined);
-    assert.equal(result.turns.length, 1);
-    assert.equal(result.turns[0].id, 't1');
-    assert.equal(result.summary.status, SessionStatus.Idle);
-  });
-
-  it('drops active turn even when clearing all turns', () => {
-    const state = makeSessionStateWithActiveTurn();
-    const result = sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-    });
-    assert.equal(result.activeTurn, undefined);
-    assert.equal(result.turns.length, 0);
-    assert.equal(result.summary.status, SessionStatus.Idle);
-  });
-
-  it('is no-op for unknown turnId', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      turns: [turn1, turn2],
-    });
-    const result = sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-      turnId: 'unknown',
-    });
-    assert.strictEqual(result, state);
-  });
-
-  it('does not mutate the original state', () => {
-    const state = makeSessionState({
-      lifecycle: SessionLifecycle.Ready,
-      turns: [turn1, turn2, turn3],
-    });
-    const original = { ...state, turns: [...state.turns] };
-    sessionReducer(state, {
-      type: ActionType.SessionTruncated,
-      session: S,
-      turnId: 't1',
-    });
-    assert.deepStrictEqual(state.turns, original.turns);
+    };
+    const original = [...state.turns];
+    sessionReducer(state, { type: ActionType.SessionTruncated, session: 'x', turnId: 't1' });
+    assert.deepStrictEqual(state.turns, original);
   });
 });

--- a/types/test-cases/reducers/001-root-agentschanged.json
+++ b/types/test-cases/reducers/001-root-agentschanged.json
@@ -1,0 +1,30 @@
+{
+  "description": "root/agentsChanged",
+  "reducer": "root",
+  "initial": {
+    "agents": []
+  },
+  "actions": [
+    {
+      "type": "root/agentsChanged",
+      "agents": [
+        {
+          "provider": "copilot",
+          "displayName": "Copilot",
+          "description": "AI",
+          "models": []
+        }
+      ]
+    }
+  ],
+  "expected": {
+    "agents": [
+      {
+        "provider": "copilot",
+        "displayName": "Copilot",
+        "description": "AI",
+        "models": []
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/002-root-activesessionschanged.json
+++ b/types/test-cases/reducers/002-root-activesessionschanged.json
@@ -1,0 +1,17 @@
+{
+  "description": "root/activeSessionsChanged",
+  "reducer": "root",
+  "initial": {
+    "agents": []
+  },
+  "actions": [
+    {
+      "type": "root/activeSessionsChanged",
+      "activeSessions": 5
+    }
+  ],
+  "expected": {
+    "agents": [],
+    "activeSessions": 5
+  }
+}

--- a/types/test-cases/reducers/003-session-ready.json
+++ b/types/test-cases/reducers/003-session-ready.json
@@ -1,0 +1,34 @@
+{
+  "description": "session/ready",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/ready",
+      "session": "copilot:/test-session"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/004-session-creationfailed.json
+++ b/types/test-cases/reducers/004-session-creationfailed.json
@@ -1,0 +1,42 @@
+{
+  "description": "session/creationFailed",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/creationFailed",
+      "session": "copilot:/test-session",
+      "error": {
+        "errorType": "init",
+        "message": "Failed to start"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creationFailed",
+    "turns": [],
+    "creationError": {
+      "errorType": "init",
+      "message": "Failed to start"
+    }
+  }
+}

--- a/types/test-cases/reducers/005-session-turnstarted.json
+++ b/types/test-cases/reducers/005-session-turnstarted.json
@@ -1,0 +1,46 @@
+{
+  "description": "session/turnStarted",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/turnStarted",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/006-turnstarted-with-queuedmessageid-removes-from-queuedmessages.json
+++ b/types/test-cases/reducers/006-turnstarted-with-queuedmessageid-removes-from-queuedmessages.json
@@ -1,0 +1,69 @@
+{
+  "description": "turnStarted with queuedMessageId removes from queuedMessages",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "q-1",
+        "userMessage": {
+          "text": "First"
+        }
+      },
+      {
+        "id": "q-2",
+        "userMessage": {
+          "text": "Second"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/turnStarted",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "userMessage": {
+        "text": "First"
+      },
+      "queuedMessageId": "q-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "q-2",
+        "userMessage": {
+          "text": "Second"
+        }
+      }
+    ],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "First"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/007-turnstarted-with-queuedmessageid-removes-last-queued-message.json
+++ b/types/test-cases/reducers/007-turnstarted-with-queuedmessageid-removes-last-queued-message.json
@@ -1,0 +1,56 @@
+{
+  "description": "turnStarted with queuedMessageId removes last queued message",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "q-1",
+        "userMessage": {
+          "text": "Only"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/turnStarted",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "userMessage": {
+        "text": "Only"
+      },
+      "queuedMessageId": "q-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "queuedMessages": null,
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Only"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/008-turnstarted-with-queuedmessageid-removes-matching-steering-message.json
+++ b/types/test-cases/reducers/008-turnstarted-with-queuedmessageid-removes-matching-steering-message.json
@@ -1,0 +1,54 @@
+{
+  "description": "turnStarted with queuedMessageId removes matching steering message",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "steeringMessage": {
+      "id": "s-1",
+      "userMessage": {
+        "text": "Steer"
+      }
+    }
+  },
+  "actions": [
+    {
+      "type": "session/turnStarted",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "userMessage": {
+        "text": "Steer"
+      },
+      "queuedMessageId": "s-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "steeringMessage": null,
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Steer"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/009-turnstarted-without-queuedmessageid-does-not-touch-pending-messages.json
+++ b/types/test-cases/reducers/009-turnstarted-without-queuedmessageid-does-not-touch-pending-messages.json
@@ -1,0 +1,74 @@
+{
+  "description": "turnStarted without queuedMessageId does not touch pending messages",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "steeringMessage": {
+      "id": "s-1",
+      "userMessage": {
+        "text": "Steer"
+      }
+    },
+    "queuedMessages": [
+      {
+        "id": "q-1",
+        "userMessage": {
+          "text": "Queued"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/turnStarted",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "steeringMessage": {
+      "id": "s-1",
+      "userMessage": {
+        "text": "Steer"
+      }
+    },
+    "queuedMessages": [
+      {
+        "id": "q-1",
+        "userMessage": {
+          "text": "Queued"
+        }
+      }
+    ],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/010-session-delta-appends-content.json
+++ b/types/test-cases/reducers/010-session-delta-appends-content.json
@@ -1,0 +1,76 @@
+{
+  "description": "session/delta appends content",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/responsePart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "part": {
+        "kind": "markdown",
+        "id": "md-1",
+        "content": ""
+      }
+    },
+    {
+      "type": "session/delta",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "partId": "md-1",
+      "content": "Hello "
+    },
+    {
+      "type": "session/delta",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "partId": "md-1",
+      "content": "world"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "markdown",
+          "id": "md-1",
+          "content": "Hello world"
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/011-session-delta-with-wrong-turnid-is-no-op.json
+++ b/types/test-cases/reducers/011-session-delta-with-wrong-turnid-is-no-op.json
@@ -1,0 +1,65 @@
+{
+  "description": "session/delta with wrong turnId is no-op",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "markdown",
+          "id": "md-1",
+          "content": ""
+        }
+      ],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/delta",
+      "session": "copilot:/test-session",
+      "turnId": "wrong-turn",
+      "partId": "md-1",
+      "content": "orphan"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "markdown",
+          "id": "md-1",
+          "content": ""
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/012-session-delta-without-activeturn-is-no-op.json
+++ b/types/test-cases/reducers/012-session-delta-without-activeturn-is-no-op.json
@@ -1,0 +1,37 @@
+{
+  "description": "session/delta without activeTurn is no-op",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/delta",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "partId": "md-1",
+      "content": "orphan"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/013-session-responsepart-adds-to-responseparts.json
+++ b/types/test-cases/reducers/013-session-responsepart-adds-to-responseparts.json
@@ -1,0 +1,62 @@
+{
+  "description": "session/responsePart adds to responseParts",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/responsePart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "part": {
+        "kind": "markdown",
+        "id": "md-1",
+        "content": "# Title"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "markdown",
+          "id": "md-1",
+          "content": "# Title"
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/014-session-turncomplete-finalizes-turn.json
+++ b/types/test-cases/reducers/014-session-turncomplete-finalizes-turn.json
@@ -1,0 +1,78 @@
+{
+  "description": "session/turnComplete finalizes turn",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/responsePart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "part": {
+        "kind": "markdown",
+        "id": "md-1",
+        "content": ""
+      }
+    },
+    {
+      "type": "session/delta",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "partId": "md-1",
+      "content": "Response text"
+    },
+    {
+      "type": "session/turnComplete",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "turn-1",
+        "userMessage": {
+          "text": "Hello"
+        },
+        "responseParts": [
+          {
+            "kind": "markdown",
+            "id": "md-1",
+            "content": "Response text"
+          }
+        ],
+        "usage": null,
+        "state": "complete",
+        "error": null
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/015-session-turncancelled-finalizes-turn.json
+++ b/types/test-cases/reducers/015-session-turncancelled-finalizes-turn.json
@@ -1,0 +1,55 @@
+{
+  "description": "session/turnCancelled finalizes turn",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/turnCancelled",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "turn-1",
+        "userMessage": {
+          "text": "Hello"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "cancelled",
+        "error": null
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/016-session-error-finalizes-turn-with-error.json
+++ b/types/test-cases/reducers/016-session-error-finalizes-turn-with-error.json
@@ -1,0 +1,62 @@
+{
+  "description": "session/error finalizes turn with error",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/error",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "error": {
+        "errorType": "runtime",
+        "message": "Something broke"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "error",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "turn-1",
+        "userMessage": {
+          "text": "Hello"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "error",
+        "error": {
+          "errorType": "runtime",
+          "message": "Something broke"
+        }
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/017-turncomplete-force-cancels-in-progress-tool-calls.json
+++ b/types/test-cases/reducers/017-turncomplete-force-cancels-in-progress-tool-calls.json
@@ -1,0 +1,78 @@
+{
+  "description": "turnComplete force-cancels in-progress tool calls",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/turnComplete",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "turn-1",
+        "userMessage": {
+          "text": "Hello"
+        },
+        "responseParts": [
+          {
+            "kind": "toolCall",
+            "toolCall": {
+              "status": "cancelled",
+              "toolCallId": "tc-1",
+              "toolName": "bash",
+              "displayName": "Run Command",
+              "toolClientId": null,
+              "_meta": null,
+              "invocationMessage": "",
+              "toolInput": null,
+              "reason": "skipped"
+            }
+          }
+        ],
+        "usage": null,
+        "state": "complete",
+        "error": null
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/018-turncomplete-with-wrong-turnid-is-no-op.json
+++ b/types/test-cases/reducers/018-turncomplete-with-wrong-turnid-is-no-op.json
@@ -1,0 +1,51 @@
+{
+  "description": "turnComplete with wrong turnId is no-op",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/turnComplete",
+      "session": "copilot:/test-session",
+      "turnId": "wrong-turn"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/019-tool-call-full-lifecycle-start-delta-ready-confirmed-complete.json
+++ b/types/test-cases/reducers/019-tool-call-full-lifecycle-start-delta-ready-confirmed-complete.json
@@ -1,0 +1,105 @@
+{
+  "description": "tool call full lifecycle: start → delta → ready → confirmed → complete",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallDelta",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "content": "ls -la",
+      "invocationMessage": "Listing files"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run: ls -la",
+      "toolInput": "ls -la"
+    },
+    {
+      "type": "session/toolCallConfirmed",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "approved": true,
+      "confirmed": "user-action"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Ran command"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "completed",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run: ls -la",
+            "toolInput": "ls -la",
+            "confirmed": "user-action",
+            "success": true,
+            "pastTenseMessage": "Ran command"
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/020-tool-call-ready-with-auto-confirm-transitions-to-running.json
+++ b/types/test-cases/reducers/020-tool-call-ready-with-auto-confirm-transitions-to-running.json
@@ -1,0 +1,77 @@
+{
+  "description": "tool call ready with auto-confirm transitions to running",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run",
+      "confirmed": "not-needed"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "running",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run",
+            "toolInput": null,
+            "confirmed": "not-needed"
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/021-tool-call-denied-transitions-to-cancelled.json
+++ b/types/test-cases/reducers/021-tool-call-denied-transitions-to-cancelled.json
@@ -1,0 +1,86 @@
+{
+  "description": "tool call denied transitions to cancelled",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run: rm -rf /"
+    },
+    {
+      "type": "session/toolCallConfirmed",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "approved": false,
+      "reason": "denied"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "cancelled",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run: rm -rf /",
+            "toolInput": null,
+            "reason": "denied",
+            "reasonMessage": null,
+            "userSuggestion": null
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/022-tool-call-result-confirmation-pending-approved.json
+++ b/types/test-cases/reducers/022-tool-call-result-confirmation-pending-approved.json
@@ -1,0 +1,100 @@
+{
+  "description": "tool call result confirmation → pending → approved",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Done"
+      },
+      "requiresResultConfirmation": true
+    },
+    {
+      "type": "session/toolCallResultConfirmed",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "approved": true
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "completed",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run",
+            "toolInput": null,
+            "confirmed": "not-needed",
+            "success": true,
+            "pastTenseMessage": "Done",
+            "content": null,
+            "structuredContent": null,
+            "error": null
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/023-tool-call-result-denied-cancelled-with-result-denied-reason.json
+++ b/types/test-cases/reducers/023-tool-call-result-denied-cancelled-with-result-denied-reason.json
@@ -1,0 +1,95 @@
+{
+  "description": "tool call result denied → cancelled with result-denied reason",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Done"
+      },
+      "requiresResultConfirmation": true
+    },
+    {
+      "type": "session/toolCallResultConfirmed",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "approved": false
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "cancelled",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run",
+            "toolInput": null,
+            "reason": "result-denied"
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/024-tool-call-complete-from-pending-confirmation-defaults-confirmed.json
+++ b/types/test-cases/reducers/024-tool-call-complete-from-pending-confirmation-defaults-confirmed.json
@@ -1,0 +1,88 @@
+{
+  "description": "tool call complete from pending-confirmation defaults confirmed",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Done"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "completed",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run",
+            "toolInput": null,
+            "confirmed": "not-needed",
+            "success": true,
+            "pastTenseMessage": "Done"
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/025-tool-call-actions-for-unknown-toolcallid-are-no-op.json
+++ b/types/test-cases/reducers/025-tool-call-actions-for-unknown-toolcallid-are-no-op.json
@@ -1,0 +1,53 @@
+{
+  "description": "tool call actions for unknown toolCallId are no-op",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallDelta",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "nonexistent",
+      "content": "data"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/026-toolcallready-transitions-running-tool-back-to-pending-confirmation.json
+++ b/types/test-cases/reducers/026-toolcallready-transitions-running-tool-back-to-pending-confirmation.json
@@ -1,0 +1,88 @@
+{
+  "description": "toolCallReady transitions running tool back to pending-confirmation",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run: rm -rf /tmp/test",
+      "_meta": {
+        "permissionKind": "shell",
+        "fullCommandText": "rm -rf /tmp/test"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "pending-confirmation",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run: rm -rf /tmp/test",
+            "toolInput": null,
+            "confirmationTitle": null
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/027-toolcallready-re-confirmation-approved-transitions-back-to-running.json
+++ b/types/test-cases/reducers/027-toolcallready-re-confirmation-approved-transitions-back-to-running.json
@@ -1,0 +1,92 @@
+{
+  "description": "toolCallReady re-confirmation approved transitions back to running",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Permission needed"
+    },
+    {
+      "type": "session/toolCallConfirmed",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "approved": true,
+      "confirmed": "user-action"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "running",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Permission needed",
+            "toolInput": null,
+            "confirmed": "user-action"
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/028-toolcallready-re-confirmation-denied-transitions-to-cancelled.json
+++ b/types/test-cases/reducers/028-toolcallready-re-confirmation-denied-transitions-to-cancelled.json
@@ -1,0 +1,94 @@
+{
+  "description": "toolCallReady re-confirmation denied transitions to cancelled",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Permission needed"
+    },
+    {
+      "type": "session/toolCallConfirmed",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "approved": false,
+      "reason": "denied"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "cancelled",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Permission needed",
+            "toolInput": null,
+            "reason": "denied",
+            "reasonMessage": null,
+            "userSuggestion": null
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/029-toolcallready-ignores-non-streaming-non-running-tool-calls.json
+++ b/types/test-cases/reducers/029-toolcallready-ignores-non-streaming-non-running-tool-calls.json
@@ -1,0 +1,83 @@
+{
+  "description": "toolCallReady ignores non-streaming/non-running tool calls",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "pending-confirmation",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run",
+            "toolInput": null,
+            "confirmationTitle": null
+          }
+        }
+      ],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallReady",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run again"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "pending-confirmation",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "toolClientId": null,
+            "_meta": null,
+            "invocationMessage": "Run",
+            "toolInput": null,
+            "confirmationTitle": null
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/030-session-titlechanged-updates-title.json
+++ b/types/test-cases/reducers/030-session-titlechanged-updates-title.json
@@ -1,0 +1,35 @@
+{
+  "description": "session/titleChanged updates title",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/titleChanged",
+      "session": "copilot:/test-session",
+      "title": "New Title"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "New Title",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/031-session-usage-updates-usage-on-active-turn.json
+++ b/types/test-cases/reducers/031-session-usage-updates-usage-on-active-turn.json
@@ -1,0 +1,58 @@
+{
+  "description": "session/usage updates usage on active turn",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/usage",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "usage": {
+        "inputTokens": 100,
+        "outputTokens": 50
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": {
+        "inputTokens": 100,
+        "outputTokens": 50
+      }
+    }
+  }
+}

--- a/types/test-cases/reducers/032-session-reasoning-appends-reasoning-content.json
+++ b/types/test-cases/reducers/032-session-reasoning-appends-reasoning-content.json
@@ -1,0 +1,76 @@
+{
+  "description": "session/reasoning appends reasoning content",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/responsePart",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "part": {
+        "kind": "reasoning",
+        "id": "r-1",
+        "content": ""
+      }
+    },
+    {
+      "type": "session/reasoning",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "partId": "r-1",
+      "content": "Thinking about "
+    },
+    {
+      "type": "session/reasoning",
+      "session": "copilot:/test-session",
+      "turnId": "turn-1",
+      "partId": "r-1",
+      "content": "the answer"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [
+        {
+          "kind": "reasoning",
+          "id": "r-1",
+          "content": "Thinking about the answer"
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/033-session-modelchanged-updates-model.json
+++ b/types/test-cases/reducers/033-session-modelchanged-updates-model.json
@@ -1,0 +1,36 @@
+{
+  "description": "session/modelChanged updates model",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/modelChanged",
+      "session": "copilot:/test-session",
+      "model": "gpt-4"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999,
+      "model": "gpt-4"
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/034-session-servertoolschanged-sets-server-tools.json
+++ b/types/test-cases/reducers/034-session-servertoolschanged-sets-server-tools.json
@@ -1,0 +1,46 @@
+{
+  "description": "session/serverToolsChanged sets server tools",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/serverToolsChanged",
+      "session": "copilot:/test-session",
+      "tools": [
+        {
+          "name": "bash",
+          "description": "Run shell commands"
+        }
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "serverTools": [
+      {
+        "name": "bash",
+        "description": "Run shell commands"
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/035-session-activeclientchanged-sets-client.json
+++ b/types/test-cases/reducers/035-session-activeclientchanged-sets-client.json
@@ -1,0 +1,44 @@
+{
+  "description": "session/activeClientChanged sets client",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/activeClientChanged",
+      "session": "copilot:/test-session",
+      "activeClient": {
+        "clientId": "vscode-1",
+        "displayName": "VS Code",
+        "tools": []
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "activeClient": {
+      "clientId": "vscode-1",
+      "displayName": "VS Code",
+      "tools": []
+    }
+  }
+}

--- a/types/test-cases/reducers/036-session-activeclientchanged-unsets-client.json
+++ b/types/test-cases/reducers/036-session-activeclientchanged-unsets-client.json
@@ -1,0 +1,40 @@
+{
+  "description": "session/activeClientChanged unsets client",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "activeClient": {
+      "clientId": "vscode-1",
+      "tools": []
+    }
+  },
+  "actions": [
+    {
+      "type": "session/activeClientChanged",
+      "session": "copilot:/test-session",
+      "activeClient": null
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "activeClient": null
+  }
+}

--- a/types/test-cases/reducers/037-session-activeclienttoolschanged-updates-tools.json
+++ b/types/test-cases/reducers/037-session-activeclienttoolschanged-updates-tools.json
@@ -1,0 +1,53 @@
+{
+  "description": "session/activeClientToolsChanged updates tools",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "activeClient": {
+      "clientId": "vscode-1",
+      "tools": []
+    }
+  },
+  "actions": [
+    {
+      "type": "session/activeClientToolsChanged",
+      "session": "copilot:/test-session",
+      "tools": [
+        {
+          "name": "openFile",
+          "description": "Open a file"
+        }
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "activeClient": {
+      "clientId": "vscode-1",
+      "tools": [
+        {
+          "name": "openFile",
+          "description": "Open a file"
+        }
+      ]
+    }
+  }
+}

--- a/types/test-cases/reducers/038-session-activeclienttoolschanged-without-activeclient-is-no-op.json
+++ b/types/test-cases/reducers/038-session-activeclienttoolschanged-without-activeclient-is-no-op.json
@@ -1,0 +1,39 @@
+{
+  "description": "session/activeClientToolsChanged without activeClient is no-op",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/activeClientToolsChanged",
+      "session": "copilot:/test-session",
+      "tools": [
+        {
+          "name": "openFile"
+        }
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/039-set-steering-message.json
+++ b/types/test-cases/reducers/039-set-steering-message.json
@@ -1,0 +1,45 @@
+{
+  "description": "set steering message",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "steering",
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Focus on tests"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Focus on tests"
+      }
+    }
+  }
+}

--- a/types/test-cases/reducers/040-replace-existing-steering-message.json
+++ b/types/test-cases/reducers/040-replace-existing-steering-message.json
@@ -1,0 +1,51 @@
+{
+  "description": "replace existing steering message",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Old"
+      }
+    }
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "steering",
+      "id": "sm-2",
+      "userMessage": {
+        "text": "New"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-2",
+      "userMessage": {
+        "text": "New"
+      }
+    }
+  }
+}

--- a/types/test-cases/reducers/041-update-steering-message-content-via-set-with-same-id.json
+++ b/types/test-cases/reducers/041-update-steering-message-content-via-set-with-same-id.json
@@ -1,0 +1,51 @@
+{
+  "description": "update steering message content via set with same ID",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Original"
+      }
+    }
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "steering",
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Updated"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Updated"
+      }
+    }
+  }
+}

--- a/types/test-cases/reducers/042-remove-steering-message.json
+++ b/types/test-cases/reducers/042-remove-steering-message.json
@@ -1,0 +1,43 @@
+{
+  "description": "remove steering message",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Steer"
+      }
+    }
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageRemoved",
+      "session": "copilot:/test-session",
+      "kind": "steering",
+      "id": "sm-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": null
+  }
+}

--- a/types/test-cases/reducers/043-remove-steering-message-is-no-op-for-mismatched-id.json
+++ b/types/test-cases/reducers/043-remove-steering-message-is-no-op-for-mismatched-id.json
@@ -1,0 +1,48 @@
+{
+  "description": "remove steering message is no-op for mismatched ID",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Hello"
+      }
+    }
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageRemoved",
+      "session": "copilot:/test-session",
+      "kind": "steering",
+      "id": "sm-unknown"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "sm-1",
+      "userMessage": {
+        "text": "Hello"
+      }
+    }
+  }
+}

--- a/types/test-cases/reducers/044-remove-steering-message-is-no-op-when-none-exists.json
+++ b/types/test-cases/reducers/044-remove-steering-message-is-no-op-when-none-exists.json
@@ -1,0 +1,36 @@
+{
+  "description": "remove steering message is no-op when none exists",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageRemoved",
+      "session": "copilot:/test-session",
+      "kind": "steering",
+      "id": "sm-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/045-set-a-new-queued-message.json
+++ b/types/test-cases/reducers/045-set-a-new-queued-message.json
@@ -1,0 +1,47 @@
+{
+  "description": "set a new queued message",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "pm-1",
+      "userMessage": {
+        "text": "Do something"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "Do something"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/046-append-queued-message-when-id-is-new.json
+++ b/types/test-cases/reducers/046-append-queued-message-when-id-is-new.json
@@ -1,0 +1,61 @@
+{
+  "description": "append queued message when ID is new",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "First"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "pm-2",
+      "userMessage": {
+        "text": "Second"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "First"
+        }
+      },
+      {
+        "id": "pm-2",
+        "userMessage": {
+          "text": "Second"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/047-update-queued-message-in-place-when-id-already-exists.json
+++ b/types/test-cases/reducers/047-update-queued-message-in-place-when-id-already-exists.json
@@ -1,0 +1,67 @@
+{
+  "description": "update queued message in place when ID already exists",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "First"
+        }
+      },
+      {
+        "id": "pm-2",
+        "userMessage": {
+          "text": "Second"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "pm-1",
+      "userMessage": {
+        "text": "Updated first"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "Updated first"
+        }
+      },
+      {
+        "id": "pm-2",
+        "userMessage": {
+          "text": "Second"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/048-remove-a-queued-message.json
+++ b/types/test-cases/reducers/048-remove-a-queued-message.json
@@ -1,0 +1,58 @@
+{
+  "description": "remove a queued message",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "First"
+        }
+      },
+      {
+        "id": "pm-2",
+        "userMessage": {
+          "text": "Second"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageRemoved",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "pm-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-2",
+        "userMessage": {
+          "text": "Second"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/049-remove-last-queued-message-sets-array-to-undefined.json
+++ b/types/test-cases/reducers/049-remove-last-queued-message-sets-array-to-undefined.json
@@ -1,0 +1,45 @@
+{
+  "description": "remove last queued message sets array to undefined",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "Only one"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageRemoved",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "pm-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": null
+  }
+}

--- a/types/test-cases/reducers/050-remove-queued-message-is-no-op-for-unknown-id.json
+++ b/types/test-cases/reducers/050-remove-queued-message-is-no-op-for-unknown-id.json
@@ -1,0 +1,52 @@
+{
+  "description": "remove queued message is no-op for unknown ID",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "Hello"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageRemoved",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "pm-unknown"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "pm-1",
+        "userMessage": {
+          "text": "Hello"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/051-remove-queued-message-is-no-op-when-array-is-empty.json
+++ b/types/test-cases/reducers/051-remove-queued-message-is-no-op-when-array-is-empty.json
@@ -1,0 +1,36 @@
+{
+  "description": "remove queued message is no-op when array is empty",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageRemoved",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "pm-1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/052-steering-and-queued-messages-are-independent.json
+++ b/types/test-cases/reducers/052-steering-and-queued-messages-are-independent.json
@@ -1,0 +1,62 @@
+{
+  "description": "steering and queued messages are independent",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "steering",
+      "id": "s-1",
+      "userMessage": {
+        "text": "Steer"
+      }
+    },
+    {
+      "type": "session/pendingMessageSet",
+      "session": "copilot:/test-session",
+      "kind": "queued",
+      "id": "q-1",
+      "userMessage": {
+        "text": "Queue"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "steeringMessage": {
+      "id": "s-1",
+      "userMessage": {
+        "text": "Steer"
+      }
+    },
+    "queuedMessages": [
+      {
+        "id": "q-1",
+        "userMessage": {
+          "text": "Queue"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/053-reorders-queued-messages.json
+++ b/types/test-cases/reducers/053-reorders-queued-messages.json
@@ -1,0 +1,79 @@
+{
+  "description": "reorders queued messages",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      },
+      {
+        "id": "b",
+        "userMessage": {
+          "text": "B"
+        }
+      },
+      {
+        "id": "c",
+        "userMessage": {
+          "text": "C"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/queuedMessagesReordered",
+      "session": "copilot:/test-session",
+      "order": [
+        "c",
+        "a",
+        "b"
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "c",
+        "userMessage": {
+          "text": "C"
+        }
+      },
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      },
+      {
+        "id": "b",
+        "userMessage": {
+          "text": "B"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/054-keeps-messages-not-in-order-at-end-in-original-order.json
+++ b/types/test-cases/reducers/054-keeps-messages-not-in-order-at-end-in-original-order.json
@@ -1,0 +1,77 @@
+{
+  "description": "keeps messages not in order at end in original order",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      },
+      {
+        "id": "b",
+        "userMessage": {
+          "text": "B"
+        }
+      },
+      {
+        "id": "c",
+        "userMessage": {
+          "text": "C"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/queuedMessagesReordered",
+      "session": "copilot:/test-session",
+      "order": [
+        "c"
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "c",
+        "userMessage": {
+          "text": "C"
+        }
+      },
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      },
+      {
+        "id": "b",
+        "userMessage": {
+          "text": "B"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/055-ignores-unknown-ids-in-reorder.json
+++ b/types/test-cases/reducers/055-ignores-unknown-ids-in-reorder.json
@@ -1,0 +1,68 @@
+{
+  "description": "ignores unknown IDs in reorder",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      },
+      {
+        "id": "b",
+        "userMessage": {
+          "text": "B"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/queuedMessagesReordered",
+      "session": "copilot:/test-session",
+      "order": [
+        "unknown",
+        "b",
+        "a",
+        "also-unknown"
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "b",
+        "userMessage": {
+          "text": "B"
+        }
+      },
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/056-empty-reorder-preserves-all-messages-in-original-order.json
+++ b/types/test-cases/reducers/056-empty-reorder-preserves-all-messages-in-original-order.json
@@ -1,0 +1,51 @@
+{
+  "description": "empty reorder preserves all messages in original order",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/queuedMessagesReordered",
+      "session": "copilot:/test-session",
+      "order": []
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "queuedMessages": [
+      {
+        "id": "a",
+        "userMessage": {
+          "text": "A"
+        }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/057-reorder-is-no-op-when-no-queued-messages-exist.json
+++ b/types/test-cases/reducers/057-reorder-is-no-op-when-no-queued-messages-exist.json
@@ -1,0 +1,38 @@
+{
+  "description": "reorder is no-op when no queued messages exist",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/queuedMessagesReordered",
+      "session": "copilot:/test-session",
+      "order": [
+        "a",
+        "b"
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/058-session-customizationschanged-replaces-entire-list.json
+++ b/types/test-cases/reducers/058-session-customizationschanged-replaces-entire-list.json
@@ -1,0 +1,68 @@
+{
+  "description": "session/customizationsChanged replaces entire list",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/customizationsChanged",
+      "session": "copilot:/test-session",
+      "customizations": [
+        {
+          "customization": {
+            "uri": "https://plugins.example/a",
+            "displayName": "Plugin A"
+          },
+          "enabled": true
+        },
+        {
+          "customization": {
+            "uri": "https://plugins.example/b",
+            "displayName": "Plugin B"
+          },
+          "enabled": false,
+          "clientId": "client-1"
+        }
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true
+      },
+      {
+        "customization": {
+          "uri": "https://plugins.example/b",
+          "displayName": "Plugin B"
+        },
+        "enabled": false,
+        "clientId": "client-1"
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/059-session-customizationschanged-replaces-existing-customizations.json
+++ b/types/test-cases/reducers/059-session-customizationschanged-replaces-existing-customizations.json
@@ -1,0 +1,61 @@
+{
+  "description": "session/customizationsChanged replaces existing customizations",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/customizationsChanged",
+      "session": "copilot:/test-session",
+      "customizations": [
+        {
+          "customization": {
+            "uri": "https://plugins.example/b",
+            "displayName": "Plugin B"
+          },
+          "enabled": false
+        }
+      ]
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/b",
+          "displayName": "Plugin B"
+        },
+        "enabled": false
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/060-session-customizationtoggled-toggles-by-uri.json
+++ b/types/test-cases/reducers/060-session-customizationtoggled-toggles-by-uri.json
@@ -1,0 +1,68 @@
+{
+  "description": "session/customizationToggled toggles by URI",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true
+      },
+      {
+        "customization": {
+          "uri": "https://plugins.example/b",
+          "displayName": "Plugin B"
+        },
+        "enabled": true
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/customizationToggled",
+      "session": "copilot:/test-session",
+      "uri": "https://plugins.example/a",
+      "enabled": false
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": false
+      },
+      {
+        "customization": {
+          "uri": "https://plugins.example/b",
+          "displayName": "Plugin B"
+        },
+        "enabled": true
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/061-session-customizationtoggled-is-no-op-for-unknown-uri.json
+++ b/types/test-cases/reducers/061-session-customizationtoggled-is-no-op-for-unknown-uri.json
@@ -1,0 +1,54 @@
+{
+  "description": "session/customizationToggled is no-op for unknown URI",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/customizationToggled",
+      "session": "copilot:/test-session",
+      "uri": "https://plugins.example/unknown",
+      "enabled": false
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/062-session-customizationtoggled-is-no-op-when-customizations-undefined.json
+++ b/types/test-cases/reducers/062-session-customizationtoggled-is-no-op-when-customizations-undefined.json
@@ -1,0 +1,36 @@
+{
+  "description": "session/customizationToggled is no-op when customizations undefined",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/customizationToggled",
+      "session": "copilot:/test-session",
+      "uri": "https://plugins.example/a",
+      "enabled": false
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/063-session-truncated-keeps-turns-up-to-turnid.json
+++ b/types/test-cases/reducers/063-session-truncated-keeps-turns-up-to-turnid.json
@@ -1,0 +1,83 @@
+{
+  "description": "session/truncated keeps turns up to turnId",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t3",
+        "userMessage": {
+          "text": "Third"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/truncated",
+      "session": "copilot:/test-session",
+      "turnId": "t2"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/064-session-truncated-keeps-all-when-turnid-is-last.json
+++ b/types/test-cases/reducers/064-session-truncated-keeps-all-when-turnid-is-last.json
@@ -1,0 +1,74 @@
+{
+  "description": "session/truncated keeps all when turnId is last",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/truncated",
+      "session": "copilot:/test-session",
+      "turnId": "t2"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/065-session-truncated-keeps-only-first-when-turnid-is-first.json
+++ b/types/test-cases/reducers/065-session-truncated-keeps-only-first-when-turnid-is-first.json
@@ -1,0 +1,74 @@
+{
+  "description": "session/truncated keeps only first when turnId is first",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t3",
+        "userMessage": {
+          "text": "Third"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/truncated",
+      "session": "copilot:/test-session",
+      "turnId": "t1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/066-session-truncated-clears-all-when-turnid-omitted.json
+++ b/types/test-cases/reducers/066-session-truncated-clears-all-when-turnid-omitted.json
@@ -1,0 +1,63 @@
+{
+  "description": "session/truncated clears all when turnId omitted",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t3",
+        "userMessage": {
+          "text": "Third"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/truncated",
+      "session": "copilot:/test-session"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/067-session-truncated-drops-active-turn.json
+++ b/types/test-cases/reducers/067-session-truncated-drops-active-turn.json
@@ -1,0 +1,73 @@
+{
+  "description": "session/truncated drops active turn",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/truncated",
+      "session": "copilot:/test-session",
+      "turnId": "t1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/068-session-truncated-drops-active-turn-even-when-clearing-all.json
+++ b/types/test-cases/reducers/068-session-truncated-drops-active-turn-even-when-clearing-all.json
@@ -1,0 +1,43 @@
+{
+  "description": "session/truncated drops active turn even when clearing all",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "in-progress",
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/truncated",
+      "session": "copilot:/test-session"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": null
+  }
+}

--- a/types/test-cases/reducers/069-session-truncated-is-no-op-for-unknown-turnid.json
+++ b/types/test-cases/reducers/069-session-truncated-is-no-op-for-unknown-turnid.json
@@ -1,0 +1,73 @@
+{
+  "description": "session/truncated is no-op for unknown turnId",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/truncated",
+      "session": "copilot:/test-session",
+      "turnId": "unknown"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "First"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      },
+      {
+        "id": "t2",
+        "userMessage": {
+          "text": "Second"
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/070-full-turn-flow-with-tool-calls-and-re-confirmation.json
+++ b/types/test-cases/reducers/070-full-turn-flow-with-tool-calls-and-re-confirmation.json
@@ -1,0 +1,237 @@
+{
+  "description": "full turn flow with tool calls and re-confirmation",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/turnStarted",
+      "session": "s",
+      "turnId": "t1",
+      "userMessage": {
+        "text": "Fix the bug"
+      }
+    },
+    {
+      "type": "session/responsePart",
+      "session": "s",
+      "turnId": "t1",
+      "part": {
+        "kind": "markdown",
+        "id": "md-1",
+        "content": ""
+      }
+    },
+    {
+      "type": "session/delta",
+      "session": "s",
+      "turnId": "t1",
+      "partId": "md-1",
+      "content": "I will "
+    },
+    {
+      "type": "session/delta",
+      "session": "s",
+      "turnId": "t1",
+      "partId": "md-1",
+      "content": "fix it."
+    },
+    {
+      "type": "session/toolCallStart",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc1",
+      "toolName": "edit",
+      "displayName": "Edit File"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc1",
+      "invocationMessage": "Edit main.ts",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc1",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Edited main.ts"
+      }
+    },
+    {
+      "type": "session/toolCallStart",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc2",
+      "toolName": "write",
+      "displayName": "Write File"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc2",
+      "invocationMessage": "Write /tmp/out",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallReady",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc2",
+      "invocationMessage": "Write to /tmp/out",
+      "_meta": {
+        "permissionKind": "write",
+        "path": "/tmp/out"
+      }
+    },
+    {
+      "type": "session/toolCallConfirmed",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc2",
+      "approved": true,
+      "confirmed": "user-action"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "session": "s",
+      "turnId": "t1",
+      "toolCallId": "tc2",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Wrote file"
+      }
+    },
+    {
+      "type": "session/usage",
+      "session": "s",
+      "turnId": "t1",
+      "usage": {
+        "inputTokens": 200,
+        "outputTokens": 100
+      }
+    },
+    {
+      "type": "session/responsePart",
+      "session": "s",
+      "turnId": "t1",
+      "part": {
+        "kind": "reasoning",
+        "id": "r-1",
+        "content": ""
+      }
+    },
+    {
+      "type": "session/reasoning",
+      "session": "s",
+      "turnId": "t1",
+      "partId": "r-1",
+      "content": "The bug was in line 42"
+    },
+    {
+      "type": "session/responsePart",
+      "session": "s",
+      "turnId": "t1",
+      "part": {
+        "kind": "markdown",
+        "id": "md-2",
+        "content": "## Fix applied"
+      }
+    },
+    {
+      "type": "session/turnComplete",
+      "session": "s",
+      "turnId": "t1"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": "idle",
+      "createdAt": 1000,
+      "modifiedAt": 9999
+    },
+    "lifecycle": "ready",
+    "turns": [
+      {
+        "id": "t1",
+        "userMessage": {
+          "text": "Fix the bug"
+        },
+        "responseParts": [
+          {
+            "kind": "markdown",
+            "id": "md-1",
+            "content": "I will fix it."
+          },
+          {
+            "kind": "toolCall",
+            "toolCall": {
+              "status": "completed",
+              "toolCallId": "tc1",
+              "toolName": "edit",
+              "displayName": "Edit File",
+              "toolClientId": null,
+              "_meta": null,
+              "invocationMessage": "Edit main.ts",
+              "toolInput": null,
+              "confirmed": "not-needed",
+              "success": true,
+              "pastTenseMessage": "Edited main.ts"
+            }
+          },
+          {
+            "kind": "toolCall",
+            "toolCall": {
+              "status": "completed",
+              "toolCallId": "tc2",
+              "toolName": "write",
+              "displayName": "Write File",
+              "toolClientId": null,
+              "_meta": null,
+              "invocationMessage": "Write to /tmp/out",
+              "toolInput": null,
+              "confirmed": "user-action",
+              "success": true,
+              "pastTenseMessage": "Wrote file"
+            }
+          },
+          {
+            "kind": "reasoning",
+            "id": "r-1",
+            "content": "The bug was in line 42"
+          },
+          {
+            "kind": "markdown",
+            "id": "md-2",
+            "content": "## Fix applied"
+          }
+        ],
+        "usage": {
+          "inputTokens": 200,
+          "outputTokens": 100
+        },
+        "state": "complete",
+        "error": null
+      }
+    ],
+    "activeTurn": null
+  }
+}


### PR DESCRIPTION
This lets reducers be written in other languages easily by keeping unit test cases independent.