### PR TITLE
state: add SystemNotificationResponsePart

### DIFF
--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -155,6 +155,8 @@ pub enum ResponsePartKind {
     ToolCall,
     #[serde(rename = "reasoning")]
     Reasoning,
+    #[serde(rename = "systemNotification")]
+    SystemNotification,
 }
 
 /// Status of a tool call in the lifecycle state machine.
@@ -1072,6 +1074,24 @@ pub struct ReasoningResponsePart {
     pub content: String,
 }
 
+/// A system notification surfaced as part of the response stream.
+///
+/// System notifications are messages authored by the agent host or a provider
+/// that need to be visible to both the agent (for situational awareness) and
+/// the user (for transcript continuity). Examples include "background subagent
+/// X completed" or "task Y was cancelled".
+///
+/// Unlike ephemeral protocol notifications (`notify/*`), system notification
+/// parts live in session state, replay on reconnect, and preserve their
+/// position in the response stream relative to markdown, reasoning, and tool
+/// calls.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemNotificationResponsePart {
+    /// Human/agent-readable content. Always renderable as a fallback.
+    pub content: StringOrMarkdown,
+}
+
 /// Tool execution result details, available after execution completes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1764,6 +1784,8 @@ pub enum ResponsePart {
     ToolCall(Box<ToolCallResponsePart>),
     #[serde(rename = "reasoning")]
     Reasoning(ReasoningResponsePart),
+    #[serde(rename = "systemNotification")]
+    SystemNotification(SystemNotificationResponsePart),
     /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
     /// Reducers treat this as a no-op.
     #[serde(untagged)]

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -1076,19 +1076,14 @@ pub struct ReasoningResponsePart {
 
 /// A system notification surfaced as part of the response stream.
 ///
-/// System notifications are messages authored by the agent host or a provider
+/// System notifications are messages authored by the agent harness
 /// that need to be visible to both the agent (for situational awareness) and
 /// the user (for transcript continuity). Examples include "background subagent
 /// X completed" or "task Y was cancelled".
-///
-/// Unlike ephemeral protocol notifications (`notify/*`), system notification
-/// parts live in session state, replay on reconnect, and preserve their
-/// position in the response stream relative to markdown, reasoning, and tool
-/// calls.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemNotificationResponsePart {
-    /// Human/agent-readable content. Always renderable as a fallback.
+    /// The text of the system notification
     pub content: StringOrMarkdown,
 }
 

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -380,7 +380,9 @@ where
             ResponsePart::ToolCall(tc) => Some(tool_call_id(&tc.tool_call).to_owned()),
             ResponsePart::Markdown(m) => Some(m.id.clone()),
             ResponsePart::Reasoning(r) => Some(r.id.clone()),
-            ResponsePart::ContentRef(_) | ResponsePart::Unknown(_) => None,
+            ResponsePart::ContentRef(_)
+            | ResponsePart::SystemNotification(_)
+            | ResponsePart::Unknown(_) => None,
         };
         if id.as_deref() == Some(part_id) {
             updater(part);

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2941,6 +2941,24 @@
         "content"
       ]
     },
+    "SystemNotificationResponsePart": {
+      "type": "object",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "description": "Discriminant"
+        },
+        "content": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Human/agent-readable content. Always renderable as a fallback."
+        }
+      },
+      "required": [
+        "kind",
+        "content"
+      ]
+    },
     "ConfirmationOption": {
       "type": "object",
       "description": "A confirmation option that the server offers for a tool call awaiting\napproval. Allows richer choices beyond simple approve/deny — for example,\n\"Approve in this Session\" or \"Deny with reason.\"",
@@ -4191,6 +4209,7 @@
     },
     "ResponsePart": {
       "oneOf": [
+        {},
         {
           "$ref": "#/$defs/MarkdownResponsePart"
         },
@@ -4202,6 +4221,9 @@
         },
         {
           "$ref": "#/$defs/ReasoningResponsePart"
+        },
+        {
+          "$ref": "#/$defs/SystemNotificationResponsePart"
         }
       ]
     },

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2943,7 +2943,7 @@
     },
     "SystemNotificationResponsePart": {
       "type": "object",
-      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
           "$ref": "#/$defs/ResponsePartKind.SystemNotification",
@@ -2951,7 +2951,7 @@
         },
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
-          "description": "Human/agent-readable content. Always renderable as a fallback."
+          "description": "The text of the system notification"
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2084,6 +2084,24 @@
         "content"
       ]
     },
+    "SystemNotificationResponsePart": {
+      "type": "object",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "description": "Discriminant"
+        },
+        "content": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Human/agent-readable content. Always renderable as a fallback."
+        }
+      },
+      "required": [
+        "kind",
+        "content"
+      ]
+    },
     "ConfirmationOption": {
       "type": "object",
       "description": "A confirmation option that the server offers for a tool call awaiting\napproval. Allows richer choices beyond simple approve/deny — for example,\n\"Approve in this Session\" or \"Deny with reason.\"",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2086,7 +2086,7 @@
     },
     "SystemNotificationResponsePart": {
       "type": "object",
-      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
           "$ref": "#/$defs/ResponsePartKind.SystemNotification",
@@ -2094,7 +2094,7 @@
         },
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
-          "description": "Human/agent-readable content. Always renderable as a fallback."
+          "description": "The text of the system notification"
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1521,6 +1521,24 @@
         "content"
       ]
     },
+    "SystemNotificationResponsePart": {
+      "type": "object",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "description": "Discriminant"
+        },
+        "content": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Human/agent-readable content. Always renderable as a fallback."
+        }
+      },
+      "required": [
+        "kind",
+        "content"
+      ]
+    },
     "ConfirmationOption": {
       "type": "object",
       "description": "A confirmation option that the server offers for a tool call awaiting\napproval. Allows richer choices beyond simple approve/deny — for example,\n\"Approve in this Session\" or \"Deny with reason.\"",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1523,7 +1523,7 @@
     },
     "SystemNotificationResponsePart": {
       "type": "object",
-      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
           "$ref": "#/$defs/ResponsePartKind.SystemNotification",
@@ -1531,7 +1531,7 @@
         },
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
-          "description": "Human/agent-readable content. Always renderable as a fallback."
+          "description": "The text of the system notification"
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1378,6 +1378,24 @@
         "content"
       ]
     },
+    "SystemNotificationResponsePart": {
+      "type": "object",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "description": "Discriminant"
+        },
+        "content": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Human/agent-readable content. Always renderable as a fallback."
+        }
+      },
+      "required": [
+        "kind",
+        "content"
+      ]
+    },
     "ConfirmationOption": {
       "type": "object",
       "description": "A confirmation option that the server offers for a tool call awaiting\napproval. Allows richer choices beyond simple approve/deny — for example,\n\"Approve in this Session\" or \"Deny with reason.\"",
@@ -2628,6 +2646,7 @@
     },
     "ResponsePart": {
       "oneOf": [
+        {},
         {
           "$ref": "#/$defs/MarkdownResponsePart"
         },
@@ -2639,6 +2658,9 @@
         },
         {
           "$ref": "#/$defs/ReasoningResponsePart"
+        },
+        {
+          "$ref": "#/$defs/SystemNotificationResponsePart"
         }
       ]
     },

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1380,7 +1380,7 @@
     },
     "SystemNotificationResponsePart": {
       "type": "object",
-      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent host or a provider\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".\n\nUnlike ephemeral protocol notifications (`notify/*`), system notification\nparts live in session state, replay on reconnect, and preserve their\nposition in the response stream relative to markdown, reasoning, and tool\ncalls.",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
           "$ref": "#/$defs/ResponsePartKind.SystemNotification",
@@ -1388,7 +1388,7 @@
         },
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
-          "description": "Human/agent-readable content. Always renderable as a fallback."
+          "description": "The text of the system notification"
         }
       },
       "required": [

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -567,6 +567,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'ResourceReponsePart', omitDiscriminants: true, rustName: 'ResourceResponsePart' },
   { name: 'ToolCallResponsePart', omitDiscriminants: true },
   { name: 'ReasoningResponsePart', omitDiscriminants: true },
+  { name: 'SystemNotificationResponsePart', omitDiscriminants: true },
   { name: 'ToolCallResult' },
   { name: 'ConfirmationOption' },
   { name: 'ToolCallStreamingState', omitDiscriminants: true },
@@ -606,6 +607,7 @@ const RESPONSE_PART_UNION: UnionConfig = {
     { variantName: 'ContentRef', innerType: 'ResourceResponsePart', wireValue: 'contentRef' },
     { variantName: 'ToolCall', innerType: 'ToolCallResponsePart', wireValue: 'toolCall', boxed: true },
     { variantName: 'Reasoning', innerType: 'ReasoningResponsePart', wireValue: 'reasoning' },
+    { variantName: 'SystemNotification', innerType: 'SystemNotificationResponsePart', wireValue: 'systemNotification' },
   ],
   unknown: true,
 };

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -495,6 +495,7 @@ const STATE_STRUCTS = [
   'SessionInputRequest',
   'MessageAttachment', 'MarkdownResponsePart', 'ContentRef',
   'ResourceReponsePart', 'ToolCallResponsePart', 'ReasoningResponsePart',
+  'SystemNotificationResponsePart',
   'ToolCallResult', 'ToolCallStreamingState',
   'ToolCallPendingConfirmationState', 'ToolCallRunningState',
   'ToolCallPendingResultConfirmationState', 'ToolCallCompletedState',
@@ -516,6 +517,7 @@ const RESPONSE_PART_UNION: UnionConfig = {
     { caseName: 'contentRef', structName: 'ResourceReponsePart', discriminantValue: 'contentRef' },
     { caseName: 'toolCall', structName: 'ToolCallResponsePart', discriminantValue: 'toolCall' },
     { caseName: 'reasoning', structName: 'ReasoningResponsePart', discriminantValue: 'reasoning' },
+    { caseName: 'systemNotification', structName: 'SystemNotificationResponsePart', discriminantValue: 'systemNotification' },
   ],
 };
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -29,6 +29,7 @@ export type {
   ContentRef,
   ToolCallResponsePart,
   ReasoningResponsePart,
+  SystemNotificationResponsePart,
   ResponsePart,
   ToolCallResult,
   ToolCallStreamingState,

--- a/types/state.ts
+++ b/types/state.ts
@@ -862,6 +862,7 @@ export const enum ResponsePartKind {
   ContentRef = 'contentRef',
   ToolCall = 'toolCall',
   Reasoning = 'reasoning',
+  SystemNotification = 'systemNotification',
 }
 
 /**
@@ -931,7 +932,35 @@ export interface ReasoningResponsePart {
 /**
  * @category Response Parts
  */
-export type ResponsePart = MarkdownResponsePart | ResourceReponsePart | ToolCallResponsePart | ReasoningResponsePart;
+export type ResponsePart =
+  | MarkdownResponsePart
+  | ResourceReponsePart
+  | ToolCallResponsePart
+  | ReasoningResponsePart
+  | SystemNotificationResponsePart;
+
+/**
+ * A system notification surfaced as part of the response stream.
+ *
+ * System notifications are messages authored by the agent host or a provider
+ * that need to be visible to both the agent (for situational awareness) and
+ * the user (for transcript continuity). Examples include "background subagent
+ * X completed" or "task Y was cancelled".
+ *
+ * Unlike ephemeral protocol notifications (`notify/*`), system notification
+ * parts live in session state, replay on reconnect, and preserve their
+ * position in the response stream relative to markdown, reasoning, and tool
+ * calls.
+ *
+ * @category Response Parts
+ */
+export interface SystemNotificationResponsePart {
+  /** Discriminant */
+  kind: ResponsePartKind.SystemNotification;
+  /** Human/agent-readable content. Always renderable as a fallback. */
+  content: StringOrMarkdown;
+}
+
 
 // ─── Tool Call Types ─────────────────────────────────────────────────────────
 

--- a/types/state.ts
+++ b/types/state.ts
@@ -942,22 +942,17 @@ export type ResponsePart =
 /**
  * A system notification surfaced as part of the response stream.
  *
- * System notifications are messages authored by the agent host or a provider
+ * System notifications are messages authored by the agent harness
  * that need to be visible to both the agent (for situational awareness) and
  * the user (for transcript continuity). Examples include "background subagent
  * X completed" or "task Y was cancelled".
- *
- * Unlike ephemeral protocol notifications (`notify/*`), system notification
- * parts live in session state, replay on reconnect, and preserve their
- * position in the response stream relative to markdown, reasoning, and tool
- * calls.
  *
  * @category Response Parts
  */
 export interface SystemNotificationResponsePart {
   /** Discriminant */
   kind: ResponsePartKind.SystemNotification;
-  /** Human/agent-readable content. Always renderable as a fallback. */
+  /** The text of the system notification */
   content: StringOrMarkdown;
 }
 

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -32,6 +32,7 @@ import type {
   ContentRef,
   ToolCallResponsePart,
   ReasoningResponsePart,
+  SystemNotificationResponsePart,
   ToolCallResult,
   ToolCallStreamingState,
   ToolCallPendingConfirmationState,
@@ -211,6 +212,7 @@ type V1_IMarkdownResponsePart = MarkdownResponsePart;
 type V1_IContentRef = ContentRef;
 type V1_IToolCallResponsePart = ToolCallResponsePart;
 type V1_IReasoningResponsePart = ReasoningResponsePart;
+type V1_ISystemNotificationResponsePart = SystemNotificationResponsePart;
 type V1_IToolCallResult = ToolCallResult;
 type V1_IToolCallStreamingState = ToolCallStreamingState;
 type V1_IToolCallPendingConfirmationState = ToolCallPendingConfirmationState;
@@ -382,6 +384,8 @@ type _CheckContentRef = AssertCompatible<V1_IContentRef, ContentRef>;
 type _CheckToolCallResponsePart = AssertCompatible<V1_IToolCallResponsePart, ToolCallResponsePart>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckReasoningResponsePart = AssertCompatible<V1_IReasoningResponsePart, ReasoningResponsePart>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckSystemNotificationResponsePart = AssertCompatible<V1_ISystemNotificationResponsePart, SystemNotificationResponsePart>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckToolCallResult = AssertCompatible<V1_IToolCallResult, ToolCallResult>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## What

Adds a new `systemNotification` response part kind to the protocol:

- New `ResponsePartKind.SystemNotification` discriminant.
- New `SystemNotificationResponsePart` interface with `kind` + `content: StringOrMarkdown`.
- Added to the `ResponsePart` union, exported from `types/index.ts`, and registered in the `v1` compatibility snapshot.
- Wired into the Swift (`scripts/generate-swift.ts`) and Rust (`scripts/generate-rust.ts`) generators; regenerated schemas and the Rust crate.

## Why

The Copilot SDK (and likely other providers) emit "system notification" events — messages authored for the agent that the user also needs to see, such as "background subagent X completed" or "task Y was cancelled". Today there is no first-class way to represent these in AHP:

- Ephemeral protocol notifications (`notify/*`) are broadcast to all clients and are explicitly not replayed on reconnect — wrong shape for transcript content.
- Squeezing them into a markdown response part forces clients to parse provider-specific tags to recover any structure, and mixes them with assistant text.

A dedicated response-part kind keeps them in session state alongside markdown / reasoning / tool calls, so they stream in order, replay on reconnect, and benefit from the existing snapshot/subscription model. The shape is intentionally minimal (`kind` + `content`) — additional structured metadata can be added later as optional fields without bumping the protocol version.

## Notes for reviewers

- Created via the existing `session/responsePart` action — no new action or reducer change needed; the reducer already appends any `ResponsePart` generically.
- No `PROTOCOL_VERSION` bump (additive change; new kinds are filtered by version automatically per the existing rules in `docs/specification/versioning.md`).
- All 190 reducer/message tests still pass; reducer coverage stays at 100%.

(Written by Copilot)