### PR TITLE
Make Swift client consumable via Swift Package Manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -29,7 +29,7 @@ jobs:
       run:
         working-directory: clients/rust
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -42,3 +42,34 @@ jobs:
       - run: cargo clippy --workspace -- -D warnings
 
       - run: cargo test --workspace
+
+  swift:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      # Verify the committed Swift sources are in sync with the TypeScript
+      # protocol definitions. If `npm run generate:swift` produces any diff,
+      # the committed Generated/ files are stale.
+      - name: Verify generated Swift is up to date
+        run: |
+          npm run generate:swift
+          if ! git diff --quiet -- clients/swift/AgentHostProtocol; then
+            echo "::error::Generated Swift sources are out of date. Run 'npm run generate:swift' and commit the result."
+            git --no-pager diff -- clients/swift/AgentHostProtocol
+            exit 1
+          fi
+
+      - name: Build Swift package
+        run: swift build
+
+      - name: Test Swift package
+        run: swift test
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -31,7 +31,7 @@ jobs:
 
       - run: npm run docs:build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -43,4 +43,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -21,7 +21,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,10 @@ docs/.vitepress/cache
 # Generated files (npm run generate)
 docs/reference/
 docs/public/schema/
-clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/
-clients/swift/AgentHostProtocol/.build/
-clients/swift/AgentHostProtocol/.swiftpm/
-clients/swift/AHPApp/.build/
-clients/swift/AHPClient/.build/
+
+# SwiftPM build artifacts
+.build/
+.swiftpm/
 clients/swift/AHPClient/AHPClient/Config/Signing.local.xcconfig
 
 # Xcode / Swift

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,13 @@
 
 import PackageDescription
 
+// AgentHostProtocol is the official Swift client for the Agent Host Protocol.
+//
+// Although this repository is polyglot (TypeScript-first, with Rust and Swift
+// clients), Package.swift lives at the repo root because Swift Package Manager
+// only resolves remote packages whose manifest is at the repository root.
+// The actual Swift sources live under clients/swift/AgentHostProtocol/.
+
 let package = Package(
     name: "AgentHostProtocol",
     platforms: [
@@ -19,12 +26,12 @@ let package = Package(
     targets: [
         .target(
             name: "AgentHostProtocol",
-            path: "Sources/AgentHostProtocol"
+            path: "clients/swift/AgentHostProtocol/Sources/AgentHostProtocol"
         ),
         .testTarget(
             name: "AgentHostProtocolTests",
             dependencies: ["AgentHostProtocol"],
-            path: "Tests/AgentHostProtocolTests"
+            path: "clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A synchronized, multi-client state protocol for AI agent sessions.
 
 The Agent Host Protocol (AHP) defines how a portable, standalone sessions server communicates with its clients. Multiple clients can connect to the server and see a synchronized view of AI agent sessions through immutable state, pure reducers, and write-ahead reconciliation.
 
+## Clients
+
+- **Swift** — Add `https://github.com/microsoft/agent-host-protocol` as a Swift Package Manager dependency to use the `AgentHostProtocol` library. See [`clients/swift/`](clients/swift/) for an example iOS client. The `Package.swift` manifest lives at the repository root because SwiftPM only resolves manifests at the root of a remote git repo; the actual Swift sources live under `clients/swift/AgentHostProtocol/`.
+- **Rust** — See [`clients/rust/`](clients/rust/) for the `ahp`, `ahp-types`, and `ahp-ws` crates.
+
 ## Development
 
 ```bash

--- a/clients/swift/AGENTS.md
+++ b/clients/swift/AGENTS.md
@@ -4,12 +4,12 @@
 
 This directory contains two Swift packages for the Agent Host Protocol (AHP):
 
-1. **AgentHostProtocol** — A pure Swift library (no external dependencies) providing auto-generated types, actions, and reducers for the protocol. Targets iOS 16+, macOS 13+, Swift 5.9+.
+1. **AgentHostProtocol** — A pure Swift library (no external dependencies) providing auto-generated types, actions, and reducers for the protocol. Targets iOS 16+, macOS 13+, Swift 5.9+. The Swift sources live in `clients/swift/AgentHostProtocol/`, but the `Package.swift` manifest lives at the **repository root** (`/Package.swift`) so that external consumers can pull this in via `.package(url:)`. SwiftPM only resolves manifests at the root of a remote git repository.
 2. **AHPClient** — An example iOS app (Xcode project) demonstrating a full AHP client with WebSocket transport, state synchronization, reconnection, and a SwiftUI chat UI. Uses [dev-tunnels-swift](https://github.com/rebornix/dev-tunnels-swift) (remote Swift Package) for tunnel discovery, authentication, and relay connections.
 
 ## Code Generation
 
-Types in `AgentHostProtocol/Sources/AgentHostProtocol/Generated/` are **auto-generated** from the TypeScript definitions in `types/`. Do not edit these files directly.
+Types in `AgentHostProtocol/Sources/AgentHostProtocol/Generated/` are **auto-generated** from the TypeScript definitions in `types/`. Do not edit these files directly. Generated files are committed to source control so the package is consumable via SwiftPM without a code-generation toolchain.
 
 To regenerate after protocol changes:
 
@@ -19,7 +19,30 @@ npm run generate:swift    # runs: tsx scripts/generate.ts --swift
 
 Generated files: `State`, `Commands`, `Actions`, `Errors`, `Messages`, `Notifications` — all suffixed `.generated.swift`.
 
+CI verifies that the committed generated files match the output of `npm run generate:swift` and fails on drift.
+
 ## AgentHostProtocol Library
+
+### Installing via Swift Package Manager
+
+Add it as a dependency in your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/microsoft/agent-host-protocol.git", from: "0.1.0")
+```
+
+…and reference the `AgentHostProtocol` product from your target:
+
+```swift
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "AgentHostProtocol", package: "agent-host-protocol"),
+    ]
+),
+```
+
+In Xcode: **File ▸ Add Package Dependencies…** and enter `https://github.com/microsoft/agent-host-protocol`.
 
 ### Key Types
 
@@ -106,7 +129,7 @@ The app uses `#available(iOS 26.0, *)` checks for:
 
 ### Build & Run
 
-Open `AHPClient/AHPClient.xcodeproj` in Xcode. The project references `AgentHostProtocol` as a local Swift package dependency and `DevTunnelsClient` as a remote Swift package from [rebornix/dev-tunnels-swift](https://github.com/rebornix/dev-tunnels-swift). Code signing requires a `Signing.local.xcconfig` file (see `Config/Signing.local.xcconfig.example`).
+Open `AHPClient/AHPClient.xcodeproj` in Xcode. The project references `AgentHostProtocol` as a local Swift package whose manifest lives at the **repository root** (`../../..` relative to the Xcode project), and `DevTunnelsClient` as a remote Swift package from [rebornix/dev-tunnels-swift](https://github.com/rebornix/dev-tunnels-swift). Code signing requires a `Signing.local.xcconfig` file (see `Config/Signing.local.xcconfig.example`).
 
 **Dev Tunnels integration:** `TunnelListView.swift` uses the `DevTunnelsClient` library directly — `TunnelManagementClient` for tunnel listing/details, `DeviceCodeAuth` for GitHub OAuth, and `TunnelConnection` helpers for relay URIs and connect tokens. All calls are `async` — no shim layer or Rust FFI needed.
 

--- a/clients/swift/AHPClient/AHPClient.xcodeproj/project.pbxproj
+++ b/clients/swift/AHPClient/AHPClient.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 			mainGroup = 6F2049802F7744ED001049F9;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				6F2049CF2F7746D3001049F9 /* XCLocalSwiftPackageReference "../AgentHostProtocol" */,
+				6F2049CF2F7746D3001049F9 /* XCLocalSwiftPackageReference "../../.." */,
 				AA000001304700000003 /* XCRemoteSwiftPackageReference "dev-tunnels-swift" */,
 				AA000002304700000003 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 			);
@@ -606,9 +606,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		6F2049CF2F7746D3001049F9 /* XCLocalSwiftPackageReference "../AgentHostProtocol" */ = {
+		6F2049CF2F7746D3001049F9 /* XCLocalSwiftPackageReference "../../.." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../AgentHostProtocol;
+			relativePath = ../../..;
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -1,0 +1,1596 @@
+// Generated from types/*.ts — do not edit
+
+import Foundation
+
+// MARK: - ActionType
+
+/// Discriminant values for all state actions.
+public enum ActionType: String, Codable, Sendable {
+    case rootAgentsChanged = "root/agentsChanged"
+    case rootActiveSessionsChanged = "root/activeSessionsChanged"
+    case sessionReady = "session/ready"
+    case sessionCreationFailed = "session/creationFailed"
+    case sessionTurnStarted = "session/turnStarted"
+    case sessionDelta = "session/delta"
+    case sessionResponsePart = "session/responsePart"
+    case sessionToolCallStart = "session/toolCallStart"
+    case sessionToolCallDelta = "session/toolCallDelta"
+    case sessionToolCallReady = "session/toolCallReady"
+    case sessionToolCallConfirmed = "session/toolCallConfirmed"
+    case sessionToolCallComplete = "session/toolCallComplete"
+    case sessionToolCallResultConfirmed = "session/toolCallResultConfirmed"
+    case sessionToolCallContentChanged = "session/toolCallContentChanged"
+    case sessionTurnComplete = "session/turnComplete"
+    case sessionTurnCancelled = "session/turnCancelled"
+    case sessionError = "session/error"
+    case sessionTitleChanged = "session/titleChanged"
+    case sessionUsage = "session/usage"
+    case sessionReasoning = "session/reasoning"
+    case sessionModelChanged = "session/modelChanged"
+    case sessionServerToolsChanged = "session/serverToolsChanged"
+    case sessionActiveClientChanged = "session/activeClientChanged"
+    case sessionActiveClientToolsChanged = "session/activeClientToolsChanged"
+    case sessionPendingMessageSet = "session/pendingMessageSet"
+    case sessionPendingMessageRemoved = "session/pendingMessageRemoved"
+    case sessionQueuedMessagesReordered = "session/queuedMessagesReordered"
+    case sessionInputRequested = "session/inputRequested"
+    case sessionInputAnswerChanged = "session/inputAnswerChanged"
+    case sessionInputCompleted = "session/inputCompleted"
+    case sessionCustomizationsChanged = "session/customizationsChanged"
+    case sessionCustomizationToggled = "session/customizationToggled"
+    case sessionTruncated = "session/truncated"
+    case sessionIsReadChanged = "session/isReadChanged"
+    case sessionIsArchivedChanged = "session/isArchivedChanged"
+    case sessionActivityChanged = "session/activityChanged"
+    case sessionDiffsChanged = "session/diffsChanged"
+    case sessionConfigChanged = "session/configChanged"
+    case sessionMetaChanged = "session/metaChanged"
+    case rootTerminalsChanged = "root/terminalsChanged"
+    case rootConfigChanged = "root/configChanged"
+    case terminalData = "terminal/data"
+    case terminalInput = "terminal/input"
+    case terminalResized = "terminal/resized"
+    case terminalClaimed = "terminal/claimed"
+    case terminalTitleChanged = "terminal/titleChanged"
+    case terminalCwdChanged = "terminal/cwdChanged"
+    case terminalExited = "terminal/exited"
+    case terminalCleared = "terminal/cleared"
+    case terminalCommandDetectionAvailable = "terminal/commandDetectionAvailable"
+    case terminalCommandExecuted = "terminal/commandExecuted"
+    case terminalCommandFinished = "terminal/commandFinished"
+}
+
+// MARK: - Action Infrastructure
+
+public struct ActionOrigin: Codable, Sendable {
+    public var clientId: String
+    public var clientSeq: Int
+
+    public init(
+        clientId: String,
+        clientSeq: Int
+    ) {
+        self.clientId = clientId
+        self.clientSeq = clientSeq
+    }
+}
+
+public struct ActionEnvelope: Codable, Sendable {
+    public var action: StateAction
+    public var serverSeq: Int
+    public var origin: ActionOrigin?
+    public var rejectionReason: String?
+
+    public init(
+        action: StateAction,
+        serverSeq: Int,
+        origin: ActionOrigin? = nil,
+        rejectionReason: String? = nil
+    ) {
+        self.action = action
+        self.serverSeq = serverSeq
+        self.origin = origin
+        self.rejectionReason = rejectionReason
+    }
+}
+
+// MARK: - Action Types
+
+public struct RootAgentsChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Updated agent list
+    public var agents: [AgentInfo]
+
+    public init(
+        type: ActionType,
+        agents: [AgentInfo]
+    ) {
+        self.type = type
+        self.agents = agents
+    }
+}
+
+public struct RootActiveSessionsChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Current count of active sessions
+    public var activeSessions: Int
+
+    public init(
+        type: ActionType,
+        activeSessions: Int
+    ) {
+        self.type = type
+        self.activeSessions = activeSessions
+    }
+}
+
+public struct SessionReadyAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+
+    public init(
+        type: ActionType,
+        session: String
+    ) {
+        self.type = type
+        self.session = session
+    }
+}
+
+public struct SessionCreationFailedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Error details
+    public var error: ErrorInfo
+
+    public init(
+        type: ActionType,
+        session: String,
+        error: ErrorInfo
+    ) {
+        self.type = type
+        self.session = session
+        self.error = error
+    }
+}
+
+public struct SessionTurnStartedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// User's message
+    public var userMessage: UserMessage
+    /// If this turn was auto-started from a queued message, the ID of that message
+    public var queuedMessageId: String?
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String,
+        userMessage: UserMessage,
+        queuedMessageId: String? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+        self.userMessage = userMessage
+        self.queuedMessageId = queuedMessageId
+    }
+}
+
+public struct SessionDeltaAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Identifier of the response part to append to
+    public var partId: String
+    /// Text chunk
+    public var content: String
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String,
+        partId: String,
+        content: String
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+        self.partId = partId
+        self.content = content
+    }
+}
+
+public struct SessionResponsePartAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Response part (markdown or content ref)
+    public var part: ResponsePart
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String,
+        part: ResponsePart
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+        self.part = part
+    }
+}
+
+public struct SessionToolCallStartAction: Codable, Sendable {
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Tool call identifier
+    public var toolCallId: String
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    public var type: ActionType
+    /// Internal tool name (for debugging/logging)
+    public var toolName: String
+    /// Human-readable tool name
+    public var displayName: String
+    /// If this tool is provided by a client, the `clientId` of the owning client.
+    /// Absent for server-side tools.
+    public var toolClientId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case session
+        case turnId
+        case toolCallId
+        case meta = "_meta"
+        case type
+        case toolName
+        case displayName
+        case toolClientId
+    }
+
+    public init(
+        session: String,
+        turnId: String,
+        toolCallId: String,
+        meta: [String: AnyCodable]? = nil,
+        type: ActionType,
+        toolName: String,
+        displayName: String,
+        toolClientId: String? = nil
+    ) {
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+        self.meta = meta
+        self.type = type
+        self.toolName = toolName
+        self.displayName = displayName
+        self.toolClientId = toolClientId
+    }
+}
+
+public struct SessionToolCallDeltaAction: Codable, Sendable {
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Tool call identifier
+    public var toolCallId: String
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    public var type: ActionType
+    /// Partial parameter content to append
+    public var content: String
+    /// Updated progress message
+    public var invocationMessage: StringOrMarkdown?
+
+    enum CodingKeys: String, CodingKey {
+        case session
+        case turnId
+        case toolCallId
+        case meta = "_meta"
+        case type
+        case content
+        case invocationMessage
+    }
+
+    public init(
+        session: String,
+        turnId: String,
+        toolCallId: String,
+        meta: [String: AnyCodable]? = nil,
+        type: ActionType,
+        content: String,
+        invocationMessage: StringOrMarkdown? = nil
+    ) {
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+        self.meta = meta
+        self.type = type
+        self.content = content
+        self.invocationMessage = invocationMessage
+    }
+}
+
+public struct SessionToolCallReadyAction: Codable, Sendable {
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Tool call identifier
+    public var toolCallId: String
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    public var type: ActionType
+    /// Message describing what the tool will do or what confirmation is needed
+    public var invocationMessage: StringOrMarkdown
+    /// Raw tool input
+    public var toolInput: String?
+    /// Short title for the confirmation prompt (e.g. `"Run in terminal"`, `"Write file"`)
+    public var confirmationTitle: StringOrMarkdown?
+    /// File edits that this tool call will perform, for preview before confirmation
+    public var edits: AnyCodable?
+    /// Whether the agent host allows the client to edit the tool's input parameters before confirming
+    public var editable: Bool?
+    /// If set, the tool was auto-confirmed and transitions directly to `running`
+    public var confirmed: ToolCallConfirmationReason?
+    /// Options the server offers for this confirmation. When present, the client
+    /// SHOULD render these instead of a plain approve/deny UI. Each option
+    /// belongs to a {@link ConfirmationOptionGroup} so the client can still
+    /// categorise the choices.
+    public var options: [ConfirmationOption]?
+
+    enum CodingKeys: String, CodingKey {
+        case session
+        case turnId
+        case toolCallId
+        case meta = "_meta"
+        case type
+        case invocationMessage
+        case toolInput
+        case confirmationTitle
+        case edits
+        case editable
+        case confirmed
+        case options
+    }
+
+    public init(
+        session: String,
+        turnId: String,
+        toolCallId: String,
+        meta: [String: AnyCodable]? = nil,
+        type: ActionType,
+        invocationMessage: StringOrMarkdown,
+        toolInput: String? = nil,
+        confirmationTitle: StringOrMarkdown? = nil,
+        edits: AnyCodable? = nil,
+        editable: Bool? = nil,
+        confirmed: ToolCallConfirmationReason? = nil,
+        options: [ConfirmationOption]? = nil
+    ) {
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+        self.meta = meta
+        self.type = type
+        self.invocationMessage = invocationMessage
+        self.toolInput = toolInput
+        self.confirmationTitle = confirmationTitle
+        self.edits = edits
+        self.editable = editable
+        self.confirmed = confirmed
+        self.options = options
+    }
+}
+
+/// Client approves or denies a pending tool call (merged approved + denied variants).
+public struct SessionToolCallConfirmedAction: Codable, Sendable {
+    /// Action type discriminant
+    public var type: String
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Tool call identifier
+    public var toolCallId: String
+    /// Whether the tool call was approved
+    public var approved: Bool
+    /// How the tool was confirmed (present when approved)
+    public var confirmed: ToolCallConfirmationReason?
+    /// Edited tool input parameters, if the client modified them before confirming
+    public var editedToolInput: String?
+    /// Why the tool was cancelled (present when denied)
+    public var reason: ToolCallCancellationReason?
+    /// What the user suggested instead (present when denied)
+    public var userSuggestion: UserMessage?
+    /// Explanation for the denial
+    public var reasonMessage: StringOrMarkdown?
+    /// ID of the selected confirmation option, if the server provided options
+    public var selectedOptionId: String?
+    /// Additional provider-specific metadata
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type, session, turnId, toolCallId, approved, confirmed, editedToolInput, reason, userSuggestion, reasonMessage, selectedOptionId
+        case meta = "_meta"
+    }
+
+    public init(
+        type: String = "session/toolCallConfirmed",
+        session: String,
+        turnId: String,
+        toolCallId: String,
+        approved: Bool,
+        confirmed: ToolCallConfirmationReason? = nil,
+        editedToolInput: String? = nil,
+        reason: ToolCallCancellationReason? = nil,
+        userSuggestion: UserMessage? = nil,
+        reasonMessage: StringOrMarkdown? = nil,
+        selectedOptionId: String? = nil,
+        meta: [String: AnyCodable]? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+        self.approved = approved
+        self.confirmed = confirmed
+        self.editedToolInput = editedToolInput
+        self.reason = reason
+        self.userSuggestion = userSuggestion
+        self.reasonMessage = reasonMessage
+        self.selectedOptionId = selectedOptionId
+        self.meta = meta
+    }
+}
+
+public struct SessionToolCallCompleteAction: Codable, Sendable {
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Tool call identifier
+    public var toolCallId: String
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    public var type: ActionType
+    /// Execution result
+    public var result: ToolCallResult
+    /// If true, the result requires client approval before finalizing
+    public var requiresResultConfirmation: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case session
+        case turnId
+        case toolCallId
+        case meta = "_meta"
+        case type
+        case result
+        case requiresResultConfirmation
+    }
+
+    public init(
+        session: String,
+        turnId: String,
+        toolCallId: String,
+        meta: [String: AnyCodable]? = nil,
+        type: ActionType,
+        result: ToolCallResult,
+        requiresResultConfirmation: Bool? = nil
+    ) {
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+        self.meta = meta
+        self.type = type
+        self.result = result
+        self.requiresResultConfirmation = requiresResultConfirmation
+    }
+}
+
+public struct SessionToolCallResultConfirmedAction: Codable, Sendable {
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Tool call identifier
+    public var toolCallId: String
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    public var type: ActionType
+    /// Whether the result was approved
+    public var approved: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case session
+        case turnId
+        case toolCallId
+        case meta = "_meta"
+        case type
+        case approved
+    }
+
+    public init(
+        session: String,
+        turnId: String,
+        toolCallId: String,
+        meta: [String: AnyCodable]? = nil,
+        type: ActionType,
+        approved: Bool
+    ) {
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+        self.meta = meta
+        self.type = type
+        self.approved = approved
+    }
+}
+
+public struct SessionTurnCompleteAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+    }
+}
+
+public struct SessionTurnCancelledAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+    }
+}
+
+public struct SessionErrorAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Error details
+    public var error: ErrorInfo
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String,
+        error: ErrorInfo
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+        self.error = error
+    }
+}
+
+public struct SessionTitleChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// New title
+    public var title: String
+
+    public init(
+        type: ActionType,
+        session: String,
+        title: String
+    ) {
+        self.type = type
+        self.session = session
+        self.title = title
+    }
+}
+
+public struct SessionUsageAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Token usage data
+    public var usage: UsageInfo
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String,
+        usage: UsageInfo
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+        self.usage = usage
+    }
+}
+
+public struct SessionReasoningAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Identifier of the reasoning response part to append to
+    public var partId: String
+    /// Reasoning text chunk
+    public var content: String
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String,
+        partId: String,
+        content: String
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+        self.partId = partId
+        self.content = content
+    }
+}
+
+public struct SessionModelChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// New model selection
+    public var model: ModelSelection
+
+    public init(
+        type: ActionType,
+        session: String,
+        model: ModelSelection
+    ) {
+        self.type = type
+        self.session = session
+        self.model = model
+    }
+}
+
+public struct SessionIsReadChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Whether the session has been read
+    public var isRead: Bool
+
+    public init(
+        type: ActionType,
+        session: String,
+        isRead: Bool
+    ) {
+        self.type = type
+        self.session = session
+        self.isRead = isRead
+    }
+}
+
+public struct SessionIsArchivedChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Whether the session is archived
+    public var isArchived: Bool
+
+    public init(
+        type: ActionType,
+        session: String,
+        isArchived: Bool
+    ) {
+        self.type = type
+        self.session = session
+        self.isArchived = isArchived
+    }
+}
+
+public struct SessionActivityChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Human-readable description of current activity, or `undefined` to clear
+    public var activity: String?
+
+    public init(
+        type: ActionType,
+        session: String,
+        activity: String? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.activity = activity
+    }
+}
+
+public struct SessionServerToolsChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Updated server tools list (full replacement)
+    public var tools: [ToolDefinition]
+
+    public init(
+        type: ActionType,
+        session: String,
+        tools: [ToolDefinition]
+    ) {
+        self.type = type
+        self.session = session
+        self.tools = tools
+    }
+}
+
+public struct SessionActiveClientChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// The new active client, or `null` to unset
+    public var activeClient: SessionActiveClient?
+
+    public init(
+        type: ActionType,
+        session: String,
+        activeClient: SessionActiveClient? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.activeClient = activeClient
+    }
+}
+
+public struct SessionActiveClientToolsChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Updated client tools list (full replacement)
+    public var tools: [ToolDefinition]
+
+    public init(
+        type: ActionType,
+        session: String,
+        tools: [ToolDefinition]
+    ) {
+        self.type = type
+        self.session = session
+        self.tools = tools
+    }
+}
+
+public struct SessionPendingMessageSetAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Whether this is a steering or queued message
+    public var kind: PendingMessageKind
+    /// Unique identifier for this pending message
+    public var id: String
+    /// The message content
+    public var userMessage: UserMessage
+
+    public init(
+        type: ActionType,
+        session: String,
+        kind: PendingMessageKind,
+        id: String,
+        userMessage: UserMessage
+    ) {
+        self.type = type
+        self.session = session
+        self.kind = kind
+        self.id = id
+        self.userMessage = userMessage
+    }
+}
+
+public struct SessionPendingMessageRemovedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Whether this is a steering or queued message
+    public var kind: PendingMessageKind
+    /// Identifier of the pending message to remove
+    public var id: String
+
+    public init(
+        type: ActionType,
+        session: String,
+        kind: PendingMessageKind,
+        id: String
+    ) {
+        self.type = type
+        self.session = session
+        self.kind = kind
+        self.id = id
+    }
+}
+
+public struct SessionQueuedMessagesReorderedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Queued message IDs in the desired order
+    public var order: [String]
+
+    public init(
+        type: ActionType,
+        session: String,
+        order: [String]
+    ) {
+        self.type = type
+        self.session = session
+        self.order = order
+    }
+}
+
+public struct SessionInputRequestedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Input request to create or replace
+    public var request: SessionInputRequest
+
+    public init(
+        type: ActionType,
+        session: String,
+        request: SessionInputRequest
+    ) {
+        self.type = type
+        self.session = session
+        self.request = request
+    }
+}
+
+public struct SessionInputAnswerChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Input request identifier
+    public var requestId: String
+    /// Question identifier within the input request
+    public var questionId: String
+    /// Updated answer, or `undefined` to clear an answer draft
+    public var answer: SessionInputAnswer?
+
+    public init(
+        type: ActionType,
+        session: String,
+        requestId: String,
+        questionId: String,
+        answer: SessionInputAnswer? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.requestId = requestId
+        self.questionId = questionId
+        self.answer = answer
+    }
+}
+
+public struct SessionInputCompletedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Input request identifier
+    public var requestId: String
+    /// Completion outcome
+    public var response: SessionInputResponseKind
+    /// Optional final answer replacement, keyed by question ID
+    public var answers: [String: SessionInputAnswer]?
+
+    public init(
+        type: ActionType,
+        session: String,
+        requestId: String,
+        response: SessionInputResponseKind,
+        answers: [String: SessionInputAnswer]? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.requestId = requestId
+        self.response = response
+        self.answers = answers
+    }
+}
+
+public struct SessionCustomizationsChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Updated customization list (full replacement)
+    public var customizations: [SessionCustomization]
+
+    public init(
+        type: ActionType,
+        session: String,
+        customizations: [SessionCustomization]
+    ) {
+        self.type = type
+        self.session = session
+        self.customizations = customizations
+    }
+}
+
+public struct SessionCustomizationToggledAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// The URI of the customization to toggle
+    public var uri: String
+    /// Whether to enable or disable the customization
+    public var enabled: Bool
+
+    public init(
+        type: ActionType,
+        session: String,
+        uri: String,
+        enabled: Bool
+    ) {
+        self.type = type
+        self.session = session
+        self.uri = uri
+        self.enabled = enabled
+    }
+}
+
+public struct SessionTruncatedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Keep turns up to and including this turn. Omit to clear all turns.
+    public var turnId: String?
+
+    public init(
+        type: ActionType,
+        session: String,
+        turnId: String? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.turnId = turnId
+    }
+}
+
+public struct SessionDiffsChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Updated file diffs for the session
+    public var diffs: [FileEdit]
+
+    public init(
+        type: ActionType,
+        session: String,
+        diffs: [FileEdit]
+    ) {
+        self.type = type
+        self.session = session
+        self.diffs = diffs
+    }
+}
+
+public struct SessionConfigChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// Updated config values
+    public var config: [String: AnyCodable]
+    /// When `true`, replaces all config values instead of merging
+    public var replace: Bool?
+
+    public init(
+        type: ActionType,
+        session: String,
+        config: [String: AnyCodable],
+        replace: Bool? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.config = config
+        self.replace = replace
+    }
+}
+
+public struct SessionMetaChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// New `_meta` payload, or `undefined` to clear it
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case session
+        case meta = "_meta"
+    }
+
+    public init(
+        type: ActionType,
+        session: String,
+        meta: [String: AnyCodable]? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.meta = meta
+    }
+}
+
+public struct SessionToolCallContentChangedAction: Codable, Sendable {
+    /// Session URI
+    public var session: String
+    /// Turn identifier
+    public var turnId: String
+    /// Tool call identifier
+    public var toolCallId: String
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    public var type: ActionType
+    /// The current partial content for the running tool call
+    public var content: [ToolResultContent]
+
+    enum CodingKeys: String, CodingKey {
+        case session
+        case turnId
+        case toolCallId
+        case meta = "_meta"
+        case type
+        case content
+    }
+
+    public init(
+        session: String,
+        turnId: String,
+        toolCallId: String,
+        meta: [String: AnyCodable]? = nil,
+        type: ActionType,
+        content: [ToolResultContent]
+    ) {
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+        self.meta = meta
+        self.type = type
+        self.content = content
+    }
+}
+
+public struct RootTerminalsChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Updated terminal list (full replacement)
+    public var terminals: [TerminalInfo]
+
+    public init(
+        type: ActionType,
+        terminals: [TerminalInfo]
+    ) {
+        self.type = type
+        self.terminals = terminals
+    }
+}
+
+public struct RootConfigChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Updated config values
+    public var config: [String: AnyCodable]
+    /// When `true`, replaces all config values instead of merging
+    public var replace: Bool?
+
+    public init(
+        type: ActionType,
+        config: [String: AnyCodable],
+        replace: Bool? = nil
+    ) {
+        self.type = type
+        self.config = config
+        self.replace = replace
+    }
+}
+
+public struct TerminalDataAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// Output data (may contain ANSI escape sequences)
+    public var data: String
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        data: String
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.data = data
+    }
+}
+
+public struct TerminalInputAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// Input data to send to the pty
+    public var data: String
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        data: String
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.data = data
+    }
+}
+
+public struct TerminalResizedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// Terminal width in columns
+    public var cols: Int
+    /// Terminal height in rows
+    public var rows: Int
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        cols: Int,
+        rows: Int
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.cols = cols
+        self.rows = rows
+    }
+}
+
+public struct TerminalClaimedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// The new claim
+    public var claim: TerminalClaim
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        claim: TerminalClaim
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.claim = claim
+    }
+}
+
+public struct TerminalTitleChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// New terminal title
+    public var title: String
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        title: String
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.title = title
+    }
+}
+
+public struct TerminalCwdChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// New working directory
+    public var cwd: String
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        cwd: String
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.cwd = cwd
+    }
+}
+
+public struct TerminalExitedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// Process exit code. `undefined` if the process was killed without an exit code.
+    public var exitCode: Int?
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        exitCode: Int? = nil
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.exitCode = exitCode
+    }
+}
+
+public struct TerminalClearedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+
+    public init(
+        type: ActionType,
+        terminal: String
+    ) {
+        self.type = type
+        self.terminal = terminal
+    }
+}
+
+public struct TerminalCommandDetectionAvailableAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+
+    public init(
+        type: ActionType,
+        terminal: String
+    ) {
+        self.type = type
+        self.terminal = terminal
+    }
+}
+
+public struct TerminalCommandExecutedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// Stable identifier for this command, scoped to the terminal URI.
+    /// Allows correlating `commandExecuted` → `commandFinished` pairs.
+    public var commandId: String
+    /// The command line text that was submitted
+    public var commandLine: String
+    /// Unix timestamp (ms) of when the command started executing, as measured
+    /// on the server.
+    public var timestamp: Int
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        commandId: String,
+        commandLine: String,
+        timestamp: Int
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.commandId = commandId
+        self.commandLine = commandLine
+        self.timestamp = timestamp
+    }
+}
+
+public struct TerminalCommandFinishedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Terminal URI
+    public var terminal: String
+    /// Matches the `commandId` from the corresponding `commandExecuted`
+    public var commandId: String
+    /// Shell exit code. `undefined` if the shell did not report one.
+    public var exitCode: Int?
+    /// Wall-clock duration of the command in milliseconds, as measured by the
+    /// shell integration script on the server side.
+    public var durationMs: Int?
+
+    public init(
+        type: ActionType,
+        terminal: String,
+        commandId: String,
+        exitCode: Int? = nil,
+        durationMs: Int? = nil
+    ) {
+        self.type = type
+        self.terminal = terminal
+        self.commandId = commandId
+        self.exitCode = exitCode
+        self.durationMs = durationMs
+    }
+}
+
+// MARK: - StateAction Union
+
+/// Discriminated union of all state actions.
+public enum StateAction: Codable, Sendable {
+    case rootAgentsChanged(RootAgentsChangedAction)
+    case rootActiveSessionsChanged(RootActiveSessionsChangedAction)
+    case sessionReady(SessionReadyAction)
+    case sessionCreationFailed(SessionCreationFailedAction)
+    case sessionTurnStarted(SessionTurnStartedAction)
+    case sessionDelta(SessionDeltaAction)
+    case sessionResponsePart(SessionResponsePartAction)
+    case sessionToolCallStart(SessionToolCallStartAction)
+    case sessionToolCallDelta(SessionToolCallDeltaAction)
+    case sessionToolCallReady(SessionToolCallReadyAction)
+    case sessionToolCallConfirmed(SessionToolCallConfirmedAction)
+    case sessionToolCallComplete(SessionToolCallCompleteAction)
+    case sessionToolCallResultConfirmed(SessionToolCallResultConfirmedAction)
+    case sessionTurnComplete(SessionTurnCompleteAction)
+    case sessionTurnCancelled(SessionTurnCancelledAction)
+    case sessionError(SessionErrorAction)
+    case sessionTitleChanged(SessionTitleChangedAction)
+    case sessionUsage(SessionUsageAction)
+    case sessionReasoning(SessionReasoningAction)
+    case sessionModelChanged(SessionModelChangedAction)
+    case sessionIsReadChanged(SessionIsReadChangedAction)
+    case sessionIsArchivedChanged(SessionIsArchivedChangedAction)
+    case sessionActivityChanged(SessionActivityChangedAction)
+    case sessionServerToolsChanged(SessionServerToolsChangedAction)
+    case sessionActiveClientChanged(SessionActiveClientChangedAction)
+    case sessionActiveClientToolsChanged(SessionActiveClientToolsChangedAction)
+    case sessionPendingMessageSet(SessionPendingMessageSetAction)
+    case sessionPendingMessageRemoved(SessionPendingMessageRemovedAction)
+    case sessionQueuedMessagesReordered(SessionQueuedMessagesReorderedAction)
+    case sessionInputRequested(SessionInputRequestedAction)
+    case sessionInputAnswerChanged(SessionInputAnswerChangedAction)
+    case sessionInputCompleted(SessionInputCompletedAction)
+    case sessionCustomizationsChanged(SessionCustomizationsChangedAction)
+    case sessionCustomizationToggled(SessionCustomizationToggledAction)
+    case sessionTruncated(SessionTruncatedAction)
+    case sessionDiffsChanged(SessionDiffsChangedAction)
+    case sessionConfigChanged(SessionConfigChangedAction)
+    case sessionMetaChanged(SessionMetaChangedAction)
+    case sessionToolCallContentChanged(SessionToolCallContentChangedAction)
+    case rootTerminalsChanged(RootTerminalsChangedAction)
+    case rootConfigChanged(RootConfigChangedAction)
+    case terminalData(TerminalDataAction)
+    case terminalInput(TerminalInputAction)
+    case terminalResized(TerminalResizedAction)
+    case terminalClaimed(TerminalClaimedAction)
+    case terminalTitleChanged(TerminalTitleChangedAction)
+    case terminalCwdChanged(TerminalCwdChangedAction)
+    case terminalExited(TerminalExitedAction)
+    case terminalCleared(TerminalClearedAction)
+    case terminalCommandDetectionAvailable(TerminalCommandDetectionAvailableAction)
+    case terminalCommandExecuted(TerminalCommandExecutedAction)
+    case terminalCommandFinished(TerminalCommandFinishedAction)
+    /// Unknown or future action type; reducers treat this as a no-op.
+    case unknown(type: String)
+
+    private enum TypeKey: String, CodingKey { case type }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: TypeKey.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "root/agentsChanged":
+            self = .rootAgentsChanged(try RootAgentsChangedAction(from: decoder))
+        case "root/activeSessionsChanged":
+            self = .rootActiveSessionsChanged(try RootActiveSessionsChangedAction(from: decoder))
+        case "session/ready":
+            self = .sessionReady(try SessionReadyAction(from: decoder))
+        case "session/creationFailed":
+            self = .sessionCreationFailed(try SessionCreationFailedAction(from: decoder))
+        case "session/turnStarted":
+            self = .sessionTurnStarted(try SessionTurnStartedAction(from: decoder))
+        case "session/delta":
+            self = .sessionDelta(try SessionDeltaAction(from: decoder))
+        case "session/responsePart":
+            self = .sessionResponsePart(try SessionResponsePartAction(from: decoder))
+        case "session/toolCallStart":
+            self = .sessionToolCallStart(try SessionToolCallStartAction(from: decoder))
+        case "session/toolCallDelta":
+            self = .sessionToolCallDelta(try SessionToolCallDeltaAction(from: decoder))
+        case "session/toolCallReady":
+            self = .sessionToolCallReady(try SessionToolCallReadyAction(from: decoder))
+        case "session/toolCallConfirmed":
+            self = .sessionToolCallConfirmed(try SessionToolCallConfirmedAction(from: decoder))
+        case "session/toolCallComplete":
+            self = .sessionToolCallComplete(try SessionToolCallCompleteAction(from: decoder))
+        case "session/toolCallResultConfirmed":
+            self = .sessionToolCallResultConfirmed(try SessionToolCallResultConfirmedAction(from: decoder))
+        case "session/turnComplete":
+            self = .sessionTurnComplete(try SessionTurnCompleteAction(from: decoder))
+        case "session/turnCancelled":
+            self = .sessionTurnCancelled(try SessionTurnCancelledAction(from: decoder))
+        case "session/error":
+            self = .sessionError(try SessionErrorAction(from: decoder))
+        case "session/titleChanged":
+            self = .sessionTitleChanged(try SessionTitleChangedAction(from: decoder))
+        case "session/usage":
+            self = .sessionUsage(try SessionUsageAction(from: decoder))
+        case "session/reasoning":
+            self = .sessionReasoning(try SessionReasoningAction(from: decoder))
+        case "session/modelChanged":
+            self = .sessionModelChanged(try SessionModelChangedAction(from: decoder))
+        case "session/isReadChanged":
+            self = .sessionIsReadChanged(try SessionIsReadChangedAction(from: decoder))
+        case "session/isArchivedChanged":
+            self = .sessionIsArchivedChanged(try SessionIsArchivedChangedAction(from: decoder))
+        case "session/activityChanged":
+            self = .sessionActivityChanged(try SessionActivityChangedAction(from: decoder))
+        case "session/serverToolsChanged":
+            self = .sessionServerToolsChanged(try SessionServerToolsChangedAction(from: decoder))
+        case "session/activeClientChanged":
+            self = .sessionActiveClientChanged(try SessionActiveClientChangedAction(from: decoder))
+        case "session/activeClientToolsChanged":
+            self = .sessionActiveClientToolsChanged(try SessionActiveClientToolsChangedAction(from: decoder))
+        case "session/pendingMessageSet":
+            self = .sessionPendingMessageSet(try SessionPendingMessageSetAction(from: decoder))
+        case "session/pendingMessageRemoved":
+            self = .sessionPendingMessageRemoved(try SessionPendingMessageRemovedAction(from: decoder))
+        case "session/queuedMessagesReordered":
+            self = .sessionQueuedMessagesReordered(try SessionQueuedMessagesReorderedAction(from: decoder))
+        case "session/inputRequested":
+            self = .sessionInputRequested(try SessionInputRequestedAction(from: decoder))
+        case "session/inputAnswerChanged":
+            self = .sessionInputAnswerChanged(try SessionInputAnswerChangedAction(from: decoder))
+        case "session/inputCompleted":
+            self = .sessionInputCompleted(try SessionInputCompletedAction(from: decoder))
+        case "session/customizationsChanged":
+            self = .sessionCustomizationsChanged(try SessionCustomizationsChangedAction(from: decoder))
+        case "session/customizationToggled":
+            self = .sessionCustomizationToggled(try SessionCustomizationToggledAction(from: decoder))
+        case "session/truncated":
+            self = .sessionTruncated(try SessionTruncatedAction(from: decoder))
+        case "session/diffsChanged":
+            self = .sessionDiffsChanged(try SessionDiffsChangedAction(from: decoder))
+        case "session/configChanged":
+            self = .sessionConfigChanged(try SessionConfigChangedAction(from: decoder))
+        case "session/metaChanged":
+            self = .sessionMetaChanged(try SessionMetaChangedAction(from: decoder))
+        case "session/toolCallContentChanged":
+            self = .sessionToolCallContentChanged(try SessionToolCallContentChangedAction(from: decoder))
+        case "root/terminalsChanged":
+            self = .rootTerminalsChanged(try RootTerminalsChangedAction(from: decoder))
+        case "root/configChanged":
+            self = .rootConfigChanged(try RootConfigChangedAction(from: decoder))
+        case "terminal/data":
+            self = .terminalData(try TerminalDataAction(from: decoder))
+        case "terminal/input":
+            self = .terminalInput(try TerminalInputAction(from: decoder))
+        case "terminal/resized":
+            self = .terminalResized(try TerminalResizedAction(from: decoder))
+        case "terminal/claimed":
+            self = .terminalClaimed(try TerminalClaimedAction(from: decoder))
+        case "terminal/titleChanged":
+            self = .terminalTitleChanged(try TerminalTitleChangedAction(from: decoder))
+        case "terminal/cwdChanged":
+            self = .terminalCwdChanged(try TerminalCwdChangedAction(from: decoder))
+        case "terminal/exited":
+            self = .terminalExited(try TerminalExitedAction(from: decoder))
+        case "terminal/cleared":
+            self = .terminalCleared(try TerminalClearedAction(from: decoder))
+        case "terminal/commandDetectionAvailable":
+            self = .terminalCommandDetectionAvailable(try TerminalCommandDetectionAvailableAction(from: decoder))
+        case "terminal/commandExecuted":
+            self = .terminalCommandExecuted(try TerminalCommandExecutedAction(from: decoder))
+        case "terminal/commandFinished":
+            self = .terminalCommandFinished(try TerminalCommandFinishedAction(from: decoder))
+        default:
+            self = .unknown(type: type)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .rootAgentsChanged(let v): try v.encode(to: encoder)
+        case .rootActiveSessionsChanged(let v): try v.encode(to: encoder)
+        case .sessionReady(let v): try v.encode(to: encoder)
+        case .sessionCreationFailed(let v): try v.encode(to: encoder)
+        case .sessionTurnStarted(let v): try v.encode(to: encoder)
+        case .sessionDelta(let v): try v.encode(to: encoder)
+        case .sessionResponsePart(let v): try v.encode(to: encoder)
+        case .sessionToolCallStart(let v): try v.encode(to: encoder)
+        case .sessionToolCallDelta(let v): try v.encode(to: encoder)
+        case .sessionToolCallReady(let v): try v.encode(to: encoder)
+        case .sessionToolCallConfirmed(let v): try v.encode(to: encoder)
+        case .sessionToolCallComplete(let v): try v.encode(to: encoder)
+        case .sessionToolCallResultConfirmed(let v): try v.encode(to: encoder)
+        case .sessionTurnComplete(let v): try v.encode(to: encoder)
+        case .sessionTurnCancelled(let v): try v.encode(to: encoder)
+        case .sessionError(let v): try v.encode(to: encoder)
+        case .sessionTitleChanged(let v): try v.encode(to: encoder)
+        case .sessionUsage(let v): try v.encode(to: encoder)
+        case .sessionReasoning(let v): try v.encode(to: encoder)
+        case .sessionModelChanged(let v): try v.encode(to: encoder)
+        case .sessionIsReadChanged(let v): try v.encode(to: encoder)
+        case .sessionIsArchivedChanged(let v): try v.encode(to: encoder)
+        case .sessionActivityChanged(let v): try v.encode(to: encoder)
+        case .sessionServerToolsChanged(let v): try v.encode(to: encoder)
+        case .sessionActiveClientChanged(let v): try v.encode(to: encoder)
+        case .sessionActiveClientToolsChanged(let v): try v.encode(to: encoder)
+        case .sessionPendingMessageSet(let v): try v.encode(to: encoder)
+        case .sessionPendingMessageRemoved(let v): try v.encode(to: encoder)
+        case .sessionQueuedMessagesReordered(let v): try v.encode(to: encoder)
+        case .sessionInputRequested(let v): try v.encode(to: encoder)
+        case .sessionInputAnswerChanged(let v): try v.encode(to: encoder)
+        case .sessionInputCompleted(let v): try v.encode(to: encoder)
+        case .sessionCustomizationsChanged(let v): try v.encode(to: encoder)
+        case .sessionCustomizationToggled(let v): try v.encode(to: encoder)
+        case .sessionTruncated(let v): try v.encode(to: encoder)
+        case .sessionDiffsChanged(let v): try v.encode(to: encoder)
+        case .sessionConfigChanged(let v): try v.encode(to: encoder)
+        case .sessionMetaChanged(let v): try v.encode(to: encoder)
+        case .sessionToolCallContentChanged(let v): try v.encode(to: encoder)
+        case .rootTerminalsChanged(let v): try v.encode(to: encoder)
+        case .rootConfigChanged(let v): try v.encode(to: encoder)
+        case .terminalData(let v): try v.encode(to: encoder)
+        case .terminalInput(let v): try v.encode(to: encoder)
+        case .terminalResized(let v): try v.encode(to: encoder)
+        case .terminalClaimed(let v): try v.encode(to: encoder)
+        case .terminalTitleChanged(let v): try v.encode(to: encoder)
+        case .terminalCwdChanged(let v): try v.encode(to: encoder)
+        case .terminalExited(let v): try v.encode(to: encoder)
+        case .terminalCleared(let v): try v.encode(to: encoder)
+        case .terminalCommandDetectionAvailable(let v): try v.encode(to: encoder)
+        case .terminalCommandExecuted(let v): try v.encode(to: encoder)
+        case .terminalCommandFinished(let v): try v.encode(to: encoder)
+        case .unknown: break
+        }
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -1,0 +1,796 @@
+// Generated from types/*.ts — do not edit
+
+import Foundation
+
+// MARK: - Command Enums
+
+/// Discriminant for reconnect result types.
+public enum ReconnectResultType: String, Codable, Sendable {
+    case replay = "replay"
+    case snapshot = "snapshot"
+}
+
+/// Encoding of fetched content data.
+public enum ContentEncoding: String, Codable, Sendable {
+    case base64 = "base64"
+    case utf8 = "utf-8"
+}
+
+// MARK: - Command Types
+
+public struct InitializeParams: Codable, Sendable {
+    /// Protocol version the client speaks
+    public var protocolVersion: Int
+    /// Unique client identifier
+    public var clientId: String
+    /// URIs to subscribe to during handshake
+    public var initialSubscriptions: [String]?
+    /// IETF BCP 47 language tag indicating the client's preferred locale
+    /// (e.g. `"en-US"`, `"ja"`). The server SHOULD use this to localise
+    /// user-facing strings such as confirmation option labels.
+    public var locale: String?
+
+    public init(
+        protocolVersion: Int,
+        clientId: String,
+        initialSubscriptions: [String]? = nil,
+        locale: String? = nil
+    ) {
+        self.protocolVersion = protocolVersion
+        self.clientId = clientId
+        self.initialSubscriptions = initialSubscriptions
+        self.locale = locale
+    }
+}
+
+public struct InitializeResult: Codable, Sendable {
+    /// Protocol version the server speaks
+    public var protocolVersion: Int
+    /// Current server sequence number
+    public var serverSeq: Int
+    /// Snapshots for each `initialSubscriptions` URI
+    public var snapshots: [Snapshot]
+    /// Suggested default directory for remote filesystem browsing
+    public var defaultDirectory: String?
+
+    public init(
+        protocolVersion: Int,
+        serverSeq: Int,
+        snapshots: [Snapshot],
+        defaultDirectory: String? = nil
+    ) {
+        self.protocolVersion = protocolVersion
+        self.serverSeq = serverSeq
+        self.snapshots = snapshots
+        self.defaultDirectory = defaultDirectory
+    }
+}
+
+public struct ReconnectParams: Codable, Sendable {
+    /// Client identifier from the original connection
+    public var clientId: String
+    /// Last `serverSeq` the client received
+    public var lastSeenServerSeq: Int
+    /// URIs the client was subscribed to
+    public var subscriptions: [String]
+
+    public init(
+        clientId: String,
+        lastSeenServerSeq: Int,
+        subscriptions: [String]
+    ) {
+        self.clientId = clientId
+        self.lastSeenServerSeq = lastSeenServerSeq
+        self.subscriptions = subscriptions
+    }
+}
+
+public struct ReconnectReplayResult: Codable, Sendable {
+    /// Discriminant
+    public var type: ReconnectResultType
+    /// Missed action envelopes since `lastSeenServerSeq`
+    public var actions: [ActionEnvelope]
+    /// URIs from `ReconnectParams.subscriptions` that the server cannot resume.
+    /// This includes resources that no longer exist (e.g. disposed sessions or
+    /// terminals) as well as resources the client is no longer permitted to
+    /// observe. Clients SHOULD drop these from their local subscription set.
+    public var missing: [String]
+
+    public init(
+        type: ReconnectResultType,
+        actions: [ActionEnvelope],
+        missing: [String]
+    ) {
+        self.type = type
+        self.actions = actions
+        self.missing = missing
+    }
+}
+
+public struct ReconnectSnapshotResult: Codable, Sendable {
+    /// Discriminant
+    public var type: ReconnectResultType
+    /// Fresh snapshots for each subscription
+    public var snapshots: [Snapshot]
+
+    public init(
+        type: ReconnectResultType,
+        snapshots: [Snapshot]
+    ) {
+        self.type = type
+        self.snapshots = snapshots
+    }
+}
+
+public struct SubscribeParams: Codable, Sendable {
+    /// URI to subscribe to
+    public var resource: String
+
+    public init(
+        resource: String
+    ) {
+        self.resource = resource
+    }
+}
+
+public struct SubscribeResult: Codable, Sendable {
+    /// Snapshot of the subscribed resource
+    public var snapshot: Snapshot
+
+    public init(
+        snapshot: Snapshot
+    ) {
+        self.snapshot = snapshot
+    }
+}
+
+public struct SessionForkSource: Codable, Sendable {
+    /// URI of the existing session to fork from
+    public var session: String
+    /// Turn ID in the source session; content up to and including this turn's response is copied
+    public var turnId: String
+
+    public init(
+        session: String,
+        turnId: String
+    ) {
+        self.session = session
+        self.turnId = turnId
+    }
+}
+
+public struct CreateSessionParams: Codable, Sendable {
+    /// Session URI (client-chosen, e.g. `copilot:/<uuid>`)
+    public var session: String
+    /// Agent provider ID
+    public var provider: String?
+    /// Model selection (ID and optional model-specific configuration)
+    public var model: ModelSelection?
+    /// Working directory for the session
+    public var workingDirectory: String?
+    /// Fork from an existing session. The new session is populated with content
+    /// from the source session up to and including the specified turn's response.
+    public var fork: SessionForkSource?
+    /// Agent-specific configuration values collected via `resolveSessionConfig`.
+    /// Keys and values correspond to the schema returned by the server.
+    public var config: [String: AnyCodable]?
+    /// Eagerly claim the active client role for the new session.
+    /// 
+    /// When provided, the server initializes the session with this client as the
+    /// active client, equivalent to dispatching a `session/activeClientChanged`
+    /// action immediately after creation. The `clientId` MUST match the
+    /// `clientId` the creating client supplied in `initialize`.
+    public var activeClient: SessionActiveClient?
+
+    public init(
+        session: String,
+        provider: String? = nil,
+        model: ModelSelection? = nil,
+        workingDirectory: String? = nil,
+        fork: SessionForkSource? = nil,
+        config: [String: AnyCodable]? = nil,
+        activeClient: SessionActiveClient? = nil
+    ) {
+        self.session = session
+        self.provider = provider
+        self.model = model
+        self.workingDirectory = workingDirectory
+        self.fork = fork
+        self.config = config
+        self.activeClient = activeClient
+    }
+}
+
+public struct DisposeSessionParams: Codable, Sendable {
+    /// Session URI to dispose
+    public var session: String
+
+    public init(
+        session: String
+    ) {
+        self.session = session
+    }
+}
+
+public struct ListSessionsParams: Codable, Sendable {
+    /// Optional filter criteria
+    public var filter: AnyCodable?
+
+    public init(
+        filter: AnyCodable? = nil
+    ) {
+        self.filter = filter
+    }
+}
+
+public struct ListSessionsResult: Codable, Sendable {
+    /// The list of session summaries.
+    public var items: [SessionSummary]
+
+    public init(
+        items: [SessionSummary]
+    ) {
+        self.items = items
+    }
+}
+
+public struct ResourceReadParams: Codable, Sendable {
+    /// Content URI from a `ContentRef`
+    public var uri: String
+    /// Preferred encoding for the returned data (default: server-chosen)
+    public var encoding: ContentEncoding?
+
+    public init(
+        uri: String,
+        encoding: ContentEncoding? = nil
+    ) {
+        self.uri = uri
+        self.encoding = encoding
+    }
+}
+
+public struct ResourceReadResult: Codable, Sendable {
+    /// Content encoded as a string
+    public var data: String
+    /// How `data` is encoded
+    public var encoding: ContentEncoding
+    /// Content type (e.g. `"image/png"`, `"text/plain"`)
+    public var contentType: String?
+
+    public init(
+        data: String,
+        encoding: ContentEncoding,
+        contentType: String? = nil
+    ) {
+        self.data = data
+        self.encoding = encoding
+        self.contentType = contentType
+    }
+}
+
+public struct ResourceWriteParams: Codable, Sendable {
+    /// Target file URI on the server filesystem
+    public var uri: String
+    /// Content encoded as a string
+    public var data: String
+    /// How `data` is encoded
+    public var encoding: ContentEncoding
+    /// Content type (e.g. `"text/plain"`, `"image/png"`)
+    public var contentType: String?
+    /// If `true`, the server MUST fail if the file already exists instead of
+    /// overwriting it. Useful for safe creation of new files.
+    public var createOnly: Bool?
+
+    public init(
+        uri: String,
+        data: String,
+        encoding: ContentEncoding,
+        contentType: String? = nil,
+        createOnly: Bool? = nil
+    ) {
+        self.uri = uri
+        self.data = data
+        self.encoding = encoding
+        self.contentType = contentType
+        self.createOnly = createOnly
+    }
+}
+
+public struct ResourceWriteResult: Codable, Sendable {
+
+    public init(
+
+    ) {
+    }
+}
+
+public struct ResourceListParams: Codable, Sendable {
+    /// Directory URI on the server filesystem
+    public var uri: String
+
+    public init(
+        uri: String
+    ) {
+        self.uri = uri
+    }
+}
+
+public struct ResourceListResult: Codable, Sendable {
+    /// Entries directly contained in the requested directory
+    public var entries: [DirectoryEntry]
+
+    public init(
+        entries: [DirectoryEntry]
+    ) {
+        self.entries = entries
+    }
+}
+
+public struct DirectoryEntry: Codable, Sendable {
+    /// Base name of the entry
+    public var name: String
+    /// Whether the entry is a file or directory
+    public var type: String
+
+    public init(
+        name: String,
+        type: String
+    ) {
+        self.name = name
+        self.type = type
+    }
+}
+
+public struct ResourceCopyParams: Codable, Sendable {
+    /// Source URI to copy from
+    public var source: String
+    /// Destination URI to copy to
+    public var destination: String
+    /// If `true`, the server MUST fail if the destination already exists instead
+    /// of overwriting it.
+    public var failIfExists: Bool?
+
+    public init(
+        source: String,
+        destination: String,
+        failIfExists: Bool? = nil
+    ) {
+        self.source = source
+        self.destination = destination
+        self.failIfExists = failIfExists
+    }
+}
+
+public struct ResourceCopyResult: Codable, Sendable {
+
+    public init(
+
+    ) {
+    }
+}
+
+public struct ResourceDeleteParams: Codable, Sendable {
+    /// URI of the resource to delete
+    public var uri: String
+    /// If `true` and the target is a directory, delete it and all its contents
+    /// recursively. If `false` (default), deleting a non-empty directory MUST fail.
+    public var recursive: Bool?
+
+    public init(
+        uri: String,
+        recursive: Bool? = nil
+    ) {
+        self.uri = uri
+        self.recursive = recursive
+    }
+}
+
+public struct ResourceDeleteResult: Codable, Sendable {
+
+    public init(
+
+    ) {
+    }
+}
+
+public struct ResourceMoveParams: Codable, Sendable {
+    /// Source URI to move from
+    public var source: String
+    /// Destination URI to move to
+    public var destination: String
+    /// If `true`, the server MUST fail if the destination already exists instead
+    /// of overwriting it.
+    public var failIfExists: Bool?
+
+    public init(
+        source: String,
+        destination: String,
+        failIfExists: Bool? = nil
+    ) {
+        self.source = source
+        self.destination = destination
+        self.failIfExists = failIfExists
+    }
+}
+
+public struct ResourceMoveResult: Codable, Sendable {
+
+    public init(
+
+    ) {
+    }
+}
+
+public struct ResourceRequestParams: Codable, Sendable {
+    /// Resource URI being requested. Typically a `file:` URI on the receiver's
+    /// filesystem, but any URI scheme that the receiver mediates access to is
+    /// allowed.
+    public var uri: String
+    /// Whether the caller needs read access to the resource.
+    public var read: Bool?
+    /// Whether the caller needs write access to the resource.
+    public var write: Bool?
+
+    public init(
+        uri: String,
+        read: Bool? = nil,
+        write: Bool? = nil
+    ) {
+        self.uri = uri
+        self.read = read
+        self.write = write
+    }
+}
+
+public struct ResourceRequestResult: Codable, Sendable {
+
+    public init(
+
+    ) {
+    }
+}
+
+public struct FetchTurnsParams: Codable, Sendable {
+    /// Session URI
+    public var session: String
+    /// Turn ID to fetch before (exclusive). Omit to fetch from the most recent turn.
+    public var before: String?
+    /// Maximum number of turns to return. Server MAY impose its own upper bound.
+    public var limit: Int?
+
+    public init(
+        session: String,
+        before: String? = nil,
+        limit: Int? = nil
+    ) {
+        self.session = session
+        self.before = before
+        self.limit = limit
+    }
+}
+
+public struct FetchTurnsResult: Codable, Sendable {
+    /// The requested turns, ordered oldest-first
+    public var turns: [Turn]
+    /// Whether more turns exist before the returned range
+    public var hasMore: Bool
+
+    public init(
+        turns: [Turn],
+        hasMore: Bool
+    ) {
+        self.turns = turns
+        self.hasMore = hasMore
+    }
+}
+
+public struct UnsubscribeParams: Codable, Sendable {
+    /// URI to unsubscribe from
+    public var resource: String
+
+    public init(
+        resource: String
+    ) {
+        self.resource = resource
+    }
+}
+
+public struct DispatchActionParams: Codable, Sendable {
+    /// Client sequence number
+    public var clientSeq: Int
+    /// The action to dispatch
+    public var action: StateAction
+
+    public init(
+        clientSeq: Int,
+        action: StateAction
+    ) {
+        self.clientSeq = clientSeq
+        self.action = action
+    }
+}
+
+public struct AuthenticateParams: Codable, Sendable {
+    /// The protected resource identifier. MUST match a `resource` value from
+    /// `ProtectedResourceMetadata` declared in `AgentInfo.protectedResources`.
+    public var resource: String
+    /// Bearer token obtained from the resource's authorization server
+    public var token: String
+
+    public init(
+        resource: String,
+        token: String
+    ) {
+        self.resource = resource
+        self.token = token
+    }
+}
+
+public struct AuthenticateResult: Codable, Sendable {
+
+    public init(
+
+    ) {
+    }
+}
+
+public struct CreateTerminalParams: Codable, Sendable {
+    /// Terminal URI (client-chosen)
+    public var terminal: String
+    /// Initial owner of the terminal
+    public var claim: TerminalClaim
+    /// Human-readable terminal name
+    public var name: String?
+    /// Initial working directory URI
+    public var cwd: String?
+    /// Initial terminal width in columns
+    public var cols: Int?
+    /// Initial terminal height in rows
+    public var rows: Int?
+
+    public init(
+        terminal: String,
+        claim: TerminalClaim,
+        name: String? = nil,
+        cwd: String? = nil,
+        cols: Int? = nil,
+        rows: Int? = nil
+    ) {
+        self.terminal = terminal
+        self.claim = claim
+        self.name = name
+        self.cwd = cwd
+        self.cols = cols
+        self.rows = rows
+    }
+}
+
+public struct DisposeTerminalParams: Codable, Sendable {
+    /// Terminal URI to dispose
+    public var terminal: String
+
+    public init(
+        terminal: String
+    ) {
+        self.terminal = terminal
+    }
+}
+
+public struct ResolveSessionConfigParams: Codable, Sendable {
+    /// Agent provider ID
+    public var provider: String?
+    /// Working directory for the session
+    public var workingDirectory: String?
+    /// Current user-filled configuration values
+    public var config: [String: AnyCodable]?
+
+    public init(
+        provider: String? = nil,
+        workingDirectory: String? = nil,
+        config: [String: AnyCodable]? = nil
+    ) {
+        self.provider = provider
+        self.workingDirectory = workingDirectory
+        self.config = config
+    }
+}
+
+public struct ResolveSessionConfigResult: Codable, Sendable {
+    /// JSON Schema describing available configuration properties given the current context
+    public var schema: SessionConfigSchema
+    /// Current configuration values (echoed back with server-resolved defaults applied)
+    public var values: [String: AnyCodable]
+
+    public init(
+        schema: SessionConfigSchema,
+        values: [String: AnyCodable]
+    ) {
+        self.schema = schema
+        self.values = values
+    }
+}
+
+public struct SessionConfigPropertySchema: Codable, Sendable {
+    /// JSON Schema: property type
+    public var type: String
+    /// JSON Schema: human-readable label for the property
+    public var title: String
+    /// JSON Schema: description / tooltip
+    public var description: String?
+    /// JSON Schema: default value
+    public var `default`: AnyCodable?
+    /// JSON Schema: allowed values (typically used with `string` type)
+    public var `enum`: [String]?
+    /// Display extension: human-readable label per enum value (parallel array)
+    public var enumLabels: [String]?
+    /// Display extension: description per enum value (parallel array)
+    public var enumDescriptions: [String]?
+    /// JSON Schema: when `true`, the property is displayed but cannot be modified by the user
+    public var readOnly: Bool?
+    /// JSON Schema: schema for array items (used when `type` is `'array'`)
+    public var items: ConfigPropertySchema?
+    /// JSON Schema: property descriptors for object properties (used when `type` is `'object'`)
+    public var properties: [String: ConfigPropertySchema]?
+    /// JSON Schema: list of required property ids (used when `type` is `'object'`)
+    public var required: [String]?
+    /// Display extension: when `true`, the full set of allowed values is too large
+    /// to enumerate statically. The client SHOULD use `sessionConfigCompletions`
+    /// to fetch matching values based on user input. Any values in `enum` are
+    /// seed/recent values for initial display.
+    public var enumDynamic: Bool?
+    /// When `true`, the user may change this property after session creation
+    public var sessionMutable: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case title
+        case description
+        case `default` = "default"
+        case `enum` = "enum"
+        case enumLabels
+        case enumDescriptions
+        case readOnly
+        case items
+        case properties
+        case required
+        case enumDynamic
+        case sessionMutable
+    }
+
+    public init(
+        type: String,
+        title: String,
+        description: String? = nil,
+        `default`: AnyCodable? = nil,
+        `enum`: [String]? = nil,
+        enumLabels: [String]? = nil,
+        enumDescriptions: [String]? = nil,
+        readOnly: Bool? = nil,
+        items: ConfigPropertySchema? = nil,
+        properties: [String: ConfigPropertySchema]? = nil,
+        required: [String]? = nil,
+        enumDynamic: Bool? = nil,
+        sessionMutable: Bool? = nil
+    ) {
+        self.type = type
+        self.title = title
+        self.description = description
+        self.`default` = `default`
+        self.`enum` = `enum`
+        self.enumLabels = enumLabels
+        self.enumDescriptions = enumDescriptions
+        self.readOnly = readOnly
+        self.items = items
+        self.properties = properties
+        self.required = required
+        self.enumDynamic = enumDynamic
+        self.sessionMutable = sessionMutable
+    }
+}
+
+public struct SessionConfigSchema: Codable, Sendable {
+    /// JSON Schema: always `'object'`
+    public var type: String
+    /// JSON Schema: property descriptors keyed by property id
+    public var properties: [String: SessionConfigPropertySchema]
+    /// JSON Schema: list of required property ids
+    public var required: [String]?
+
+    public init(
+        type: String,
+        properties: [String: SessionConfigPropertySchema],
+        required: [String]? = nil
+    ) {
+        self.type = type
+        self.properties = properties
+        self.required = required
+    }
+}
+
+public struct SessionConfigCompletionsParams: Codable, Sendable {
+    /// Agent provider ID
+    public var provider: String?
+    /// Working directory for the session
+    public var workingDirectory: String?
+    /// Current user-filled configuration values (provides context for the query)
+    public var config: [String: AnyCodable]?
+    /// Property id from the schema to query values for
+    public var property: String
+    /// Search filter text (empty or omitted returns default/recent values)
+    public var query: String?
+
+    public init(
+        provider: String? = nil,
+        workingDirectory: String? = nil,
+        config: [String: AnyCodable]? = nil,
+        property: String,
+        query: String? = nil
+    ) {
+        self.provider = provider
+        self.workingDirectory = workingDirectory
+        self.config = config
+        self.property = property
+        self.query = query
+    }
+}
+
+public struct SessionConfigCompletionsResult: Codable, Sendable {
+    /// Matching value items
+    public var items: [SessionConfigValueItem]
+
+    public init(
+        items: [SessionConfigValueItem]
+    ) {
+        self.items = items
+    }
+}
+
+public struct SessionConfigValueItem: Codable, Sendable {
+    /// The value to store in config
+    public var value: String
+    /// Human-readable display label
+    public var label: String
+    /// Optional secondary description
+    public var description: String?
+
+    public init(
+        value: String,
+        label: String,
+        description: String? = nil
+    ) {
+        self.value = value
+        self.label = label
+        self.description = description
+    }
+}
+
+// MARK: - ReconnectResult Union
+
+public enum ReconnectResult: Codable, Sendable {
+    case replay(ReconnectReplayResult)
+    case snapshot(ReconnectSnapshotResult)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "type"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "replay":
+            self = .replay(try ReconnectReplayResult(from: decoder))
+        case "snapshot":
+            self = .snapshot(try ReconnectSnapshotResult(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ReconnectResult discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .replay(let value): try value.encode(to: encoder)
+        case .snapshot(let value): try value.encode(to: encoder)
+        }
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
@@ -1,0 +1,69 @@
+// Generated from types/*.ts — do not edit
+
+import Foundation
+
+// MARK: - Standard JSON-RPC Error Codes
+
+public enum JsonRpcErrorCodes {
+    /// Invalid JSON
+    public static let parseError = -32700
+    /// Not a valid JSON-RPC request
+    public static let invalidRequest = -32600
+    /// Unknown method name
+    public static let methodNotFound = -32601
+    /// Invalid method parameters
+    public static let invalidParams = -32602
+    /// Unspecified server error
+    public static let internalError = -32603
+}
+
+// MARK: - AHP Application Error Codes
+
+public enum AhpErrorCodes {
+    /// The referenced session URI does not exist
+    public static let sessionNotFound = -32001
+    /// The requested agent provider is not registered
+    public static let providerNotFound = -32002
+    /// A session with the given URI already exists
+    public static let sessionAlreadyExists = -32003
+    /// The operation requires no active turn, but one is in progress
+    public static let turnInProgress = -32004
+    /// The client's protocol version is not supported by the server
+    public static let unsupportedProtocolVersion = -32005
+    /// The requested content URI does not exist
+    public static let contentNotFound = -32006
+    /// Authentication required for a protected resource
+    public static let authRequired = -32007
+    /// The requested file, folder, or URI does not exist
+    public static let notFound = -32008
+    /// The client is not permitted to access the requested resource
+    public static let permissionDenied = -32009
+    /// The target resource already exists and the operation does not allow overwriting
+    public static let alreadyExists = -32010
+}
+
+// MARK: - Error Detail Payloads
+
+public struct AuthRequiredErrorData: Codable, Sendable {
+    /// Protected resources that require authentication.
+    public var resources: [ProtectedResourceMetadata]
+
+    public init(
+        resources: [ProtectedResourceMetadata]
+    ) {
+        self.resources = resources
+    }
+}
+
+public struct PermissionDeniedErrorData: Codable, Sendable {
+    /// The resource access that, if granted via `resourceRequest`, would unlock
+    /// the operation. Omitted when no specific access grant would resolve the
+    /// denial (for example, when the resource is fundamentally inaccessible).
+    public var request: ResourceRequestParams?
+
+    public init(
+        request: ResourceRequestParams? = nil
+    ) {
+        self.request = request
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Messages.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Messages.generated.swift
@@ -1,0 +1,150 @@
+// Generated from types/*.ts — do not edit
+
+import Foundation
+
+// MARK: - JSON-RPC Base Types
+
+/// A JSON-RPC 2.0 request.
+public struct JsonRpcRequest<Params: Codable>: Codable, Sendable where Params: Sendable {
+    public let jsonrpc: String
+    public let id: Int
+    public let method: String
+    public let params: Params
+
+    public init(id: Int, method: String, params: Params) {
+        self.jsonrpc = "2.0"
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+}
+
+/// A JSON-RPC 2.0 error object.
+public struct JsonRpcError: Codable, Sendable {
+    public let code: Int
+    public let message: String
+    public let data: AnyCodable?
+
+    public init(code: Int, message: String, data: AnyCodable? = nil) {
+        self.code = code
+        self.message = message
+        self.data = data
+    }
+}
+
+/// A JSON-RPC 2.0 success response.
+public struct JsonRpcSuccessResponse<Result: Codable>: Codable, Sendable where Result: Sendable {
+    public let jsonrpc: String
+    public let id: Int
+    public let result: Result
+}
+
+/// A JSON-RPC 2.0 error response.
+public struct JsonRpcErrorResponse: Codable, Sendable {
+    public let jsonrpc: String
+    public let id: Int
+    public let error: JsonRpcError
+}
+
+/// A JSON-RPC 2.0 notification (no id).
+public struct JsonRpcNotification<Params: Codable>: Codable, Sendable where Params: Sendable {
+    public let jsonrpc: String
+    public let method: String
+    public let params: Params
+
+    public init(method: String, params: Params) {
+        self.jsonrpc = "2.0"
+        self.method = method
+        self.params = params
+    }
+}
+
+// MARK: - Server → Client Notification Params
+
+/// Params for the server → client `action` notification.
+public typealias ActionNotificationParams = ActionEnvelope
+
+/// Params for the server → client `notification` method.
+public struct NotificationMethodParams: Codable, Sendable {
+    public let notification: ProtocolNotification
+
+    public init(notification: ProtocolNotification) {
+        self.notification = notification
+    }
+}
+
+// MARK: - AHP Command Helpers
+
+/// Typed helper for constructing AHP JSON-RPC requests.
+public enum AHPCommands {
+    public static func initialize(id: Int, params: InitializeParams) -> JsonRpcRequest<InitializeParams> {
+        JsonRpcRequest(id: id, method: "initialize", params: params)
+    }
+
+    public static func reconnect(id: Int, params: ReconnectParams) -> JsonRpcRequest<ReconnectParams> {
+        JsonRpcRequest(id: id, method: "reconnect", params: params)
+    }
+
+    public static func subscribe(id: Int, params: SubscribeParams) -> JsonRpcRequest<SubscribeParams> {
+        JsonRpcRequest(id: id, method: "subscribe", params: params)
+    }
+
+    public static func createSession(id: Int, params: CreateSessionParams) -> JsonRpcRequest<CreateSessionParams> {
+        JsonRpcRequest(id: id, method: "createSession", params: params)
+    }
+
+    public static func disposeSession(id: Int, params: DisposeSessionParams) -> JsonRpcRequest<DisposeSessionParams> {
+        JsonRpcRequest(id: id, method: "disposeSession", params: params)
+    }
+
+    public static func listSessions(id: Int, params: ListSessionsParams) -> JsonRpcRequest<ListSessionsParams> {
+        JsonRpcRequest(id: id, method: "listSessions", params: params)
+    }
+
+    public static func resourceRead(id: Int, params: ResourceReadParams) -> JsonRpcRequest<ResourceReadParams> {
+        JsonRpcRequest(id: id, method: "resourceRead", params: params)
+    }
+
+    public static func resourceWrite(id: Int, params: ResourceWriteParams) -> JsonRpcRequest<ResourceWriteParams> {
+        JsonRpcRequest(id: id, method: "resourceWrite", params: params)
+    }
+
+    public static func resourceList(id: Int, params: ResourceListParams) -> JsonRpcRequest<ResourceListParams> {
+        JsonRpcRequest(id: id, method: "resourceList", params: params)
+    }
+
+    public static func resourceCopy(id: Int, params: ResourceCopyParams) -> JsonRpcRequest<ResourceCopyParams> {
+        JsonRpcRequest(id: id, method: "resourceCopy", params: params)
+    }
+
+    public static func resourceDelete(id: Int, params: ResourceDeleteParams) -> JsonRpcRequest<ResourceDeleteParams> {
+        JsonRpcRequest(id: id, method: "resourceDelete", params: params)
+    }
+
+    public static func resourceMove(id: Int, params: ResourceMoveParams) -> JsonRpcRequest<ResourceMoveParams> {
+        JsonRpcRequest(id: id, method: "resourceMove", params: params)
+    }
+
+    public static func resourceRequest(id: Int, params: ResourceRequestParams) -> JsonRpcRequest<ResourceRequestParams> {
+        JsonRpcRequest(id: id, method: "resourceRequest", params: params)
+    }
+
+    public static func fetchTurns(id: Int, params: FetchTurnsParams) -> JsonRpcRequest<FetchTurnsParams> {
+        JsonRpcRequest(id: id, method: "fetchTurns", params: params)
+    }
+
+    public static func authenticate(id: Int, params: AuthenticateParams) -> JsonRpcRequest<AuthenticateParams> {
+        JsonRpcRequest(id: id, method: "authenticate", params: params)
+    }
+}
+
+/// Typed helper for constructing client → server notifications.
+public enum AHPClientNotifications {
+    public static func unsubscribe(params: UnsubscribeParams) -> JsonRpcNotification<UnsubscribeParams> {
+        JsonRpcNotification(method: "unsubscribe", params: params)
+    }
+
+    public static func dispatchAction(params: DispatchActionParams) -> JsonRpcNotification<DispatchActionParams> {
+        JsonRpcNotification(method: "dispatchAction", params: params)
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -1,0 +1,182 @@
+// Generated from types/*.ts — do not edit
+
+import Foundation
+
+// MARK: - Notification Enums
+
+/// Reason why authentication is required.
+public enum AuthRequiredReason: String, Codable, Sendable {
+    /// The client has not yet authenticated for the resource
+    case required = "required"
+    /// A previously valid token has expired or been revoked
+    case expired = "expired"
+}
+
+/// Discriminant values for all protocol notifications.
+public enum NotificationType: String, Codable, Sendable {
+    case sessionAdded = "notify/sessionAdded"
+    case sessionRemoved = "notify/sessionRemoved"
+    case sessionSummaryChanged = "notify/sessionSummaryChanged"
+    case authRequired = "notify/authRequired"
+}
+
+// MARK: - Notification Types
+
+public struct SessionAddedNotification: Codable, Sendable {
+    public var type: NotificationType
+    /// Summary of the new session
+    public var summary: SessionSummary
+
+    public init(
+        type: NotificationType,
+        summary: SessionSummary
+    ) {
+        self.type = type
+        self.summary = summary
+    }
+}
+
+public struct SessionRemovedNotification: Codable, Sendable {
+    public var type: NotificationType
+    /// URI of the removed session
+    public var session: String
+
+    public init(
+        type: NotificationType,
+        session: String
+    ) {
+        self.type = type
+        self.session = session
+    }
+}
+
+public struct SessionSummaryChangedNotification: Codable, Sendable {
+    public var type: NotificationType
+    /// URI of the session whose summary changed
+    public var session: String
+    /// Mutable summary fields that changed; omitted fields are unchanged.
+    /// 
+    /// Identity fields (`resource`, `provider`, `createdAt`) never change and
+    /// MUST be omitted by senders; receivers SHOULD ignore them if present.
+    public var changes: PartialSessionSummary
+
+    public init(
+        type: NotificationType,
+        session: String,
+        changes: PartialSessionSummary
+    ) {
+        self.type = type
+        self.session = session
+        self.changes = changes
+    }
+}
+
+public struct AuthRequiredNotification: Codable, Sendable {
+    public var type: NotificationType
+    /// The protected resource identifier that requires authentication
+    public var resource: String
+    /// Why authentication is required
+    public var reason: AuthRequiredReason?
+
+    public init(
+        type: NotificationType,
+        resource: String,
+        reason: AuthRequiredReason? = nil
+    ) {
+        self.type = type
+        self.resource = resource
+        self.reason = reason
+    }
+}
+
+// MARK: - Partial Summary Types
+
+public struct PartialSessionSummary: Codable, Sendable {
+    /// Session URI
+    public var resource: String?
+    /// Agent provider ID
+    public var provider: String?
+    /// Session title
+    public var title: String?
+    /// Current session status
+    public var status: SessionStatus?
+    /// Human-readable description of what the session is currently doing
+    public var activity: String?
+    /// Creation timestamp
+    public var createdAt: Int?
+    /// Last modification timestamp
+    public var modifiedAt: Int?
+    /// Server-owned project for this session
+    public var project: ProjectInfo?
+    /// Currently selected model
+    public var model: ModelSelection?
+    /// The working directory URI for this session
+    public var workingDirectory: String?
+    /// Files changed during this session with diff statistics
+    public var diffs: [FileEdit]?
+
+    public init(
+        resource: String? = nil,
+        provider: String? = nil,
+        title: String? = nil,
+        status: SessionStatus? = nil,
+        activity: String? = nil,
+        createdAt: Int? = nil,
+        modifiedAt: Int? = nil,
+        project: ProjectInfo? = nil,
+        model: ModelSelection? = nil,
+        workingDirectory: String? = nil,
+        diffs: [FileEdit]? = nil
+    ) {
+        self.resource = resource
+        self.provider = provider
+        self.title = title
+        self.status = status
+        self.activity = activity
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+        self.project = project
+        self.model = model
+        self.workingDirectory = workingDirectory
+        self.diffs = diffs
+    }
+}
+
+// MARK: - ProtocolNotification Union
+
+public enum ProtocolNotification: Codable, Sendable {
+    case sessionAdded(SessionAddedNotification)
+    case sessionRemoved(SessionRemovedNotification)
+    case sessionSummaryChanged(SessionSummaryChangedNotification)
+    case authRequired(AuthRequiredNotification)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "type"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "notify/sessionAdded":
+            self = .sessionAdded(try SessionAddedNotification(from: decoder))
+        case "notify/sessionRemoved":
+            self = .sessionRemoved(try SessionRemovedNotification(from: decoder))
+        case "notify/sessionSummaryChanged":
+            self = .sessionSummaryChanged(try SessionSummaryChangedNotification(from: decoder))
+        case "notify/authRequired":
+            self = .authRequired(try AuthRequiredNotification(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ProtocolNotification discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .sessionAdded(let value): try value.encode(to: encoder)
+        case .sessionRemoved(let value): try value.encode(to: encoder)
+        case .sessionSummaryChanged(let value): try value.encode(to: encoder)
+        case .authRequired(let value): try value.encode(to: encoder)
+        }
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -1,0 +1,2677 @@
+// Generated from types/*.ts — do not edit
+
+import Foundation
+
+// MARK: - Type Aliases
+
+public typealias URI = String
+
+// MARK: - StringOrMarkdown
+
+/// A value that is either a plain string or a markdown-formatted string.
+public enum StringOrMarkdown: Codable, Sendable, Equatable {
+    case string(String)
+    case markdown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let str = try? container.decode(String.self) {
+            self = .string(str)
+            return
+        }
+        let obj = try MarkdownWrapper(from: decoder)
+        self = .markdown(obj.markdown)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .string(let value):
+            var container = encoder.singleValueContainer()
+            try container.encode(value)
+        case .markdown(let value):
+            try MarkdownWrapper(markdown: value).encode(to: encoder)
+        }
+    }
+
+    private struct MarkdownWrapper: Codable {
+        let markdown: String
+    }
+}
+
+// MARK: - Enums
+
+/// Policy configuration state for a model.
+public enum PolicyState: String, Codable, Sendable {
+    case enabled = "enabled"
+    case disabled = "disabled"
+    case unconfigured = "unconfigured"
+}
+
+/// Discriminant for pending message kinds.
+public enum PendingMessageKind: String, Codable, Sendable {
+    /// Injected into the current turn at a convenient point
+    case steering = "steering"
+    /// Sent automatically as a new turn after the current turn finishes
+    case queued = "queued"
+}
+
+/// Session initialization state.
+public enum SessionLifecycle: String, Codable, Sendable {
+    case creating = "creating"
+    case ready = "ready"
+    case creationFailed = "creationFailed"
+}
+
+/// Bitset of summary-level session status flags.
+/// 
+/// Use bitwise checks instead of equality for non-terminal activity. For example,
+/// `status & SessionStatus.InProgress` matches both ordinary in-progress turns
+/// and turns that are paused waiting for input.
+public struct SessionStatus: OptionSet, Codable, Sendable, Hashable {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+
+    /// Session is idle — no turn is active.
+    public static let idle = SessionStatus(rawValue: 1)
+    /// Session ended with an error.
+    public static let error = SessionStatus(rawValue: 2)
+    /// A turn is actively streaming.
+    public static let inProgress = SessionStatus(rawValue: 8)
+    /// A turn is in progress but blocked waiting for user input or tool confirmation.
+    public static let inputNeeded = SessionStatus(rawValue: 24)
+    /// The client has viewed this session since its last modification.
+    public static let isRead = SessionStatus(rawValue: 32)
+    /// The session has been archived by the client.
+    public static let isArchived = SessionStatus(rawValue: 64)
+}
+
+/// Answer lifecycle state.
+public enum SessionInputAnswerState: String, Codable, Sendable {
+    case draft = "draft"
+    case submitted = "submitted"
+    case skipped = "skipped"
+}
+
+/// Answer value kind.
+public enum SessionInputAnswerValueKind: String, Codable, Sendable {
+    case text = "text"
+    case number = "number"
+    case boolean = "boolean"
+    case selected = "selected"
+    case selectedMany = "selected-many"
+}
+
+/// Question/input control kind.
+public enum SessionInputQuestionKind: String, Codable, Sendable {
+    case text = "text"
+    case number = "number"
+    case integer = "integer"
+    case boolean = "boolean"
+    case singleSelect = "single-select"
+    case multiSelect = "multi-select"
+}
+
+/// How a client completed an input request.
+public enum SessionInputResponseKind: String, Codable, Sendable {
+    case accept = "accept"
+    case decline = "decline"
+    case cancel = "cancel"
+}
+
+/// How a turn ended.
+public enum TurnState: String, Codable, Sendable {
+    case complete = "complete"
+    case cancelled = "cancelled"
+    case error = "error"
+}
+
+/// Type of a message attachment.
+public enum AttachmentType: String, Codable, Sendable {
+    case file = "file"
+    case directory = "directory"
+    case selection = "selection"
+}
+
+/// Discriminant for response part types.
+public enum ResponsePartKind: String, Codable, Sendable {
+    case markdown = "markdown"
+    case contentRef = "contentRef"
+    case toolCall = "toolCall"
+    case reasoning = "reasoning"
+    case systemNotification = "systemNotification"
+}
+
+/// Status of a tool call in the lifecycle state machine.
+public enum ToolCallStatus: String, Codable, Sendable {
+    case streaming = "streaming"
+    case pendingConfirmation = "pending-confirmation"
+    case running = "running"
+    case pendingResultConfirmation = "pending-result-confirmation"
+    case completed = "completed"
+    case cancelled = "cancelled"
+}
+
+/// How a tool call was confirmed for execution.
+/// 
+/// - `NotNeeded` — No confirmation required (auto-approved)
+/// - `UserAction` — User explicitly approved
+/// - `Setting` — Approved by a persistent user setting
+public enum ToolCallConfirmationReason: String, Codable, Sendable {
+    case notNeeded = "not-needed"
+    case userAction = "user-action"
+    case setting = "setting"
+}
+
+/// Why a tool call was cancelled.
+public enum ToolCallCancellationReason: String, Codable, Sendable {
+    case denied = "denied"
+    case skipped = "skipped"
+    case resultDenied = "result-denied"
+}
+
+/// Whether a confirmation option represents an approval or denial action.
+public enum ConfirmationOptionKind: String, Codable, Sendable {
+    case approve = "approve"
+    case deny = "deny"
+}
+
+/// Discriminant for tool result content types.
+public enum ToolResultContentType: String, Codable, Sendable {
+    case text = "text"
+    case embeddedResource = "embeddedResource"
+    case resource = "resource"
+    case fileEdit = "fileEdit"
+    case terminal = "terminal"
+    case subagent = "subagent"
+}
+
+/// Loading status for a server-managed customization.
+public enum CustomizationStatus: String, Codable, Sendable {
+    /// Plugin is being loaded
+    case loading = "loading"
+    /// Plugin is fully operational
+    case loaded = "loaded"
+    /// Plugin partially loaded but has warnings
+    case degraded = "degraded"
+    /// Plugin was unable to load
+    case error = "error"
+}
+
+/// Discriminant for terminal claim kinds.
+public enum TerminalClaimKind: String, Codable, Sendable {
+    case client = "client"
+    case session = "session"
+}
+
+// MARK: - State Types
+
+public struct Icon: Codable, Sendable {
+    /// A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a
+    /// `data:` URI with Base64-encoded image data.
+    /// 
+    /// Consumers SHOULD take steps to ensure URLs serving icons are from the
+    /// same domain as the client/server or a trusted domain.
+    /// 
+    /// Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain
+    /// executable JavaScript.
+    public var src: String
+    /// Optional MIME type override if the source MIME type is missing or generic.
+    /// For example: `"image/png"`, `"image/jpeg"`, or `"image/svg+xml"`.
+    public var contentType: String?
+    /// Optional array of strings that specify sizes at which the icon can be used.
+    /// Each string should be in WxH format (e.g., `"48x48"`, `"96x96"`) or `"any"` for scalable formats like SVG.
+    /// 
+    /// If not provided, the client should assume that the icon can be used at any size.
+    public var sizes: [String]?
+    /// Optional specifier for the theme this icon is designed for. `"light"` indicates
+    /// the icon is designed to be used with a light background, and `"dark"` indicates
+    /// the icon is designed to be used with a dark background.
+    /// 
+    /// If not provided, the client should assume the icon can be used with any theme.
+    public var theme: String?
+
+    public init(
+        src: String,
+        contentType: String? = nil,
+        sizes: [String]? = nil,
+        theme: String? = nil
+    ) {
+        self.src = src
+        self.contentType = contentType
+        self.sizes = sizes
+        self.theme = theme
+    }
+}
+
+public struct ProtectedResourceMetadata: Codable, Sendable {
+    /// REQUIRED. The protected resource's resource identifier, a URL using the
+    /// `https` scheme with no fragment component (e.g. `"https://api.github.com"`).
+    public var resource: String
+    /// OPTIONAL. Human-readable name of the protected resource.
+    public var resourceName: String?
+    /// OPTIONAL. JSON array of OAuth authorization server identifier URLs.
+    public var authorizationServers: [String]?
+    /// OPTIONAL. URL of the protected resource's JWK Set document.
+    public var jwksUri: String?
+    /// RECOMMENDED. JSON array of OAuth 2.0 scope values used in authorization requests.
+    public var scopesSupported: [String]?
+    /// OPTIONAL. JSON array of Bearer Token presentation methods supported.
+    public var bearerMethodsSupported: [String]?
+    /// OPTIONAL. JSON array of JWS signing algorithms supported.
+    public var resourceSigningAlgValuesSupported: [String]?
+    /// OPTIONAL. JSON array of JWE encryption algorithms (alg) supported.
+    public var resourceEncryptionAlgValuesSupported: [String]?
+    /// OPTIONAL. JSON array of JWE encryption algorithms (enc) supported.
+    public var resourceEncryptionEncValuesSupported: [String]?
+    /// OPTIONAL. URL of human-readable documentation for the resource.
+    public var resourceDocumentation: String?
+    /// OPTIONAL. URL of the resource's data-usage policy.
+    public var resourcePolicyUri: String?
+    /// OPTIONAL. URL of the resource's terms of service.
+    public var resourceTosUri: String?
+    /// AHP extension. Whether authentication is required for this resource.
+    /// 
+    /// - `true` (default) — the agent cannot be used without a valid token.
+    /// The server SHOULD return `AuthRequired` (`-32007`) if the client
+    /// attempts to use the agent without authenticating.
+    /// - `false` — the agent works without authentication but MAY offer
+    /// enhanced capabilities when a token is provided.
+    /// 
+    /// Clients SHOULD treat an absent field the same as `true`.
+    public var required: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case resource
+        case resourceName = "resource_name"
+        case authorizationServers = "authorization_servers"
+        case jwksUri = "jwks_uri"
+        case scopesSupported = "scopes_supported"
+        case bearerMethodsSupported = "bearer_methods_supported"
+        case resourceSigningAlgValuesSupported = "resource_signing_alg_values_supported"
+        case resourceEncryptionAlgValuesSupported = "resource_encryption_alg_values_supported"
+        case resourceEncryptionEncValuesSupported = "resource_encryption_enc_values_supported"
+        case resourceDocumentation = "resource_documentation"
+        case resourcePolicyUri = "resource_policy_uri"
+        case resourceTosUri = "resource_tos_uri"
+        case required
+    }
+
+    public init(
+        resource: String,
+        resourceName: String? = nil,
+        authorizationServers: [String]? = nil,
+        jwksUri: String? = nil,
+        scopesSupported: [String]? = nil,
+        bearerMethodsSupported: [String]? = nil,
+        resourceSigningAlgValuesSupported: [String]? = nil,
+        resourceEncryptionAlgValuesSupported: [String]? = nil,
+        resourceEncryptionEncValuesSupported: [String]? = nil,
+        resourceDocumentation: String? = nil,
+        resourcePolicyUri: String? = nil,
+        resourceTosUri: String? = nil,
+        required: Bool? = nil
+    ) {
+        self.resource = resource
+        self.resourceName = resourceName
+        self.authorizationServers = authorizationServers
+        self.jwksUri = jwksUri
+        self.scopesSupported = scopesSupported
+        self.bearerMethodsSupported = bearerMethodsSupported
+        self.resourceSigningAlgValuesSupported = resourceSigningAlgValuesSupported
+        self.resourceEncryptionAlgValuesSupported = resourceEncryptionAlgValuesSupported
+        self.resourceEncryptionEncValuesSupported = resourceEncryptionEncValuesSupported
+        self.resourceDocumentation = resourceDocumentation
+        self.resourcePolicyUri = resourcePolicyUri
+        self.resourceTosUri = resourceTosUri
+        self.required = required
+    }
+}
+
+public struct RootState: Codable, Sendable {
+    /// Available agent backends and their models
+    public var agents: [AgentInfo]
+    /// Number of active (non-disposed) sessions on the server
+    public var activeSessions: Int?
+    /// Known terminals on the server. Subscribe to individual terminal URIs for full state.
+    public var terminals: [TerminalInfo]?
+    /// Agent host configuration schema and current values
+    public var config: RootConfigState?
+
+    public init(
+        agents: [AgentInfo],
+        activeSessions: Int? = nil,
+        terminals: [TerminalInfo]? = nil,
+        config: RootConfigState? = nil
+    ) {
+        self.agents = agents
+        self.activeSessions = activeSessions
+        self.terminals = terminals
+        self.config = config
+    }
+}
+
+public struct RootConfigState: Codable, Sendable {
+    /// JSON Schema describing available configuration properties
+    public var schema: ConfigSchema
+    /// Current configuration values
+    public var values: [String: AnyCodable]
+
+    public init(
+        schema: ConfigSchema,
+        values: [String: AnyCodable]
+    ) {
+        self.schema = schema
+        self.values = values
+    }
+}
+
+public struct AgentInfo: Codable, Sendable {
+    /// Agent provider ID (e.g. `'copilot'`)
+    public var provider: String
+    /// Human-readable name
+    public var displayName: String
+    /// Description string
+    public var description: String
+    /// Available models for this agent
+    public var models: [SessionModelInfo]
+    /// Protected resources this agent requires authentication for.
+    /// 
+    /// Each entry describes an OAuth 2.0 protected resource using
+    /// [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) semantics.
+    /// Clients should obtain tokens from the declared `authorization_servers`
+    /// and push them via the `authenticate` command before creating sessions
+    /// with this agent.
+    public var protectedResources: [ProtectedResourceMetadata]?
+    /// Customizations (Open Plugins) associated with this agent.
+    /// 
+    /// Each entry is a reference to an [Open Plugins](https://open-plugins.com/)
+    /// plugin that the agent host can activate for sessions using this agent.
+    public var customizations: [CustomizationRef]?
+
+    public init(
+        provider: String,
+        displayName: String,
+        description: String,
+        models: [SessionModelInfo],
+        protectedResources: [ProtectedResourceMetadata]? = nil,
+        customizations: [CustomizationRef]? = nil
+    ) {
+        self.provider = provider
+        self.displayName = displayName
+        self.description = description
+        self.models = models
+        self.protectedResources = protectedResources
+        self.customizations = customizations
+    }
+}
+
+public struct SessionModelInfo: Codable, Sendable {
+    /// Model identifier
+    public var id: String
+    /// Provider this model belongs to
+    public var provider: String
+    /// Human-readable model name
+    public var name: String
+    /// Maximum context window size
+    public var maxContextWindow: Int?
+    /// Whether the model supports vision
+    public var supportsVision: Bool?
+    /// Policy configuration state
+    public var policyState: PolicyState?
+    /// Configuration schema describing model-specific options (e.g. thinking
+    /// level). Clients present this as a form and pass the resolved values in
+    /// {@link ModelSelection.config} when creating or changing sessions.
+    public var configSchema: ConfigSchema?
+
+    public init(
+        id: String,
+        provider: String,
+        name: String,
+        maxContextWindow: Int? = nil,
+        supportsVision: Bool? = nil,
+        policyState: PolicyState? = nil,
+        configSchema: ConfigSchema? = nil
+    ) {
+        self.id = id
+        self.provider = provider
+        self.name = name
+        self.maxContextWindow = maxContextWindow
+        self.supportsVision = supportsVision
+        self.policyState = policyState
+        self.configSchema = configSchema
+    }
+}
+
+public struct ModelSelection: Codable, Sendable {
+    /// Model identifier
+    public var id: String
+    /// Model-specific configuration values
+    public var config: [String: String]?
+
+    public init(
+        id: String,
+        config: [String: String]? = nil
+    ) {
+        self.id = id
+        self.config = config
+    }
+}
+
+public final class ConfigPropertySchema: Codable, @unchecked Sendable {
+    /// JSON Schema: property type
+    public var type: String
+    /// JSON Schema: human-readable label for the property
+    public var title: String
+    /// JSON Schema: description / tooltip
+    public var description: String?
+    /// JSON Schema: default value
+    public var `default`: AnyCodable?
+    /// JSON Schema: allowed values (typically used with `string` type)
+    public var `enum`: [String]?
+    /// Display extension: human-readable label per enum value (parallel array)
+    public var enumLabels: [String]?
+    /// Display extension: description per enum value (parallel array)
+    public var enumDescriptions: [String]?
+    /// JSON Schema: when `true`, the property is displayed but cannot be modified by the user
+    public var readOnly: Bool?
+    /// JSON Schema: schema for array items (used when `type` is `'array'`)
+    public var items: ConfigPropertySchema?
+    /// JSON Schema: property descriptors for object properties (used when `type` is `'object'`)
+    public var properties: [String: ConfigPropertySchema]?
+    /// JSON Schema: list of required property ids (used when `type` is `'object'`)
+    public var required: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case title
+        case description
+        case `default` = "default"
+        case `enum` = "enum"
+        case enumLabels
+        case enumDescriptions
+        case readOnly
+        case items
+        case properties
+        case required
+    }
+
+    public init(
+        type: String,
+        title: String,
+        description: String? = nil,
+        `default`: AnyCodable? = nil,
+        `enum`: [String]? = nil,
+        enumLabels: [String]? = nil,
+        enumDescriptions: [String]? = nil,
+        readOnly: Bool? = nil,
+        items: ConfigPropertySchema? = nil,
+        properties: [String: ConfigPropertySchema]? = nil,
+        required: [String]? = nil
+    ) {
+        self.type = type
+        self.title = title
+        self.description = description
+        self.`default` = `default`
+        self.`enum` = `enum`
+        self.enumLabels = enumLabels
+        self.enumDescriptions = enumDescriptions
+        self.readOnly = readOnly
+        self.items = items
+        self.properties = properties
+        self.required = required
+    }
+}
+
+public struct ConfigSchema: Codable, Sendable {
+    /// JSON Schema: always `'object'`
+    public var type: String
+    /// JSON Schema: property descriptors keyed by property id
+    public var properties: [String: ConfigPropertySchema]
+    /// JSON Schema: list of required property ids
+    public var required: [String]?
+
+    public init(
+        type: String,
+        properties: [String: ConfigPropertySchema],
+        required: [String]? = nil
+    ) {
+        self.type = type
+        self.properties = properties
+        self.required = required
+    }
+}
+
+public struct PendingMessage: Codable, Sendable {
+    /// Unique identifier for this pending message
+    public var id: String
+    /// The message content
+    public var userMessage: UserMessage
+
+    public init(
+        id: String,
+        userMessage: UserMessage
+    ) {
+        self.id = id
+        self.userMessage = userMessage
+    }
+}
+
+public struct SessionState: Codable, Sendable {
+    /// Lightweight session metadata
+    public var summary: SessionSummary
+    /// Session initialization state
+    public var lifecycle: SessionLifecycle
+    /// Error details if creation failed
+    public var creationError: ErrorInfo?
+    /// Tools provided by the server (agent host) for this session
+    public var serverTools: [ToolDefinition]?
+    /// The client currently providing tools and interactive capabilities to this session
+    public var activeClient: SessionActiveClient?
+    /// Completed turns
+    public var turns: [Turn]
+    /// Currently in-progress turn
+    public var activeTurn: ActiveTurn?
+    /// Message to inject into the current turn at a convenient point
+    public var steeringMessage: PendingMessage?
+    /// Messages to send automatically as new turns after the current turn finishes
+    public var queuedMessages: [PendingMessage]?
+    /// Requests for user input that are currently blocking or informing session progress
+    public var inputRequests: [SessionInputRequest]?
+    /// Session configuration schema and current values
+    public var config: SessionConfigState?
+    /// Server-provided customizations active in this session.
+    /// 
+    /// Client-provided customizations are available on
+    /// {@link SessionActiveClient.customizations | activeClient.customizations}.
+    public var customizations: [SessionCustomization]?
+    /// Additional provider-specific metadata for this session.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `git` key may provide extra git metadata about the session's
+    /// workingDirectory.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case summary
+        case lifecycle
+        case creationError
+        case serverTools
+        case activeClient
+        case turns
+        case activeTurn
+        case steeringMessage
+        case queuedMessages
+        case inputRequests
+        case config
+        case customizations
+        case meta = "_meta"
+    }
+
+    public init(
+        summary: SessionSummary,
+        lifecycle: SessionLifecycle,
+        creationError: ErrorInfo? = nil,
+        serverTools: [ToolDefinition]? = nil,
+        activeClient: SessionActiveClient? = nil,
+        turns: [Turn],
+        activeTurn: ActiveTurn? = nil,
+        steeringMessage: PendingMessage? = nil,
+        queuedMessages: [PendingMessage]? = nil,
+        inputRequests: [SessionInputRequest]? = nil,
+        config: SessionConfigState? = nil,
+        customizations: [SessionCustomization]? = nil,
+        meta: [String: AnyCodable]? = nil
+    ) {
+        self.summary = summary
+        self.lifecycle = lifecycle
+        self.creationError = creationError
+        self.serverTools = serverTools
+        self.activeClient = activeClient
+        self.turns = turns
+        self.activeTurn = activeTurn
+        self.steeringMessage = steeringMessage
+        self.queuedMessages = queuedMessages
+        self.inputRequests = inputRequests
+        self.config = config
+        self.customizations = customizations
+        self.meta = meta
+    }
+}
+
+public struct SessionActiveClient: Codable, Sendable {
+    /// Client identifier (matches `clientId` from `initialize`)
+    public var clientId: String
+    /// Human-readable client name (e.g. `"VS Code"`)
+    public var displayName: String?
+    /// Tools this client provides to the session
+    public var tools: [ToolDefinition]
+    /// Customizations this client contributes to the session
+    public var customizations: [CustomizationRef]?
+
+    public init(
+        clientId: String,
+        displayName: String? = nil,
+        tools: [ToolDefinition],
+        customizations: [CustomizationRef]? = nil
+    ) {
+        self.clientId = clientId
+        self.displayName = displayName
+        self.tools = tools
+        self.customizations = customizations
+    }
+}
+
+public struct SessionSummary: Codable, Sendable {
+    /// Session URI
+    public var resource: String
+    /// Agent provider ID
+    public var provider: String
+    /// Session title
+    public var title: String
+    /// Current session status
+    public var status: SessionStatus
+    /// Human-readable description of what the session is currently doing
+    public var activity: String?
+    /// Creation timestamp
+    public var createdAt: Int
+    /// Last modification timestamp
+    public var modifiedAt: Int
+    /// Server-owned project for this session
+    public var project: ProjectInfo?
+    /// Currently selected model
+    public var model: ModelSelection?
+    /// The working directory URI for this session
+    public var workingDirectory: String?
+    /// Files changed during this session with diff statistics
+    public var diffs: [FileEdit]?
+
+    public init(
+        resource: String,
+        provider: String,
+        title: String,
+        status: SessionStatus,
+        activity: String? = nil,
+        createdAt: Int,
+        modifiedAt: Int,
+        project: ProjectInfo? = nil,
+        model: ModelSelection? = nil,
+        workingDirectory: String? = nil,
+        diffs: [FileEdit]? = nil
+    ) {
+        self.resource = resource
+        self.provider = provider
+        self.title = title
+        self.status = status
+        self.activity = activity
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+        self.project = project
+        self.model = model
+        self.workingDirectory = workingDirectory
+        self.diffs = diffs
+    }
+}
+
+public struct ProjectInfo: Codable, Sendable {
+    /// Project URI
+    public var uri: String
+    /// Human-readable project name
+    public var displayName: String
+
+    public init(
+        uri: String,
+        displayName: String
+    ) {
+        self.uri = uri
+        self.displayName = displayName
+    }
+}
+
+public struct SessionConfigState: Codable, Sendable {
+    /// JSON Schema describing available configuration properties
+    public var schema: SessionConfigSchema
+    /// Current configuration values
+    public var values: [String: AnyCodable]
+
+    public init(
+        schema: SessionConfigSchema,
+        values: [String: AnyCodable]
+    ) {
+        self.schema = schema
+        self.values = values
+    }
+}
+
+public struct Turn: Codable, Sendable {
+    /// Turn identifier
+    public var id: String
+    /// The user's input
+    public var userMessage: UserMessage
+    /// All response content in stream order: text, tool calls, reasoning, and content refs.
+    /// 
+    /// Consumers should derive display text by concatenating markdown parts,
+    /// and find tool calls by filtering for `ToolCall` parts.
+    public var responseParts: [ResponsePart]
+    /// Token usage info
+    public var usage: UsageInfo?
+    /// How the turn ended
+    public var state: TurnState
+    /// Error details if state is `'error'`
+    public var error: ErrorInfo?
+
+    public init(
+        id: String,
+        userMessage: UserMessage,
+        responseParts: [ResponsePart],
+        usage: UsageInfo? = nil,
+        state: TurnState,
+        error: ErrorInfo? = nil
+    ) {
+        self.id = id
+        self.userMessage = userMessage
+        self.responseParts = responseParts
+        self.usage = usage
+        self.state = state
+        self.error = error
+    }
+}
+
+public struct ActiveTurn: Codable, Sendable {
+    /// Turn identifier
+    public var id: String
+    /// The user's input
+    public var userMessage: UserMessage
+    /// All response content in stream order: text, tool calls, reasoning, and content refs.
+    /// 
+    /// Tool call parts include `pendingPermissions` when permissions are awaiting user approval.
+    public var responseParts: [ResponsePart]
+    /// Token usage info
+    public var usage: UsageInfo?
+
+    public init(
+        id: String,
+        userMessage: UserMessage,
+        responseParts: [ResponsePart],
+        usage: UsageInfo? = nil
+    ) {
+        self.id = id
+        self.userMessage = userMessage
+        self.responseParts = responseParts
+        self.usage = usage
+    }
+}
+
+public struct UserMessage: Codable, Sendable {
+    /// Message text
+    public var text: String
+    /// File/selection attachments
+    public var attachments: [MessageAttachment]?
+
+    public init(
+        text: String,
+        attachments: [MessageAttachment]? = nil
+    ) {
+        self.text = text
+        self.attachments = attachments
+    }
+}
+
+public struct SessionInputOption: Codable, Sendable {
+    /// Stable option identifier; for MCP enum values this is the enum string
+    public var id: String
+    /// Display label
+    public var label: String
+    /// Optional secondary text
+    public var description: String?
+    /// Whether this option is the recommended/default choice
+    public var recommended: Bool?
+
+    public init(
+        id: String,
+        label: String,
+        description: String? = nil,
+        recommended: Bool? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.description = description
+        self.recommended = recommended
+    }
+}
+
+public struct SessionInputTextAnswerValue: Codable, Sendable {
+    public var kind: SessionInputAnswerValueKind
+    public var value: String
+
+    public init(
+        kind: SessionInputAnswerValueKind,
+        value: String
+    ) {
+        self.kind = kind
+        self.value = value
+    }
+}
+
+public struct SessionInputNumberAnswerValue: Codable, Sendable {
+    public var kind: SessionInputAnswerValueKind
+    public var value: Double
+
+    public init(
+        kind: SessionInputAnswerValueKind,
+        value: Double
+    ) {
+        self.kind = kind
+        self.value = value
+    }
+}
+
+public struct SessionInputBooleanAnswerValue: Codable, Sendable {
+    public var kind: SessionInputAnswerValueKind
+    public var value: Bool
+
+    public init(
+        kind: SessionInputAnswerValueKind,
+        value: Bool
+    ) {
+        self.kind = kind
+        self.value = value
+    }
+}
+
+public struct SessionInputSelectedAnswerValue: Codable, Sendable {
+    public var kind: SessionInputAnswerValueKind
+    public var value: String
+    /// Free-form text entered instead of selecting an option
+    public var freeformValues: [String]?
+
+    public init(
+        kind: SessionInputAnswerValueKind,
+        value: String,
+        freeformValues: [String]? = nil
+    ) {
+        self.kind = kind
+        self.value = value
+        self.freeformValues = freeformValues
+    }
+}
+
+public struct SessionInputSelectedManyAnswerValue: Codable, Sendable {
+    public var kind: SessionInputAnswerValueKind
+    public var value: [String]
+    /// Free-form text entered in addition to selected options
+    public var freeformValues: [String]?
+
+    public init(
+        kind: SessionInputAnswerValueKind,
+        value: [String],
+        freeformValues: [String]? = nil
+    ) {
+        self.kind = kind
+        self.value = value
+        self.freeformValues = freeformValues
+    }
+}
+
+public struct SessionInputAnswered: Codable, Sendable {
+    /// Answer state
+    public var state: SessionInputAnswerState
+    /// Answer value
+    public var value: SessionInputAnswerValue
+
+    public init(
+        state: SessionInputAnswerState,
+        value: SessionInputAnswerValue
+    ) {
+        self.state = state
+        self.value = value
+    }
+}
+
+public struct SessionInputSkipped: Codable, Sendable {
+    /// Answer state
+    public var state: SessionInputAnswerState
+    /// Free-form reason or value captured while skipping, if any
+    public var freeformValues: [String]?
+
+    public init(
+        state: SessionInputAnswerState,
+        freeformValues: [String]? = nil
+    ) {
+        self.state = state
+        self.freeformValues = freeformValues
+    }
+}
+
+public struct SessionInputTextQuestion: Codable, Sendable {
+    /// Stable question identifier used as the key in `answers`
+    public var id: String
+    /// Short display title
+    public var title: String?
+    /// Prompt shown to the user
+    public var message: String
+    /// Whether the user must answer this question to accept the request
+    public var required: Bool?
+    public var kind: SessionInputQuestionKind
+    /// Format hint for text questions, such as `email`, `uri`, `date`, or `date-time`
+    public var format: String?
+    /// Minimum string length
+    public var min: Int?
+    /// Maximum string length
+    public var max: Int?
+    /// Default text
+    public var defaultValue: String?
+
+    public init(
+        id: String,
+        title: String? = nil,
+        message: String,
+        required: Bool? = nil,
+        kind: SessionInputQuestionKind,
+        format: String? = nil,
+        min: Int? = nil,
+        max: Int? = nil,
+        defaultValue: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.message = message
+        self.required = required
+        self.kind = kind
+        self.format = format
+        self.min = min
+        self.max = max
+        self.defaultValue = defaultValue
+    }
+}
+
+public struct SessionInputNumberQuestion: Codable, Sendable {
+    /// Stable question identifier used as the key in `answers`
+    public var id: String
+    /// Short display title
+    public var title: String?
+    /// Prompt shown to the user
+    public var message: String
+    /// Whether the user must answer this question to accept the request
+    public var required: Bool?
+    public var kind: SessionInputQuestionKind
+    /// Minimum value
+    public var min: Double?
+    /// Maximum value
+    public var max: Double?
+    /// Default numeric value
+    public var defaultValue: Double?
+
+    public init(
+        id: String,
+        title: String? = nil,
+        message: String,
+        required: Bool? = nil,
+        kind: SessionInputQuestionKind,
+        min: Double? = nil,
+        max: Double? = nil,
+        defaultValue: Double? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.message = message
+        self.required = required
+        self.kind = kind
+        self.min = min
+        self.max = max
+        self.defaultValue = defaultValue
+    }
+}
+
+public struct SessionInputBooleanQuestion: Codable, Sendable {
+    /// Stable question identifier used as the key in `answers`
+    public var id: String
+    /// Short display title
+    public var title: String?
+    /// Prompt shown to the user
+    public var message: String
+    /// Whether the user must answer this question to accept the request
+    public var required: Bool?
+    public var kind: SessionInputQuestionKind
+    /// Default boolean value
+    public var defaultValue: Bool?
+
+    public init(
+        id: String,
+        title: String? = nil,
+        message: String,
+        required: Bool? = nil,
+        kind: SessionInputQuestionKind,
+        defaultValue: Bool? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.message = message
+        self.required = required
+        self.kind = kind
+        self.defaultValue = defaultValue
+    }
+}
+
+public struct SessionInputSingleSelectQuestion: Codable, Sendable {
+    /// Stable question identifier used as the key in `answers`
+    public var id: String
+    /// Short display title
+    public var title: String?
+    /// Prompt shown to the user
+    public var message: String
+    /// Whether the user must answer this question to accept the request
+    public var required: Bool?
+    public var kind: SessionInputQuestionKind
+    /// Options the user may select from
+    public var options: [SessionInputOption]
+    /// Whether the user may enter text instead of selecting an option
+    public var allowFreeformInput: Bool?
+
+    public init(
+        id: String,
+        title: String? = nil,
+        message: String,
+        required: Bool? = nil,
+        kind: SessionInputQuestionKind,
+        options: [SessionInputOption],
+        allowFreeformInput: Bool? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.message = message
+        self.required = required
+        self.kind = kind
+        self.options = options
+        self.allowFreeformInput = allowFreeformInput
+    }
+}
+
+public struct SessionInputMultiSelectQuestion: Codable, Sendable {
+    /// Stable question identifier used as the key in `answers`
+    public var id: String
+    /// Short display title
+    public var title: String?
+    /// Prompt shown to the user
+    public var message: String
+    /// Whether the user must answer this question to accept the request
+    public var required: Bool?
+    public var kind: SessionInputQuestionKind
+    /// Options the user may select from
+    public var options: [SessionInputOption]
+    /// Whether the user may enter text in addition to selecting options
+    public var allowFreeformInput: Bool?
+    /// Minimum selected item count
+    public var min: Int?
+    /// Maximum selected item count
+    public var max: Int?
+
+    public init(
+        id: String,
+        title: String? = nil,
+        message: String,
+        required: Bool? = nil,
+        kind: SessionInputQuestionKind,
+        options: [SessionInputOption],
+        allowFreeformInput: Bool? = nil,
+        min: Int? = nil,
+        max: Int? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.message = message
+        self.required = required
+        self.kind = kind
+        self.options = options
+        self.allowFreeformInput = allowFreeformInput
+        self.min = min
+        self.max = max
+    }
+}
+
+public struct SessionInputRequest: Codable, Sendable {
+    /// Stable request identifier
+    public var id: String
+    /// Display message for the request as a whole
+    public var message: String?
+    /// URL the user should review or open, for URL-style elicitations
+    public var url: String?
+    /// Ordered questions to ask the user
+    public var questions: [SessionInputQuestion]?
+    /// Current draft or submitted answers, keyed by question ID
+    public var answers: [String: SessionInputAnswer]?
+
+    public init(
+        id: String,
+        message: String? = nil,
+        url: String? = nil,
+        questions: [SessionInputQuestion]? = nil,
+        answers: [String: SessionInputAnswer]? = nil
+    ) {
+        self.id = id
+        self.message = message
+        self.url = url
+        self.questions = questions
+        self.answers = answers
+    }
+}
+
+public struct MessageAttachment: Codable, Sendable {
+    /// Attachment type
+    public var type: AttachmentType
+    /// File/directory URI
+    public var uri: String
+    /// Display name
+    public var displayName: String?
+
+    public init(
+        type: AttachmentType,
+        uri: String,
+        displayName: String? = nil
+    ) {
+        self.type = type
+        self.uri = uri
+        self.displayName = displayName
+    }
+}
+
+public struct MarkdownResponsePart: Codable, Sendable {
+    /// Discriminant
+    public var kind: ResponsePartKind
+    /// Part identifier, used by `session/delta` to target this part for content appends
+    public var id: String
+    /// Markdown content
+    public var content: String
+
+    public init(
+        kind: ResponsePartKind,
+        id: String,
+        content: String
+    ) {
+        self.kind = kind
+        self.id = id
+        self.content = content
+    }
+}
+
+public struct ContentRef: Codable, Sendable {
+    /// Content URI
+    public var uri: String
+    /// Approximate size in bytes
+    public var sizeHint: Int?
+    /// Content MIME type
+    public var contentType: String?
+
+    public init(
+        uri: String,
+        sizeHint: Int? = nil,
+        contentType: String? = nil
+    ) {
+        self.uri = uri
+        self.sizeHint = sizeHint
+        self.contentType = contentType
+    }
+}
+
+public struct ResourceReponsePart: Codable, Sendable {
+    /// Content URI
+    public var uri: String
+    /// Approximate size in bytes
+    public var sizeHint: Int?
+    /// Content MIME type
+    public var contentType: String?
+    /// Discriminant
+    public var kind: ResponsePartKind
+
+    public init(
+        uri: String,
+        sizeHint: Int? = nil,
+        contentType: String? = nil,
+        kind: ResponsePartKind
+    ) {
+        self.uri = uri
+        self.sizeHint = sizeHint
+        self.contentType = contentType
+        self.kind = kind
+    }
+}
+
+public struct ToolCallResponsePart: Codable, Sendable {
+    /// Discriminant
+    public var kind: ResponsePartKind
+    /// Full tool call lifecycle state
+    public var toolCall: ToolCallState
+
+    public init(
+        kind: ResponsePartKind,
+        toolCall: ToolCallState
+    ) {
+        self.kind = kind
+        self.toolCall = toolCall
+    }
+}
+
+public struct ReasoningResponsePart: Codable, Sendable {
+    /// Discriminant
+    public var kind: ResponsePartKind
+    /// Part identifier, used by `session/reasoning` to target this part for content appends
+    public var id: String
+    /// Accumulated reasoning text
+    public var content: String
+
+    public init(
+        kind: ResponsePartKind,
+        id: String,
+        content: String
+    ) {
+        self.kind = kind
+        self.id = id
+        self.content = content
+    }
+}
+
+public struct SystemNotificationResponsePart: Codable, Sendable {
+    /// Discriminant
+    public var kind: ResponsePartKind
+    /// The text of the system notification
+    public var content: StringOrMarkdown
+
+    public init(
+        kind: ResponsePartKind,
+        content: StringOrMarkdown
+    ) {
+        self.kind = kind
+        self.content = content
+    }
+}
+
+public struct ToolCallResult: Codable, Sendable {
+    /// Whether the tool succeeded
+    public var success: Bool
+    /// Past-tense description of what the tool did
+    public var pastTenseMessage: StringOrMarkdown
+    /// Unstructured result content blocks.
+    /// 
+    /// This mirrors the `content` field of MCP `CallToolResult`.
+    public var content: [ToolResultContent]?
+    /// Optional structured result object.
+    /// 
+    /// This mirrors the `structuredContent` field of MCP `CallToolResult`.
+    public var structuredContent: [String: AnyCodable]?
+    /// Error details if the tool failed
+    public var error: AnyCodable?
+
+    public init(
+        success: Bool,
+        pastTenseMessage: StringOrMarkdown,
+        content: [ToolResultContent]? = nil,
+        structuredContent: [String: AnyCodable]? = nil,
+        error: AnyCodable? = nil
+    ) {
+        self.success = success
+        self.pastTenseMessage = pastTenseMessage
+        self.content = content
+        self.structuredContent = structuredContent
+        self.error = error
+    }
+}
+
+public struct ToolCallStreamingState: Codable, Sendable {
+    /// Unique tool call identifier
+    public var toolCallId: String
+    /// Internal tool name (for debugging/logging)
+    public var toolName: String
+    /// Human-readable tool name
+    public var displayName: String
+    /// If this tool is provided by a client, the `clientId` of the owning client.
+    /// Absent for server-side tools.
+    /// 
+    /// When set, the identified client is responsible for executing the tool and
+    /// dispatching `session/toolCallComplete` with the result.
+    public var toolClientId: String?
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    public var status: ToolCallStatus
+    /// Partial parameters accumulated so far
+    public var partialInput: String?
+    /// Progress message shown while parameters are streaming
+    public var invocationMessage: StringOrMarkdown?
+
+    enum CodingKeys: String, CodingKey {
+        case toolCallId
+        case toolName
+        case displayName
+        case toolClientId
+        case meta = "_meta"
+        case status
+        case partialInput
+        case invocationMessage
+    }
+
+    public init(
+        toolCallId: String,
+        toolName: String,
+        displayName: String,
+        toolClientId: String? = nil,
+        meta: [String: AnyCodable]? = nil,
+        status: ToolCallStatus,
+        partialInput: String? = nil,
+        invocationMessage: StringOrMarkdown? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+        self.displayName = displayName
+        self.toolClientId = toolClientId
+        self.meta = meta
+        self.status = status
+        self.partialInput = partialInput
+        self.invocationMessage = invocationMessage
+    }
+}
+
+public struct ToolCallPendingConfirmationState: Codable, Sendable {
+    /// Unique tool call identifier
+    public var toolCallId: String
+    /// Internal tool name (for debugging/logging)
+    public var toolName: String
+    /// Human-readable tool name
+    public var displayName: String
+    /// If this tool is provided by a client, the `clientId` of the owning client.
+    /// Absent for server-side tools.
+    /// 
+    /// When set, the identified client is responsible for executing the tool and
+    /// dispatching `session/toolCallComplete` with the result.
+    public var toolClientId: String?
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    /// Message describing what the tool will do
+    public var invocationMessage: StringOrMarkdown
+    /// Raw tool input
+    public var toolInput: String?
+    public var status: ToolCallStatus
+    /// Short title for the confirmation prompt (e.g. `"Run in terminal"`, `"Write file"`)
+    public var confirmationTitle: StringOrMarkdown?
+    /// File edits that this tool call will perform, for preview before confirmation
+    public var edits: AnyCodable?
+    /// Whether the agent host allows the client to edit the tool's input parameters before confirming
+    public var editable: Bool?
+    /// Options the server offers for this confirmation. When present, the client
+    /// SHOULD render these instead of a plain approve/deny UI. Each option
+    /// belongs to a {@link ConfirmationOptionGroup} so the client can still
+    /// categorise the choices.
+    public var options: [ConfirmationOption]?
+
+    enum CodingKeys: String, CodingKey {
+        case toolCallId
+        case toolName
+        case displayName
+        case toolClientId
+        case meta = "_meta"
+        case invocationMessage
+        case toolInput
+        case status
+        case confirmationTitle
+        case edits
+        case editable
+        case options
+    }
+
+    public init(
+        toolCallId: String,
+        toolName: String,
+        displayName: String,
+        toolClientId: String? = nil,
+        meta: [String: AnyCodable]? = nil,
+        invocationMessage: StringOrMarkdown,
+        toolInput: String? = nil,
+        status: ToolCallStatus,
+        confirmationTitle: StringOrMarkdown? = nil,
+        edits: AnyCodable? = nil,
+        editable: Bool? = nil,
+        options: [ConfirmationOption]? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+        self.displayName = displayName
+        self.toolClientId = toolClientId
+        self.meta = meta
+        self.invocationMessage = invocationMessage
+        self.toolInput = toolInput
+        self.status = status
+        self.confirmationTitle = confirmationTitle
+        self.edits = edits
+        self.editable = editable
+        self.options = options
+    }
+}
+
+public struct ToolCallRunningState: Codable, Sendable {
+    /// Unique tool call identifier
+    public var toolCallId: String
+    /// Internal tool name (for debugging/logging)
+    public var toolName: String
+    /// Human-readable tool name
+    public var displayName: String
+    /// If this tool is provided by a client, the `clientId` of the owning client.
+    /// Absent for server-side tools.
+    /// 
+    /// When set, the identified client is responsible for executing the tool and
+    /// dispatching `session/toolCallComplete` with the result.
+    public var toolClientId: String?
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    /// Message describing what the tool will do
+    public var invocationMessage: StringOrMarkdown
+    /// Raw tool input
+    public var toolInput: String?
+    public var status: ToolCallStatus
+    /// How the tool was confirmed for execution
+    public var confirmed: ToolCallConfirmationReason
+    /// The confirmation option the user selected, if confirmation options were provided
+    public var selectedOption: ConfirmationOption?
+    /// Partial content produced while the tool is still executing.
+    /// 
+    /// For example, a terminal content block lets clients subscribe to live
+    /// output before the tool completes.
+    public var content: [ToolResultContent]?
+
+    enum CodingKeys: String, CodingKey {
+        case toolCallId
+        case toolName
+        case displayName
+        case toolClientId
+        case meta = "_meta"
+        case invocationMessage
+        case toolInput
+        case status
+        case confirmed
+        case selectedOption
+        case content
+    }
+
+    public init(
+        toolCallId: String,
+        toolName: String,
+        displayName: String,
+        toolClientId: String? = nil,
+        meta: [String: AnyCodable]? = nil,
+        invocationMessage: StringOrMarkdown,
+        toolInput: String? = nil,
+        status: ToolCallStatus,
+        confirmed: ToolCallConfirmationReason,
+        selectedOption: ConfirmationOption? = nil,
+        content: [ToolResultContent]? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+        self.displayName = displayName
+        self.toolClientId = toolClientId
+        self.meta = meta
+        self.invocationMessage = invocationMessage
+        self.toolInput = toolInput
+        self.status = status
+        self.confirmed = confirmed
+        self.selectedOption = selectedOption
+        self.content = content
+    }
+}
+
+public struct ToolCallPendingResultConfirmationState: Codable, Sendable {
+    /// Unique tool call identifier
+    public var toolCallId: String
+    /// Internal tool name (for debugging/logging)
+    public var toolName: String
+    /// Human-readable tool name
+    public var displayName: String
+    /// If this tool is provided by a client, the `clientId` of the owning client.
+    /// Absent for server-side tools.
+    /// 
+    /// When set, the identified client is responsible for executing the tool and
+    /// dispatching `session/toolCallComplete` with the result.
+    public var toolClientId: String?
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    /// Message describing what the tool will do
+    public var invocationMessage: StringOrMarkdown
+    /// Raw tool input
+    public var toolInput: String?
+    /// Whether the tool succeeded
+    public var success: Bool
+    /// Past-tense description of what the tool did
+    public var pastTenseMessage: StringOrMarkdown
+    /// Unstructured result content blocks.
+    /// 
+    /// This mirrors the `content` field of MCP `CallToolResult`.
+    public var content: [ToolResultContent]?
+    /// Optional structured result object.
+    /// 
+    /// This mirrors the `structuredContent` field of MCP `CallToolResult`.
+    public var structuredContent: [String: AnyCodable]?
+    /// Error details if the tool failed
+    public var error: AnyCodable?
+    public var status: ToolCallStatus
+    /// How the tool was confirmed for execution
+    public var confirmed: ToolCallConfirmationReason
+    /// The confirmation option the user selected, if confirmation options were provided
+    public var selectedOption: ConfirmationOption?
+
+    enum CodingKeys: String, CodingKey {
+        case toolCallId
+        case toolName
+        case displayName
+        case toolClientId
+        case meta = "_meta"
+        case invocationMessage
+        case toolInput
+        case success
+        case pastTenseMessage
+        case content
+        case structuredContent
+        case error
+        case status
+        case confirmed
+        case selectedOption
+    }
+
+    public init(
+        toolCallId: String,
+        toolName: String,
+        displayName: String,
+        toolClientId: String? = nil,
+        meta: [String: AnyCodable]? = nil,
+        invocationMessage: StringOrMarkdown,
+        toolInput: String? = nil,
+        success: Bool,
+        pastTenseMessage: StringOrMarkdown,
+        content: [ToolResultContent]? = nil,
+        structuredContent: [String: AnyCodable]? = nil,
+        error: AnyCodable? = nil,
+        status: ToolCallStatus,
+        confirmed: ToolCallConfirmationReason,
+        selectedOption: ConfirmationOption? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+        self.displayName = displayName
+        self.toolClientId = toolClientId
+        self.meta = meta
+        self.invocationMessage = invocationMessage
+        self.toolInput = toolInput
+        self.success = success
+        self.pastTenseMessage = pastTenseMessage
+        self.content = content
+        self.structuredContent = structuredContent
+        self.error = error
+        self.status = status
+        self.confirmed = confirmed
+        self.selectedOption = selectedOption
+    }
+}
+
+public struct ToolCallCompletedState: Codable, Sendable {
+    /// Unique tool call identifier
+    public var toolCallId: String
+    /// Internal tool name (for debugging/logging)
+    public var toolName: String
+    /// Human-readable tool name
+    public var displayName: String
+    /// If this tool is provided by a client, the `clientId` of the owning client.
+    /// Absent for server-side tools.
+    /// 
+    /// When set, the identified client is responsible for executing the tool and
+    /// dispatching `session/toolCallComplete` with the result.
+    public var toolClientId: String?
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    /// Message describing what the tool will do
+    public var invocationMessage: StringOrMarkdown
+    /// Raw tool input
+    public var toolInput: String?
+    /// Whether the tool succeeded
+    public var success: Bool
+    /// Past-tense description of what the tool did
+    public var pastTenseMessage: StringOrMarkdown
+    /// Unstructured result content blocks.
+    /// 
+    /// This mirrors the `content` field of MCP `CallToolResult`.
+    public var content: [ToolResultContent]?
+    /// Optional structured result object.
+    /// 
+    /// This mirrors the `structuredContent` field of MCP `CallToolResult`.
+    public var structuredContent: [String: AnyCodable]?
+    /// Error details if the tool failed
+    public var error: AnyCodable?
+    public var status: ToolCallStatus
+    /// How the tool was confirmed for execution
+    public var confirmed: ToolCallConfirmationReason
+    /// The confirmation option the user selected, if confirmation options were provided
+    public var selectedOption: ConfirmationOption?
+
+    enum CodingKeys: String, CodingKey {
+        case toolCallId
+        case toolName
+        case displayName
+        case toolClientId
+        case meta = "_meta"
+        case invocationMessage
+        case toolInput
+        case success
+        case pastTenseMessage
+        case content
+        case structuredContent
+        case error
+        case status
+        case confirmed
+        case selectedOption
+    }
+
+    public init(
+        toolCallId: String,
+        toolName: String,
+        displayName: String,
+        toolClientId: String? = nil,
+        meta: [String: AnyCodable]? = nil,
+        invocationMessage: StringOrMarkdown,
+        toolInput: String? = nil,
+        success: Bool,
+        pastTenseMessage: StringOrMarkdown,
+        content: [ToolResultContent]? = nil,
+        structuredContent: [String: AnyCodable]? = nil,
+        error: AnyCodable? = nil,
+        status: ToolCallStatus,
+        confirmed: ToolCallConfirmationReason,
+        selectedOption: ConfirmationOption? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+        self.displayName = displayName
+        self.toolClientId = toolClientId
+        self.meta = meta
+        self.invocationMessage = invocationMessage
+        self.toolInput = toolInput
+        self.success = success
+        self.pastTenseMessage = pastTenseMessage
+        self.content = content
+        self.structuredContent = structuredContent
+        self.error = error
+        self.status = status
+        self.confirmed = confirmed
+        self.selectedOption = selectedOption
+    }
+}
+
+public struct ToolCallCancelledState: Codable, Sendable {
+    /// Unique tool call identifier
+    public var toolCallId: String
+    /// Internal tool name (for debugging/logging)
+    public var toolName: String
+    /// Human-readable tool name
+    public var displayName: String
+    /// If this tool is provided by a client, the `clientId` of the owning client.
+    /// Absent for server-side tools.
+    /// 
+    /// When set, the identified client is responsible for executing the tool and
+    /// dispatching `session/toolCallComplete` with the result.
+    public var toolClientId: String?
+    /// Additional provider-specific metadata for this tool call.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `ptyTerminal` key with `{ input: string; output: string }`
+    /// indicates the tool operated on a terminal (both `input` and `output` may
+    /// contain escape sequences).
+    public var meta: [String: AnyCodable]?
+    /// Message describing what the tool will do
+    public var invocationMessage: StringOrMarkdown
+    /// Raw tool input
+    public var toolInput: String?
+    public var status: ToolCallStatus
+    /// Why the tool was cancelled
+    public var reason: ToolCallCancellationReason
+    /// Optional message explaining the cancellation
+    public var reasonMessage: StringOrMarkdown?
+    /// What the user suggested doing instead
+    public var userSuggestion: UserMessage?
+    /// The confirmation option the user selected, if confirmation options were provided
+    public var selectedOption: ConfirmationOption?
+
+    enum CodingKeys: String, CodingKey {
+        case toolCallId
+        case toolName
+        case displayName
+        case toolClientId
+        case meta = "_meta"
+        case invocationMessage
+        case toolInput
+        case status
+        case reason
+        case reasonMessage
+        case userSuggestion
+        case selectedOption
+    }
+
+    public init(
+        toolCallId: String,
+        toolName: String,
+        displayName: String,
+        toolClientId: String? = nil,
+        meta: [String: AnyCodable]? = nil,
+        invocationMessage: StringOrMarkdown,
+        toolInput: String? = nil,
+        status: ToolCallStatus,
+        reason: ToolCallCancellationReason,
+        reasonMessage: StringOrMarkdown? = nil,
+        userSuggestion: UserMessage? = nil,
+        selectedOption: ConfirmationOption? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+        self.displayName = displayName
+        self.toolClientId = toolClientId
+        self.meta = meta
+        self.invocationMessage = invocationMessage
+        self.toolInput = toolInput
+        self.status = status
+        self.reason = reason
+        self.reasonMessage = reasonMessage
+        self.userSuggestion = userSuggestion
+        self.selectedOption = selectedOption
+    }
+}
+
+public struct ConfirmationOption: Codable, Sendable {
+    /// Unique identifier for the option, returned in the confirmed action
+    public var id: String
+    /// Human-readable label displayed to the user
+    public var label: String
+    /// Whether this option represents an approval or denial
+    public var kind: ConfirmationOptionKind
+    /// Logical group number for visual categorisation.
+    /// 
+    /// Clients SHOULD display options in the order they are defined and MAY
+    /// use differing group numbers to insert dividers between logical clusters
+    /// of options.
+    public var group: Int?
+
+    public init(
+        id: String,
+        label: String,
+        kind: ConfirmationOptionKind,
+        group: Int? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.kind = kind
+        self.group = group
+    }
+}
+
+public struct ToolDefinition: Codable, Sendable {
+    /// Unique tool identifier
+    public var name: String
+    /// Human-readable display name
+    public var title: String?
+    /// Description of what the tool does
+    public var description: String?
+    /// JSON Schema defining the expected input parameters.
+    /// 
+    /// Optional because client-provided tools may not have formal schemas.
+    /// Mirrors MCP `Tool.inputSchema`.
+    public var inputSchema: AnyCodable?
+    /// JSON Schema defining the structure of the tool's output.
+    /// 
+    /// Mirrors MCP `Tool.outputSchema`.
+    public var outputSchema: AnyCodable?
+    /// Behavioral hints about the tool. All properties are advisory.
+    public var annotations: ToolAnnotations?
+    /// Additional provider-specific metadata.
+    /// 
+    /// Mirrors the MCP `_meta` convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case title
+        case description
+        case inputSchema
+        case outputSchema
+        case annotations
+        case meta = "_meta"
+    }
+
+    public init(
+        name: String,
+        title: String? = nil,
+        description: String? = nil,
+        inputSchema: AnyCodable? = nil,
+        outputSchema: AnyCodable? = nil,
+        annotations: ToolAnnotations? = nil,
+        meta: [String: AnyCodable]? = nil
+    ) {
+        self.name = name
+        self.title = title
+        self.description = description
+        self.inputSchema = inputSchema
+        self.outputSchema = outputSchema
+        self.annotations = annotations
+        self.meta = meta
+    }
+}
+
+public struct ToolAnnotations: Codable, Sendable {
+    /// Alternate human-readable title
+    public var title: String?
+    /// Tool does not modify its environment (default: false)
+    public var readOnlyHint: Bool?
+    /// Tool may perform destructive updates (default: true)
+    public var destructiveHint: Bool?
+    /// Repeated calls with the same arguments have no additional effect (default: false)
+    public var idempotentHint: Bool?
+    /// Tool may interact with external entities (default: true)
+    public var openWorldHint: Bool?
+
+    public init(
+        title: String? = nil,
+        readOnlyHint: Bool? = nil,
+        destructiveHint: Bool? = nil,
+        idempotentHint: Bool? = nil,
+        openWorldHint: Bool? = nil
+    ) {
+        self.title = title
+        self.readOnlyHint = readOnlyHint
+        self.destructiveHint = destructiveHint
+        self.idempotentHint = idempotentHint
+        self.openWorldHint = openWorldHint
+    }
+}
+
+public struct ToolResultTextContent: Codable, Sendable {
+    public var type: ToolResultContentType
+    /// The text content
+    public var text: String
+
+    public init(
+        type: ToolResultContentType,
+        text: String
+    ) {
+        self.type = type
+        self.text = text
+    }
+}
+
+public struct ToolResultEmbeddedResourceContent: Codable, Sendable {
+    public var type: ToolResultContentType
+    /// Base64-encoded data
+    public var data: String
+    /// Content type (e.g. `"image/png"`, `"application/pdf"`)
+    public var contentType: String
+
+    public init(
+        type: ToolResultContentType,
+        data: String,
+        contentType: String
+    ) {
+        self.type = type
+        self.data = data
+        self.contentType = contentType
+    }
+}
+
+public struct ToolResultResourceContent: Codable, Sendable {
+    /// Content URI
+    public var uri: String
+    /// Approximate size in bytes
+    public var sizeHint: Int?
+    /// Content MIME type
+    public var contentType: String?
+    public var type: ToolResultContentType
+
+    public init(
+        uri: String,
+        sizeHint: Int? = nil,
+        contentType: String? = nil,
+        type: ToolResultContentType
+    ) {
+        self.uri = uri
+        self.sizeHint = sizeHint
+        self.contentType = contentType
+        self.type = type
+    }
+}
+
+public struct ToolResultFileEditContent: Codable, Sendable {
+    /// The file state before the edit. Absent for file creations or for in-place file edits.
+    public var before: AnyCodable?
+    /// The file state after the edit. Absent for file deletions.
+    public var after: AnyCodable?
+    /// Optional diff display metadata
+    public var diff: AnyCodable?
+    public var type: ToolResultContentType
+
+    public init(
+        before: AnyCodable? = nil,
+        after: AnyCodable? = nil,
+        diff: AnyCodable? = nil,
+        type: ToolResultContentType
+    ) {
+        self.before = before
+        self.after = after
+        self.diff = diff
+        self.type = type
+    }
+}
+
+public struct ToolResultTerminalContent: Codable, Sendable {
+    public var type: ToolResultContentType
+    /// Terminal URI (subscribable for full terminal state)
+    public var resource: String
+    /// Display title for the terminal content
+    public var title: String
+
+    public init(
+        type: ToolResultContentType,
+        resource: String,
+        title: String
+    ) {
+        self.type = type
+        self.resource = resource
+        self.title = title
+    }
+}
+
+public struct ToolResultSubagentContent: Codable, Sendable {
+    public var type: ToolResultContentType
+    /// Subagent session URI (subscribable for full session state)
+    public var resource: String
+    /// Display title for the subagent
+    public var title: String
+    /// Internal agent name
+    public var agentName: String?
+    /// Human-readable description of the subagent's task
+    public var description: String?
+
+    public init(
+        type: ToolResultContentType,
+        resource: String,
+        title: String,
+        agentName: String? = nil,
+        description: String? = nil
+    ) {
+        self.type = type
+        self.resource = resource
+        self.title = title
+        self.agentName = agentName
+        self.description = description
+    }
+}
+
+public struct CustomizationRef: Codable, Sendable {
+    /// Plugin URI (e.g. an HTTPS URL or marketplace identifier)
+    public var uri: String
+    /// Human-readable name
+    public var displayName: String
+    /// Description of what the plugin provides
+    public var description: String?
+    /// Icons for the plugin
+    public var icons: [Icon]?
+    /// Opaque version token for this customization.
+    /// 
+    /// Clients SHOULD include a nonce with every customization they provide.
+    /// Consumers can compare nonces to detect whether a customization has
+    /// changed since it was last seen, avoiding redundant reloads or copies.
+    public var nonce: String?
+
+    public init(
+        uri: String,
+        displayName: String,
+        description: String? = nil,
+        icons: [Icon]? = nil,
+        nonce: String? = nil
+    ) {
+        self.uri = uri
+        self.displayName = displayName
+        self.description = description
+        self.icons = icons
+        self.nonce = nonce
+    }
+}
+
+public struct SessionCustomization: Codable, Sendable {
+    /// The plugin this customization refers to
+    public var customization: CustomizationRef
+    /// Whether this customization is currently enabled
+    public var enabled: Bool
+    /// The `clientId` of the client that contributed this customization.
+    /// Absent for server-provided customizations.
+    public var clientId: String?
+    /// Server-reported loading status
+    public var status: CustomizationStatus?
+    /// Human-readable status detail (e.g. error message or degradation warning).
+    public var statusMessage: String?
+
+    public init(
+        customization: CustomizationRef,
+        enabled: Bool,
+        clientId: String? = nil,
+        status: CustomizationStatus? = nil,
+        statusMessage: String? = nil
+    ) {
+        self.customization = customization
+        self.enabled = enabled
+        self.clientId = clientId
+        self.status = status
+        self.statusMessage = statusMessage
+    }
+}
+
+public struct FileEdit: Codable, Sendable {
+    /// The file state before the edit. Absent for file creations or for in-place file edits.
+    public var before: AnyCodable?
+    /// The file state after the edit. Absent for file deletions.
+    public var after: AnyCodable?
+    /// Optional diff display metadata
+    public var diff: AnyCodable?
+
+    public init(
+        before: AnyCodable? = nil,
+        after: AnyCodable? = nil,
+        diff: AnyCodable? = nil
+    ) {
+        self.before = before
+        self.after = after
+        self.diff = diff
+    }
+}
+
+public struct TerminalInfo: Codable, Sendable {
+    /// Terminal URI (subscribable for full terminal state)
+    public var resource: String
+    /// Human-readable terminal title
+    public var title: String
+    /// Who currently holds this terminal
+    public var claim: TerminalClaim
+    /// Process exit code, if the terminal process has exited
+    public var exitCode: Int?
+
+    public init(
+        resource: String,
+        title: String,
+        claim: TerminalClaim,
+        exitCode: Int? = nil
+    ) {
+        self.resource = resource
+        self.title = title
+        self.claim = claim
+        self.exitCode = exitCode
+    }
+}
+
+public struct TerminalClientClaim: Codable, Sendable {
+    /// Discriminant
+    public var kind: TerminalClaimKind
+    /// The `clientId` of the claiming client
+    public var clientId: String
+
+    public init(
+        kind: TerminalClaimKind,
+        clientId: String
+    ) {
+        self.kind = kind
+        self.clientId = clientId
+    }
+}
+
+public struct TerminalSessionClaim: Codable, Sendable {
+    /// Discriminant
+    public var kind: TerminalClaimKind
+    /// Session URI that claimed the terminal
+    public var session: String
+    /// Optional turn identifier within the session
+    public var turnId: String?
+    /// Optional tool call identifier within the turn
+    public var toolCallId: String?
+
+    public init(
+        kind: TerminalClaimKind,
+        session: String,
+        turnId: String? = nil,
+        toolCallId: String? = nil
+    ) {
+        self.kind = kind
+        self.session = session
+        self.turnId = turnId
+        self.toolCallId = toolCallId
+    }
+}
+
+public struct TerminalState: Codable, Sendable {
+    /// Human-readable terminal title
+    public var title: String
+    /// Current working directory of the terminal process
+    public var cwd: String?
+    /// Terminal width in columns
+    public var cols: Int?
+    /// Terminal height in rows
+    public var rows: Int?
+    /// Typed content parts, replacing the flat `content: string`.
+    /// 
+    /// Naive consumers that only need the raw VT stream can reconstruct it with:
+    /// `content.map(p => p.type === 'command' ? p.output : p.value).join('')`
+    /// 
+    /// Consumers that need command boundaries can filter by part type.
+    public var content: [TerminalContentPart]
+    /// Process exit code, set when the terminal process exits
+    public var exitCode: Int?
+    /// Who currently holds this terminal
+    public var claim: TerminalClaim
+    /// Whether this terminal emits `terminal/commandExecuted` and
+    /// `terminal/commandFinished` actions and populates `command`-typed parts.
+    /// 
+    /// Clients MUST check this flag before relying on command detection.
+    /// Do NOT use the presence of a `command` part as a feature flag — parts
+    /// are absent in the normal idle state.
+    public var supportsCommandDetection: Bool?
+
+    public init(
+        title: String,
+        cwd: String? = nil,
+        cols: Int? = nil,
+        rows: Int? = nil,
+        content: [TerminalContentPart],
+        exitCode: Int? = nil,
+        claim: TerminalClaim,
+        supportsCommandDetection: Bool? = nil
+    ) {
+        self.title = title
+        self.cwd = cwd
+        self.cols = cols
+        self.rows = rows
+        self.content = content
+        self.exitCode = exitCode
+        self.claim = claim
+        self.supportsCommandDetection = supportsCommandDetection
+    }
+}
+
+public struct TerminalUnclassifiedPart: Codable, Sendable {
+    public var type: String
+    /// Accumulated VT output. Appended to by `terminal/data` when no command is executing.
+    public var value: String
+
+    public init(
+        type: String,
+        value: String
+    ) {
+        self.type = type
+        self.value = value
+    }
+}
+
+public struct TerminalCommandPart: Codable, Sendable {
+    public var type: String
+    /// Stable id matching the `commandId` on the corresponding
+    /// `terminal/commandExecuted` and `terminal/commandFinished` actions.
+    public var commandId: String
+    /// The command line submitted to the shell.
+    public var commandLine: String
+    /// Accumulated VT output. Appended to by `terminal/data` while `isComplete`
+    /// is false. Shell integration escape sequences are stripped by the server.
+    public var output: String
+    /// Unix timestamp (ms) when execution started, as reported by the server.
+    public var timestamp: Int
+    /// Whether the command has finished.
+    public var isComplete: Bool
+    /// Shell exit code. Set at completion. `undefined` if unknown.
+    public var exitCode: Int?
+    /// Wall-clock duration in milliseconds. Set at completion.
+    public var durationMs: Int?
+
+    public init(
+        type: String,
+        commandId: String,
+        commandLine: String,
+        output: String,
+        timestamp: Int,
+        isComplete: Bool,
+        exitCode: Int? = nil,
+        durationMs: Int? = nil
+    ) {
+        self.type = type
+        self.commandId = commandId
+        self.commandLine = commandLine
+        self.output = output
+        self.timestamp = timestamp
+        self.isComplete = isComplete
+        self.exitCode = exitCode
+        self.durationMs = durationMs
+    }
+}
+
+public struct UsageInfo: Codable, Sendable {
+    /// Input tokens consumed
+    public var inputTokens: Int?
+    /// Output tokens generated
+    public var outputTokens: Int?
+    /// Model used
+    public var model: String?
+    /// Tokens read from cache
+    public var cacheReadTokens: Int?
+
+    public init(
+        inputTokens: Int? = nil,
+        outputTokens: Int? = nil,
+        model: String? = nil,
+        cacheReadTokens: Int? = nil
+    ) {
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.model = model
+        self.cacheReadTokens = cacheReadTokens
+    }
+}
+
+public struct ErrorInfo: Codable, Sendable {
+    /// Error type identifier
+    public var errorType: String
+    /// Human-readable error message
+    public var message: String
+    /// Stack trace
+    public var stack: String?
+
+    public init(
+        errorType: String,
+        message: String,
+        stack: String? = nil
+    ) {
+        self.errorType = errorType
+        self.message = message
+        self.stack = stack
+    }
+}
+
+public struct Snapshot: Codable, Sendable {
+    /// The subscribed resource URI (e.g. `agenthost:/root` or `copilot:/<uuid>`)
+    public var resource: String
+    /// The current state of the resource
+    public var state: SnapshotState
+    /// The `serverSeq` at which this snapshot was taken. Subsequent actions will have `serverSeq > fromSeq`.
+    public var fromSeq: Int
+
+    public init(
+        resource: String,
+        state: SnapshotState,
+        fromSeq: Int
+    ) {
+        self.resource = resource
+        self.state = state
+        self.fromSeq = fromSeq
+    }
+}
+
+// MARK: - Discriminated Unions
+
+public enum ResponsePart: Codable, Sendable {
+    case markdown(MarkdownResponsePart)
+    case contentRef(ResourceReponsePart)
+    case toolCall(ToolCallResponsePart)
+    case reasoning(ReasoningResponsePart)
+    case systemNotification(SystemNotificationResponsePart)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "kind"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "markdown":
+            self = .markdown(try MarkdownResponsePart(from: decoder))
+        case "contentRef":
+            self = .contentRef(try ResourceReponsePart(from: decoder))
+        case "toolCall":
+            self = .toolCall(try ToolCallResponsePart(from: decoder))
+        case "reasoning":
+            self = .reasoning(try ReasoningResponsePart(from: decoder))
+        case "systemNotification":
+            self = .systemNotification(try SystemNotificationResponsePart(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ResponsePart discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .markdown(let value): try value.encode(to: encoder)
+        case .contentRef(let value): try value.encode(to: encoder)
+        case .toolCall(let value): try value.encode(to: encoder)
+        case .reasoning(let value): try value.encode(to: encoder)
+        case .systemNotification(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum ToolCallState: Codable, Sendable {
+    case streaming(ToolCallStreamingState)
+    case pendingConfirmation(ToolCallPendingConfirmationState)
+    case running(ToolCallRunningState)
+    case pendingResultConfirmation(ToolCallPendingResultConfirmationState)
+    case completed(ToolCallCompletedState)
+    case cancelled(ToolCallCancelledState)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "status"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "streaming":
+            self = .streaming(try ToolCallStreamingState(from: decoder))
+        case "pending-confirmation":
+            self = .pendingConfirmation(try ToolCallPendingConfirmationState(from: decoder))
+        case "running":
+            self = .running(try ToolCallRunningState(from: decoder))
+        case "pending-result-confirmation":
+            self = .pendingResultConfirmation(try ToolCallPendingResultConfirmationState(from: decoder))
+        case "completed":
+            self = .completed(try ToolCallCompletedState(from: decoder))
+        case "cancelled":
+            self = .cancelled(try ToolCallCancelledState(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ToolCallState discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .streaming(let value): try value.encode(to: encoder)
+        case .pendingConfirmation(let value): try value.encode(to: encoder)
+        case .running(let value): try value.encode(to: encoder)
+        case .pendingResultConfirmation(let value): try value.encode(to: encoder)
+        case .completed(let value): try value.encode(to: encoder)
+        case .cancelled(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum TerminalClaim: Codable, Sendable {
+    case client(TerminalClientClaim)
+    case session(TerminalSessionClaim)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "kind"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "client":
+            self = .client(try TerminalClientClaim(from: decoder))
+        case "session":
+            self = .session(try TerminalSessionClaim(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown TerminalClaim discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .client(let value): try value.encode(to: encoder)
+        case .session(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum TerminalContentPart: Codable, Sendable {
+    case unclassified(TerminalUnclassifiedPart)
+    case command(TerminalCommandPart)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "type"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "unclassified":
+            self = .unclassified(try TerminalUnclassifiedPart(from: decoder))
+        case "command":
+            self = .command(try TerminalCommandPart(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown TerminalContentPart discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .unclassified(let value): try value.encode(to: encoder)
+        case .command(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum SessionInputQuestion: Codable, Sendable {
+    case text(SessionInputTextQuestion)
+    case number(SessionInputNumberQuestion)
+    case integer(SessionInputNumberQuestion)
+    case boolean(SessionInputBooleanQuestion)
+    case singleSelect(SessionInputSingleSelectQuestion)
+    case multiSelect(SessionInputMultiSelectQuestion)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "kind"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "text":
+            self = .text(try SessionInputTextQuestion(from: decoder))
+        case "number":
+            self = .number(try SessionInputNumberQuestion(from: decoder))
+        case "integer":
+            self = .integer(try SessionInputNumberQuestion(from: decoder))
+        case "boolean":
+            self = .boolean(try SessionInputBooleanQuestion(from: decoder))
+        case "single-select":
+            self = .singleSelect(try SessionInputSingleSelectQuestion(from: decoder))
+        case "multi-select":
+            self = .multiSelect(try SessionInputMultiSelectQuestion(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown SessionInputQuestion discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .text(let value): try value.encode(to: encoder)
+        case .number(let value): try value.encode(to: encoder)
+        case .integer(let value): try value.encode(to: encoder)
+        case .boolean(let value): try value.encode(to: encoder)
+        case .singleSelect(let value): try value.encode(to: encoder)
+        case .multiSelect(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum SessionInputAnswerValue: Codable, Sendable {
+    case text(SessionInputTextAnswerValue)
+    case number(SessionInputNumberAnswerValue)
+    case boolean(SessionInputBooleanAnswerValue)
+    case selected(SessionInputSelectedAnswerValue)
+    case selectedMany(SessionInputSelectedManyAnswerValue)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "kind"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "text":
+            self = .text(try SessionInputTextAnswerValue(from: decoder))
+        case "number":
+            self = .number(try SessionInputNumberAnswerValue(from: decoder))
+        case "boolean":
+            self = .boolean(try SessionInputBooleanAnswerValue(from: decoder))
+        case "selected":
+            self = .selected(try SessionInputSelectedAnswerValue(from: decoder))
+        case "selected-many":
+            self = .selectedMany(try SessionInputSelectedManyAnswerValue(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown SessionInputAnswerValue discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .text(let value): try value.encode(to: encoder)
+        case .number(let value): try value.encode(to: encoder)
+        case .boolean(let value): try value.encode(to: encoder)
+        case .selected(let value): try value.encode(to: encoder)
+        case .selectedMany(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum SessionInputAnswer: Codable, Sendable {
+    case draft(SessionInputAnswered)
+    case submitted(SessionInputAnswered)
+    case skipped(SessionInputSkipped)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "state"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "draft":
+            self = .draft(try SessionInputAnswered(from: decoder))
+        case "submitted":
+            self = .submitted(try SessionInputAnswered(from: decoder))
+        case "skipped":
+            self = .skipped(try SessionInputSkipped(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown SessionInputAnswer discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .draft(let value): try value.encode(to: encoder)
+        case .submitted(let value): try value.encode(to: encoder)
+        case .skipped(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum ToolResultContent: Codable, Sendable {
+    case text(ToolResultTextContent)
+    case embeddedResource(ToolResultEmbeddedResourceContent)
+    case resource(ToolResultResourceContent)
+    case fileEdit(ToolResultFileEditContent)
+    case terminal(ToolResultTerminalContent)
+    case subagent(ToolResultSubagentContent)
+
+    private enum Keys: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Keys.self)
+        if let type = try container.decodeIfPresent(String.self, forKey: .type) {
+            switch type {
+            case "text":
+                self = .text(try ToolResultTextContent(from: decoder))
+            case "embeddedResource":
+                self = .embeddedResource(try ToolResultEmbeddedResourceContent(from: decoder))
+            case "resource":
+                self = .resource(try ToolResultResourceContent(from: decoder))
+            case "fileEdit":
+                self = .fileEdit(try ToolResultFileEditContent(from: decoder))
+            case "terminal":
+                self = .terminal(try ToolResultTerminalContent(from: decoder))
+            case "subagent":
+                self = .subagent(try ToolResultSubagentContent(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .type, in: container,
+                    debugDescription: "Unknown ToolResultContent type: \(type)"
+                )
+            }
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: decoder.codingPath,
+                    debugDescription: "ToolResultContent missing type")
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .text(let v): try v.encode(to: encoder)
+        case .embeddedResource(let v): try v.encode(to: encoder)
+        case .resource(let v): try v.encode(to: encoder)
+        case .fileEdit(let v): try v.encode(to: encoder)
+        case .terminal(let v): try v.encode(to: encoder)
+        case .subagent(let v): try v.encode(to: encoder)
+        }
+    }
+}
+
+/// The state payload of a snapshot — root state, session state, or terminal state.
+public enum SnapshotState: Codable, Sendable {
+    case root(RootState)
+    case session(SessionState)
+    case terminal(TerminalState)
+
+    public init(from decoder: Decoder) throws {
+        // SessionState has required `summary` field, try it first
+        if let session = try? SessionState(from: decoder) {
+            self = .session(session)
+        } else if let terminal = try? TerminalState(from: decoder) {
+            self = .terminal(terminal)
+        } else {
+            self = .root(try RootState(from: decoder))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .root(let state): try state.encode(to: encoder)
+        case .session(let state): try state.encode(to: encoder)
+        case .terminal(let state): try state.encode(to: encoder)
+        }
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/ToolCallStateExtensions.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/ToolCallStateExtensions.swift
@@ -69,6 +69,7 @@ extension ResponsePart {
         case .reasoning(let r): return r.id
         case .toolCall(let t): return t.toolCall.toolCallId
         case .contentRef: return nil
+        case .systemNotification: return nil
         }
     }
 }

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1,8 +1,14 @@
 /**
- * Swift Package Generator — Generates a Swift Package from TypeScript type
- * definitions parsed via ts-morph.
+ * Swift Package Generator — Generates the Swift sources of the AgentHostProtocol
+ * package from TypeScript type definitions parsed via ts-morph.
  *
- * Output: swift/AgentHostProtocol/ with Package.swift and Sources/
+ * Outputs (under clients/swift/AgentHostProtocol/):
+ *   - Sources/AgentHostProtocol/Generated/*.generated.swift   (always overwritten)
+ *   - Sources/AgentHostProtocol/AnyCodable.swift              (only if missing)
+ *
+ * Note: Package.swift lives at the repository root (see /Package.swift). It
+ * is hand-maintained, not generated, because SwiftPM requires the manifest to
+ * live at the repo root for remote (`.package(url:)`) consumption.
  */
 
 import {
@@ -1394,37 +1400,6 @@ public struct AnyCodable: Codable, Sendable, Equatable {
 `;
 }
 
-// ─── Package.swift ───────────────────────────────────────────────────────────
-
-function packageSwiftContent(): string {
-  return `// swift-tools-version: 5.9
-
-import PackageDescription
-
-let package = Package(
-    name: "AgentHostProtocol",
-    platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
-        .tvOS(.v16),
-        .watchOS(.v9),
-    ],
-    products: [
-        .library(
-            name: "AgentHostProtocol",
-            targets: ["AgentHostProtocol"]
-        ),
-    ],
-    targets: [
-        .target(
-            name: "AgentHostProtocol",
-            path: "Sources/AgentHostProtocol"
-        ),
-    ]
-)
-`;
-}
-
 // ─── Exhaustiveness Check ─────────────────────────────────────────────────────
 
 /**
@@ -1509,12 +1484,11 @@ export function generateSwiftPackage(project: Project, outputDir: string): void 
   const generatedDir = path.join(outputDir, 'Sources', 'AgentHostProtocol', 'Generated');
   fs.mkdirSync(generatedDir, { recursive: true });
 
-  // Package.swift and AnyCodable are only written if they don't exist yet,
-  // so hand-edits to Package.swift are preserved across regeneration.
-  const pkgPath = path.join(outputDir, 'Package.swift');
-  if (!fs.existsSync(pkgPath)) {
-    fs.writeFileSync(pkgPath, packageSwiftContent());
-  }
+  // AnyCodable is only written if it doesn't exist yet, so hand-edits are
+  // preserved across regeneration. Package.swift is hand-maintained at the
+  // repository root (see /Package.swift) — SwiftPM requires the manifest to
+  // live at the repo root for remote consumption — so it is not generated
+  // here.
   const anyCodablePath = path.join(outputDir, 'Sources', 'AgentHostProtocol', 'AnyCodable.swift');
   if (!fs.existsSync(anyCodablePath)) {
     fs.mkdirSync(path.dirname(anyCodablePath), { recursive: true });


### PR DESCRIPTION
## Summary

Make `AgentHostProtocol` consumable as a remote Swift Package Manager dependency:

```swift
.package(url: "https://github.com/microsoft/agent-host-protocol.git", from: "x.y.z")
```

SwiftPM only resolves manifests at the root of a remote git repo, so this PR moves the package manifest to the repository root while keeping the actual Swift sources where they live today (`clients/swift/AgentHostProtocol/`).

## Why

Today no external consumer can pull this in via SPM:
- The package's `Package.swift` lives in a subdirectory, which SwiftPM cannot resolve remotely.
- The bulk of the implementation (`Sources/AgentHostProtocol/Generated/`) was `.gitignore`d, so even if SPM could see the manifest there'd be nothing to compile.

## What changed

- **`.gitignore`** — Stop ignoring `Generated/`. Switch the per-subdir `.build/`/`.swiftpm/` ignores to root-level globs (the manifest now lives at the root).
- **`/Package.swift`** (new) — Hand-maintained at the repo root. Targets use `path:` to point into `clients/swift/AgentHostProtocol/{Sources,Tests}`.
- **`clients/swift/AgentHostProtocol/Package.swift`** — Deleted; replaced by the root manifest. (Two manifests for the same package would drift.)
- **`clients/swift/AHPClient/AHPClient.xcodeproj/project.pbxproj`** — `XCLocalSwiftPackageReference` retargeted from `../AgentHostProtocol` to `../../..` so the example app keeps consuming the same package via its new location.
- **`scripts/generate-swift.ts`** — No longer writes `Package.swift` (it's hand-maintained at the root now). Still owns `Generated/*.generated.swift` and seeds `AnyCodable.swift` if missing.
- **`clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/`** — Now committed. CI regenerates and fails on drift, so this can't go stale.
- **`ToolCallStateExtensions.swift`** — Added the missing `.systemNotification` case in the `partId` switch. Pre-existing exhaustiveness bug that only surfaced once `swift build` actually runs in CI.
- **`.github/workflows/ci.yml`** — New `swift` job on `macos-latest`: regenerates Swift, fails on diff, then runs `swift build` + `swift test`. Bumped common GitHub Actions to current majors across all three workflows: `actions/checkout` v4 → v6, `actions/setup-node` v4 → v6, `actions/upload-pages-artifact` v3 → v5, `actions/deploy-pages` v4 → v5. (`Swatinem/rust-cache@v2` is still the latest major.)
- **`README.md`, `clients/swift/AGENTS.md`** — Documented SPM consumption and the root-manifest layout.

## Design notes

- **Why not split the Swift package into its own repo?** Generated sources stay in lockstep with the TypeScript protocol definitions in the same commit; splitting would create a constant sync burden. The polyglot-monorepo with a root `Package.swift` is a small price.
- **Why a `Generated/` subfolder?** The package mixes hand-written reducers with generated types. The directory boundary makes it obvious to contributors which files get clobbered by `npm run generate:swift` and is a common Swift convention (SwiftGen, Sourcery, Apollo iOS, swift-protobuf).
- **The example AHPClient app is not declared in any SPM target**, so it never reaches a consumer's binary. SPM does still clone the whole repo on resolve (no sparse-checkout), but the AHPClient sources are ~320KB out of ~2.4MB tracked content — small enough that splitting the example into its own repo isn't worth the maintenance cost.

## Verification

- `swift build` ✅
- `swift test` ✅ 14/14 pass
- `npm test`, `npm run typecheck`, `npm run lint` ✅
- `npm run generate:swift` is idempotent against the committed tree ✅
