### PR TITLE
rust: polish crate docs for docs.rs

### DIFF
--- a/clients/rust/crates/ahp-types/Cargo.toml
+++ b/clients/rust/crates/ahp-types/Cargo.toml
@@ -7,6 +7,14 @@ license.workspace = true
 repository.workspace = true
 description = "Wire protocol types for the Agent Host Protocol (AHP)."
 readme = "README.md"
+homepage = "https://microsoft.github.io/agent-host-protocol/"
+documentation = "https://docs.rs/ahp-types"
+keywords = ["ahp", "agent", "protocol", "json-rpc", "serde"]
+categories = ["api-bindings", "encoding", "data-structures"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde = { workspace = true }

--- a/clients/rust/crates/ahp-types/src/lib.rs
+++ b/clients/rust/crates/ahp-types/src/lib.rs
@@ -1,40 +1,111 @@
-//! Wire protocol types for the Agent Host Protocol (AHP).
+//! Wire protocol types for the [Agent Host Protocol (AHP)][spec].
 //!
-//! This crate provides Rust counterparts for the TypeScript source-of-truth
-//! types in `types/`. All types are `Serialize` + `Deserialize` and use the
-//! same JSON field names as the protocol.
+//! `ahp-types` is the data-only crate of the AHP family. Every command,
+//! action, notification, and state object defined by the protocol has a
+//! Rust counterpart here — `Serialize` + `Deserialize`, using the exact
+//! same JSON field names as the wire format. There is no I/O, no async
+//! runtime, and no transport code; if you only need to parse or
+//! construct AHP messages, this is the only crate you need.
 //!
-//! # Modules
+//! These types are generated from the TypeScript source of truth in
+//! `types/*.ts`, so any change to the protocol surfaces here first.
 //!
-//! - [`state`] — `RootState`, `SessionState`, tool call lifecycle, terminal state
-//! - [`actions`] — `StateAction` discriminated union and `ActionEnvelope`
-//! - [`commands`] — command params and results
-//! - [`notifications`] — protocol notifications
-//! - [`messages`] — JSON-RPC wire envelopes
-//! - [`errors`] — AHP and JSON-RPC error codes
-//! - [`version`] — protocol version constants
+//! [spec]: https://microsoft.github.io/agent-host-protocol/
 //!
-//! # Example
+//! # Companion crates
+//!
+//! | Crate | What it adds |
+//! |---|---|
+//! | [`ahp`](https://docs.rs/ahp) | Async client, reducers, and pluggable [`Transport`](https://docs.rs/ahp/latest/ahp/transport/trait.Transport.html) trait |
+//! | [`ahp-ws`](https://docs.rs/ahp-ws) | WebSocket transport built on `tokio-tungstenite` |
+//!
+//! # Module map
+//!
+//! | Module | Contents |
+//! |---|---|
+//! | [`state`]         | [`RootState`], [`SessionState`], [`TerminalState`], tool-call lifecycle |
+//! | [`actions`]       | [`StateAction`] discriminated union and [`ActionEnvelope`] |
+//! | [`commands`]      | Request/response parameter and result types (`initialize`, `subscribe`, …) |
+//! | [`notifications`] | Server-pushed [`ProtocolNotification`]s |
+//! | [`messages`]      | JSON-RPC wire envelopes ([`JsonRpcMessage`] and friends) |
+//! | [`errors`]        | AHP and JSON-RPC [error codes][errors::AhpErrorCode] |
+//! | [`version`]       | Negotiation constants ([`PROTOCOL_VERSION`]) |
+//! | [`common`]        | Hand-written primitives ([`Uri`], [`StringOrMarkdown`], …) |
+//!
+//! # Examples
+//!
+//! ## Parse an action envelope
 //!
 //! ```
 //! use ahp_types::actions::{ActionEnvelope, StateAction};
-//! use ahp_types::state::SessionStatus;
 //!
 //! let json = r#"{
 //!   "action": { "type": "session/titleChanged", "session": "copilot:/s1", "title": "Hi" },
 //!   "serverSeq": 7,
 //!   "origin": null
 //! }"#;
-//! let env: ActionEnvelope = serde_json::from_str(json).unwrap();
+//! let env: ActionEnvelope = serde_json::from_str(json)?;
 //! assert_eq!(env.server_seq, 7);
 //! match env.action {
 //!     StateAction::SessionTitleChanged(a) => assert_eq!(a.title, "Hi"),
 //!     _ => panic!("unexpected variant"),
 //! }
+//! # Ok::<_, serde_json::Error>(())
 //! ```
+//!
+//! ## Build an `initialize` request
+//!
+//! ```
+//! use ahp_types::commands::InitializeParams;
+//! use ahp_types::messages::{JsonRpcMessage, JsonRpcRequest, JsonRpcVersion};
+//! use ahp_types::common::AnyValue;
+//!
+//! let params = InitializeParams {
+//!     protocol_version: ahp_types::PROTOCOL_VERSION as i64,
+//!     client_id: "my-host/1.0".into(),
+//!     initial_subscriptions: Some(vec!["agenthost:/root".into()]),
+//!     locale: Some("en".into()),
+//! };
+//!
+//! let req = JsonRpcMessage::Request(JsonRpcRequest {
+//!     jsonrpc: JsonRpcVersion::V2,
+//!     id: 1,
+//!     method: "initialize".into(),
+//!     params: Some(AnyValue::from(serde_json::to_value(&params)?)),
+//! });
+//!
+//! let wire = serde_json::to_string(&req)?;
+//! assert!(wire.contains("\"method\":\"initialize\""));
+//! # Ok::<_, serde_json::Error>(())
+//! ```
+//!
+//! ## Inspect a session status bitset
+//!
+//! [`SessionStatus`](state::SessionStatus) packs activity and metadata
+//! flags into a single value — use bitwise checks rather than equality:
+//!
+//! ```
+//! use ahp_types::state::SessionStatus;
+//!
+//! let status = SessionStatus::InProgress as u32 | SessionStatus::IsArchived as u32;
+//! assert_ne!(status & SessionStatus::InProgress as u32, 0);
+//! assert_ne!(status & SessionStatus::IsArchived as u32, 0);
+//! ```
+//!
+//! # Compatibility
+//!
+//! - JSON field names match the protocol exactly (`camelCase`); use the
+//!   provided `Serialize`/`Deserialize` derives rather than manually
+//!   building JSON.
+//! - Unknown enum variants surface as a generic `Unknown` arm where the
+//!   protocol allows forward-compatible extension (see e.g.
+//!   [`state::ToolCallState`]).
+//! - The protocol version this crate speaks is exposed as
+//!   [`PROTOCOL_VERSION`].
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod actions;
 pub mod commands;

--- a/clients/rust/crates/ahp-ws/Cargo.toml
+++ b/clients/rust/crates/ahp-ws/Cargo.toml
@@ -7,6 +7,14 @@ license.workspace = true
 repository.workspace = true
 description = "WebSocket transport adapter for the Agent Host Protocol SDK."
 readme = "README.md"
+homepage = "https://microsoft.github.io/agent-host-protocol/"
+documentation = "https://docs.rs/ahp-ws"
+keywords = ["ahp", "agent", "websocket", "transport", "tokio"]
+categories = ["api-bindings", "asynchronous", "network-programming::websocket"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 ahp = { workspace = true }

--- a/clients/rust/crates/ahp-ws/src/lib.rs
+++ b/clients/rust/crates/ahp-ws/src/lib.rs
@@ -1,10 +1,67 @@
-//! WebSocket transport adapter for the Agent Host Protocol SDK.
+//! WebSocket transport adapter for the [Agent Host Protocol][spec] Rust
+//! SDK.
 //!
-//! Provides [`WebSocketTransport`], an implementation of
-//! [`ahp::Transport`] on top of `tokio-tungstenite`.
+//! [spec]: https://microsoft.github.io/agent-host-protocol/
+//!
+//! This crate provides [`WebSocketTransport`], an implementation of
+//! [`ahp::Transport`] backed by [`tokio-tungstenite`][tt]. It supports
+//! both `ws://` and `wss://` URLs (TLS via `native-tls`).
+//!
+//! [tt]: https://crates.io/crates/tokio-tungstenite
+//!
+//! # Companion crates
+//!
+//! - [`ahp`](https://docs.rs/ahp) — the async client and reducers
+//! - [`ahp-types`](https://docs.rs/ahp-types) — wire types only
+//!
+//! # Quickstart
+//!
+//! ```no_run
+//! use ahp::{Client, ClientConfig, SubscriptionEvent};
+//! use ahp_ws::WebSocketTransport;
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let transport = WebSocketTransport::connect("ws://localhost:12345").await?;
+//! let client = Client::connect(transport, ClientConfig::default()).await?;
+//!
+//! client.initialize("my-client".into(), 1, vec!["agenthost:/root".into()]).await?;
+//!
+//! let mut sub = client.attach_subscription("agenthost:/root").await;
+//! while let Some(SubscriptionEvent::Action(env)) = sub.recv().await {
+//!     println!("seq={} action={:?}", env.server_seq, env.action);
+//! }
+//!
+//! client.shutdown().await;
+//! # Ok(()) }
+//! ```
+//!
+//! # Bring your own connection
+//!
+//! When you need custom TLS, headers, or a pre-existing socket, drive
+//! `tokio-tungstenite` yourself and wrap the result with
+//! [`WebSocketTransport::from_stream`]:
+//!
+//! ```no_run
+//! use ahp_ws::WebSocketTransport;
+//! use tokio_tungstenite::connect_async;
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let (stream, _resp) = connect_async("wss://example.com/ahp").await?;
+//! let transport = WebSocketTransport::from_stream(stream);
+//! # Ok(()) }
+//! ```
+//!
+//! # Errors
+//!
+//! Connection-time errors surface as [`WebSocketTransportError`] (URL
+//! parse or handshake failure). Once the transport is handed to
+//! [`ahp::Client`], runtime errors are reported as
+//! [`ahp::TransportError`] on the client's request and subscription
+//! futures.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod transport;
 

--- a/clients/rust/crates/ahp-ws/src/transport.rs
+++ b/clients/rust/crates/ahp-ws/src/transport.rs
@@ -23,15 +23,33 @@ type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// A [`Transport`] backed by a `tokio-tungstenite` WebSocket stream.
 ///
-/// Connect with [`WebSocketTransport::connect`] for the common case, or
-/// pass an existing [`WebSocketStream`] to [`WebSocketTransport::from_stream`]
-/// when you need custom connection options.
+/// Use [`WebSocketTransport::connect`] for the common case, or
+/// [`WebSocketTransport::from_stream`] when you need custom connection
+/// options (custom TLS configuration, additional headers, etc.).
+///
+/// # Example
+///
+/// ```no_run
+/// use ahp::{Client, ClientConfig};
+/// use ahp_ws::WebSocketTransport;
+///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let transport = WebSocketTransport::connect("ws://localhost:12345").await?;
+/// let client = Client::connect(transport, ClientConfig::default()).await?;
+/// client.initialize("demo".into(), 1, vec![]).await?;
+/// # Ok(()) }
+/// ```
 pub struct WebSocketTransport {
     inner: WsStream,
 }
 
 impl WebSocketTransport {
     /// Open a new WebSocket connection to `url`.
+    ///
+    /// Both `ws://` and `wss://` schemes are accepted; TLS is handled
+    /// transparently via `native-tls`. The URL is parsed eagerly so
+    /// malformed URLs surface as
+    /// [`WebSocketTransportError::InvalidUrl`] before any network I/O.
     pub async fn connect(url: &str) -> Result<Self, WebSocketTransportError> {
         let _parsed = Url::parse(url)?; // validate early
         let (stream, _resp) = connect_async(url).await?;
@@ -39,6 +57,10 @@ impl WebSocketTransport {
     }
 
     /// Wrap an already-connected WebSocket stream.
+    ///
+    /// Use this when you need to drive the `tokio-tungstenite`
+    /// handshake yourself — for custom TLS configuration, request
+    /// headers, or to reuse an existing socket.
     pub fn from_stream(inner: WsStream) -> Self {
         Self { inner }
     }

--- a/clients/rust/crates/ahp/Cargo.toml
+++ b/clients/rust/crates/ahp/Cargo.toml
@@ -7,6 +7,14 @@ license.workspace = true
 repository.workspace = true
 description = "Agent Host Protocol SDK — transport-agnostic client, reducers, and JSON-RPC plumbing."
 readme = "README.md"
+homepage = "https://microsoft.github.io/agent-host-protocol/"
+documentation = "https://docs.rs/ahp"
+keywords = ["ahp", "agent", "protocol", "json-rpc", "tokio"]
+categories = ["api-bindings", "asynchronous", "network-programming"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 ahp-types = { workspace = true }
@@ -25,3 +33,7 @@ tracing-subscriber = "0.3"
 [[example]]
 name = "connect_ws"
 path = "examples/connect_ws.rs"
+
+[[example]]
+name = "reducers_demo"
+path = "examples/reducers_demo.rs"

--- a/clients/rust/crates/ahp/examples/reducers_demo.rs
+++ b/clients/rust/crates/ahp/examples/reducers_demo.rs
@@ -1,0 +1,63 @@
+//! Apply a stream of actions to a local `RootState` and print the
+//! result.
+//!
+//! The example mirrors what a UI client does internally: it consumes
+//! [`ActionEnvelope`]s, fans them out to the matching reducer, and
+//! reports each [`ReduceOutcome`].
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example reducers_demo
+//! ```
+
+use ahp::reducers::{apply_action_to_root, ReduceOutcome};
+use ahp_types::actions::{
+    ActionEnvelope, RootActiveSessionsChangedAction, RootAgentsChangedAction, StateAction,
+};
+use ahp_types::state::{AgentInfo, RootState};
+
+fn main() {
+    let mut root = RootState {
+        agents: vec![],
+        active_sessions: None,
+        terminals: None,
+        config: None,
+    };
+
+    let envelopes = vec![
+        ActionEnvelope {
+            action: StateAction::RootAgentsChanged(RootAgentsChangedAction {
+                agents: vec![AgentInfo {
+                    provider: "copilot".into(),
+                    display_name: "GitHub Copilot".into(),
+                    description: "AI pair programmer".into(),
+                    models: vec![],
+                    protected_resources: None,
+                    customizations: None,
+                }],
+            }),
+            server_seq: 1,
+            origin: None,
+            rejection_reason: None,
+        },
+        ActionEnvelope {
+            action: StateAction::RootActiveSessionsChanged(RootActiveSessionsChangedAction {
+                active_sessions: 3,
+            }),
+            server_seq: 2,
+            origin: None,
+            rejection_reason: None,
+        },
+    ];
+
+    for env in &envelopes {
+        let outcome = apply_action_to_root(&mut root, &env.action);
+        println!("seq={} outcome={:?}", env.server_seq, outcome);
+        debug_assert_eq!(outcome, ReduceOutcome::Applied);
+    }
+
+    println!("\nfinal RootState:");
+    println!("  agents: {}", root.agents.len());
+    println!("  active_sessions: {:?}", root.active_sessions);
+}

--- a/clients/rust/crates/ahp/src/error.rs
+++ b/clients/rust/crates/ahp/src/error.rs
@@ -1,4 +1,16 @@
 //! Error types used across the SDK.
+//!
+//! Two error families are exposed:
+//!
+//! - [`TransportError`] — failures of an underlying [`crate::Transport`]
+//!   implementation (closed connection, framing/IO errors).
+//! - [`ClientError`] — failures of the higher-level [`crate::Client`]
+//!   API: transport errors, JSON-RPC error responses, deserialization
+//!   problems, shutdown, cancellation, missing subscriptions, and
+//!   sequence gaps that require resubscribing.
+//!
+//! `ClientError` implements `From<TransportError>` and
+//! `From<serde_json::Error>` so client code can use `?` freely.
 
 use ahp_types::messages::JsonRpcError;
 use thiserror::Error;

--- a/clients/rust/crates/ahp/src/lib.rs
+++ b/clients/rust/crates/ahp/src/lib.rs
@@ -1,17 +1,148 @@
-//! Agent Host Protocol SDK — transport-agnostic client, reducers, and
-//! JSON-RPC plumbing.
+//! Agent Host Protocol SDK — async client, reducers, and pluggable
+//! transports.
 //!
-//! This crate builds on [`ahp_types`] and adds:
+//! AHP is a JSON-RPC protocol that lets a host (an editor, IDE, shell,
+//! or test harness) talk to an agent backend through a small set of
+//! subscribe / dispatch / reduce primitives. This crate is the Rust
+//! implementation of the **client** side.
 //!
-//! - [`reducers`] — pure state reducers ported from `types/reducers.ts`
-//! - [`transport`] — pluggable [`transport::Transport`] trait for any
-//!   framed byte stream (WebSocket, TCP, stdio, …)
-//! - [`client`] — async JSON-RPC client with action subscription,
-//!   write-ahead dispatch, and reconnect/replay
-//! - [`error`] — error types returned by the client and reducers
+//! For a tour of the protocol itself, see the
+//! [protocol documentation](https://microsoft.github.io/agent-host-protocol/).
+//!
+//! # Crate layout
+//!
+//! | Item | Use it for |
+//! |---|---|
+//! | [`Client`] | Connect to a server, subscribe to resources, dispatch actions |
+//! | [`reducers`] | Apply [`StateAction`](ahp_types::actions::StateAction) to local state in a fully deterministic way |
+//! | [`Transport`] | Pluggable trait for any framed message stream |
+//! | [`ClientError`] / [`TransportError`] | Error taxonomy |
+//!
+//! # Companion crates
+//!
+//! - [`ahp_types`] — wire types only, no I/O
+//! - [`ahp-ws`](https://docs.rs/ahp-ws) — WebSocket transport built on `tokio-tungstenite`
+//!
+//! # Quickstart (WebSocket)
+//!
+//! Connect over WebSocket, initialize, and stream events from a
+//! session. The example below uses the [`ahp-ws`](https://docs.rs/ahp-ws)
+//! crate; replace the transport line with any other [`Transport`]
+//! implementation if you have one.
+//!
+//! ```no_run
+//! use ahp::{Client, ClientConfig, SubscriptionEvent};
+//! use ahp_ws::WebSocketTransport;
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let transport = WebSocketTransport::connect("ws://localhost:12345").await?;
+//! let client = Client::connect(transport, ClientConfig::default()).await?;
+//!
+//! client.initialize("my-client".into(), 1, vec![]).await?;
+//! let (_snap, mut sub) = client.subscribe("copilot:/s1".into()).await?;
+//!
+//! while let Some(SubscriptionEvent::Action(env)) = sub.recv().await {
+//!     println!("seq={} action={:?}", env.server_seq, env.action);
+//! }
+//!
+//! client.shutdown().await;
+//! # Ok(()) }
+//! ```
+//!
+//! # Quickstart (any transport)
+//!
+//! The same flow works against any [`Transport`] implementation:
+//!
+//! ```no_run
+//! # async fn run<T: ahp::Transport>(transport: T) -> Result<(), ahp::ClientError> {
+//! use ahp::{Client, ClientConfig, SubscriptionEvent};
+//!
+//! let client = Client::connect(transport, ClientConfig::default()).await?;
+//! client.initialize("my-client".into(), 1, vec!["agenthost:/root".into()]).await?;
+//!
+//! let mut sub = client.attach_subscription("agenthost:/root").await;
+//! while let Some(ev) = sub.recv().await {
+//!     match ev {
+//!         SubscriptionEvent::Action(a) => println!("seq={}", a.server_seq),
+//!         SubscriptionEvent::Notification(_) => {}
+//!     }
+//! }
+//!
+//! client.shutdown().await;
+//! # Ok(()) }
+//! ```
+//!
+//! # Subscriptions
+//!
+//! Subscribe to a URI to receive its [`SubscriptionEvent`] stream:
+//!
+//! - `agenthost:/root` — global agent host state (agents, session index)
+//! - `copilot:/<id>` (or any provider scheme) — a single chat session
+//! - `terminal:/<id>` — a terminal
+//!
+//! [`Client::subscribe`] sends a `subscribe` request and returns the
+//! initial snapshot together with a [`SessionSubscription`] handle.
+//! [`Client::attach_subscription`] creates a local handle without an
+//! extra round-trip — useful when the URI was already passed to
+//! `initialize` via `initialSubscriptions`.
+//!
+//! Multiple [`SessionSubscription`]s can fan out from a single URI;
+//! each handle has its own broadcast cursor. Drop the handle to stop
+//! receiving events; call [`Client::unsubscribe`] to release the
+//! server-side subscription.
+//!
+//! # Dispatching actions
+//!
+//! Local UI mutations are dispatched through [`Client::dispatch`]. The
+//! client assigns a monotonically increasing `clientSeq` and sends a
+//! `dispatchAction` notification. The server eventually echoes the
+//! action back as a normal envelope; reducers can be applied identically
+//! to both sources, so write-ahead state is naturally reconciled.
+//!
+//! # Reducers
+//!
+//! Reducers are pure functions that translate a [`StateAction`](ahp_types::actions::StateAction)
+//! into mutations on [`RootState`](ahp_types::state::RootState),
+//! [`SessionState`](ahp_types::state::SessionState), or
+//! [`TerminalState`](ahp_types::state::TerminalState).
+//!
+//! ```
+//! use ahp::reducers::{apply_action_to_root, ReduceOutcome};
+//! use ahp::ahp_types::actions::{RootActiveSessionsChangedAction, StateAction};
+//! use ahp::ahp_types::state::RootState;
+//!
+//! let mut root = RootState {
+//!     agents: vec![],
+//!     active_sessions: None,
+//!     terminals: None,
+//!     config: None,
+//! };
+//!
+//! let action = StateAction::RootActiveSessionsChanged(
+//!     RootActiveSessionsChangedAction { active_sessions: 3 },
+//! );
+//!
+//! assert_eq!(apply_action_to_root(&mut root, &action), ReduceOutcome::Applied);
+//! assert_eq!(root.active_sessions, Some(3));
+//! ```
+//!
+//! Each reducer returns a [`ReduceOutcome`] that distinguishes mutations
+//! ([`ReduceOutcome::Applied`]), recognized but inert events
+//! ([`ReduceOutcome::NoOp`]), and out-of-scope routing
+//! ([`ReduceOutcome::OutOfScope`]). A client holding all three state
+//! trees can blindly fan every action out to every reducer without
+//! special-casing.
+//!
+//! # Cancellation and shutdown
+//!
+//! All async client APIs are cancel-safe at await points. The background
+//! driver is owned by the [`Client`] and aborted when the last clone is
+//! dropped, or when [`Client::shutdown`] is called. In-flight requests
+//! resolve with [`ClientError::Shutdown`] in either case.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod client;
 pub mod error;

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -6,6 +6,44 @@
 //! the matching scope; unrelated actions short-circuit as
 //! [`ReduceOutcome::OutOfScope`] so a client holding all three state
 //! trees can blindly fan every action out.
+//!
+//! All three reducers are pure functions over `(state, action)` — no
+//! I/O, no allocation beyond what the action itself carries — which
+//! makes them safe to run inside a UI render loop or a snapshot
+//! reconciler.
+//!
+//! # Example
+//!
+//! ```
+//! use ahp::reducers::{apply_action_to_root, ReduceOutcome};
+//! use ahp_types::actions::{
+//!     RootActiveSessionsChangedAction, SessionTitleChangedAction, StateAction,
+//! };
+//! use ahp_types::state::RootState;
+//!
+//! let mut root = RootState {
+//!     agents: vec![],
+//!     active_sessions: None,
+//!     terminals: None,
+//!     config: None,
+//! };
+//!
+//! // A root-scoped action mutates `RootState`.
+//! let action = StateAction::RootActiveSessionsChanged(
+//!     RootActiveSessionsChangedAction { active_sessions: 5 },
+//! );
+//! assert_eq!(apply_action_to_root(&mut root, &action), ReduceOutcome::Applied);
+//! assert_eq!(root.active_sessions, Some(5));
+//!
+//! // A session-scoped action is reported as out-of-scope at the root.
+//! let session_action = StateAction::SessionTitleChanged(
+//!     SessionTitleChangedAction { session: "copilot:/s1".into(), title: "Hi".into() },
+//! );
+//! assert_eq!(
+//!     apply_action_to_root(&mut root, &session_action),
+//!     ReduceOutcome::OutOfScope,
+//! );
+//! ```
 
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/clients/rust/crates/ahp/src/transport.rs
+++ b/clients/rust/crates/ahp/src/transport.rs
@@ -4,6 +4,37 @@
 //! WebSocket, raw TCP, Unix socket, stdio, an in-memory pair for tests —
 //! can back a [`Transport`] implementation. The client consumes typed
 //! [`TransportMessage`]s; framing and TLS are the transport's concern.
+//!
+//! # Implementing a transport
+//!
+//! Three async methods are required: [`Transport::send`],
+//! [`Transport::recv`], and (optionally) [`Transport::close`]. The
+//! crate uses the `impl Future` form of async-fn-in-trait, so no
+//! dynamic dispatch box is required.
+//!
+//! ```
+//! use ahp::{Transport, TransportError, TransportMessage};
+//! use std::future::Future;
+//! use tokio::sync::mpsc;
+//!
+//! /// One half of an in-memory transport pair — handy for tests.
+//! pub struct MemTransport {
+//!     tx: mpsc::Sender<TransportMessage>,
+//!     rx: mpsc::Receiver<TransportMessage>,
+//! }
+//!
+//! impl Transport for MemTransport {
+//!     async fn send(&mut self, msg: TransportMessage) -> Result<(), TransportError> {
+//!         self.tx.send(msg).await.map_err(|_| TransportError::Closed)
+//!     }
+//!     async fn recv(&mut self) -> Result<Option<TransportMessage>, TransportError> {
+//!         Ok(self.rx.recv().await)
+//!     }
+//! }
+//! ```
+//!
+//! For ready-made transports, see the [`ahp-ws`](https://docs.rs/ahp-ws)
+//! crate (WebSocket via `tokio-tungstenite`).
 
 use std::future::Future;
 


### PR DESCRIPTION
rust: polish crate docs for docs.rs

Expands the rustdoc landing pages, module docs, and Cargo metadata
across the Rust client crates so they render well on docs.rs.

- Rewrites `ahp-types`, `ahp`, and `ahp-ws` crate-level docs with
  module maps, companion-crate links, and runnable examples.
- Adds module-level prose and runnable doctests to `ahp::reducers`,
  `ahp::transport`, and `ahp::error`.
- Documents `WebSocketTransport::connect`/`from_stream` with usage
  notes and converts the WebSocket quickstart and `from_stream`
  examples from `ignore` to `no_run` so they still type-check.
- Adds `homepage`, `documentation`, `keywords`, `categories`, and a
  `[package.metadata.docs.rs]` block to all three Cargo.toml files,
  enabling `--cfg docsrs` builds.
- Adds a `reducers_demo` runnable example for the `ahp` crate that
  applies a couple of root actions to a `RootState` and prints the
  reduced state.

(Commit message generated by Copilot)
