### PR TITLE
Fix protocol Swift generation

### DIFF
--- a/.github/instructions/general-instructions.instructions.md
+++ b/.github/instructions/general-instructions.instructions.md
@@ -38,3 +38,7 @@ applyTo: 'types/**/*.ts'
 - For actions or commands that could be implemented by returning an array `T[]` directly, still prefer to wrap it in `{ items: T[] }` for forward compatibility. This allows adding additional fields later without breaking the shape.
 - After making your changes, check to make sure the documentation in `docs` is up to date. For significant new flows or features, consider adding new documentation for it. Note that Mermaid diagrams are allowed.
 - Whenever you change or add an action, you must review the reducers in `types/reducers.ts` to see if that needs to be propagated into the state. If it does, add the appropriate logic and unit tests for it.
+
+## Finalizing changes
+
+Before declaring a protocol repo change complete, run `npm run generate` and `npm run test` from the repo root. Resolve any generated-output, typecheck, lint, test, or generator issues those commands expose before handing the change back.

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -37,6 +37,20 @@ function toCamelCase(name: string): string {
   return name[0].toLowerCase() + name.slice(1);
 }
 
+const SWIFT_RESERVED_KEYWORDS = new Set([
+  'associatedtype', 'class', 'deinit', 'enum', 'extension', 'fileprivate',
+  'func', 'import', 'init', 'inout', 'internal', 'let', 'open', 'operator',
+  'private', 'precedencegroup', 'protocol', 'public', 'rethrows', 'static',
+  'struct', 'subscript', 'typealias', 'var', 'break', 'case', 'catch',
+  'continue', 'default', 'defer', 'do', 'else', 'fallthrough', 'for', 'guard',
+  'if', 'in', 'repeat', 'return', 'throw', 'switch', 'where', 'while', 'as',
+  'Any', 'false', 'is', 'nil', 'self', 'Self', 'super', 'throws', 'true', 'try',
+]);
+
+function swiftIdentifier(name: string): string {
+  return SWIFT_RESERVED_KEYWORDS.has(name) ? `\`${name}\`` : name;
+}
+
 /** Convert _meta → meta, otherwise keep as-is */
 function swiftPropName(tsPropName: string): string {
   if (tsPropName.startsWith('_')) return tsPropName.substring(1);
@@ -227,7 +241,7 @@ function extractProps(iface: InterfaceDeclaration, project: Project): SwiftProp[
           : tsName;
 
       return {
-        name: sName,
+        name: swiftIdentifier(sName),
         wireName: tsName,
         type: finalType,
         optional: isOptional,
@@ -253,7 +267,7 @@ function generateSwiftEnum(enumDecl: EnumDeclaration): string {
   lines.push(`public enum ${name}: ${rawType}, Codable, Sendable {`);
 
   for (const member of enumDecl.getMembers()) {
-    const memberName = toCamelCase(member.getName());
+    const memberName = swiftIdentifier(toCamelCase(member.getName()));
     const value = member.getValue();
     const memberDoc = member.getJsDocs()[0]?.getDescription().trim();
     if (memberDoc) {
@@ -431,7 +445,8 @@ const STATE_ENUMS = [
 
 const STATE_STRUCTS = [
   'Icon', 'IProtectedResourceMetadata', 'IRootState', 'IAgentInfo',
-  'ISessionModelInfo', 'IPendingMessage', 'ISessionState', 'ISessionActiveClient',
+  'ISessionModelInfo', 'IModelSelection', 'IConfigPropertySchema', 'IConfigSchema',
+  'IPendingMessage', 'ISessionState', 'ISessionActiveClient',
   'ISessionSummary', 'IProjectInfo', 'ISessionConfigState', 'ITurn', 'IActiveTurn', 'IUserMessage',
   'ISessionInputOption',
   'ISessionInputTextAnswerValue', 'ISessionInputNumberAnswerValue',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
Fixes protocol generation after adding model configuration types by covering the new state structs in the Swift generator and escaping Swift reserved keywords in generated identifiers.

Also adds a root script tsconfig so the Node-based generator scripts get Node typings in the editor, and documents the protocol repo finalization steps.

Validation:
- `npm run generate`
- `npm run test`
- `npx tsc --noEmit -p tsconfig.json`
- `swift build` from `examples/swift/AgentHostProtocol`

(Written by Copilot)