### PR TITLE
add loaded sessions to the root

### DIFF
--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -4,11 +4,12 @@ All state in AHP is identified by URIs. Clients subscribe to a URI to receive it
 
 ## Root State
 
-Subscribable at `agenthost:/root`. Contains global, lightweight data that all clients need. **Does not contain the session list** — that is fetched imperatively via RPC (see [Commands](/reference/commands)).
+Subscribable at `agenthost:/root`. Contains global, lightweight data that all clients need. **Does not contain the full session list** — that is fetched imperatively via RPC (see [Commands](/reference/commands)). Root state MAY carry a small "hot" subset of session summaries in `loadedSessions` for live sync (see [Loaded Sessions](#loaded-sessions) below).
 
 ```typescript
 RootState {
   agents: AgentInfo[]
+  loadedSessions?: SessionSummary[]
 }
 ```
 
@@ -259,6 +260,42 @@ The session list can be arbitrarily large and is **not** part of the state tree.
 - The server sends lightweight **notifications** (`sessionAdded`, `sessionRemoved`) so connected clients can update a local cache without re-fetching.
 
 Notifications are ephemeral — not processed by reducers, not stored in state, not replayed on reconnect. On reconnect, clients re-fetch the list.
+
+## Loaded Sessions
+
+`loadedSessions` on root state is a small "hot" subset of session summaries that the server is actively live-syncing on the root subscription. Clients that are displaying a session list or sidebar can subscribe to `agenthost:/root` and receive summary updates (title, status, diffs, `isRead`, `isDone`, `modifiedAt`, …) for this subset without having to subscribe to each session URI individually.
+
+```typescript
+RootState {
+  // ...
+  loadedSessions?: SessionSummary[]
+}
+```
+
+### Relationship to the session list
+
+`loadedSessions` is **complementary** to — not a replacement for — the existing session-list mechanisms:
+
+| Mechanism | Purpose | Delivery |
+|---|---|---|
+| `listSessions()` | Fetch the full catalog of sessions (may be arbitrarily large). | Imperative RPC. |
+| `notify/sessionAdded` / `notify/sessionRemoved` | Signal session creation/disposal so clients can update a local cache. | Ephemeral notifications (not replayed). |
+| `loadedSessions` + `root/loadedSession*` actions | Live summary updates for a tracked subset. | Part of the root state tree; replayed on reconnect via the standard subscription machinery. |
+
+A client that wants up-to-date summaries without subscribing to every session SHOULD:
+
+1. Fetch the catalog once via `listSessions()`.
+2. Subscribe to `agenthost:/root` and maintain its cache from `loadedSessions` whenever an entry exists.
+3. Listen to `notify/sessionAdded` / `notify/sessionRemoved` for lifecycle changes.
+
+### Action semantics
+
+The server drives `loadedSessions` with two actions:
+
+- `root/loadedSessionChanged` — Upserts a session summary into `loadedSessions`, keyed by `summary.resource`. Used both to start tracking a session and to push subsequent summary updates for an already loaded session.
+- `root/loadedSessionRemoved` — Removes the entry for `session` from `loadedSessions`. This does **not** imply the session was disposed; session disposal is signaled by `notify/sessionRemoved`. The field collapses to `undefined` when the last entry is removed.
+
+Both actions are server-originated. Which sessions the server chooses to load is a server policy (for example, a server may auto-track recently active sessions).
 
 ## Pending Messages
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -129,6 +129,40 @@
         "terminals"
       ]
     },
+    "IRootLoadedSessionChangedAction": {
+      "type": "object",
+      "description": "Upserts a session summary into {@link IRootState.loadedSessions | loadedSessions}.\n\nDispatched by the server both to start tracking a session for live updates\non the root subscription and to push subsequent summary changes (title,\nstatus, diffs, isRead, isDone, modifiedAt, …) for an already loaded\nsession. Entries are keyed by `summary.resource`; an existing entry with\nthe same resource is replaced in place, otherwise the summary is appended.\n\nThis action is orthogonal to `notify/sessionAdded`: that notification\nsignals that a new session exists on the server, while this action\ncontrols which sessions the server is live-syncing on the root\nsubscription.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootLoadedSessionChanged"
+        },
+        "summary": {
+          "$ref": "#/$defs/ISessionSummary",
+          "description": "The session summary to upsert into `loadedSessions`, keyed by `summary.resource`."
+        }
+      },
+      "required": [
+        "type",
+        "summary"
+      ]
+    },
+    "IRootLoadedSessionRemovedAction": {
+      "type": "object",
+      "description": "Removes a session summary from {@link IRootState.loadedSessions | loadedSessions}.\n\nThis action signals that the server has stopped pushing live summary\nupdates for `session` on the root subscription. It does **not** imply the\nsession was disposed — session disposal is signaled by\n`notify/sessionRemoved`.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootLoadedSessionRemoved"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the session to drop from `loadedSessions`."
+        }
+      },
+      "required": [
+        "type",
+        "session"
+      ]
+    },
     "ISessionReadyAction": {
       "type": "object",
       "description": "Session backend initialized successfully.",
@@ -1492,6 +1526,13 @@
             "$ref": "#/$defs/ITerminalInfo"
           },
           "description": "Known terminals on the server. Subscribe to individual terminal URIs for full state."
+        },
+        "loadedSessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ISessionSummary"
+          },
+          "description": "Session summaries the server is currently tracking for live updates on\nthe root subscription.\n\nThis is a small \"hot\" subset — typically sessions a that are in use\nby a client or agent loop  — that the server pushes summary updates\nfor (title, status, diffs, isRead, isDone, modifiedAt, …) without\nrequiring clients to subscribe to each session URI individually.\n\nThis field is complementary to, not a replacement for:\n\n- `listSessions()` — the imperative command used to fetch the full\n  catalog of session summaries (which may be arbitrarily large).\n- `notify/sessionAdded` / `notify/sessionRemoved` — the ephemeral\n  lifecycle notifications sent when a session is created or disposed.\n\nSummaries are keyed by `summary.resource`. Entries are added or updated\nvia `root/loadedSessionChanged` and removed via\n`root/loadedSessionRemoved`. A removal from `loadedSessions` does not\nimply the session was disposed; it only means the server is no longer\npushing live updates for it on the root subscription."
         }
       },
       "required": [
@@ -3588,6 +3629,12 @@
         },
         {
           "$ref": "#/$defs/IRootTerminalsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/IRootLoadedSessionChangedAction"
+        },
+        {
+          "$ref": "#/$defs/IRootLoadedSessionRemovedAction"
         },
         {
           "$ref": "#/$defs/ISessionReadyAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -716,6 +716,13 @@
             "$ref": "#/$defs/ITerminalInfo"
           },
           "description": "Known terminals on the server. Subscribe to individual terminal URIs for full state."
+        },
+        "loadedSessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ISessionSummary"
+          },
+          "description": "Session summaries the server is currently tracking for live updates on\nthe root subscription.\n\nThis is a small \"hot\" subset — typically sessions a that are in use\nby a client or agent loop  — that the server pushes summary updates\nfor (title, status, diffs, isRead, isDone, modifiedAt, …) without\nrequiring clients to subscribe to each session URI individually.\n\nThis field is complementary to, not a replacement for:\n\n- `listSessions()` — the imperative command used to fetch the full\n  catalog of session summaries (which may be arbitrarily large).\n- `notify/sessionAdded` / `notify/sessionRemoved` — the ephemeral\n  lifecycle notifications sent when a session is created or disposed.\n\nSummaries are keyed by `summary.resource`. Entries are added or updated\nvia `root/loadedSessionChanged` and removed via\n`root/loadedSessionRemoved`. A removal from `loadedSessions` does not\nimply the session was disposed; it only means the server is no longer\npushing live updates for it on the root subscription."
         }
       },
       "required": [
@@ -2776,6 +2783,40 @@
       "required": [
         "type",
         "terminals"
+      ]
+    },
+    "IRootLoadedSessionChangedAction": {
+      "type": "object",
+      "description": "Upserts a session summary into {@link IRootState.loadedSessions | loadedSessions}.\n\nDispatched by the server both to start tracking a session for live updates\non the root subscription and to push subsequent summary changes (title,\nstatus, diffs, isRead, isDone, modifiedAt, …) for an already loaded\nsession. Entries are keyed by `summary.resource`; an existing entry with\nthe same resource is replaced in place, otherwise the summary is appended.\n\nThis action is orthogonal to `notify/sessionAdded`: that notification\nsignals that a new session exists on the server, while this action\ncontrols which sessions the server is live-syncing on the root\nsubscription.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootLoadedSessionChanged"
+        },
+        "summary": {
+          "$ref": "#/$defs/ISessionSummary",
+          "description": "The session summary to upsert into `loadedSessions`, keyed by `summary.resource`."
+        }
+      },
+      "required": [
+        "type",
+        "summary"
+      ]
+    },
+    "IRootLoadedSessionRemovedAction": {
+      "type": "object",
+      "description": "Removes a session summary from {@link IRootState.loadedSessions | loadedSessions}.\n\nThis action signals that the server has stopped pushing live summary\nupdates for `session` on the root subscription. It does **not** imply the\nsession was disposed — session disposal is signaled by\n`notify/sessionRemoved`.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.RootLoadedSessionRemoved"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the session to drop from `loadedSessions`."
+        }
+      },
+      "required": [
+        "type",
+        "session"
       ]
     },
     "ISessionReadyAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -206,6 +206,13 @@
             "$ref": "#/$defs/ITerminalInfo"
           },
           "description": "Known terminals on the server. Subscribe to individual terminal URIs for full state."
+        },
+        "loadedSessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ISessionSummary"
+          },
+          "description": "Session summaries the server is currently tracking for live updates on\nthe root subscription.\n\nThis is a small \"hot\" subset — typically sessions a that are in use\nby a client or agent loop  — that the server pushes summary updates\nfor (title, status, diffs, isRead, isDone, modifiedAt, …) without\nrequiring clients to subscribe to each session URI individually.\n\nThis field is complementary to, not a replacement for:\n\n- `listSessions()` — the imperative command used to fetch the full\n  catalog of session summaries (which may be arbitrarily large).\n- `notify/sessionAdded` / `notify/sessionRemoved` — the ephemeral\n  lifecycle notifications sent when a session is created or disposed.\n\nSummaries are keyed by `summary.resource`. Entries are added or updated\nvia `root/loadedSessionChanged` and removed via\n`root/loadedSessionRemoved`. A removal from `loadedSessions` does not\nimply the session was disposed; it only means the server is no longer\npushing live updates for it on the root subscription."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -137,6 +137,13 @@
             "$ref": "#/$defs/ITerminalInfo"
           },
           "description": "Known terminals on the server. Subscribe to individual terminal URIs for full state."
+        },
+        "loadedSessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ISessionSummary"
+          },
+          "description": "Session summaries the server is currently tracking for live updates on\nthe root subscription.\n\nThis is a small \"hot\" subset — typically sessions a that are in use\nby a client or agent loop  — that the server pushes summary updates\nfor (title, status, diffs, isRead, isDone, modifiedAt, …) without\nrequiring clients to subscribe to each session URI individually.\n\nThis field is complementary to, not a replacement for:\n\n- `listSessions()` — the imperative command used to fetch the full\n  catalog of session summaries (which may be arbitrarily large).\n- `notify/sessionAdded` / `notify/sessionRemoved` — the ephemeral\n  lifecycle notifications sent when a session is created or disposed.\n\nSummaries are keyed by `summary.resource`. Entries are added or updated\nvia `root/loadedSessionChanged` and removed via\n`root/loadedSessionRemoved`. A removal from `loadedSessions` does not\nimply the session was disposed; it only means the server is no longer\npushing live updates for it on the root subscription."
         }
       },
       "required": [

--- a/scripts/generate-markdown.ts
+++ b/scripts/generate-markdown.ts
@@ -488,6 +488,8 @@ interface ActionMeta {
 const ACTION_ORDER: ActionMeta[] = [
   // Root
   { interfaceName: 'IRootAgentsChangedAction', typeValue: 'root/agentsChanged', description: 'Fired when available agent backends or their models change.', clientDispatchable: false, version: 1 },
+  { interfaceName: 'IRootLoadedSessionChangedAction', typeValue: 'root/loadedSessionChanged', description: 'Upserts a session summary into `loadedSessions` on root state.', clientDispatchable: false, version: 1 },
+  { interfaceName: 'IRootLoadedSessionRemovedAction', typeValue: 'root/loadedSessionRemoved', description: 'Removes a session summary from `loadedSessions` on root state.', clientDispatchable: false, version: 1 },
   // Session
   { interfaceName: 'ISessionReadyAction', typeValue: 'session/ready', description: 'Session backend initialized successfully.', clientDispatchable: false, version: 1 },
   { interfaceName: 'ISessionCreationFailedAction', typeValue: 'session/creationFailed', description: 'Session backend failed to initialize.', clientDispatchable: false, version: 1 },
@@ -742,6 +744,7 @@ function generateNotificationsPage(project: Project): string {
   lines.push('1. On connect, fetch the full session list via `listSessions()`.');
   lines.push('2. Listen for `notify/sessionAdded` and `notify/sessionRemoved` to keep the cache updated.');
   lines.push('3. On reconnect, **re-fetch** the full list — notifications are not replayed.\n');
+  lines.push('For live summary updates (title, status, diffs, …) on a small tracked subset without subscribing to each session URI, see [`loadedSessions`](/guide/state-model#loaded-sessions) on root state. It is complementary to, not a replacement for, these lifecycle notifications.\n');
 
   // Version Introduction
   lines.push('## Version Introduction\n');

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -658,6 +658,8 @@ function generateStateFile(project: Project): string {
 const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[] = [
   { type: 'root/agentsChanged', caseName: 'rootAgentsChanged', tsInterface: 'IRootAgentsChangedAction' },
   { type: 'root/activeSessionsChanged', caseName: 'rootActiveSessionsChanged', tsInterface: 'IRootActiveSessionsChangedAction' },
+  { type: 'root/loadedSessionChanged', caseName: 'rootLoadedSessionChanged', tsInterface: 'IRootLoadedSessionChangedAction' },
+  { type: 'root/loadedSessionRemoved', caseName: 'rootLoadedSessionRemoved', tsInterface: 'IRootLoadedSessionRemovedAction' },
   { type: 'session/ready', caseName: 'sessionReady', tsInterface: 'ISessionReadyAction' },
   { type: 'session/creationFailed', caseName: 'sessionCreationFailed', tsInterface: 'ISessionCreationFailedAction' },
   { type: 'session/turnStarted', caseName: 'sessionTurnStarted', tsInterface: 'ISessionTurnStartedAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -6,6 +6,8 @@ import type {
   IRootAgentsChangedAction,
   IRootActiveSessionsChangedAction,
   IRootTerminalsChangedAction,
+  IRootLoadedSessionChangedAction,
+  IRootLoadedSessionRemovedAction,
   ISessionReadyAction,
   ISessionCreationFailedAction,
   ISessionTurnStartedAction,
@@ -59,6 +61,8 @@ export type IRootAction =
   | IRootAgentsChangedAction
   | IRootActiveSessionsChangedAction
   | IRootTerminalsChangedAction
+  | IRootLoadedSessionChangedAction
+  | IRootLoadedSessionRemovedAction
 ;
 
 /** Union of all session-scoped actions. */
@@ -179,6 +183,8 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in IStateAction['type']]: boo
   [ActionType.RootAgentsChanged]: false,
   [ActionType.RootActiveSessionsChanged]: false,
   [ActionType.RootTerminalsChanged]: false,
+  [ActionType.RootLoadedSessionChanged]: false,
+  [ActionType.RootLoadedSessionRemoved]: false,
   [ActionType.SessionReady]: false,
   [ActionType.SessionCreationFailed]: false,
   [ActionType.SessionTurnStarted]: true,

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -17,6 +17,7 @@ import type {
   IToolResultContent,
   IToolDefinition,
   ISessionActiveClient,
+  ISessionSummary,
   IUsageInfo,
   ISessionCustomization,
   ISessionFileDiff,
@@ -39,6 +40,8 @@ import { ToolCallConfirmationReason, ToolCallCancellationReason, PendingMessageK
 export const enum ActionType {
   RootAgentsChanged = 'root/agentsChanged',
   RootActiveSessionsChanged = 'root/activeSessionsChanged',
+  RootLoadedSessionChanged = 'root/loadedSessionChanged',
+  RootLoadedSessionRemoved = 'root/loadedSessionRemoved',
   SessionReady = 'session/ready',
   SessionCreationFailed = 'session/creationFailed',
   SessionTurnStarted = 'session/turnStarted',
@@ -167,6 +170,46 @@ export interface IRootTerminalsChangedAction {
   type: ActionType.RootTerminalsChanged;
   /** Updated terminal list (full replacement) */
   terminals: ITerminalInfo[];
+}
+
+/**
+ * Upserts a session summary into {@link IRootState.loadedSessions | loadedSessions}.
+ *
+ * Dispatched by the server both to start tracking a session for live updates
+ * on the root subscription and to push subsequent summary changes (title,
+ * status, diffs, isRead, isDone, modifiedAt, …) for an already loaded
+ * session. Entries are keyed by `summary.resource`; an existing entry with
+ * the same resource is replaced in place, otherwise the summary is appended.
+ *
+ * This action is orthogonal to `notify/sessionAdded`: that notification
+ * signals that a new session exists on the server, while this action
+ * controls which sessions the server is live-syncing on the root
+ * subscription.
+ *
+ * @category Root Actions
+ * @version 1
+ */
+export interface IRootLoadedSessionChangedAction {
+  type: ActionType.RootLoadedSessionChanged;
+  /** The session summary to upsert into `loadedSessions`, keyed by `summary.resource`. */
+  summary: ISessionSummary;
+}
+
+/**
+ * Removes a session summary from {@link IRootState.loadedSessions | loadedSessions}.
+ *
+ * This action signals that the server has stopped pushing live summary
+ * updates for `session` on the root subscription. It does **not** imply the
+ * session was disposed — session disposal is signaled by
+ * `notify/sessionRemoved`.
+ *
+ * @category Root Actions
+ * @version 1
+ */
+export interface IRootLoadedSessionRemovedAction {
+  type: ActionType.RootLoadedSessionRemoved;
+  /** URI of the session to drop from `loadedSessions`. */
+  session: URI;
 }
 
 // ─── Session Actions ─────────────────────────────────────────────────────────
@@ -992,6 +1035,8 @@ export type IStateAction =
   | IRootAgentsChangedAction
   | IRootActiveSessionsChangedAction
   | IRootTerminalsChangedAction
+  | IRootLoadedSessionChangedAction
+  | IRootLoadedSessionRemovedAction
   | ISessionReadyAction
   | ISessionCreationFailedAction
   | ISessionTurnStartedAction

--- a/types/index.ts
+++ b/types/index.ts
@@ -98,6 +98,8 @@ export type {
   IActionOrigin,
   IRootAgentsChangedAction,
   IRootActiveSessionsChangedAction,
+  IRootLoadedSessionChangedAction,
+  IRootLoadedSessionRemovedAction,
   ISessionReadyAction,
   ISessionCreationFailedAction,
   ISessionTurnStartedAction,

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -245,6 +245,32 @@ export function rootReducer(state: IRootState, action: IRootAction, log?: (msg: 
     case ActionType.RootTerminalsChanged:
       return { ...state, terminals: action.terminals };
 
+    case ActionType.RootLoadedSessionChanged: {
+      const existing = state.loadedSessions ?? [];
+      const idx = existing.findIndex(s => s.resource === action.summary.resource);
+      if (idx >= 0) {
+        const updated = [...existing];
+        updated[idx] = action.summary;
+        return { ...state, loadedSessions: updated };
+      }
+      return { ...state, loadedSessions: [...existing, action.summary] };
+    }
+
+    case ActionType.RootLoadedSessionRemoved: {
+      const existing = state.loadedSessions;
+      if (!existing) {
+        return state;
+      }
+      const filtered = existing.filter(s => s.resource !== action.session);
+      if (filtered.length === existing.length) {
+        return state;
+      }
+      return {
+        ...state,
+        loadedSessions: filtered.length > 0 ? filtered : undefined,
+      };
+    }
+
     default:
       softAssertNever(action, log);
       return state;

--- a/types/state.ts
+++ b/types/state.ts
@@ -153,6 +153,29 @@ export interface IRootState {
   activeSessions?: number;
   /** Known terminals on the server. Subscribe to individual terminal URIs for full state. */
   terminals?: ITerminalInfo[];
+  /**
+   * Session summaries the server is currently tracking for live updates on
+   * the root subscription.
+   *
+   * This is a small "hot" subset — typically sessions a that are in use
+   * by a client or agent loop  — that the server pushes summary updates
+   * for (title, status, diffs, isRead, isDone, modifiedAt, …) without
+   * requiring clients to subscribe to each session URI individually.
+   *
+   * This field is complementary to, not a replacement for:
+   *
+   * - `listSessions()` — the imperative command used to fetch the full
+   *   catalog of session summaries (which may be arbitrarily large).
+   * - `notify/sessionAdded` / `notify/sessionRemoved` — the ephemeral
+   *   lifecycle notifications sent when a session is created or disposed.
+   *
+   * Summaries are keyed by `summary.resource`. Entries are added or updated
+   * via `root/loadedSessionChanged` and removed via
+   * `root/loadedSessionRemoved`. A removal from `loadedSessions` does not
+   * imply the session was disposed; it only means the server is no longer
+   * pushing live updates for it on the root subscription.
+   */
+  loadedSessions?: ISessionSummary[];
 }
 
 /**

--- a/types/test-cases/reducers/113-root-loadedsessionchanged-adds-new-summary.json
+++ b/types/test-cases/reducers/113-root-loadedsessionchanged-adds-new-summary.json
@@ -1,0 +1,33 @@
+{
+  "description": "root/loadedSessionChanged adds a new summary when loadedSessions is absent",
+  "reducer": "root",
+  "initial": {
+    "agents": []
+  },
+  "actions": [
+    {
+      "type": "root/loadedSessionChanged",
+      "summary": {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "First session",
+        "status": 1,
+        "createdAt": 1000,
+        "modifiedAt": 1000
+      }
+    }
+  ],
+  "expected": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "First session",
+        "status": 1,
+        "createdAt": 1000,
+        "modifiedAt": 1000
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/114-root-loadedsessionchanged-upserts-existing-by-resource.json
+++ b/types/test-cases/reducers/114-root-loadedsessionchanged-upserts-existing-by-resource.json
@@ -1,0 +1,61 @@
+{
+  "description": "root/loadedSessionChanged upserts an existing summary in place by resource",
+  "reducer": "root",
+  "initial": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "Old title",
+        "status": 1,
+        "createdAt": 1000,
+        "modifiedAt": 1000
+      },
+      {
+        "resource": "copilot:/s2",
+        "provider": "copilot",
+        "title": "Other",
+        "status": 1,
+        "createdAt": 2000,
+        "modifiedAt": 2000
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "root/loadedSessionChanged",
+      "summary": {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "New title",
+        "status": 8,
+        "createdAt": 1000,
+        "modifiedAt": 1500,
+        "isRead": false
+      }
+    }
+  ],
+  "expected": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "New title",
+        "status": 8,
+        "createdAt": 1000,
+        "modifiedAt": 1500,
+        "isRead": false
+      },
+      {
+        "resource": "copilot:/s2",
+        "provider": "copilot",
+        "title": "Other",
+        "status": 1,
+        "createdAt": 2000,
+        "modifiedAt": 2000
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/115-root-loadedsessionremoved-removes-by-resource.json
+++ b/types/test-cases/reducers/115-root-loadedsessionremoved-removes-by-resource.json
@@ -1,0 +1,44 @@
+{
+  "description": "root/loadedSessionRemoved removes a summary by resource",
+  "reducer": "root",
+  "initial": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "First",
+        "status": 1,
+        "createdAt": 1000,
+        "modifiedAt": 1000
+      },
+      {
+        "resource": "copilot:/s2",
+        "provider": "copilot",
+        "title": "Second",
+        "status": 1,
+        "createdAt": 2000,
+        "modifiedAt": 2000
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "root/loadedSessionRemoved",
+      "session": "copilot:/s1"
+    }
+  ],
+  "expected": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s2",
+        "provider": "copilot",
+        "title": "Second",
+        "status": 1,
+        "createdAt": 2000,
+        "modifiedAt": 2000
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/116-root-loadedsessionremoved-last-entry-clears-field.json
+++ b/types/test-cases/reducers/116-root-loadedsessionremoved-last-entry-clears-field.json
@@ -1,0 +1,27 @@
+{
+  "description": "root/loadedSessionRemoved clears loadedSessions when removing the last entry",
+  "reducer": "root",
+  "initial": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "Only",
+        "status": 1,
+        "createdAt": 1000,
+        "modifiedAt": 1000
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "root/loadedSessionRemoved",
+      "session": "copilot:/s1"
+    }
+  ],
+  "expected": {
+    "agents": [],
+    "loadedSessions": null
+  }
+}

--- a/types/test-cases/reducers/117-root-loadedsessionremoved-unknown-resource-is-noop.json
+++ b/types/test-cases/reducers/117-root-loadedsessionremoved-unknown-resource-is-noop.json
@@ -1,0 +1,36 @@
+{
+  "description": "root/loadedSessionRemoved is a no-op for an unknown session resource",
+  "reducer": "root",
+  "initial": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "First",
+        "status": 1,
+        "createdAt": 1000,
+        "modifiedAt": 1000
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "root/loadedSessionRemoved",
+      "session": "copilot:/unknown"
+    }
+  ],
+  "expected": {
+    "agents": [],
+    "loadedSessions": [
+      {
+        "resource": "copilot:/s1",
+        "provider": "copilot",
+        "title": "First",
+        "status": 1,
+        "createdAt": 1000,
+        "modifiedAt": 1000
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/118-root-loadedsessionremoved-absent-is-noop.json
+++ b/types/test-cases/reducers/118-root-loadedsessionremoved-absent-is-noop.json
@@ -1,0 +1,16 @@
+{
+  "description": "root/loadedSessionRemoved is a no-op when loadedSessions is absent",
+  "reducer": "root",
+  "initial": {
+    "agents": []
+  },
+  "actions": [
+    {
+      "type": "root/loadedSessionRemoved",
+      "session": "copilot:/s1"
+    }
+  ],
+  "expected": {
+    "agents": []
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -26,6 +26,8 @@ export const MIN_PROTOCOL_VERSION = 1;
 export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: number } = {
   [ActionType.RootAgentsChanged]: 1,
   [ActionType.RootActiveSessionsChanged]: 1,
+  [ActionType.RootLoadedSessionChanged]: 1,
+  [ActionType.RootLoadedSessionRemoved]: 1,
   [ActionType.SessionReady]: 1,
   [ActionType.SessionCreationFailed]: 1,
   [ActionType.SessionTurnStarted]: 1,

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -79,6 +79,8 @@ import type {
   IActionEnvelope,
   IActionOrigin,
   IRootActiveSessionsChangedAction,
+  IRootLoadedSessionChangedAction,
+  IRootLoadedSessionRemovedAction,
   ISessionToolCallApprovedAction,
   ISessionToolCallDeniedAction,
   ISessionServerToolsChangedAction,
@@ -220,6 +222,8 @@ type V1_IStateAction = IStateAction;
 type V1_IActionEnvelope = IActionEnvelope;
 type V1_IActionOrigin = IActionOrigin;
 type V1_IRootActiveSessionsChangedAction = IRootActiveSessionsChangedAction;
+type V1_IRootLoadedSessionChangedAction = IRootLoadedSessionChangedAction;
+type V1_IRootLoadedSessionRemovedAction = IRootLoadedSessionRemovedAction;
 type V1_ISessionToolCallApprovedAction = ISessionToolCallApprovedAction;
 type V1_ISessionToolCallDeniedAction = ISessionToolCallDeniedAction;
 type V1_ISessionServerToolsChangedAction = ISessionServerToolsChangedAction;
@@ -342,6 +346,10 @@ type _CheckActionEnvelope = AssertCompatible<V1_IActionEnvelope, IActionEnvelope
 type _CheckActionOrigin = AssertCompatible<V1_IActionOrigin, IActionOrigin>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckActiveSessionsChangedAction = AssertCompatible<V1_IRootActiveSessionsChangedAction, IRootActiveSessionsChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckRootLoadedSessionChangedAction = AssertCompatible<V1_IRootLoadedSessionChangedAction, IRootLoadedSessionChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckRootLoadedSessionRemovedAction = AssertCompatible<V1_IRootLoadedSessionRemovedAction, IRootLoadedSessionRemovedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallApprovedAction = AssertCompatible<V1_ISessionToolCallApprovedAction, ISessionToolCallApprovedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Implementing InputNeeded I ran into the problem that a client can display the list of loaded sessions obtained via the listSessions command, but unless it subscribes to every session's updates it cannot know when any of those session attributes change.

I didn't find any solution to this that I loved, but the one I hated least was this -- letting the agent host having a list of "hot" sessions on its root state that it can publish updates to. Generally these should be the sessions that are in use / actively being updated by a client or agent loop, up to the agent host's discretion.