### PR TITLE
Enhance IToolCallPendingConfirmationState with file edits, editable flag, and edited parameters

### DIFF
--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -210,7 +210,7 @@ stateDiagram-v2
 | Status | Key Fields | Description |
 |---|---|---|
 | `streaming` | `partialInput?` | LM is streaming tool call parameters. `partialInput` accumulates via `toolCallDelta`. |
-| `pending-confirmation` | `invocationMessage`, `toolInput?` | Parameters complete or mid-execution confirmation needed. Uses `_meta` for context (e.g. permission kind, command text). |
+| `pending-confirmation` | `invocationMessage`, `toolInput?`, `edits?`, `editable?` | Parameters complete or mid-execution confirmation needed. `edits` previews file changes. `editable` indicates the client may edit parameters before confirming. Uses `_meta` for additional context. |
 | `running` | `confirmed` | Tool is executing. `confirmed` records how it was approved. |
 | `pending-result-confirmation` | `success`, `pastTenseMessage`, `content?` | Execution finished, waiting for client to approve the result. |
 | `completed` | `success`, `pastTenseMessage`, `content?` | Terminal state. Tool finished. |
@@ -219,6 +219,10 @@ stateDiagram-v2
 ### Mid-execution Re-confirmation
 
 When a running tool needs additional user approval (e.g. a shell permission), the server dispatches `session/toolCallReady` again without `confirmed`. This transitions the tool call from `running` back to `pending-confirmation`, updating `invocationMessage` and `_meta` with context about what needs approval. The client uses the standard `session/toolCallConfirmed` flow to approve or deny.
+
+### Editable Parameters
+
+When `editable` is `true` on a `pending-confirmation` tool call, the client may allow the user to modify the tool's input parameters before confirming. If the user edits the parameters, the client includes `editedToolInput` on the `session/toolCallConfirmed` action. The reducer uses `editedToolInput` (if present) in place of the original `toolInput` when transitioning to `running`.
 
 When a turn completes, non-terminal tool calls in `responseParts` are force-cancelled with reason `'skipped'`.
 

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -24,6 +24,7 @@ import type {
   ISessionInputRequest,
   ITerminalInfo,
   ITerminalClaim,
+  IFileEdit,
   SessionInputResponseKind,
 } from './state.js';
 
@@ -320,6 +321,10 @@ export interface ISessionToolCallReadyAction extends IToolCallActionBase {
   toolInput?: string;
   /** Short title for the confirmation prompt (e.g. `"Run in terminal"`, `"Write file"`) */
   confirmationTitle?: StringOrMarkdown;
+  /** File edits that this tool call will perform, for preview before confirmation */
+  edits?: { items: IFileEdit[] };
+  /** Whether the agent host allows the client to edit the tool's input parameters before confirming */
+  editable?: boolean;
   /** If set, the tool was auto-confirmed and transitions directly to `running` */
   confirmed?: ToolCallConfirmationReason;
 }
@@ -337,6 +342,8 @@ export interface ISessionToolCallApprovedAction extends IToolCallActionBase {
   approved: true;
   /** How the tool was confirmed */
   confirmed: ToolCallConfirmationReason;
+  /** Edited tool input parameters, if the client modified them before confirming */
+  editedToolInput?: string;
 }
 
 /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -43,6 +43,7 @@ export type {
   IToolResultEmbeddedResourceContent,
   IToolResultResourceContent,
   IToolResultContent,
+  IFileEdit,
   IToolResultFileEditContent,
   IToolResultTerminalContent,
   IToolResultSubagentContent,

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -394,6 +394,8 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
           invocationMessage: action.invocationMessage,
           toolInput: action.toolInput,
           confirmationTitle: action.confirmationTitle,
+          edits: action.edits,
+          editable: action.editable,
         };
       }));
 
@@ -408,7 +410,7 @@ export function sessionReducer(state: ISessionState, action: ISessionAction, log
             status: ToolCallStatus.Running,
             ...base,
             invocationMessage: tc.invocationMessage,
-            toolInput: tc.toolInput,
+            toolInput: action.editedToolInput ?? tc.toolInput,
             confirmed: action.confirmed,
           };
         }

--- a/types/state.ts
+++ b/types/state.ts
@@ -983,6 +983,10 @@ export interface IToolCallPendingConfirmationState extends IToolCallBase, IToolC
   status: ToolCallStatus.PendingConfirmation;
   /** Short title for the confirmation prompt (e.g. `"Run in terminal"`, `"Write file"`) */
   confirmationTitle?: StringOrMarkdown;
+  /** File edits that this tool call will perform, for preview before confirmation */
+  edits?: { items: IFileEdit[] };
+  /** Whether the agent host allows the client to edit the tool's input parameters before confirming */
+  editable?: boolean;
 }
 
 /**
@@ -1178,15 +1182,14 @@ export interface IToolResultResourceContent extends IContentRef {
 }
 
 /**
- * Describes a file modification performed by a tool.
+ * Describes a file modification with before/after state and diff metadata.
  *
  * Supports creates (only `after`), deletes (only `before`), renames/moves
  * (different `uri` in `before` and `after`), and edits (same `uri`, different content).
  *
  * @category Tool Result Content
  */
-export interface IToolResultFileEditContent {
-  type: ToolResultContentType.FileEdit;
+export interface IFileEdit {
   /** The file state before the edit. Absent for file creations or for in-place file edits. */
   before?: {
     /** URI of the file before the edit */
@@ -1208,6 +1211,15 @@ export interface IToolResultFileEditContent {
     /** Number of items removed (e.g., lines for text files, cells for notebooks) */
     removed?: number;
   };
+}
+
+/**
+ * Describes a file modification performed by a tool.
+ *
+ * @category Tool Result Content
+ */
+export interface IToolResultFileEditContent extends IFileEdit {
+  type: ToolResultContentType.FileEdit;
 }
 
 /**

--- a/types/test-cases/reducers/026-toolcallready-transitions-running-tool-back-to-pending-confirmation.json
+++ b/types/test-cases/reducers/026-toolcallready-transitions-running-tool-back-to-pending-confirmation.json
@@ -78,7 +78,9 @@
             "_meta": null,
             "invocationMessage": "Run: rm -rf /tmp/test",
             "toolInput": null,
-            "confirmationTitle": null
+            "confirmationTitle": null,
+            "edits": null,
+            "editable": null
           }
         }
       ],

--- a/types/test-cases/reducers/111-toolcall-pending-confirmation-sets-input-needed-status.json
+++ b/types/test-cases/reducers/111-toolcall-pending-confirmation-sets-input-needed-status.json
@@ -67,7 +67,9 @@
             "_meta": null,
             "invocationMessage": "Run: rm -rf /tmp/test",
             "toolInput": "rm -rf /tmp/test",
-            "confirmationTitle": null
+            "confirmationTitle": null,
+            "edits": null,
+            "editable": null
           }
         }
       ],

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -42,6 +42,7 @@ import type {
   IToolResultTextContent,
   IToolResultEmbeddedResourceContent,
   IToolResultResourceContent,
+  IFileEdit,
   IToolResultFileEditContent,
   IToolResultTerminalContent,
   IToolResultSubagentContent,
@@ -208,6 +209,7 @@ type V1_IToolAnnotations = IToolAnnotations;
 type V1_IToolResultTextContent = IToolResultTextContent;
 type V1_IToolResultEmbeddedResourceContent = IToolResultEmbeddedResourceContent;
 type V1_IToolResultResourceContent = IToolResultResourceContent;
+type V1_IFileEdit = IFileEdit;
 type V1_IToolResultFileEditContent = IToolResultFileEditContent;
 type V1_IToolResultTerminalContent = IToolResultTerminalContent;
 type V1_IToolResultSubagentContent = IToolResultSubagentContent;
@@ -396,6 +398,8 @@ type _CheckToolResultTextContent = AssertCompatible<V1_IToolResultTextContent, I
 type _CheckToolResultEmbeddedResourceContent = AssertCompatible<V1_IToolResultEmbeddedResourceContent, IToolResultEmbeddedResourceContent>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolResultResourceContent = AssertCompatible<V1_IToolResultResourceContent, IToolResultResourceContent>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckFileEdit = AssertCompatible<V1_IFileEdit, IFileEdit>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolResultFileEditContent = AssertCompatible<V1_IToolResultFileEditContent, IToolResultFileEditContent>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
- Extract IFileEdit base interface from IToolResultFileEditContent with before/after/diff fields
- Add optional edits (wrapped in { items: IFileEdit[] }) and editable flag to IToolCallPendingConfirmationState for previewing file changes and allowing parameter editing before confirmation
- Add edits and editable to ISessionToolCallReadyAction so they flow through to pending-confirmation state
- Add editedToolInput to ISessionToolCallApprovedAction for clients to send modified parameters when confirming
- Update reducer to propagate edits/editable to state and use editedToolInput when transitioning to running
- Update v1 compatibility types and test fixtures
- Update state-model docs with new fields and editable parameters section

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>