### PR TITLE
allow passing the active client eagerly when making a session

### DIFF
--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -201,6 +201,10 @@
             "type": "string"
           },
           "description": "Agent-specific configuration values collected via `resolveSessionConfig`.\nKeys and values correspond to the schema returned by the server."
+        },
+        "activeClient": {
+          "$ref": "#/$defs/ISessionActiveClient",
+          "description": "Eagerly claim the active client role for the new session.\n\nWhen provided, the server initializes the session with this client as the\nactive client, equivalent to dispatching a `session/activeClientChanged`\naction immediately after creation. The `clientId` MUST match the\n`clientId` the creating client supplied in `initialize`."
         }
       },
       "required": [

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -6,7 +6,7 @@
  * They return a result or a JSON-RPC error.
  */
 
-import type { URI, ISnapshot, ISessionConfigSchema, ISessionSummary, IModelSelection, ITurn, ITerminalClaim } from './state.js';
+import type { URI, ISnapshot, ISessionConfigSchema, ISessionSummary, IModelSelection, ITurn, ITerminalClaim, ISessionActiveClient } from './state.js';
 import type { IActionEnvelope, IStateAction } from './actions.js';
 
 export type { IConfigPropertySchema, IConfigSchema, ISessionConfigPropertySchema, ISessionConfigSchema } from './state.js';
@@ -198,6 +198,15 @@ export interface ICreateSessionParams {
    * Keys and values correspond to the schema returned by the server.
    */
   config?: Record<string, string>;
+  /**
+   * Eagerly claim the active client role for the new session.
+   *
+   * When provided, the server initializes the session with this client as the
+   * active client, equivalent to dispatching a `session/activeClientChanged`
+   * action immediately after creation. The `clientId` MUST match the
+   * `clientId` the creating client supplied in `initialize`.
+   */
+  activeClient?: ISessionActiveClient;
 }
 
 // ─── disposeSession ──────────────────────────────────────────────────────────

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -144,6 +144,7 @@ import type {
   IResourceMoveParams,
   IResourceMoveResult,
   ICreateTerminalParams,
+  ICreateSessionParams,
   IDisposeTerminalParams,
   IResolveSessionConfigParams,
   IResolveSessionConfigResult,
@@ -283,6 +284,7 @@ type V1_ITerminalContentPart = ITerminalContentPart;
 type V1_ITerminalUnclassifiedPart = ITerminalUnclassifiedPart;
 type V1_ITerminalCommandPart = ITerminalCommandPart;
 type V1_ICreateTerminalParams = ICreateTerminalParams;
+type V1_ICreateSessionParams = ICreateSessionParams;
 type V1_IDisposeTerminalParams = IDisposeTerminalParams;
 type V1_ISessionForkSource = ISessionForkSource;
 type V1_IProtocolNotification = IProtocolNotification;
@@ -576,6 +578,8 @@ type _CheckTerminalUnclassifiedPart = AssertCompatible<V1_ITerminalUnclassifiedP
 type _CheckTerminalCommandPart = AssertCompatible<V1_ITerminalCommandPart, ITerminalCommandPart>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckCreateTerminalParams = AssertCompatible<V1_ICreateTerminalParams, ICreateTerminalParams>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckCreateSessionParams = AssertCompatible<V1_ICreateSessionParams, ICreateSessionParams>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckDisposeTerminalParams = AssertCompatible<V1_IDisposeTerminalParams, IDisposeTerminalParams>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Avoids the awkward immediate activeClient action needed after the session initially gets created.