### PR TITLE
agentHost: include IFileEdit in session summary

### DIFF
--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -381,6 +381,22 @@
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         },
+        "edits": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "File edits that this tool call will perform, for preview before confirmation"
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Whether the agent host allows the client to edit the tool's input parameters before confirming"
+        },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
           "description": "If set, the tool was auto-confirmed and transitions directly to `running`"
@@ -424,6 +440,10 @@
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
           "description": "How the tool was confirmed"
+        },
+        "editedToolInput": {
+          "type": "string",
+          "description": "Edited tool input parameters, if the client modified them before confirming"
         }
       },
       "required": [
@@ -841,7 +861,7 @@
         "diffs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ISessionFileDiff"
+            "$ref": "#/$defs/IFileEdit"
           },
           "description": "Updated file diffs for the session"
         }
@@ -1804,27 +1824,6 @@
         "tools"
       ]
     },
-    "ISessionFileDiff": {
-      "type": "object",
-      "description": "A summary of changes to a single file within a session.",
-      "properties": {
-        "uri": {
-          "$ref": "#/$defs/URI",
-          "description": "URI of the affected file"
-        },
-        "added": {
-          "type": "number",
-          "description": "Number of items added (e.g., lines for text files, cells for notebooks)"
-        },
-        "removed": {
-          "type": "number",
-          "description": "Number of items removed (e.g., lines for text files, cells for notebooks)"
-        }
-      },
-      "required": [
-        "uri"
-      ]
-    },
     "IProjectInfo": {
       "type": "object",
       "description": "Server-owned project metadata for a session.",
@@ -1893,7 +1892,7 @@
         "diffs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ISessionFileDiff"
+            "$ref": "#/$defs/IFileEdit"
           },
           "description": "Files changed during this session with diff statistics"
         }
@@ -2864,6 +2863,22 @@
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
+        },
+        "edits": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "File edits that this tool call will perform, for preview before confirmation"
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Whether the agent host allows the client to edit the tool's input parameters before confirming"
         }
       },
       "required": [
@@ -3319,13 +3334,10 @@
         "type"
       ]
     },
-    "IToolResultFileEditContent": {
+    "IFileEdit": {
       "type": "object",
-      "description": "Describes a file modification performed by a tool.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
+      "description": "Describes a file modification with before/after state and diff metadata.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
       "properties": {
-        "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
-        },
         "before": {
           "type": "object",
           "properties": {
@@ -3369,6 +3381,59 @@
             }
           },
           "description": "Optional diff display metadata"
+        }
+      }
+    },
+    "IToolResultFileEditContent": {
+      "type": "object",
+      "description": "Describes a file modification performed by a tool.",
+      "properties": {
+        "before": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state before the edit. Absent for file creations or for in-place file edits."
+        },
+        "after": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state after the edit. Absent for file deletions."
+        },
+        "diff": {
+          "type": "object",
+          "properties": {
+            "added": {
+              "type": "number"
+            },
+            "removed": {
+              "type": "number"
+            }
+          },
+          "description": "Optional diff display metadata"
+        },
+        "type": {
+          "$ref": "#/$defs/ToolResultContentType.FileEdit"
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1043,27 +1043,6 @@
         "tools"
       ]
     },
-    "ISessionFileDiff": {
-      "type": "object",
-      "description": "A summary of changes to a single file within a session.",
-      "properties": {
-        "uri": {
-          "$ref": "#/$defs/URI",
-          "description": "URI of the affected file"
-        },
-        "added": {
-          "type": "number",
-          "description": "Number of items added (e.g., lines for text files, cells for notebooks)"
-        },
-        "removed": {
-          "type": "number",
-          "description": "Number of items removed (e.g., lines for text files, cells for notebooks)"
-        }
-      },
-      "required": [
-        "uri"
-      ]
-    },
     "IProjectInfo": {
       "type": "object",
       "description": "Server-owned project metadata for a session.",
@@ -1132,7 +1111,7 @@
         "diffs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ISessionFileDiff"
+            "$ref": "#/$defs/IFileEdit"
           },
           "description": "Files changed during this session with diff statistics"
         }
@@ -2103,6 +2082,22 @@
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
+        },
+        "edits": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "File edits that this tool call will perform, for preview before confirmation"
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Whether the agent host allows the client to edit the tool's input parameters before confirming"
         }
       },
       "required": [
@@ -2558,13 +2553,10 @@
         "type"
       ]
     },
-    "IToolResultFileEditContent": {
+    "IFileEdit": {
       "type": "object",
-      "description": "Describes a file modification performed by a tool.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
+      "description": "Describes a file modification with before/after state and diff metadata.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
       "properties": {
-        "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
-        },
         "before": {
           "type": "object",
           "properties": {
@@ -2608,6 +2600,59 @@
             }
           },
           "description": "Optional diff display metadata"
+        }
+      }
+    },
+    "IToolResultFileEditContent": {
+      "type": "object",
+      "description": "Describes a file modification performed by a tool.",
+      "properties": {
+        "before": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state before the edit. Absent for file creations or for in-place file edits."
+        },
+        "after": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state after the edit. Absent for file deletions."
+        },
+        "diff": {
+          "type": "object",
+          "properties": {
+            "added": {
+              "type": "number"
+            },
+            "removed": {
+              "type": "number"
+            }
+          },
+          "description": "Optional diff display metadata"
+        },
+        "type": {
+          "$ref": "#/$defs/ToolResultContentType.FileEdit"
         }
       },
       "required": [
@@ -3361,6 +3406,22 @@
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
         },
+        "edits": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "File edits that this tool call will perform, for preview before confirmation"
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Whether the agent host allows the client to edit the tool's input parameters before confirming"
+        },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
           "description": "If set, the tool was auto-confirmed and transitions directly to `running`"
@@ -3404,6 +3465,10 @@
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
           "description": "How the tool was confirmed"
+        },
+        "editedToolInput": {
+          "type": "string",
+          "description": "Edited tool input parameters, if the client modified them before confirming"
         }
       },
       "required": [
@@ -3821,7 +3886,7 @@
         "diffs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ISessionFileDiff"
+            "$ref": "#/$defs/IFileEdit"
           },
           "description": "Updated file diffs for the session"
         }

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -100,7 +100,7 @@
             "diffs": {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/ISessionFileDiff"
+                "$ref": "#/$defs/IFileEdit"
               },
               "description": "Files changed during this session with diff statistics"
             }
@@ -492,27 +492,6 @@
         "tools"
       ]
     },
-    "ISessionFileDiff": {
-      "type": "object",
-      "description": "A summary of changes to a single file within a session.",
-      "properties": {
-        "uri": {
-          "$ref": "#/$defs/URI",
-          "description": "URI of the affected file"
-        },
-        "added": {
-          "type": "number",
-          "description": "Number of items added (e.g., lines for text files, cells for notebooks)"
-        },
-        "removed": {
-          "type": "number",
-          "description": "Number of items removed (e.g., lines for text files, cells for notebooks)"
-        }
-      },
-      "required": [
-        "uri"
-      ]
-    },
     "IProjectInfo": {
       "type": "object",
       "description": "Server-owned project metadata for a session.",
@@ -581,7 +560,7 @@
         "diffs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ISessionFileDiff"
+            "$ref": "#/$defs/IFileEdit"
           },
           "description": "Files changed during this session with diff statistics"
         }
@@ -1552,6 +1531,22 @@
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
+        },
+        "edits": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "File edits that this tool call will perform, for preview before confirmation"
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Whether the agent host allows the client to edit the tool's input parameters before confirming"
         }
       },
       "required": [
@@ -2007,13 +2002,10 @@
         "type"
       ]
     },
-    "IToolResultFileEditContent": {
+    "IFileEdit": {
       "type": "object",
-      "description": "Describes a file modification performed by a tool.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
+      "description": "Describes a file modification with before/after state and diff metadata.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
       "properties": {
-        "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
-        },
         "before": {
           "type": "object",
           "properties": {
@@ -2057,6 +2049,59 @@
             }
           },
           "description": "Optional diff display metadata"
+        }
+      }
+    },
+    "IToolResultFileEditContent": {
+      "type": "object",
+      "description": "Describes a file modification performed by a tool.",
+      "properties": {
+        "before": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state before the edit. Absent for file creations or for in-place file edits."
+        },
+        "after": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state after the edit. Absent for file deletions."
+        },
+        "diff": {
+          "type": "object",
+          "properties": {
+            "added": {
+              "type": "number"
+            },
+            "removed": {
+              "type": "number"
+            }
+          },
+          "description": "Optional diff display metadata"
+        },
+        "type": {
+          "$ref": "#/$defs/ToolResultContentType.FileEdit"
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -345,27 +345,6 @@
         "tools"
       ]
     },
-    "ISessionFileDiff": {
-      "type": "object",
-      "description": "A summary of changes to a single file within a session.",
-      "properties": {
-        "uri": {
-          "$ref": "#/$defs/URI",
-          "description": "URI of the affected file"
-        },
-        "added": {
-          "type": "number",
-          "description": "Number of items added (e.g., lines for text files, cells for notebooks)"
-        },
-        "removed": {
-          "type": "number",
-          "description": "Number of items removed (e.g., lines for text files, cells for notebooks)"
-        }
-      },
-      "required": [
-        "uri"
-      ]
-    },
     "IProjectInfo": {
       "type": "object",
       "description": "Server-owned project metadata for a session.",
@@ -434,7 +413,7 @@
         "diffs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ISessionFileDiff"
+            "$ref": "#/$defs/IFileEdit"
           },
           "description": "Files changed during this session with diff statistics"
         }
@@ -1405,6 +1384,22 @@
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
+        },
+        "edits": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "File edits that this tool call will perform, for preview before confirmation"
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Whether the agent host allows the client to edit the tool's input parameters before confirming"
         }
       },
       "required": [
@@ -1860,13 +1855,10 @@
         "type"
       ]
     },
-    "IToolResultFileEditContent": {
+    "IFileEdit": {
       "type": "object",
-      "description": "Describes a file modification performed by a tool.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
+      "description": "Describes a file modification with before/after state and diff metadata.\n\nSupports creates (only `after`), deletes (only `before`), renames/moves\n(different `uri` in `before` and `after`), and edits (same `uri`, different content).",
       "properties": {
-        "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
-        },
         "before": {
           "type": "object",
           "properties": {
@@ -1910,6 +1902,59 @@
             }
           },
           "description": "Optional diff display metadata"
+        }
+      }
+    },
+    "IToolResultFileEditContent": {
+      "type": "object",
+      "description": "Describes a file modification performed by a tool.",
+      "properties": {
+        "before": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state before the edit. Absent for file creations or for in-place file edits."
+        },
+        "after": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "content"
+          ],
+          "description": "The file state after the edit. Absent for file deletions."
+        },
+        "diff": {
+          "type": "object",
+          "properties": {
+            "added": {
+              "type": "number"
+            },
+            "removed": {
+              "type": "number"
+            }
+          },
+          "description": "Optional diff display metadata"
+        },
+        "type": {
+          "$ref": "#/$defs/ToolResultContentType.FileEdit"
         }
       },
       "required": [

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -451,7 +451,7 @@ const STATE_STRUCTS = [
   'IToolResultTextContent', 'IToolResultEmbeddedResourceContent',
   'IToolResultResourceContent', 'IToolResultFileEditContent',
   'IToolResultTerminalContent', 'IToolResultSubagentContent', 'ICustomizationRef',
-  'ISessionCustomization', 'ISessionFileDiff', 'ITerminalInfo',
+  'ISessionCustomization', 'IFileEdit', 'ITerminalInfo',
   'ITerminalClientClaim', 'ITerminalSessionClaim', 'ITerminalState',
   'ITerminalUnclassifiedPart', 'ITerminalCommandPart',
   'IUsageInfo', 'IErrorInfo', 'ISnapshot',

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -19,12 +19,11 @@ import type {
   ISessionActiveClient,
   IUsageInfo,
   ISessionCustomization,
-  ISessionFileDiff,
+  IFileEdit,
   ISessionInputAnswer,
   ISessionInputRequest,
   ITerminalInfo,
   ITerminalClaim,
-  IFileEdit,
   SessionInputResponseKind,
 } from './state.js';
 
@@ -603,7 +602,7 @@ export interface ISessionDiffsChangedAction {
   /** Session URI */
   session: URI;
   /** Updated file diffs for the session */
-  diffs: ISessionFileDiff[];
+  diffs: IFileEdit[];
 }
 
 /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,7 +18,6 @@ export type {
   ISessionModelInfo,
   ISessionState,
   ISessionSummary,
-  ISessionFileDiff,
   ISessionConfigState,
   ITurn,
   IActiveTurn,

--- a/types/state.ts
+++ b/types/state.ts
@@ -322,20 +322,6 @@ export interface ISessionActiveClient {
 }
 
 /**
- * A summary of changes to a single file within a session.
- *
- * @category Session State
- */
-export interface ISessionFileDiff {
-  /** URI of the affected file */
-  uri: URI;
-  /** Number of items added (e.g., lines for text files, cells for notebooks) */
-  added?: number;
-  /** Number of items removed (e.g., lines for text files, cells for notebooks) */
-  removed?: number;
-}
-
-/**
  * Server-owned project metadata for a session.
  *
  * @category Session State
@@ -374,7 +360,7 @@ export interface ISessionSummary {
   /** Whether the session has been marked as done by the client */
   isDone?: boolean;
   /** Files changed during this session with diff statistics */
-  diffs?: ISessionFileDiff[];
+  diffs?: IFileEdit[];
 }
 
 // ─── Session Config Types ────────────────────────────────────────────────────

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -17,7 +17,6 @@ import type {
   StringOrMarkdown,
   ISessionState,
   ISessionSummary,
-  ISessionFileDiff,
   ISessionConfigState,
   IProjectInfo,
   ISessionActiveClient,
@@ -184,7 +183,6 @@ type V1_IProtectedResourceMetadata = IProtectedResourceMetadata;
 type V1_ISessionModelInfo = ISessionModelInfo;
 type V1_ISessionState = ISessionState;
 type V1_ISessionSummary = ISessionSummary;
-type V1_ISessionFileDiff = ISessionFileDiff;
 type V1_ISessionConfigState = ISessionConfigState;
 type V1_IProjectInfo = IProjectInfo;
 type V1_ISessionActiveClient = ISessionActiveClient;
@@ -332,8 +330,6 @@ type _CheckSessionState = AssertCompatible<V1_ISessionState, ISessionState>;
 type _CheckSessionSummary = AssertCompatible<V1_ISessionSummary, ISessionSummary>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckSessionConfigState = AssertCompatible<V1_ISessionConfigState, ISessionConfigState>;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _CheckSessionFileDiff = AssertCompatible<V1_ISessionFileDiff, ISessionFileDiff>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckProjectInfo = AssertCompatible<V1_IProjectInfo, IProjectInfo>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
This is needed to display summary changes in a reasonable way. It's not much more work/data than what we had before, it just allows content from old and new files to be reference