### PR TITLE
reconnect: add `missing` URIs to ReconnectReplayResult

### DIFF
--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -99,6 +99,11 @@ pub struct ReconnectParams {
 pub struct ReconnectReplayResult {
     /// Missed action envelopes since `lastSeenServerSeq`
     pub actions: Vec<ActionEnvelope>,
+    /// URIs from `ReconnectParams.subscriptions` that the server cannot resume.
+    /// This includes resources that no longer exist (e.g. disposed sessions or
+    /// terminals) as well as resources the client is no longer permitted to
+    /// observe. Clients SHOULD drop these from their local subscription set.
+    pub missing: Vec<Uri>,
 }
 
 /// Reconnect result when the gap exceeds the replay buffer.

--- a/clients/swift/AHPClient/AHPClientTests/AHPClientTests.swift
+++ b/clients/swift/AHPClient/AHPClientTests/AHPClientTests.swift
@@ -66,7 +66,8 @@ struct ReconnectResultTests {
         )
         let result = ReconnectResult.replay(ReconnectReplayResult(
             type: .replay,
-            actions: [action1, action2]
+            actions: [action1, action2],
+            missing: []
         ))
 
         store.applyReconnectResult(result)
@@ -84,7 +85,7 @@ struct ReconnectResultTests {
             fromSeq: 50
         ))
 
-        let result = ReconnectResult.replay(ReconnectReplayResult(type: .replay, actions: []))
+        let result = ReconnectResult.replay(ReconnectReplayResult(type: .replay, actions: [], missing: []))
         store.applyReconnectResult(result)
 
         #expect(store.rootState.agents[0].provider == "stable")

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -201,10 +201,13 @@ The server MUST include all replayed data in the response before returning. If t
     "actions": [
       { "action": { "type": "session/delta", ... }, "serverSeq": 43 },
       { "action": { "type": "session/delta", ... }, "serverSeq": 44 }
-    ]
+    ],
+    "missing": ["copilot:/<disposed-uuid>"]
   }
 }
 ```
+
+The `missing` array lists subscriptions from the request that the server cannot resume — for example, sessions or terminals that have been disposed, or resources the client is no longer permitted to observe. Clients SHOULD drop these from their local subscription set.
 
 If the gap exceeds the replay buffer, the server sends fresh snapshots instead:
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -3832,7 +3832,7 @@
     },
     "SessionCustomization": {
       "type": "object",
-      "description": "A customization active in a session.\n\nEntries without a `clientId` are server-provided; entries with a `clientId`\noriginate from that client.",
+      "description": "A customization active in a session.",
       "properties": {
         "customization": {
           "$ref": "#/$defs/CustomizationRef",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -104,11 +104,19 @@
             "$ref": "#/$defs/ActionEnvelope"
           },
           "description": "Missed action envelopes since `lastSeenServerSeq`"
+        },
+        "missing": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/URI"
+          },
+          "description": "URIs from `ReconnectParams.subscriptions` that the server cannot resume.\nThis includes resources that no longer exist (e.g. disposed sessions or\nterminals) as well as resources the client is no longer permitted to\nobserve. Clients SHOULD drop these from their local subscription set."
         }
       },
       "required": [
         "type",
-        "actions"
+        "actions",
+        "missing"
       ]
     },
     "ReconnectSnapshotResult": {
@@ -2967,7 +2975,7 @@
     },
     "SessionCustomization": {
       "type": "object",
-      "description": "A customization active in a session.\n\nEntries without a `clientId` are server-provided; entries with a `clientId`\noriginate from that client.",
+      "description": "A customization active in a session.",
       "properties": {
         "customization": {
           "$ref": "#/$defs/CustomizationRef",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -2412,7 +2412,7 @@
     },
     "SessionCustomization": {
       "type": "object",
-      "description": "A customization active in a session.\n\nEntries without a `clientId` are server-provided; entries with a `clientId`\noriginate from that client.",
+      "description": "A customization active in a session.",
       "properties": {
         "customization": {
           "$ref": "#/$defs/CustomizationRef",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -2269,7 +2269,7 @@
     },
     "SessionCustomization": {
       "type": "object",
-      "description": "A customization active in a session.\n\nEntries without a `clientId` are server-provided; entries with a `clientId`\noriginate from that client.",
+      "description": "A customization active in a session.",
       "properties": {
         "customization": {
           "$ref": "#/$defs/CustomizationRef",

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1292,6 +1292,7 @@ function checkExhaustiveness(project: Project): void {
     'SessionInputQuestion',
     'SessionInputAnswerValue',
     'SessionInputAnswer',
+    'ReconnectResult',
   ]);
 
   const missing = [...imported].filter(n => !coveredByLists.has(n) && !knownSpecial.has(n));

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1461,6 +1461,7 @@ function checkExhaustiveness(project: Project): void {
     'SessionInputQuestion',         // SESSION_INPUT_QUESTION_UNION discriminated union
     'SessionInputAnswerValue',      // SESSION_INPUT_ANSWER_VALUE_UNION discriminated union
     'SessionInputAnswer',           // SESSION_INPUT_ANSWER_UNION discriminated union
+    'ReconnectResult',              // RECONNECT_RESULT_UNION discriminated union
   ]);
 
   const missing = [...imported].filter(n => !coveredByLists.has(n) && !knownSpecial.has(n));

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -98,6 +98,13 @@ export interface ReconnectReplayResult {
   type: ReconnectResultType.Replay;
   /** Missed action envelopes since `lastSeenServerSeq` */
   actions: ActionEnvelope[];
+  /**
+   * URIs from `ReconnectParams.subscriptions` that the server cannot resume.
+   * This includes resources that no longer exist (e.g. disposed sessions or
+   * terminals) as well as resources the client is no longer permitted to
+   * observe. Clients SHOULD drop these from their local subscription set.
+   */
+  missing: URI[];
 }
 
 /**

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -160,6 +160,10 @@ import type {
   SessionConfigValueItem,
   InitializeParams,
   InitializeResult,
+  ReconnectParams,
+  ReconnectResult,
+  ReconnectReplayResult,
+  ReconnectSnapshotResult,
 } from '../commands.js';
 
 import type {
@@ -328,6 +332,10 @@ type V1_ISessionConfigCompletionsResult = SessionConfigCompletionsResult;
 type V1_ISessionConfigValueItem = SessionConfigValueItem;
 type V1_IInitializeParams = InitializeParams;
 type V1_IInitializeResult = InitializeResult;
+type V1_IReconnectParams = ReconnectParams;
+type V1_IReconnectResult = ReconnectResult;
+type V1_IReconnectReplayResult = ReconnectReplayResult;
+type V1_IReconnectSnapshotResult = ReconnectSnapshotResult;
 type V1_ICommandMap = CommandMap;
 type V1_IClientNotificationMap = ClientNotificationMap;
 type V1_IServerNotificationMap = ServerNotificationMap;
@@ -628,3 +636,11 @@ type _CheckConfirmationOptionKind = AssertCompatible<V1_ConfirmationOptionKind, 
 type _CheckInitializeParams = AssertCompatible<V1_IInitializeParams, InitializeParams>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckInitializeResult = AssertCompatible<V1_IInitializeResult, InitializeResult>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckReconnectParams = AssertCompatible<V1_IReconnectParams, ReconnectParams>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckReconnectResult = AssertCompatible<V1_IReconnectResult, ReconnectResult>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckReconnectReplayResult = AssertCompatible<V1_IReconnectReplayResult, ReconnectReplayResult>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckReconnectSnapshotResult = AssertCompatible<V1_IReconnectSnapshotResult, ReconnectSnapshotResult>;


### PR DESCRIPTION
reconnect: add `missing` URIs to ReconnectReplayResultAdds a required `missing: URI[]` field to `ReconnectReplayResult` so the server can tellthe client which subscriptions from `ReconnectParams.subscriptions` it cannot resume.- Lists resources that no longer exist (e.g. disposed sessions or terminals) and resources  the client is no longer permitted to observe. Clients SHOULD drop these from their local  subscription set.- Adds v1 compatibility checks for the previously-unchecked `ReconnectParams`,  `ReconnectResult`, `ReconnectReplayResult`, and `ReconnectSnapshotResult` types.- Updates the lifecycle spec example and prose to document the new field.- Teaches the Swift and Rust generator exhaustiveness checks that `ReconnectResult` is  emitted via the discriminated-union code path.- Regenerates schemas, markdown docs, Rust crate, and Swift package; updates Swift tests  to pass `missing: []` in fixture data.(Commit message generated by Copilot)