### PR TITLE
Make SessionInputRequest.message optional

### DIFF
--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -948,7 +948,8 @@ pub struct SessionInputRequest {
     /// Stable request identifier
     pub id: String,
     /// Display message for the request as a whole
-    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
     /// URL the user should review or open, for URL-style elicitations
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<Uri>,

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2581,8 +2581,7 @@
         }
       },
       "required": [
-        "id",
-        "message"
+        "id"
       ]
     },
     "SessionInputTextAnswerValue": {

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1716,8 +1716,7 @@
         }
       },
       "required": [
-        "id",
-        "message"
+        "id"
       ]
     },
     "SessionInputTextAnswerValue": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1161,8 +1161,7 @@
         }
       },
       "required": [
-        "id",
-        "message"
+        "id"
       ]
     },
     "SessionInputTextAnswerValue": {

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1018,8 +1018,7 @@
         }
       },
       "required": [
-        "id",
-        "message"
+        "id"
       ]
     },
     "SessionInputTextAnswerValue": {

--- a/types/state.ts
+++ b/types/state.ts
@@ -664,7 +664,7 @@ export interface SessionInputRequest {
   /** Stable request identifier */
   id: string;
   /** Display message for the request as a whole */
-  message: string;
+  message?: string;
   /** URL the user should review or open, for URL-style elicitations */
   url?: URI;
   /** Ordered questions to ask the user */


### PR DESCRIPTION
Fixes microsoft/vscode#311121.

The `message` field on `SessionInputRequest` was required, but agents using `ask_user` with only questions/choices don't have a meaningful top-level message to provide — the question text itself serves that purpose. Making `message` optional unblocks those cases.

(Written by Copilot)