### PR TITLE
state: add _meta to SessionModelInfo for intrinsic facts (e.g. pricing)

### DIFF
--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -468,25 +468,8 @@ pub struct SessionModelInfo {
     pub config_schema: Option<ConfigSchema>,
     /// Additional provider-specific metadata for this model.
     ///
-    /// Unlike {@link configSchema}, which describes the *input* surface a client
-    /// should render as a form and round-trip through {@link ModelSelection.config},
-    /// `_meta` carries intrinsic, server-asserted facts about the model that the
-    /// client may read and display but never sends back.
-    ///
-    /// Clients MAY look for well-known keys here to provide enhanced UI:
-    ///
-    /// - `pricing` — billing information for the model. Recommended shape is an
-    ///   object that may include any of:
-    ///   - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot
-    ///     premium-request multipliers like `1`, `0.33`, `5`).
-    ///   - `inputPer1M` (number): cost per 1,000,000 input tokens.
-    ///   - `outputPer1M` (number): cost per 1,000,000 output tokens.
-    ///   - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.
-    ///   - `currency` (string): ISO 4217 currency code, defaults to `USD`.
-    ///
-    ///   Providers SHOULD omit the `pricing` key entirely when no billing data is
-    ///   available rather than emitting a `null` or empty object, so clients can
-    ///   distinguish "no pricing info" from a partially-populated payload.
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `pricing` key may carry model pricing metadata.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<JsonObject>,
 }

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -466,6 +466,29 @@ pub struct SessionModelInfo {
     /// {@link ModelSelection.config} when creating or changing sessions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_schema: Option<ConfigSchema>,
+    /// Additional provider-specific metadata for this model.
+    ///
+    /// Unlike {@link configSchema}, which describes the *input* surface a client
+    /// should render as a form and round-trip through {@link ModelSelection.config},
+    /// `_meta` carries intrinsic, server-asserted facts about the model that the
+    /// client may read and display but never sends back.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI:
+    ///
+    /// - `pricing` — billing information for the model. Recommended shape is an
+    ///   object that may include any of:
+    ///   - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot
+    ///     premium-request multipliers like `1`, `0.33`, `5`).
+    ///   - `inputPer1M` (number): cost per 1,000,000 input tokens.
+    ///   - `outputPer1M` (number): cost per 1,000,000 output tokens.
+    ///   - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.
+    ///   - `currency` (string): ISO 4217 currency code, defaults to `USD`.
+    ///
+    ///   Providers SHOULD omit the `pricing` key entirely when no billing data is
+    ///   available rather than emitting a `null` or empty object, so clients can
+    ///   distinguish "no pricing info" from a partially-populated payload.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// A model selection: the chosen model ID together with any model-specific

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -422,6 +422,39 @@ public struct SessionModelInfo: Codable, Sendable {
     /// level). Clients present this as a form and pass the resolved values in
     /// {@link ModelSelection.config} when creating or changing sessions.
     public var configSchema: ConfigSchema?
+    /// Additional provider-specific metadata for this model.
+    /// 
+    /// Unlike {@link configSchema}, which describes the *input* surface a client
+    /// should render as a form and round-trip through {@link ModelSelection.config},
+    /// `_meta` carries intrinsic, server-asserted facts about the model that the
+    /// client may read and display but never sends back.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI:
+    /// 
+    /// - `pricing` — billing information for the model. Recommended shape is an
+    /// object that may include any of:
+    /// - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot
+    /// premium-request multipliers like `1`, `0.33`, `5`).
+    /// - `inputPer1M` (number): cost per 1,000,000 input tokens.
+    /// - `outputPer1M` (number): cost per 1,000,000 output tokens.
+    /// - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.
+    /// - `currency` (string): ISO 4217 currency code, defaults to `USD`.
+    /// 
+    /// Providers SHOULD omit the `pricing` key entirely when no billing data is
+    /// available rather than emitting a `null` or empty object, so clients can
+    /// distinguish "no pricing info" from a partially-populated payload.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case provider
+        case name
+        case maxContextWindow
+        case supportsVision
+        case policyState
+        case configSchema
+        case meta = "_meta"
+    }
 
     public init(
         id: String,
@@ -430,7 +463,8 @@ public struct SessionModelInfo: Codable, Sendable {
         maxContextWindow: Int? = nil,
         supportsVision: Bool? = nil,
         policyState: PolicyState? = nil,
-        configSchema: ConfigSchema? = nil
+        configSchema: ConfigSchema? = nil,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.id = id
         self.provider = provider
@@ -439,6 +473,7 @@ public struct SessionModelInfo: Codable, Sendable {
         self.supportsVision = supportsVision
         self.policyState = policyState
         self.configSchema = configSchema
+        self.meta = meta
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -424,25 +424,8 @@ public struct SessionModelInfo: Codable, Sendable {
     public var configSchema: ConfigSchema?
     /// Additional provider-specific metadata for this model.
     /// 
-    /// Unlike {@link configSchema}, which describes the *input* surface a client
-    /// should render as a form and round-trip through {@link ModelSelection.config},
-    /// `_meta` carries intrinsic, server-asserted facts about the model that the
-    /// client may read and display but never sends back.
-    /// 
-    /// Clients MAY look for well-known keys here to provide enhanced UI:
-    /// 
-    /// - `pricing` — billing information for the model. Recommended shape is an
-    /// object that may include any of:
-    /// - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot
-    /// premium-request multipliers like `1`, `0.33`, `5`).
-    /// - `inputPer1M` (number): cost per 1,000,000 input tokens.
-    /// - `outputPer1M` (number): cost per 1,000,000 output tokens.
-    /// - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.
-    /// - `currency` (string): ISO 4217 currency code, defaults to `USD`.
-    /// 
-    /// Providers SHOULD omit the `pricing` key entirely when no billing data is
-    /// available rather than emitting a `null` or empty object, so clients can
-    /// distinguish "no pricing info" from a partially-populated payload.
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
+    /// For example, a `pricing` key may carry model pricing metadata.
     public var meta: [String: AnyCodable]?
 
     enum CodingKeys: String, CodingKey {

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -31,6 +31,7 @@ ModelInfo {
   supportsVision?: boolean
   policyState?: 'enabled' | 'disabled' | 'unconfigured'
   configSchema?: ConfigSchema   // model-specific options (e.g. thinking level)
+  _meta?: Record<string, unknown>  // intrinsic facts (e.g. pricing); see below
 }
 
 ConfigSchema {
@@ -52,6 +53,12 @@ ConfigPropertySchema {
 ```
 
 When a model has a `configSchema`, clients present it as a form and pass the resolved values in a `ModelSelection` (see [Session Summary](#session-summary)).
+
+`_meta` is a generic metadata bag for **intrinsic, server-asserted facts** about the model — things the client displays but never echoes back to the agent. This is distinct from `configSchema`, which describes *input* the client renders as a form and round-trips via `ModelSelection.config`.
+
+Clients MAY look for well-known keys in `_meta` to provide enhanced UI. The current convention:
+
+- `pricing` — billing information for the model. Recommended shape is an object that may include any of `multiplier` (number, provider-defined quota multiplier such as Copilot's premium-request multipliers `1`, `0.33`, `5`), `inputPer1M` / `outputPer1M` / `cachedInputPer1M` (number, cost per 1,000,000 tokens), and `currency` (ISO 4217, defaults to `USD`). Providers SHOULD omit the key entirely when no billing data is available rather than emitting `null` or an empty object.
 
 Root state is mutated only by server-originated actions (e.g. `root/agentsChanged`).
 

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -54,11 +54,7 @@ ConfigPropertySchema {
 
 When a model has a `configSchema`, clients present it as a form and pass the resolved values in a `ModelSelection` (see [Session Summary](#session-summary)).
 
-`_meta` is a generic metadata bag for **intrinsic, server-asserted facts** about the model — things the client displays but never echoes back to the agent. This is distinct from `configSchema`, which describes *input* the client renders as a form and round-trips via `ModelSelection.config`.
-
-Clients MAY look for well-known keys in `_meta` to provide enhanced UI. The current convention:
-
-- `pricing` — billing information for the model. Recommended shape is an object that may include any of `multiplier` (number, provider-defined quota multiplier such as Copilot's premium-request multipliers `1`, `0.33`, `5`), `inputPer1M` / `outputPer1M` / `cachedInputPer1M` (number, cost per 1,000,000 tokens), and `currency` (ISO 4217, defaults to `USD`). Providers SHOULD omit the key entirely when no billing data is available rather than emitting `null` or an empty object.
+`_meta` carries additional provider-specific metadata. Clients MAY look for well-known keys here to provide enhanced UI — for example, a `pricing` key may carry model pricing metadata.
 
 Root state is mutated only by server-originated actions (e.g. `root/agentsChanged`).
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1784,6 +1784,11 @@
         "configSchema": {
           "$ref": "#/$defs/ConfigSchema",
           "description": "Configuration schema describing model-specific options (e.g. thinking\nlevel). Clients present this as a form and pass the resolved values in\n{@link ModelSelection.config} when creating or changing sessions."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
         }
       },
       "required": [

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1788,7 +1788,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
+          "description": "Additional provider-specific metadata for this model.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `pricing` key may carry model pricing metadata."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -953,6 +953,11 @@
         "configSchema": {
           "$ref": "#/$defs/ConfigSchema",
           "description": "Configuration schema describing model-specific options (e.g. thinking\nlevel). Clients present this as a form and pass the resolved values in\n{@link ModelSelection.config} when creating or changing sessions."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -957,7 +957,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
+          "description": "Additional provider-specific metadata for this model.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `pricing` key may carry model pricing metadata."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -294,7 +294,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
+          "description": "Additional provider-specific metadata for this model.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `pricing` key may carry model pricing metadata."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -290,6 +290,11 @@
         "configSchema": {
           "$ref": "#/$defs/ConfigSchema",
           "description": "Configuration schema describing model-specific options (e.g. thinking\nlevel). Clients present this as a form and pass the resolved values in\n{@link ModelSelection.config} when creating or changing sessions."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
         }
       },
       "required": [
@@ -1444,6 +1449,24 @@
       "required": [
         "kind",
         "id",
+        "content"
+      ]
+    },
+    "SystemNotificationResponsePart": {
+      "type": "object",
+      "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "description": "Discriminant"
+        },
+        "content": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "The text of the system notification"
+        }
+      },
+      "required": [
+        "kind",
         "content"
       ]
     },

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -368,7 +368,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
+          "description": "Additional provider-specific metadata for this model.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `pricing` key may carry model pricing metadata."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -364,6 +364,11 @@
         "configSchema": {
           "$ref": "#/$defs/ConfigSchema",
           "description": "Configuration schema describing model-specific options (e.g. thinking\nlevel). Clients present this as a form and pass the resolved values in\n{@link ModelSelection.config} when creating or changing sessions."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -221,6 +221,11 @@
         "configSchema": {
           "$ref": "#/$defs/ConfigSchema",
           "description": "Configuration schema describing model-specific options (e.g. thinking\nlevel). Clients present this as a form and pass the resolved values in\n{@link ModelSelection.config} when creating or changing sessions."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -225,7 +225,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this model.\n\nUnlike {@link configSchema}, which describes the *input* surface a client\nshould render as a form and round-trip through {@link ModelSelection.config},\n`_meta` carries intrinsic, server-asserted facts about the model that the\nclient may read and display but never sends back.\n\nClients MAY look for well-known keys here to provide enhanced UI:\n\n- `pricing` — billing information for the model. Recommended shape is an\n  object that may include any of:\n  - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot\n    premium-request multipliers like `1`, `0.33`, `5`).\n  - `inputPer1M` (number): cost per 1,000,000 input tokens.\n  - `outputPer1M` (number): cost per 1,000,000 output tokens.\n  - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.\n  - `currency` (string): ISO 4217 currency code, defaults to `USD`.\n\n  Providers SHOULD omit the `pricing` key entirely when no billing data is\n  available rather than emitting a `null` or empty object, so clients can\n  distinguish \"no pricing info\" from a partially-populated payload."
+          "description": "Additional provider-specific metadata for this model.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `pricing` key may carry model pricing metadata."
         }
       },
       "required": [

--- a/types/state.ts
+++ b/types/state.ts
@@ -215,25 +215,8 @@ export interface SessionModelInfo {
   /**
    * Additional provider-specific metadata for this model.
    *
-   * Unlike {@link configSchema}, which describes the *input* surface a client
-   * should render as a form and round-trip through {@link ModelSelection.config},
-   * `_meta` carries intrinsic, server-asserted facts about the model that the
-   * client may read and display but never sends back.
-   *
-   * Clients MAY look for well-known keys here to provide enhanced UI:
-   *
-   * - `pricing` — billing information for the model. Recommended shape is an
-   *   object that may include any of:
-   *   - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot
-   *     premium-request multipliers like `1`, `0.33`, `5`).
-   *   - `inputPer1M` (number): cost per 1,000,000 input tokens.
-   *   - `outputPer1M` (number): cost per 1,000,000 output tokens.
-   *   - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.
-   *   - `currency` (string): ISO 4217 currency code, defaults to `USD`.
-   *
-   *   Providers SHOULD omit the `pricing` key entirely when no billing data is
-   *   available rather than emitting a `null` or empty object, so clients can
-   *   distinguish "no pricing info" from a partially-populated payload.
+   * Clients MAY look for well-known keys here to provide enhanced UI.
+   * For example, a `pricing` key may carry model pricing metadata.
    */
   _meta?: Record<string, unknown>;
 }

--- a/types/state.ts
+++ b/types/state.ts
@@ -212,6 +212,30 @@ export interface SessionModelInfo {
    * {@link ModelSelection.config} when creating or changing sessions.
    */
   configSchema?: ConfigSchema;
+  /**
+   * Additional provider-specific metadata for this model.
+   *
+   * Unlike {@link configSchema}, which describes the *input* surface a client
+   * should render as a form and round-trip through {@link ModelSelection.config},
+   * `_meta` carries intrinsic, server-asserted facts about the model that the
+   * client may read and display but never sends back.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI:
+   *
+   * - `pricing` — billing information for the model. Recommended shape is an
+   *   object that may include any of:
+   *   - `multiplier` (number): provider-defined quota multiplier (e.g. Copilot
+   *     premium-request multipliers like `1`, `0.33`, `5`).
+   *   - `inputPer1M` (number): cost per 1,000,000 input tokens.
+   *   - `outputPer1M` (number): cost per 1,000,000 output tokens.
+   *   - `cachedInputPer1M` (number): cost per 1,000,000 cached input tokens.
+   *   - `currency` (string): ISO 4217 currency code, defaults to `USD`.
+   *
+   *   Providers SHOULD omit the `pricing` key entirely when no billing data is
+   *   available rather than emitting a `null` or empty object, so clients can
+   *   distinguish "no pricing info" from a partially-populated payload.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Why

We need `SessionModelInfo` to carry intrinsic, non-configurable facts about a model — pricing / quota multiplier first, but the shape should generalize. The existing `configSchema` is contractually the **input** surface that clients render as a form and round-trip back via `ModelSelection.config`. Pricing isn't input — it's a server-asserted fact for display only — so it doesn't belong there even with `readOnly: true`.

## What

Add an optional `_meta?: Record<string, unknown>` bag to `SessionModelInfo`, matching the existing pattern already used on `SessionSummary`, `ToolCall*` states, etc. Document `pricing` as the first well-known key, with a recommended payload that supports both Copilot-style quota multipliers and per-token rates:

```ts
pricing?: {
  multiplier?: number;        // e.g. Copilot premium-request multipliers
  inputPer1M?: number;        // cost per 1M input tokens
  outputPer1M?: number;
  cachedInputPer1M?: number;
  currency?: string;          // ISO 4217, defaults to 'USD'
}
```

Providers SHOULD omit the key when no billing data is available (rather than emitting `null`/`{}`) so clients can distinguish "no data" from "partial data".

## Why not the alternatives

- **Typed `pricing`/`multiplier` field on `SessionModelInfo`** — bakes one vendor's billing model into AHP; violates "model the agent domain directly".
- **Read-only entry in `configSchema`** — `configSchema` is the form-input surface that round-trips through `ModelSelection.config`. A read-only entry still has a `default` and is still echoed back. Pricing is neither editable nor something the client should send back. Also, structured pricing (rates/currency/unit) doesn't fit the flat JSON-Schema-per-leaf shape.
- **`metadataSchema` + `metadata` (mirror `RootConfigState`)** — overengineered; current consumers recognize fields by well-known key, not via generic introspection.

## Notes

- v1 compatibility snapshot in `types/version/v1.ts` uses live-type aliases that auto-track until v1 freezes; no edit needed for an additive optional field.
- Regenerated `schema/`, Swift, and Rust clients. The non-`state.schema.json` schema diffs are (a) the same `_meta` field cascading into schemas that `$ref` `SessionModelInfo`, and (b) `SystemNotificationResponsePart` definitions that #98 added but didn't regenerate.
- All 192 existing tests pass; no reducer change required (`_meta` on `SessionModelInfo` is server-asserted only).

(Written by Copilot)