### PR TITLE
Use npx for c8 in npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:preview": "vitepress preview docs",
     "typecheck": "tsc --noEmit -p types/tsconfig.json",
     "lint": "eslint",
-    "test": "npm run typecheck && npm run lint && c8 --include types/reducers.ts --check-coverage --branches 100 tsx --test types/*.test.ts"
+    "test": "npm run typecheck && npm run lint && npx c8 --include types/reducers.ts --check-coverage --branches 100 tsx --test types/*.test.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates the npm test script to invoke c8 through npx so the coverage check can run when c8 is not directly available on PATH.

Validation:
- npm test

(Written by Copilot)