### PR TITLE
add an `activity` to the sessions status

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -68,6 +68,7 @@ A `session/toolUpdate` action for streaming incremental tool output (e.g. termin
 | `session/modelChanged` | **Yes** | Model changed for this session |
 | `session/isReadChanged` | **Yes** | Client marked session as read or unread |
 | `session/isArchivedChanged` | **Yes** | Client archived or unarchived session |
+| `session/activityChanged` | No | Server updated the session's current activity description |
 
 ### Pending Messages
 
@@ -119,6 +120,7 @@ The client applies the action **optimistically** to its local state before sendi
 | `session/customizationToggled` | Toggles a customization on or off by URI |
 | `session/isReadChanged` | Marks the session as read or unread |
 | `session/isArchivedChanged` | Archives or unarchives the session |
+| `session/activityChanged` | Updates the session's current activity description |
 
 ## Reducers
 

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -85,6 +85,7 @@ SessionSummary {
   provider: string
   title: string
   status: number  // SessionStatus bitset
+  activity?: string
   createdAt: number
   modifiedAt: number
   project?: ProjectInfo
@@ -103,7 +104,7 @@ ProjectInfo {
 }
 ```
 
-The `status` bitset encodes both the session's activity state and metadata flags like read/done state. See the [Session Status Bitset](#session-status-bitset) table below for details.
+The `status` bitset encodes both the session's activity state and metadata flags like read/archived state. See the [Session Status Bitset](#session-status-bitset) table below for details.
 
 ### Session Status Bitset
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -884,6 +884,28 @@
         "isArchived"
       ]
     },
+    "SessionActivityChangedAction": {
+      "type": "object",
+      "description": "The activity description of the session changed.\n\nDispatched by the server to indicate what the session is currently doing\n(e.g. running a tool, thinking). Clear activity by setting it to `undefined`.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionActivityChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of current activity, or `undefined` to clear"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "activity"
+      ]
+    },
     "SessionDiffsChangedAction": {
       "type": "object",
       "description": "The file diffs for the session changed.\n\nFull-replacement semantics: the `diffs` array replaces the previous\n`summary.diffs` entirely.",
@@ -1927,6 +1949,10 @@
         "status": {
           "$ref": "#/$defs/SessionStatus",
           "description": "Current session status"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of what the session is currently doing"
         },
         "createdAt": {
           "type": "number",
@@ -4335,6 +4361,9 @@
         },
         {
           "$ref": "#/$defs/SessionIsArchivedChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionActivityChangedAction"
         },
         {
           "$ref": "#/$defs/SessionDiffsChangedAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1108,6 +1108,10 @@
           "$ref": "#/$defs/SessionStatus",
           "description": "Current session status"
         },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of what the session is currently doing"
+        },
         "createdAt": {
           "type": "number",
           "description": "Creation timestamp"
@@ -4120,6 +4124,28 @@
         "type",
         "session",
         "isArchived"
+      ]
+    },
+    "SessionActivityChangedAction": {
+      "type": "object",
+      "description": "The activity description of the session changed.\n\nDispatched by the server to indicate what the session is currently doing\n(e.g. running a tool, thinking). Clear activity by setting it to `undefined`.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionActivityChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of current activity, or `undefined` to clear"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "activity"
       ]
     },
     "SessionDiffsChangedAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -69,6 +69,10 @@
               "$ref": "#/$defs/SessionStatus",
               "description": "Current session status"
             },
+            "activity": {
+              "type": "string",
+              "description": "Human-readable description of what the session is currently doing"
+            },
             "createdAt": {
               "type": "number",
               "description": "Creation timestamp"
@@ -548,6 +552,10 @@
         "status": {
           "$ref": "#/$defs/SessionStatus",
           "description": "Current session status"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of what the session is currently doing"
         },
         "createdAt": {
           "type": "number",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -410,6 +410,10 @@
           "$ref": "#/$defs/SessionStatus",
           "description": "Current session status"
         },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of what the session is currently doing"
+        },
         "createdAt": {
           "type": "number",
           "description": "Creation timestamp"

--- a/scripts/generate-markdown.ts
+++ b/scripts/generate-markdown.ts
@@ -510,6 +510,7 @@ const ACTION_ORDER: ActionMeta[] = [
   { interfaceName: 'SessionModelChangedAction', typeValue: 'session/modelChanged', description: 'Model changed for this session.', clientDispatchable: true, version: 1 },
   { interfaceName: 'SessionIsReadChangedAction', typeValue: 'session/isReadChanged', description: 'Read state changed for this session.', clientDispatchable: true, version: 1 },
   { interfaceName: 'SessionIsArchivedChangedAction', typeValue: 'session/isArchivedChanged', description: 'Archived state changed for this session.', clientDispatchable: true, version: 1 },
+  { interfaceName: 'SessionActivityChangedAction', typeValue: 'session/activityChanged', description: 'Activity description changed for this session.', clientDispatchable: false, version: 1 },
 ];
 
 function generateActionsPage(project: Project): string {

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -730,6 +730,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'session/modelChanged', caseName: 'sessionModelChanged', tsInterface: 'SessionModelChangedAction' },
   { type: 'session/isReadChanged', caseName: 'sessionIsReadChanged', tsInterface: 'SessionIsReadChangedAction' },
   { type: 'session/isArchivedChanged', caseName: 'sessionIsArchivedChanged', tsInterface: 'SessionIsArchivedChangedAction' },
+  { type: 'session/activityChanged', caseName: 'sessionActivityChanged', tsInterface: 'SessionActivityChangedAction' },
   { type: 'session/serverToolsChanged', caseName: 'sessionServerToolsChanged', tsInterface: 'SessionServerToolsChangedAction' },
   { type: 'session/activeClientChanged', caseName: 'sessionActiveClientChanged', tsInterface: 'SessionActiveClientChangedAction' },
   { type: 'session/activeClientToolsChanged', caseName: 'sessionActiveClientToolsChanged', tsInterface: 'SessionActiveClientToolsChangedAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -40,6 +40,7 @@ import type {
   SessionTruncatedAction,
   SessionIsReadChangedAction,
   SessionIsArchivedChangedAction,
+  SessionActivityChangedAction,
   SessionDiffsChangedAction,
   SessionConfigChangedAction,
   TerminalDataAction,
@@ -102,6 +103,7 @@ export type SessionAction =
   | SessionTruncatedAction
   | SessionIsReadChangedAction
   | SessionIsArchivedChangedAction
+  | SessionActivityChangedAction
   | SessionDiffsChangedAction
   | SessionConfigChangedAction
 ;
@@ -146,6 +148,7 @@ export type ServerSessionAction =
   | SessionServerToolsChangedAction
   | SessionInputRequestedAction
   | SessionCustomizationsChangedAction
+  | SessionActivityChangedAction
   | SessionDiffsChangedAction
 ;
 
@@ -227,6 +230,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.SessionTruncated]: true,
   [ActionType.SessionIsReadChanged]: true,
   [ActionType.SessionIsArchivedChanged]: true,
+  [ActionType.SessionActivityChanged]: false,
   [ActionType.SessionDiffsChanged]: false,
   [ActionType.SessionConfigChanged]: true,
   [ActionType.TerminalData]: false,

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -74,6 +74,7 @@ export const enum ActionType {
   SessionTruncated = 'session/truncated',
   SessionIsReadChanged = 'session/isReadChanged',
   SessionIsArchivedChanged = 'session/isArchivedChanged',
+  SessionActivityChanged = 'session/activityChanged',
   SessionDiffsChanged = 'session/diffsChanged',
   SessionConfigChanged = 'session/configChanged',
   RootTerminalsChanged = 'root/terminalsChanged',
@@ -621,6 +622,23 @@ export interface SessionIsArchivedChangedAction {
 }
 
 /**
+ * The activity description of the session changed.
+ *
+ * Dispatched by the server to indicate what the session is currently doing
+ * (e.g. running a tool, thinking). Clear activity by setting it to `undefined`.
+ *
+ * @category Session Actions
+ * @version 1
+ */
+export interface SessionActivityChangedAction {
+  type: ActionType.SessionActivityChanged;
+  /** Session URI */
+  session: URI;
+  /** Human-readable description of current activity, or `undefined` to clear */
+  activity: string | undefined;
+}
+
+/**
  * The file diffs for the session changed.
  *
  * Full-replacement semantics: the `diffs` array replaces the previous
@@ -1165,6 +1183,7 @@ export type StateAction =
   | SessionTruncatedAction
   | SessionIsReadChangedAction
   | SessionIsArchivedChangedAction
+  | SessionActivityChangedAction
   | SessionDiffsChangedAction
   | SessionConfigChangedAction
   | TerminalDataAction

--- a/types/index.ts
+++ b/types/index.ts
@@ -140,6 +140,7 @@ export type {
   SessionTruncatedAction,
   SessionIsReadChangedAction,
   SessionIsArchivedChangedAction,
+  SessionActivityChangedAction,
   SessionDiffsChangedAction,
   SessionConfigChangedAction,
   StateAction,

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -578,6 +578,12 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
         summary: { ...state.summary, status: withStatusFlag(state.summary.status, SessionStatus.IsArchived, action.isArchived) },
       };
 
+    case ActionType.SessionActivityChanged:
+      return {
+        ...state,
+        summary: { ...state.summary, activity: action.activity },
+      };
+
     case ActionType.SessionDiffsChanged:
       return {
         ...state,

--- a/types/state.ts
+++ b/types/state.ts
@@ -375,6 +375,8 @@ export interface SessionSummary {
   title: string;
   /** Current session status */
   status: SessionStatus;
+  /** Human-readable description of what the session is currently doing */
+  activity?: string;
   /** Creation timestamp */
   createdAt: number;
   /** Last modification timestamp */

--- a/types/test-cases/reducers/133-session-activitychanged-sets-activity.json
+++ b/types/test-cases/reducers/133-session-activitychanged-sets-activity.json
@@ -1,0 +1,36 @@
+{
+  "description": "session/activityChanged sets activity on summary",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/activityChanged",
+      "session": "copilot:/test-session",
+      "activity": "Running terminal command"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "activity": "Running terminal command",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/134-session-activitychanged-clears-activity.json
+++ b/types/test-cases/reducers/134-session-activitychanged-clears-activity.json
@@ -1,0 +1,37 @@
+{
+  "description": "session/activityChanged clears activity with null",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "activity": "Thinking",
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/activityChanged",
+      "session": "copilot:/test-session",
+      "activity": null
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "activity": null,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": []
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -59,6 +59,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: number
   [ActionType.SessionTruncated]: 1,
   [ActionType.SessionIsReadChanged]: 1,
   [ActionType.SessionIsArchivedChanged]: 1,
+  [ActionType.SessionActivityChanged]: 1,
   [ActionType.SessionDiffsChanged]: 1,
   [ActionType.SessionConfigChanged]: 1,
   [ActionType.RootTerminalsChanged]: 1,

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -103,6 +103,7 @@ import type {
   SessionTruncatedAction,
   SessionIsReadChangedAction,
   SessionIsArchivedChangedAction,
+  SessionActivityChangedAction,
   SessionDiffsChangedAction,
   SessionConfigChangedAction,
   RootTerminalsChangedAction,
@@ -266,6 +267,7 @@ type V1_ISessionCustomizationToggledAction = SessionCustomizationToggledAction;
 type V1_ISessionTruncatedAction = SessionTruncatedAction;
 type V1_ISessionIsReadChangedAction = SessionIsReadChangedAction;
 type V1_ISessionIsArchivedChangedAction = SessionIsArchivedChangedAction;
+type V1_ISessionActivityChangedAction = SessionActivityChangedAction;
 type V1_ISessionDiffsChangedAction = SessionDiffsChangedAction;
 type V1_ISessionConfigChangedAction = SessionConfigChangedAction;
 type V1_ISessionToolCallContentChangedAction = SessionToolCallContentChangedAction;
@@ -496,6 +498,8 @@ type _CheckTruncatedAction = AssertCompatible<V1_ISessionTruncatedAction, Sessio
 type _CheckIsReadChangedAction = AssertCompatible<V1_ISessionIsReadChangedAction, SessionIsReadChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckIsArchivedChangedAction = AssertCompatible<V1_ISessionIsArchivedChangedAction, SessionIsArchivedChangedAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckActivityChangedAction = AssertCompatible<V1_ISessionActivityChangedAction, SessionActivityChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckDiffsChangedAction = AssertCompatible<V1_ISessionDiffsChangedAction, SessionDiffsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Can be used to indicate the currently-running job.