### PR TITLE
Remove session config icon metadata

### DIFF
--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1834,7 +1834,7 @@
     },
     "ISessionConfigPropertySchema": {
       "type": "object",
-      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`, `enumIcons`) are parallel arrays that provide UI metadata for each `enum` value.",
+      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`) are parallel arrays that provide UI metadata for each `enum` value.",
       "properties": {
         "type": {
           "type": "string",
@@ -1875,13 +1875,6 @@
             "type": "string"
           },
           "description": "Display extension: description per enum value (parallel array)"
-        },
-        "enumIcons": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Display extension: icon identifier per enum value (parallel array)"
         },
         "enumDynamic": {
           "type": "boolean",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -653,10 +653,6 @@
         "description": {
           "type": "string",
           "description": "Optional secondary description"
-        },
-        "icon": {
-          "type": "string",
-          "description": "Optional icon identifier"
         }
       },
       "required": [
@@ -1161,7 +1157,7 @@
     },
     "ISessionConfigPropertySchema": {
       "type": "object",
-      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`, `enumIcons`) are parallel arrays that provide UI metadata for each `enum` value.",
+      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`) are parallel arrays that provide UI metadata for each `enum` value.",
       "properties": {
         "type": {
           "type": "string",
@@ -1202,13 +1198,6 @@
             "type": "string"
           },
           "description": "Display extension: description per enum value (parallel array)"
-        },
-        "enumIcons": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Display extension: icon identifier per enum value (parallel array)"
         },
         "enumDynamic": {
           "type": "boolean",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -601,7 +601,7 @@
     },
     "ISessionConfigPropertySchema": {
       "type": "object",
-      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`, `enumIcons`) are parallel arrays that provide UI metadata for each `enum` value.",
+      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`) are parallel arrays that provide UI metadata for each `enum` value.",
       "properties": {
         "type": {
           "type": "string",
@@ -642,13 +642,6 @@
             "type": "string"
           },
           "description": "Display extension: description per enum value (parallel array)"
-        },
-        "enumIcons": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Display extension: icon identifier per enum value (parallel array)"
         },
         "enumDynamic": {
           "type": "boolean",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -454,7 +454,7 @@
     },
     "ISessionConfigPropertySchema": {
       "type": "object",
-      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`, `enumIcons`) are parallel arrays that provide UI metadata for each `enum` value.",
+      "description": "A JSON Schema-compatible string enum property descriptor with display extensions.\n\nStandard JSON Schema fields (`type`, `title`, `description`, `default`,\n`enum`) allow validators to process the schema. Display extensions\n(`enumLabels`, `enumDescriptions`) are parallel arrays that provide UI metadata for each `enum` value.",
       "properties": {
         "type": {
           "type": "string",
@@ -495,13 +495,6 @@
             "type": "string"
           },
           "description": "Display extension: description per enum value (parallel array)"
-        },
-        "enumIcons": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Display extension: icon identifier per enum value (parallel array)"
         },
         "enumDynamic": {
           "type": "boolean",

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -790,8 +790,6 @@ export interface ISessionConfigValueItem {
   label: string;
   /** Optional secondary description */
   description?: string;
-  /** Optional icon identifier */
-  icon?: string;
 }
 
 /**

--- a/types/state.ts
+++ b/types/state.ts
@@ -386,7 +386,7 @@ export interface ISessionSummary {
  *
  * Standard JSON Schema fields (`type`, `title`, `description`, `default`,
  * `enum`) allow validators to process the schema. Display extensions
- * (`enumLabels`, `enumDescriptions`, `enumIcons`) are parallel arrays that provide UI metadata for each `enum` value.
+ * (`enumLabels`, `enumDescriptions`) are parallel arrays that provide UI metadata for each `enum` value.
  *
  * @category Session Config Types
  */
@@ -405,8 +405,6 @@ export interface ISessionConfigPropertySchema {
   enumLabels?: string[];
   /** Display extension: description per enum value (parallel array) */
   enumDescriptions?: string[];
-  /** Display extension: icon identifier per enum value (parallel array) */
-  enumIcons?: string[];
   /**
    * Display extension: when `true`, the full set of allowed values is too large
    * to enumerate statically. The client SHOULD use `sessionConfigCompletions`


### PR DESCRIPTION
Removes icon metadata from session config protocol shapes so clients can decide how to render icons for well-known config properties and values.

Changes:
- Remove `icon` from `ISessionConfigValueItem`.
- Remove `enumIcons` from `ISessionConfigPropertySchema`.
- Regenerate JSON schemas after the type change.

Validation:
- `npm test`

(Written by Copilot)