### PR TITLE
allow notifying the client when session summaries update

### DIFF
--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -256,7 +256,9 @@ UsageInfo {
 The session list can be arbitrarily large and is **not** part of the state tree. Instead:
 
 - Clients fetch the list imperatively via `listSessions()` RPC.
-- The server sends lightweight **notifications** (`sessionAdded`, `sessionRemoved`) so connected clients can update a local cache without re-fetching.
+- The server sends lightweight **notifications** to keep connected clients' caches in sync without re-fetching:
+  - `notify/sessionAdded` and `notify/sessionRemoved` signal lifecycle (creation and disposal).
+  - `notify/sessionSummaryChanged` streams partial updates to an existing session's summary (title, status, `modifiedAt`, model, working directory, `isRead`, `isDone`, `diffs`) so clients that are displaying a session list can stay in sync without subscribing to every session URI individually. Only fields present in `changes` carry new values; omitted fields are unchanged. The server SHOULD emit this notification whenever any mutable summary field changes, and MAY coalesce or debounce noisy updates (for example, rapid `modifiedAt` bumps while a turn is streaming) at its discretion.
 
 Notifications are ephemeral — not processed by reducers, not stored in state, not replayed on reconnect. On reconnect, clients re-fetch the list.
 

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -144,6 +144,32 @@ Steering messages added while idle are silently stored and consumed when a turn 
 
 The server disposes the session and broadcasts a `notify/sessionRemoved` notification to all clients.
 
+## Session Summary Updates
+
+While a session is alive, its [summary](/guide/state-model#session-summary) may change in response to agent activity or client actions (for example, the title is auto-generated, the status transitions from `Idle` to `InProgress`, `modifiedAt` advances, or `diffs` accumulate). The server SHOULD broadcast a `notify/sessionSummaryChanged` notification to all connected clients whenever any mutable field of `ISessionSummary` changes, carrying only the changed fields:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notification",
+  "params": {
+    "notification": {
+      "type": "notify/sessionSummaryChanged",
+      "session": "copilot:/<uuid>",
+      "changes": {
+        "title": "Refactor auth middleware",
+        "status": 8,
+        "modifiedAt": 1710000123456
+      }
+    }
+  }
+}
+```
+
+This lets clients that maintain a cached session list (for example, from a previous `listSessions()` call) patch their entries in place without subscribing to every session URI. Identity fields (`resource`, `provider`, `createdAt`) never change and are not carried.
+
+Servers MAY coalesce or debounce this notification for noisy fields — for example, rapid `modifiedAt` bumps while a turn is streaming, or frequent `diffs` updates during an edit burst — at their discretion. Like all protocol notifications, `notify/sessionSummaryChanged` is ephemeral and is **not** replayed on reconnect; clients should re-fetch via `listSessions()` when they reconnect.
+
 ## Reconnection
 
 If the transport connection drops, the client reconnects and sends a `reconnect` **request**:

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -109,4 +109,20 @@ In addition to action envelopes, the server broadcasts **protocol notifications*
 }
 ```
 
+For partial updates to an existing session's summary (title, status, `modifiedAt`, etc.), the server broadcasts `notify/sessionSummaryChanged` with only the fields that changed:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notification",
+  "params": {
+    "notification": {
+      "type": "notify/sessionSummaryChanged",
+      "session": "copilot:/<uuid>",
+      "changes": { "title": "Refactor auth middleware", "status": 8 }
+    }
+  }
+}
+```
+
 Protocol notifications go to all connected clients regardless of subscriptions. They are not stored in state and are not replayed on reconnection.

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -39,6 +39,77 @@
         "session"
       ]
     },
+    "ISessionSummaryChangedNotification": {
+      "type": "object",
+      "description": "Broadcast to all connected clients when an existing session's summary\nchanges (title, status, `modifiedAt`, model, working directory, read/done\nstate, or diff statistics).\n\nThis notification lets clients that maintain a cached session list — for\nexample, the result of a previous `listSessions()` call — stay in sync with\nin-flight sessions without having to subscribe to every session URI\nindividually. It is complementary to, not a replacement for,\n`notify/sessionAdded` and `notify/sessionRemoved`: those signal lifecycle\n(creation/disposal), while this signals summary-level mutations on an\nalready-known session.\n\nSemantics:\n\n- Only fields present in `changes` have new values; omitted fields are\n  unchanged on the client's cached summary.\n- Identity fields (`resource`, `provider`, `createdAt`) never change and\n  are not carried.\n- Like all protocol notifications, this is ephemeral: it is **not**\n  replayed on reconnect. On reconnect, clients should re-fetch the full\n  catalog via `listSessions()` as usual.\n- The server SHOULD emit this notification whenever any mutable field on\n  {@link ISessionSummary | `ISessionSummary`} changes for a session the\n  server has surfaced via `listSessions()` or `notify/sessionAdded`.\n  Servers MAY coalesce or debounce updates for noisy fields (for example,\n  `modifiedAt` bumps while a turn is streaming, or rapidly changing\n  `diffs`) at their discretion.\n- Clients that have no cached entry for `session` MAY ignore the\n  notification; it is not a substitute for `notify/sessionAdded`.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/NotificationType.SessionSummaryChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the session whose summary changed"
+        },
+        "changes": {
+          "type": "object",
+          "properties": {
+            "resource": {
+              "$ref": "#/$defs/URI",
+              "description": "Session URI"
+            },
+            "provider": {
+              "type": "string",
+              "description": "Agent provider ID"
+            },
+            "title": {
+              "type": "string",
+              "description": "Session title"
+            },
+            "status": {
+              "$ref": "#/$defs/SessionStatus",
+              "description": "Current session status"
+            },
+            "createdAt": {
+              "type": "number",
+              "description": "Creation timestamp"
+            },
+            "modifiedAt": {
+              "type": "number",
+              "description": "Last modification timestamp"
+            },
+            "model": {
+              "type": "string",
+              "description": "Currently selected model"
+            },
+            "workingDirectory": {
+              "$ref": "#/$defs/URI",
+              "description": "The working directory URI for this session"
+            },
+            "isRead": {
+              "type": "boolean",
+              "description": "Whether the client has viewed this session since its last modification"
+            },
+            "isDone": {
+              "type": "boolean",
+              "description": "Whether the session has been marked as done by the client"
+            },
+            "diffs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ISessionFileDiff"
+              },
+              "description": "Files changed during this session with diff statistics"
+            }
+          },
+          "description": "Mutable summary fields that changed; omitted fields are unchanged.\n\nIdentity fields (`resource`, `provider`, `createdAt`) never change and\nMUST be omitted by senders; receivers SHOULD ignore them if present."
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "changes"
+      ]
+    },
     "IAuthRequiredNotification": {
       "type": "object",
       "description": "Sent by the server when a protected resource requires (re-)authentication.\n\nThis notification is sent when a previously valid token expires or is\nrevoked, or when the server discovers a new authentication requirement.\nClients should obtain a fresh token and push it via the `authenticate`\ncommand.",
@@ -68,6 +139,9 @@
         },
         {
           "$ref": "#/$defs/ISessionRemovedNotification"
+        },
+        {
+          "$ref": "#/$defs/ISessionSummaryChangedNotification"
         },
         {
           "$ref": "#/$defs/IAuthRequiredNotification"

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -130,6 +130,20 @@ function typeTextToSchema(typeText: string, project: Project): JsonSchema {
     return typeTextToSchema(undefinedMatch[1], project);
   }
 
+  // Partial<X> — inline every property of X as optional (no `required`).
+  // Keeps the generated schema self-describing without introducing synthetic
+  // $defs entries that have no counterpart in the TS source.
+  const partialMatch = cleaned.match(/^Partial<(\w+)>$/);
+  if (partialMatch) {
+    const iface = findInterface(project, partialMatch[1]);
+    if (iface) {
+      const inner = interfaceToSchema(iface, project);
+      delete inner.required;
+      delete inner.description;
+      return inner;
+    }
+  }
+
   // Union types (not string literals): A | B
   if (cleaned.includes(' | ') && !cleaned.startsWith("'")) {
     const parts = splitUnionType(cleaned);

--- a/scripts/generate-markdown.ts
+++ b/scripts/generate-markdown.ts
@@ -736,11 +736,22 @@ function generateNotificationsPage(project: Project): string {
     lines.push(example + '\n');
   }
 
+  const sessionSummaryChanged = getInterface(project, 'ISessionSummaryChangedNotification');
+  lines.push(`### \`notify/sessionSummaryChanged\` ${sourceLink(sessionSummaryChanged)}\n`);
+  lines.push(getJsDocDescription(sessionSummaryChanged) + '\n');
+  lines.push(renderInterfaceTable(sessionSummaryChanged) + '\n');
+
+  const sessionSummaryChangedExamples = getJsDocExamples(sessionSummaryChanged);
+  for (const example of sessionSummaryChangedExamples) {
+    lines.push('**Example:**\n');
+    lines.push(example + '\n');
+  }
+
   // Usage Pattern
   lines.push('## Usage Pattern\n');
   lines.push('Clients use notifications to maintain a local session list cache:\n');
   lines.push('1. On connect, fetch the full session list via `listSessions()`.');
-  lines.push('2. Listen for `notify/sessionAdded` and `notify/sessionRemoved` to keep the cache updated.');
+  lines.push('2. Listen for `notify/sessionAdded` and `notify/sessionRemoved` to track lifecycle, and `notify/sessionSummaryChanged` to patch cached summaries in place.');
   lines.push('3. On reconnect, **re-fetch** the full list — notifications are not replayed.\n');
 
   // Version Introduction
@@ -748,7 +759,8 @@ function generateNotificationsPage(project: Project): string {
   lines.push('| Notification Type | Version |');
   lines.push('|---|---|');
   lines.push('| `notify/sessionAdded` | 1 |');
-  lines.push('| `notify/sessionRemoved` | 1 |\n');
+  lines.push('| `notify/sessionRemoved` | 1 |');
+  lines.push('| `notify/sessionSummaryChanged` | 1 |\n');
 
   // Server Notifications (action delivery)
   lines.push('## Server Notifications\n');

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -58,6 +58,19 @@ function needsCodingKey(tsPropName: string): boolean {
 /** Known inline object types mapped to named Swift structs */
 const INLINE_TYPE_OVERRIDES: Record<string, string> = {};
 
+/**
+ * Synthetic Swift structs required for `Partial<T>` references encountered
+ * during type mapping. Swift has no structural `Partial`, so we emit a
+ * sibling struct with every property forced optional. Populated by
+ * `mapType`, consumed by the file generators that reference them.
+ */
+const requiredPartialStructs = new Set<string>();
+
+/** Swift name for `Partial<ISessionSummary>` → `PartialSessionSummary`. */
+function partialSwiftName(tsInterfaceName: string): string {
+  return `Partial${swiftTypeName(tsInterfaceName)}`;
+}
+
 /** Map a TypeScript type string to a Swift type string */
 function mapType(tsType: string, propName?: string, containerName?: string): string {
   tsType = tsType.replace(/import\([^)]+\)\./g, '').trim();
@@ -107,6 +120,14 @@ function mapType(tsType: string, propName?: string, containerName?: string): str
   // Record<string, T>
   const recordMatch = tsType.match(/^Record<string,\s*(.+)>$/);
   if (recordMatch) return `[String: ${mapType(recordMatch[1])}]`;
+
+  // Partial<T> — Swift has no structural Partial; emit/ reuse a sibling
+  // struct with every property optional. Tracked for later emission.
+  const partialMatch = tsType.match(/^Partial<(\w+)>$/);
+  if (partialMatch) {
+    requiredPartialStructs.add(partialMatch[1]);
+    return partialSwiftName(partialMatch[1]);
+  }
 
   // Enum member union: EnumName.A | EnumName.B | ...
   const enumUnionMatch = tsType.match(/^(\w+)\.\w+(\s*\|\s*\1\.\w+)*$/);
@@ -376,6 +397,25 @@ function generateStructFromInterface(
   const name = swiftNameOverride ?? swiftTypeName(tsInterfaceName);
   const props = extractProps(iface, project);
   return generateSwiftStruct(name, props);
+}
+
+/**
+ * Emit a Swift counterpart for `Partial<T>`: same properties as `T` but with
+ * every field forced optional. The synthetic struct is referenced by
+ * `mapType` via `partialSwiftName`.
+ */
+function generatePartialStructFromInterface(
+  project: Project,
+  tsInterfaceName: string,
+): string {
+  const iface = findInterface(project, tsInterfaceName);
+  if (!iface) throw new Error(`Interface ${tsInterfaceName} not found`);
+  const props = extractProps(iface, project).map(p => ({
+    ...p,
+    optional: true,
+    type: p.type.endsWith('?') ? p.type : `${p.type}?`,
+  }));
+  return generateSwiftStruct(partialSwiftName(tsInterfaceName), props);
 }
 
 // ─── State File Generator ────────────────────────────────────────────────────
@@ -911,7 +951,7 @@ function generateCommandsFile(project: Project): string {
 const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'NotificationType'];
 
 const NOTIFICATION_STRUCTS = [
-  'ISessionAddedNotification', 'ISessionRemovedNotification', 'IAuthRequiredNotification',
+  'ISessionAddedNotification', 'ISessionRemovedNotification', 'ISessionSummaryChangedNotification', 'IAuthRequiredNotification',
 ];
 
 const PROTOCOL_NOTIFICATION_UNION: UnionConfig = {
@@ -920,6 +960,7 @@ const PROTOCOL_NOTIFICATION_UNION: UnionConfig = {
   variants: [
     { caseName: 'sessionAdded', structName: 'SessionAddedNotification', discriminantValue: 'notify/sessionAdded' },
     { caseName: 'sessionRemoved', structName: 'SessionRemovedNotification', discriminantValue: 'notify/sessionRemoved' },
+    { caseName: 'sessionSummaryChanged', structName: 'SessionSummaryChangedNotification', discriminantValue: 'notify/sessionSummaryChanged' },
     { caseName: 'authRequired', structName: 'AuthRequiredNotification', discriminantValue: 'notify/authRequired' },
   ],
 };
@@ -937,6 +978,11 @@ function generateNotificationsFile(project: Project): string {
     }
   }
 
+  // Snapshot partials requested before notifications (typically empty) so we
+  // can emit exactly the partials introduced by notification structs in this
+  // file, keeping them co-located with their sole consumer.
+  const priorPartials = new Set(requiredPartialStructs);
+
   lines.push('// MARK: - Notification Types\n');
   for (const ifaceName of NOTIFICATION_STRUCTS) {
     try {
@@ -945,6 +991,20 @@ function generateNotificationsFile(project: Project): string {
     } catch (e) {
       lines.push(`// TODO: Could not generate ${ifaceName}: ${e}`);
       lines.push('');
+    }
+  }
+
+  const newPartials = [...requiredPartialStructs].filter(n => !priorPartials.has(n));
+  if (newPartials.length > 0) {
+    lines.push('// MARK: - Partial Summary Types\n');
+    for (const tsName of newPartials) {
+      try {
+        lines.push(generatePartialStructFromInterface(project, tsName));
+        lines.push('');
+      } catch (e) {
+        lines.push(`// TODO: Could not generate Partial<${tsName}>: ${e}`);
+        lines.push('');
+      }
     }
   }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -211,6 +211,7 @@ export { ReconnectResultType, ContentEncoding } from './commands.js';
 export type {
   ISessionAddedNotification,
   ISessionRemovedNotification,
+  ISessionSummaryChangedNotification,
   IAuthRequiredNotification,
   IProtocolNotification,
 } from './notifications.js';

--- a/types/notifications.ts
+++ b/types/notifications.ts
@@ -30,6 +30,7 @@ export const enum AuthRequiredReason {
 export const enum NotificationType {
   SessionAdded = 'notify/sessionAdded',
   SessionRemoved = 'notify/sessionRemoved',
+  SessionSummaryChanged = 'notify/sessionSummaryChanged',
   AuthRequired = 'notify/authRequired',
 }
 
@@ -91,6 +92,71 @@ export interface ISessionRemovedNotification {
 }
 
 /**
+ * Broadcast to all connected clients when an existing session's summary
+ * changes (title, status, `modifiedAt`, model, working directory, read/done
+ * state, or diff statistics).
+ *
+ * This notification lets clients that maintain a cached session list — for
+ * example, the result of a previous `listSessions()` call — stay in sync with
+ * in-flight sessions without having to subscribe to every session URI
+ * individually. It is complementary to, not a replacement for,
+ * `notify/sessionAdded` and `notify/sessionRemoved`: those signal lifecycle
+ * (creation/disposal), while this signals summary-level mutations on an
+ * already-known session.
+ *
+ * Semantics:
+ *
+ * - Only fields present in `changes` have new values; omitted fields are
+ *   unchanged on the client's cached summary.
+ * - Identity fields (`resource`, `provider`, `createdAt`) never change and
+ *   are not carried.
+ * - Like all protocol notifications, this is ephemeral: it is **not**
+ *   replayed on reconnect. On reconnect, clients should re-fetch the full
+ *   catalog via `listSessions()` as usual.
+ * - The server SHOULD emit this notification whenever any mutable field on
+ *   {@link ISessionSummary | `ISessionSummary`} changes for a session the
+ *   server has surfaced via `listSessions()` or `notify/sessionAdded`.
+ *   Servers MAY coalesce or debounce updates for noisy fields (for example,
+ *   `modifiedAt` bumps while a turn is streaming, or rapidly changing
+ *   `diffs`) at their discretion.
+ * - Clients that have no cached entry for `session` MAY ignore the
+ *   notification; it is not a substitute for `notify/sessionAdded`.
+ *
+ * @category Protocol Notifications
+ * @version 1
+ * @example
+ * ```json
+ * {
+ *   "jsonrpc": "2.0",
+ *   "method": "notification",
+ *   "params": {
+ *     "notification": {
+ *       "type": "notify/sessionSummaryChanged",
+ *       "session": "copilot:/<uuid>",
+ *       "changes": {
+ *         "title": "Refactor auth middleware",
+ *         "status": 8,
+ *         "modifiedAt": 1710000123456
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export interface ISessionSummaryChangedNotification {
+  type: NotificationType.SessionSummaryChanged;
+  /** URI of the session whose summary changed */
+  session: URI;
+  /**
+   * Mutable summary fields that changed; omitted fields are unchanged.
+   *
+   * Identity fields (`resource`, `provider`, `createdAt`) never change and
+   * MUST be omitted by senders; receivers SHOULD ignore them if present.
+   */
+  changes: Partial<ISessionSummary>;
+}
+
+/**
  * Sent by the server when a protected resource requires (re-)authentication.
  *
  * This notification is sent when a previously valid token expires or is
@@ -130,4 +196,5 @@ export interface IAuthRequiredNotification {
 export type IProtocolNotification =
   | ISessionAddedNotification
   | ISessionRemovedNotification
+  | ISessionSummaryChangedNotification
   | IAuthRequiredNotification;

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -88,6 +88,7 @@ export function isActionKnownToVersion(action: IStateAction, clientVersion: numb
 export const NOTIFICATION_INTRODUCED_IN: { readonly [K in IProtocolNotification['type']]: number } = {
   [NotificationType.SessionAdded]: 1,
   [NotificationType.SessionRemoved]: 1,
+  [NotificationType.SessionSummaryChanged]: 1,
   [NotificationType.AuthRequired]: 1,
 };
 

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -111,6 +111,7 @@ import type {
 import type {
   IProtocolNotification,
   IAuthRequiredNotification,
+  ISessionSummaryChangedNotification,
 } from '../notifications.js';
 
 import type {
@@ -257,6 +258,7 @@ type V1_IDisposeTerminalParams = IDisposeTerminalParams;
 type V1_ISessionForkSource = ISessionForkSource;
 type V1_IProtocolNotification = IProtocolNotification;
 type V1_IAuthRequiredNotification = IAuthRequiredNotification;
+type V1_ISessionSummaryChangedNotification = ISessionSummaryChangedNotification;
 type V1_IListSessionsResult = IListSessionsResult;
 type V1_IAuthenticateParams = IAuthenticateParams;
 type V1_IAuthenticateResult = IAuthenticateResult;
@@ -442,6 +444,8 @@ type _CheckToolCallContentChangedAction = AssertCompatible<V1_ISessionToolCallCo
 type _CheckSessionForkSource = AssertCompatible<V1_ISessionForkSource, ISessionForkSource>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckProtocolNotification = AssertCompatible<V1_IProtocolNotification, IProtocolNotification>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSessionSummaryChangedNotification = AssertCompatible<V1_ISessionSummaryChangedNotification, ISessionSummaryChangedNotification>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckListSessionsResult = AssertCompatible<V1_IListSessionsResult, IListSessionsResult>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Just a notification from the AH (which may be delayed/delivered at any time) so that clients showing a session list can keep their state in sync.