### PR TITLE
version protocol as semver, refine version promises

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
   },
   "files.readonlyExclude": {
     "clients/rust/crates/ahp-types/src/common.rs": true,
+    "clients/rust/crates/ahp-types/src/lib.rs": true,
   },
 	"rust-analyzer.linkedProjects": [
 		"clients/rust/Cargo.toml"

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -46,8 +46,14 @@ pub enum ContentEncoding {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeParams {
-    /// Protocol version the client speaks
-    pub protocol_version: i64,
+    /// Protocol versions the client is willing to speak, ordered from most
+    /// preferred to least preferred. Each entry is a [SemVer](https://semver.org)
+    /// `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
+    ///
+    /// The server selects one entry and returns it as `InitializeResult.protocolVersion`.
+    /// If the server cannot speak any of the offered versions, it MUST return
+    /// error code `-32005` (`UnsupportedProtocolVersion`).
+    pub protocol_versions: Vec<String>,
     /// Unique client identifier
     pub client_id: String,
     /// URIs to subscribe to during handshake
@@ -62,13 +68,18 @@ pub struct InitializeParams {
 
 /// Result of the `initialize` command.
 ///
-/// If the server does not support the client's protocol version, it MUST return
-/// error code `-32005` (`UnsupportedProtocolVersion`).
+/// `protocolVersion` is the version the server has selected from the client's
+/// `protocolVersions` list. The client and server MUST use this version for
+/// the rest of the connection. If the server cannot speak any of the offered
+/// versions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)
+/// instead of a result.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResult {
-    /// Protocol version the server speaks
-    pub protocol_version: i64,
+    /// Protocol version selected by the server. MUST be one of the entries in
+    /// `InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)
+    /// `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
+    pub protocol_version: String,
     /// Current server sequence number
     pub server_seq: i64,
     /// Snapshots for each `initialSubscriptions` URI

--- a/clients/rust/crates/ahp-types/src/errors.rs
+++ b/clients/rust/crates/ahp-types/src/errors.rs
@@ -40,7 +40,8 @@ pub mod ahp_error_codes {
     pub const SESSION_ALREADY_EXISTS: i32 = -32003;
     /// The operation requires no active turn, but one is in progress.
     pub const TURN_IN_PROGRESS: i32 = -32004;
-    /// The client's protocol version is not supported by the server.
+    /// The server cannot speak any of the protocol versions offered by the
+    /// client in `InitializeParams.protocolVersions`.
     pub const UNSUPPORTED_PROTOCOL_VERSION: i32 = -32005;
     /// The requested content URI does not exist.
     pub const CONTENT_NOT_FOUND: i32 = -32006;

--- a/clients/rust/crates/ahp-types/src/lib.rs
+++ b/clients/rust/crates/ahp-types/src/lib.rs
@@ -61,7 +61,7 @@
 //! use ahp_types::common::AnyValue;
 //!
 //! let params = InitializeParams {
-//!     protocol_version: ahp_types::PROTOCOL_VERSION as i64,
+//!     protocol_versions: vec![ahp_types::PROTOCOL_VERSION.to_string()],
 //!     client_id: "my-host/1.0".into(),
 //!     initial_subscriptions: Some(vec!["agenthost:/root".into()]),
 //!     locale: Some("en".into()),

--- a/clients/rust/crates/ahp-types/src/version.rs
+++ b/clients/rust/crates/ahp-types/src/version.rs
@@ -4,8 +4,5 @@
 
 #![allow(missing_docs)]
 
-/// Current protocol version.
-pub const PROTOCOL_VERSION: u32 = 1;
-
-/// Minimum protocol version this SDK can negotiate.
-pub const MIN_PROTOCOL_VERSION: u32 = 1;
+/// Current protocol version (SemVer `MAJOR.MINOR.PATCH`).
+pub const PROTOCOL_VERSION: &str = "0.1.0";

--- a/clients/rust/crates/ahp-ws/src/lib.rs
+++ b/clients/rust/crates/ahp-ws/src/lib.rs
@@ -24,7 +24,7 @@
 //! let transport = WebSocketTransport::connect("ws://localhost:12345").await?;
 //! let client = Client::connect(transport, ClientConfig::default()).await?;
 //!
-//! client.initialize("my-client".into(), 1, vec!["agenthost:/root".into()]).await?;
+//! client.initialize("my-client".into(), vec!["0.1.0".into()], vec!["agenthost:/root".into()]).await?;
 //!
 //! let mut sub = client.attach_subscription("agenthost:/root").await;
 //! while let Some(SubscriptionEvent::Action(env)) = sub.recv().await {

--- a/clients/rust/crates/ahp-ws/src/transport.rs
+++ b/clients/rust/crates/ahp-ws/src/transport.rs
@@ -36,7 +36,7 @@ type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let transport = WebSocketTransport::connect("ws://localhost:12345").await?;
 /// let client = Client::connect(transport, ClientConfig::default()).await?;
-/// client.initialize("demo".into(), 1, vec![]).await?;
+/// client.initialize("demo".into(), vec!["0.1.0".into()], vec![]).await?;
 /// # Ok(()) }
 /// ```
 pub struct WebSocketTransport {

--- a/clients/rust/crates/ahp/examples/connect_ws.rs
+++ b/clients/rust/crates/ahp/examples/connect_ws.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::connect(transport, ClientConfig::default()).await?;
 
     let init = client
-        .initialize("rust-example".into(), 1, vec!["root:/".into()])
+        .initialize("rust-example".into(), vec![ahp_types::PROTOCOL_VERSION.to_string()], vec!["root:/".into()])
         .await?;
     println!("connected (protocolVersion={})", init.protocol_version);
 

--- a/clients/rust/crates/ahp/src/client.rs
+++ b/clients/rust/crates/ahp/src/client.rs
@@ -12,7 +12,7 @@
 //! use ahp::{Client, ClientConfig};
 //!
 //! let client = Client::connect(transport, ClientConfig::default()).await?;
-//! let init = client.initialize("my-client".into(), 1, vec![]).await?;
+//! let init = client.initialize("my-client".into(), vec!["0.1.0".into()], vec![]).await?;
 //! // ... use client ...
 //! client.shutdown().await;
 //! # Ok(()) }
@@ -282,14 +282,18 @@ impl Client {
     }
 
     /// Issue the `initialize` handshake.
+    ///
+    /// `protocol_versions` is the list of protocol versions the client is
+    /// willing to speak, ordered most preferred first. The server picks one
+    /// and returns it as `InitializeResult.protocol_version`.
     pub async fn initialize(
         &self,
         client_id: String,
-        protocol_version: i64,
+        protocol_versions: Vec<String>,
         initial_subscriptions: Vec<String>,
     ) -> Result<InitializeResult, ClientError> {
         let params = InitializeParams {
-            protocol_version,
+            protocol_versions,
             client_id,
             initial_subscriptions: if initial_subscriptions.is_empty() {
                 None

--- a/clients/rust/crates/ahp/src/lib.rs
+++ b/clients/rust/crates/ahp/src/lib.rs
@@ -38,7 +38,7 @@
 //! let transport = WebSocketTransport::connect("ws://localhost:12345").await?;
 //! let client = Client::connect(transport, ClientConfig::default()).await?;
 //!
-//! client.initialize("my-client".into(), 1, vec![]).await?;
+//! client.initialize("my-client".into(), vec!["0.1.0".into()], vec![]).await?;
 //! let (_snap, mut sub) = client.subscribe("copilot:/s1".into()).await?;
 //!
 //! while let Some(SubscriptionEvent::Action(env)) = sub.recv().await {
@@ -58,7 +58,7 @@
 //! use ahp::{Client, ClientConfig, SubscriptionEvent};
 //!
 //! let client = Client::connect(transport, ClientConfig::default()).await?;
-//! client.initialize("my-client".into(), 1, vec!["agenthost:/root".into()]).await?;
+//! client.initialize("my-client".into(), vec!["0.1.0".into()], vec!["agenthost:/root".into()]).await?;
 //!
 //! let mut sub = client.attach_subscription("agenthost:/root").await;
 //! while let Some(ev) = sub.recv().await {

--- a/clients/rust/crates/ahp/tests/client_roundtrip.rs
+++ b/clients/rust/crates/ahp/tests/client_roundtrip.rs
@@ -58,7 +58,7 @@ async fn request_response_and_action_fanout() {
 
         // Reply with a minimal InitializeResult.
         let result = serde_json::json!({
-            "protocolVersion": 1,
+            "protocolVersion": "0.1.0",
             "serverSeq": 0,
             "snapshots": [],
         });
@@ -122,10 +122,10 @@ async fn request_response_and_action_fanout() {
 
     // Initialize handshake.
     let init = client
-        .initialize("test-client".into(), 1, vec![])
+        .initialize("test-client".into(), vec!["0.1.0".into()], vec![])
         .await
         .expect("initialize");
-    assert_eq!(init.protocol_version, 1);
+    assert_eq!(init.protocol_version, "0.1.0");
 
     // Subscribe and await the action broadcast.
     let (_snap, mut sub) = client

--- a/clients/swift/AHPClient/AHPClient/Store/AHPConnection.swift
+++ b/clients/swift/AHPClient/AHPClient/Store/AHPConnection.swift
@@ -165,7 +165,7 @@ actor AHPConnection {
             await installWebSocket(ws)
 
             let params = InitializeParams(
-                protocolVersion: 1,
+                protocolVersions: ["0.1.0"],
                 clientId: clientId,
                 initialSubscriptions: ["agenthost:/root"]
             )

--- a/clients/swift/AHPClient/AHPClientTests/AHPClientTests.swift
+++ b/clients/swift/AHPClient/AHPClientTests/AHPClientTests.swift
@@ -1484,7 +1484,7 @@ private func decodeNotification<Params: Codable & Sendable>(
 
 private func makeInitializeResult(serverSeq: Int) -> InitializeResult {
     InitializeResult(
-        protocolVersion: 1,
+        protocolVersion: "0.1.0",
         serverSeq: serverSeq,
         snapshots: [Snapshot(
             resource: "agenthost:/root",

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -19,8 +19,14 @@ public enum ContentEncoding: String, Codable, Sendable {
 // MARK: - Command Types
 
 public struct InitializeParams: Codable, Sendable {
-    /// Protocol version the client speaks
-    public var protocolVersion: Int
+    /// Protocol versions the client is willing to speak, ordered from most
+    /// preferred to least preferred. Each entry is a [SemVer](https://semver.org)
+    /// `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
+    /// 
+    /// The server selects one entry and returns it as `InitializeResult.protocolVersion`.
+    /// If the server cannot speak any of the offered versions, it MUST return
+    /// error code `-32005` (`UnsupportedProtocolVersion`).
+    public var protocolVersions: [String]
     /// Unique client identifier
     public var clientId: String
     /// URIs to subscribe to during handshake
@@ -31,12 +37,12 @@ public struct InitializeParams: Codable, Sendable {
     public var locale: String?
 
     public init(
-        protocolVersion: Int,
+        protocolVersions: [String],
         clientId: String,
         initialSubscriptions: [String]? = nil,
         locale: String? = nil
     ) {
-        self.protocolVersion = protocolVersion
+        self.protocolVersions = protocolVersions
         self.clientId = clientId
         self.initialSubscriptions = initialSubscriptions
         self.locale = locale
@@ -44,8 +50,10 @@ public struct InitializeParams: Codable, Sendable {
 }
 
 public struct InitializeResult: Codable, Sendable {
-    /// Protocol version the server speaks
-    public var protocolVersion: Int
+    /// Protocol version selected by the server. MUST be one of the entries in
+    /// `InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)
+    /// `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
+    public var protocolVersion: String
     /// Current server sequence number
     public var serverSeq: Int
     /// Snapshots for each `initialSubscriptions` URI
@@ -54,7 +62,7 @@ public struct InitializeResult: Codable, Sendable {
     public var defaultDirectory: String?
 
     public init(
-        protocolVersion: Int,
+        protocolVersion: String,
         serverSeq: Int,
         snapshots: [Snapshot],
         defaultDirectory: String? = nil

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
@@ -28,7 +28,7 @@ public enum AhpErrorCodes {
     public static let sessionAlreadyExists = -32003
     /// The operation requires no active turn, but one is in progress
     public static let turnInProgress = -32004
-    /// The client's protocol version is not supported by the server
+    /// The server cannot speak any of the protocol versions offered by the client in `InitializeParams.protocolVersions`
     public static let unsupportedProtocolVersion = -32005
     /// The requested content URI does not exist
     public static let contentNotFound = -32006

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -7,7 +7,7 @@ This guide walks through a basic client-server interaction using the Agent Host 
 Every AHP session starts with a JSON-RPC handshake over the transport (WebSocket, MessagePort, etc.):
 
 ```
-1. Client → Server:  initialize(protocolVersion, clientId, initialSubscriptions?)
+1. Client → Server:  initialize(protocolVersions[], clientId, initialSubscriptions?)
 2. Server → Client:  { protocolVersion, serverSeq, snapshots[], defaultDirectory? }
 ```
 

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -4,10 +4,10 @@ The lifecycle defines how AHP connections are established, sessions are created 
 
 ## Connection Handshake
 
-The client initiates the connection with an `initialize` **request**. The server responds with the protocol version and initial state snapshots:
+The client initiates the connection with an `initialize` **request**. The client offers a list of protocol versions it can speak; the server picks one and responds with the negotiated version and initial state snapshots:
 
 ```
-1. Client → Server:  initialize(protocolVersion, clientId, initialSubscriptions?, locale?)
+1. Client → Server:  initialize(protocolVersions[], clientId, initialSubscriptions?, locale?)
 2. Server → Client:  { protocolVersion, serverSeq, snapshots[], defaultDirectory? }
 ```
 
@@ -21,13 +21,15 @@ The client initiates the connection with an `initialize` **request**. The server
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": 1,
+    "protocolVersions": ["0.1.0"],
     "clientId": "client-abc",
     "initialSubscriptions": ["agenthost:/root"],
     "locale": "en-US"
   }
 }
 ```
+
+`protocolVersions` is ordered from most preferred to least preferred. The server picks one entry and returns it as `InitializeResult.protocolVersion`. If the server cannot speak any of the offered versions it MUST return [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) instead of a result. See [Versioning](/specification/versioning) for the negotiation rules.
 
 `initialSubscriptions` allows the client to subscribe to root state (and any previously-open sessions) in the same round-trip as the handshake.
 
@@ -40,7 +42,7 @@ The client initiates the connection with an `initialize` **request**. The server
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": 1,
+    "protocolVersion": "0.1.0",
     "serverSeq": 42,
     "defaultDirectory": "file:///home/testuser",
     "snapshots": [
@@ -54,11 +56,11 @@ The client initiates the connection with an `initialize` **request**. The server
 }
 ```
 
-The `protocolVersion` in the response tells the client what version the server speaks. The client derives `ProtocolCapabilities` from this and gates feature usage accordingly.
+`protocolVersion` is the version the server selected from the client's `protocolVersions` list. Both peers MUST use this version for the rest of the connection.
 
 If present, `defaultDirectory` provides a server-local starting location for remote filesystem browsing.
 
-If the server cannot accept the connection (e.g. unsupported protocol version), it MUST return a JSON-RPC error. See [Error Codes](/reference/error-codes) for defined codes.
+If the server cannot accept the connection for any other reason, it MUST return a JSON-RPC error. See [Error Codes](/reference/error-codes) for defined codes.
 
 ## Authentication
 

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -86,7 +86,7 @@ During the connection handshake, clients MAY include `initialSubscriptions` in t
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": 1,
+    "protocolVersions": ["0.1.0"],
     "clientId": "client-abc",
     "initialSubscriptions": ["agenthost:/root", "copilot:/<prev-session>"]
   }

--- a/docs/specification/versioning.md
+++ b/docs/specification/versioning.md
@@ -1,121 +1,62 @@
 # Versioning
 
-AHP uses a forward-compatible versioning strategy. Newer clients can connect to older servers and degrade gracefully. A single protocol version number maps to a capabilities object.
+AI is an evolving space. Unlike LSP or DAP — which largely guarantee backwards compatibility in perpetuity — the design space for agent hosts is open-ended and moving quickly. Backwards-incompatible changes to AHP are inevitable. Versioning gives clients and hosts a shared vocabulary for negotiating which behaviors are safe to use on a given connection.
 
-## Protocol Version Constants
+## Version Format
 
-Two constants define the version window:
+Protocol versions are [SemVer](https://semver.org) `MAJOR.MINOR.PATCH` strings (e.g. `"0.1.0"`). Pre-release and build metadata are not used.
 
-- **`PROTOCOL_VERSION`** — The current version that new code speaks.
-- **`MIN_PROTOCOL_VERSION`** — The oldest version the implementation maintains compatibility with.
+## Negotiation
 
-```
-Version history:
-  1 — Initial: core session lifecycle, streaming, tools, permissions
-```
+Version selection happens once, during the [`initialize`](/specification/lifecycle) handshake — modelled after WebSocket subprotocol negotiation:
 
-## When to Bump the Version
+1. The client sends `InitializeParams.protocolVersions`: an array of every protocol version it is willing to speak, ordered from most preferred to least preferred.
+2. The server picks one entry it can speak and returns it as `InitializeResult.protocolVersion`. Servers SHOULD honor the client's preference order when multiple offered versions are acceptable.
+3. If the server cannot speak any of the offered versions, it MUST respond with [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) instead of a result, and close the connection.
 
-Bump `PROTOCOL_VERSION` when:
-- A new feature area requires capability negotiation (client must know server supports it before sending commands).
-- Behavioral semantics of existing actions change.
+Both peers MUST use the selected version for the rest of the connection. There is no per-message renegotiation.
 
-The following do **not** require a version bump:
-- Adding **optional** fields to existing action/state types.
-- Adding new action types (they're filtered by version automatically).
+## Compatibility Guarantee
 
-## Version Type Snapshots
+AHP follows standard SemVer compatibility:
 
-Each protocol version has a type file (`v1.ts`, `v2.ts`, etc.) that captures the wire format shape of every state type and action type in that version.
+- Two peers speaking versions `X.y.z` and `X.y'.z'` (same `MAJOR ≥ 1`) are compatible.
+- Two peers speaking versions `0.X.y` and `0.X.y'` (same pre-1.0 `MINOR`) are compatible.
+- Any other combination is **not** guaranteed to be compatible.
 
-The **latest** version file is the editable "tip" — it can be modified alongside the living types. When `PROTOCOL_VERSION` is bumped, the previous version file becomes frozen and a new tip is created.
+Within a compatible range, additive changes — new optional fields on existing types, new action types, new commands — are introduced in `PATCH` (or `MINOR`, while `MAJOR` is `0`) bumps and MUST be ignored by older peers that do not understand them.
 
-## Compatibility Checks
+## Capabilities First, Then Required
 
-The version registry performs **bidirectional assignability checks** between version types and living types:
+New behavior generally lands in two stages:
 
-```typescript
-// AssertCompatible requires BOTH directions:
-//   Current extends Frozen → can't remove fields or change field types
-//   Frozen extends Current → can't add required fields
-// The only allowed evolution is adding optional fields.
-type AssertCompatible<Frozen, Current extends Frozen> =
-  Frozen extends Current ? true : never;
-```
+1. **Capability-gated.** A new feature is introduced as an opt-in capability advertised by a host or clients. Implementors check for the capability before exercising the feature. This lets hosts and clients adopt the feature on independent schedules without a version bump.
+2. **Required.** Once a capability has matured, a future protocol version may promote it to baseline behavior and remove the capability flag. This reduces long-term implementation complexity.
 
-| Change to living type | Compile result |
-|---|---|
-| Add optional field | ✅ Passes |
-| Remove a field | ❌ `Current extends Frozen` fails |
-| Change a field's type | ❌ `Current extends Frozen` fails |
-| Add required field | ❌ `Frozen extends Current` fails |
+## Client and Host Update Cadence
 
-## Exhaustive Action → Version Map
+Agent hosts may be remote machines, cloud services, or other external APIs that the user does not control. Clients (IDEs, CLI tools, embedded UIs) are typically easier for a user to update than hosts.
 
-The registry maintains a runtime map with a TypeScript index signature that forces an entry for every action type in the union:
+As a result:
 
-```typescript
-const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: number } = {
-  'root/agentsChanged': 1,
-  'session/turnStarted': 1,
-  'session/delta': 1,
-  // ...every action type must have an entry
-};
-```
-
-Adding a new action to the union without adding it to this map is a compile error.
-
-The server uses this for one-line filtering:
-
-```typescript
-function isActionKnownToVersion(action: StateAction, clientVersion: number): boolean {
-  return ACTION_INTRODUCED_IN[action.type] <= clientVersion;
-}
-```
-
-## Capabilities
-
-The protocol version maps to a `ProtocolCapabilities` interface for feature gating:
-
-```typescript
-interface ProtocolCapabilities {
-  // v1 — always present
-  readonly sessions: true;
-  readonly tools: true;
-  readonly permissions: true;
-  // v2+ (example)
-  readonly reasoning?: true;
-}
-
-function capabilitiesForVersion(version: number): ProtocolCapabilities {
-  return {
-    sessions: true,
-    tools: true,
-    permissions: true,
-    // ...(version >= 2 ? { reasoning: true } : {}),
-  };
-}
-```
+- **Clients SHOULD offer a wide range of protocol versions** when feasible so that older hosts can still pick a version they understand. Clients then degrade features gracefully when the negotiated version lacks a capability they would otherwise use.
+- **Hosts SHOULD pick the highest offered version they implement.** Lower entries in the client's array are fallbacks for older hosts.
+- **Hosts MUST refuse incompatible clients** by returning [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) when no offered version is acceptable.
 
 ## Forward Compatibility
 
-A newer client connecting to an older server:
+When a newer client connects to an older host:
 
-1. During handshake, the client learns the server's protocol version from the `initialize` response.
-2. The client derives `ProtocolCapabilities` from the server version.
-3. Command factories check capabilities before dispatching; if unsupported, the client degrades gracefully.
-4. The server only sends action types known to the client's declared version (via `isActionKnownToVersion`).
-5. As a safety net, clients SHOULD silently ignore actions with unrecognized `type` values.
+1. The client offers its full version list, including older versions it can fall back to.
+2. The host picks the newest entry it understands and returns it.
+3. The client checks the capability set advertised by the host before using newer features.
+4. If a feature is unavailable, the client degrades gracefully — disabling UI affordances, falling back to older code paths, or surfacing a clear message to the user.
+5. The host only sends action types known to the negotiated version. As a safety net, clients SHOULD silently ignore actions with unrecognized `type` values.
 
 ## Backward Compatibility
 
-Backward compatibility (older clients connecting to newer servers) is not guaranteed. Clients should update before the server.
+When an older client connects to a newer host:
 
-## Raising the Minimum Version
-
-When `MIN_PROTOCOL_VERSION` is raised from N to N+1:
-
-1. Delete the version N type file (`vN.ts`).
-2. Remove the vN compatibility checks from the version registry.
-3. The compiler surfaces any dead code that only existed for vN compatibility.
-4. Clean up that dead code.
+1. The client offers only the versions it knows.
+2. The host picks one of those (typically the newest the client offered) or returns `UnsupportedProtocolVersion` if it can no longer speak any of them.
+3. On a successful negotiation the host MUST NOT use newer-version-only behaviors on that connection unless gated behind a capability the client has acknowledged.

--- a/plugins/copilot-plugin/skills/ahp-client/SKILL.md
+++ b/plugins/copilot-plugin/skills/ahp-client/SKILL.md
@@ -57,7 +57,7 @@ Send an `initialize` **notification** (no `id` field):
   "jsonrpc": "2.0",
   "method": "initialize",
   "params": {
-    "protocolVersion": 1,
+    "protocolVersions": ["0.1.0"],
     "clientId": "<unique-client-id>",
     "initialSubscriptions": ["agenthost:/root"]
   }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -9,9 +9,12 @@
       "type": "object",
       "description": "Establishes a new connection and negotiates the protocol version.\nThis MUST be the first message sent by the client.",
       "properties": {
-        "protocolVersion": {
-          "type": "number",
-          "description": "Protocol version the client speaks"
+        "protocolVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Protocol versions the client is willing to speak, ordered from most\npreferred to least preferred. Each entry is a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`).\n\nThe server selects one entry and returns it as `InitializeResult.protocolVersion`.\nIf the server cannot speak any of the offered versions, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`)."
         },
         "clientId": {
           "type": "string",
@@ -30,17 +33,17 @@
         }
       },
       "required": [
-        "protocolVersion",
+        "protocolVersions",
         "clientId"
       ]
     },
     "InitializeResult": {
       "type": "object",
-      "description": "Result of the `initialize` command.\n\nIf the server does not support the client's protocol version, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`).",
+      "description": "Result of the `initialize` command.\n\n`protocolVersion` is the version the server has selected from the client's\n`protocolVersions` list. The client and server MUST use this version for\nthe rest of the connection. If the server cannot speak any of the offered\nversions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)\ninstead of a result.",
       "properties": {
         "protocolVersion": {
-          "type": "number",
-          "description": "Protocol version the server speaks"
+          "type": "string",
+          "description": "Protocol version selected by the server. MUST be one of the entries in\n`InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`)."
         },
         "serverSeq": {
           "type": "number",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2653,9 +2653,12 @@
       "type": "object",
       "description": "Establishes a new connection and negotiates the protocol version.\nThis MUST be the first message sent by the client.",
       "properties": {
-        "protocolVersion": {
-          "type": "number",
-          "description": "Protocol version the client speaks"
+        "protocolVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Protocol versions the client is willing to speak, ordered from most\npreferred to least preferred. Each entry is a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`).\n\nThe server selects one entry and returns it as `InitializeResult.protocolVersion`.\nIf the server cannot speak any of the offered versions, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`)."
         },
         "clientId": {
           "type": "string",
@@ -2674,17 +2677,17 @@
         }
       },
       "required": [
-        "protocolVersion",
+        "protocolVersions",
         "clientId"
       ]
     },
     "InitializeResult": {
       "type": "object",
-      "description": "Result of the `initialize` command.\n\nIf the server does not support the client's protocol version, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`).",
+      "description": "Result of the `initialize` command.\n\n`protocolVersion` is the version the server has selected from the client's\n`protocolVersions` list. The client and server MUST use this version for\nthe rest of the connection. If the server cannot speak any of the offered\nversions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)\ninstead of a result.",
       "properties": {
         "protocolVersion": {
-          "type": "number",
-          "description": "Protocol version the server speaks"
+          "type": "string",
+          "description": "Protocol version selected by the server. MUST be one of the entries in\n`InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`)."
         },
         "serverSeq": {
           "type": "number",

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1122,7 +1122,8 @@ pub mod ahp_error_codes {
     pub const SESSION_ALREADY_EXISTS: i32 = -32003;
     /// The operation requires no active turn, but one is in progress.
     pub const TURN_IN_PROGRESS: i32 = -32004;
-    /// The client's protocol version is not supported by the server.
+    /// The server cannot speak any of the protocol versions offered by the
+    /// client in \`InitializeParams.protocolVersions\`.
     pub const UNSUPPORTED_PROTOCOL_VERSION: i32 = -32005;
     /// The requested content URI does not exist.
     pub const CONTENT_NOT_FOUND: i32 = -32006;
@@ -1254,26 +1255,21 @@ pub type ActionNotificationParams = ActionEnvelope;
 
 function generateVersionFile(project: Project): string {
   const sf = project.getSourceFiles().find(f => f.getBaseName().endsWith('registry.ts'));
-  let protocolVersion = 1;
-  let minProtocolVersion = 1;
+  let protocolVersion = '0.1.0';
   if (sf) {
     for (const decl of sf.getVariableDeclarations()) {
-      if (decl.getName() === 'PROTOCOL_VERSION') {
-        const init = decl.getInitializer()?.getText() ?? '1';
-        protocolVersion = Number(init) || 1;
-      } else if (decl.getName() === 'MIN_PROTOCOL_VERSION') {
-        const init = decl.getInitializer()?.getText() ?? '1';
-        minProtocolVersion = Number(init) || 1;
+      const init = decl.getInitializer()?.getText() ?? '';
+      // Initializers are TS source text, e.g. `'0.1.0'`. Strip surrounding quotes.
+      const literal = init.replace(/^['"`]|['"`]$/g, '');
+      if (decl.getName() === 'PROTOCOL_VERSION' && literal) {
+        protocolVersion = literal;
       }
     }
   }
 
   return `${GENERATED_BANNER}
-/// Current protocol version.
-pub const PROTOCOL_VERSION: u32 = ${protocolVersion};
-
-/// Minimum protocol version this SDK can negotiate.
-pub const MIN_PROTOCOL_VERSION: u32 = ${minProtocolVersion};
+/// Current protocol version (SemVer \`MAJOR.MINOR.PATCH\`).
+pub const PROTOCOL_VERSION: &str = ${JSON.stringify(protocolVersion)};
 `;
 }
 

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1133,7 +1133,7 @@ function generateErrorsFile(project: Project): string {
   lines.push('    public static let sessionAlreadyExists = -32003');
   lines.push('    /// The operation requires no active turn, but one is in progress');
   lines.push('    public static let turnInProgress = -32004');
-  lines.push('    /// The client\'s protocol version is not supported by the server');
+  lines.push('    /// The server cannot speak any of the protocol versions offered by the client in `InitializeParams.protocolVersions`');
   lines.push('    public static let unsupportedProtocolVersion = -32005');
   lines.push('    /// The requested content URI does not exist');
   lines.push('    public static let contentNotFound = -32006');

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -25,8 +25,16 @@ export type { ConfigPropertySchema, ConfigSchema, SessionConfigPropertySchema, S
  * @see {@link /specification/lifecycle | Lifecycle} for the full handshake flow.
  */
 export interface InitializeParams {
-  /** Protocol version the client speaks */
-  protocolVersion: number;
+  /**
+   * Protocol versions the client is willing to speak, ordered from most
+   * preferred to least preferred. Each entry is a [SemVer](https://semver.org)
+   * `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
+   *
+   * The server selects one entry and returns it as `InitializeResult.protocolVersion`.
+   * If the server cannot speak any of the offered versions, it MUST return
+   * error code `-32005` (`UnsupportedProtocolVersion`).
+   */
+  protocolVersions: string[];
   /** Unique client identifier */
   clientId: string;
   /** URIs to subscribe to during handshake */
@@ -42,12 +50,19 @@ export interface InitializeParams {
 /**
  * Result of the `initialize` command.
  *
- * If the server does not support the client's protocol version, it MUST return
- * error code `-32005` (`UnsupportedProtocolVersion`).
+ * `protocolVersion` is the version the server has selected from the client's
+ * `protocolVersions` list. The client and server MUST use this version for
+ * the rest of the connection. If the server cannot speak any of the offered
+ * versions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)
+ * instead of a result.
  */
 export interface InitializeResult {
-  /** Protocol version the server speaks */
-  protocolVersion: number;
+  /**
+   * Protocol version selected by the server. MUST be one of the entries in
+   * `InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)
+   * `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
+   */
+  protocolVersion: string;
   /** Current server sequence number */
   serverSeq: number;
   /** Snapshots for each `initialSubscriptions` URI */

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -47,7 +47,10 @@ export const AhpErrorCodes = {
   SessionAlreadyExists: -32003,
   /** The operation requires no active turn, but one is in progress */
   TurnInProgress: -32004,
-  /** The client's protocol version is not supported by the server */
+  /**
+   * The server cannot speak any of the protocol versions offered by the
+   * client in `InitializeParams.protocolVersions`.
+   */
   UnsupportedProtocolVersion: -32005,
   /** The requested content URI does not exist */
   ContentNotFound: -32006,

--- a/types/index.ts
+++ b/types/index.ts
@@ -289,11 +289,9 @@ export type {
 // Version registry
 export {
   PROTOCOL_VERSION,
-  MIN_PROTOCOL_VERSION,
   ACTION_INTRODUCED_IN,
   NOTIFICATION_INTRODUCED_IN,
   isActionKnownToVersion,
   isNotificationKnownToVersion,
-  capabilitiesForVersion,
+  compareProtocolVersions,
 } from './version/registry.js';
-export type { ProtocolCapabilities } from './version/registry.js';

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -11,78 +11,110 @@ import { NotificationType } from '../notifications.js';
 
 // ─── Protocol Version Constants ──────────────────────────────────────────────
 
-/** The current protocol version that new code speaks. */
-export const PROTOCOL_VERSION = 1;
+/**
+ * The current protocol version that new code speaks.
+ *
+ * Formatted as a [SemVer](https://semver.org) `MAJOR.MINOR.PATCH` string.
+ */
+export const PROTOCOL_VERSION = '0.1.0';
 
-/** The oldest protocol version the implementation maintains compatibility with. */
-export const MIN_PROTOCOL_VERSION = 1;
+// ─── SemVer Comparison ───────────────────────────────────────────────────────
+
+/**
+ * Parses a `MAJOR.MINOR.PATCH` SemVer string into its three numeric
+ * components. Pre-release and build metadata are not supported and MUST NOT
+ * be present in protocol version strings.
+ *
+ * Throws if `version` is not a well-formed `MAJOR.MINOR.PATCH` string.
+ */
+function parseSemver(version: string): readonly [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    throw new Error(`Invalid protocol version: ${version}`);
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])] as const;
+}
+
+/**
+ * Compares two `MAJOR.MINOR.PATCH` SemVer strings.
+ *
+ * Returns a negative number if `a < b`, zero if `a === b`, and a positive
+ * number if `a > b`.
+ */
+export function compareProtocolVersions(a: string, b: string): number {
+  const [aMajor, aMinor, aPatch] = parseSemver(a);
+  const [bMajor, bMinor, bPatch] = parseSemver(b);
+  return (aMajor - bMajor) || (aMinor - bMinor) || (aPatch - bPatch);
+}
 
 // ─── Exhaustive Action → Version Map ─────────────────────────────────────────
 
 /**
  * Maps every action type to the protocol version that introduced it.
  * Adding a new action to `StateAction` without adding it here is a compile error.
+ *
+ * Versions are SemVer `MAJOR.MINOR.PATCH` strings (see `PROTOCOL_VERSION`).
  */
-export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: number } = {
-  [ActionType.RootAgentsChanged]: 1,
-  [ActionType.RootActiveSessionsChanged]: 1,
-  [ActionType.SessionReady]: 1,
-  [ActionType.SessionCreationFailed]: 1,
-  [ActionType.SessionTurnStarted]: 1,
-  [ActionType.SessionDelta]: 1,
-  [ActionType.SessionResponsePart]: 1,
-  [ActionType.SessionToolCallStart]: 1,
-  [ActionType.SessionToolCallDelta]: 1,
-  [ActionType.SessionToolCallReady]: 1,
-  [ActionType.SessionToolCallConfirmed]: 1,
-  [ActionType.SessionToolCallComplete]: 1,
-  [ActionType.SessionToolCallResultConfirmed]: 1,
-  [ActionType.SessionToolCallContentChanged]: 1,
-  [ActionType.SessionTurnComplete]: 1,
-  [ActionType.SessionTurnCancelled]: 1,
-  [ActionType.SessionError]: 1,
-  [ActionType.SessionTitleChanged]: 1,
-  [ActionType.SessionUsage]: 1,
-  [ActionType.SessionReasoning]: 1,
-  [ActionType.SessionModelChanged]: 1,
-  [ActionType.SessionServerToolsChanged]: 1,
-  [ActionType.SessionActiveClientChanged]: 1,
-  [ActionType.SessionActiveClientToolsChanged]: 1,
-  [ActionType.SessionPendingMessageSet]: 1,
-  [ActionType.SessionPendingMessageRemoved]: 1,
-  [ActionType.SessionQueuedMessagesReordered]: 1,
-  [ActionType.SessionInputRequested]: 1,
-  [ActionType.SessionInputAnswerChanged]: 1,
-  [ActionType.SessionInputCompleted]: 1,
-  [ActionType.SessionCustomizationsChanged]: 1,
-  [ActionType.SessionCustomizationToggled]: 1,
-  [ActionType.SessionTruncated]: 1,
-  [ActionType.SessionIsReadChanged]: 1,
-  [ActionType.SessionIsArchivedChanged]: 1,
-  [ActionType.SessionActivityChanged]: 1,
-  [ActionType.SessionDiffsChanged]: 1,
-  [ActionType.SessionConfigChanged]: 1,
-  [ActionType.SessionMetaChanged]: 1,
-  [ActionType.RootTerminalsChanged]: 1,
-  [ActionType.RootConfigChanged]: 1,
-  [ActionType.TerminalData]: 1,
-  [ActionType.TerminalInput]: 1,
-  [ActionType.TerminalResized]: 1,
-  [ActionType.TerminalClaimed]: 1,
-  [ActionType.TerminalTitleChanged]: 1,
-  [ActionType.TerminalCwdChanged]: 1,
-  [ActionType.TerminalExited]: 1,
-  [ActionType.TerminalCleared]: 1,
-  [ActionType.TerminalCommandDetectionAvailable]: 1,
-  [ActionType.TerminalCommandExecuted]: 1,
-  [ActionType.TerminalCommandFinished]: 1,
+export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string } = {
+  [ActionType.RootAgentsChanged]: '0.1.0',
+  [ActionType.RootActiveSessionsChanged]: '0.1.0',
+  [ActionType.SessionReady]: '0.1.0',
+  [ActionType.SessionCreationFailed]: '0.1.0',
+  [ActionType.SessionTurnStarted]: '0.1.0',
+  [ActionType.SessionDelta]: '0.1.0',
+  [ActionType.SessionResponsePart]: '0.1.0',
+  [ActionType.SessionToolCallStart]: '0.1.0',
+  [ActionType.SessionToolCallDelta]: '0.1.0',
+  [ActionType.SessionToolCallReady]: '0.1.0',
+  [ActionType.SessionToolCallConfirmed]: '0.1.0',
+  [ActionType.SessionToolCallComplete]: '0.1.0',
+  [ActionType.SessionToolCallResultConfirmed]: '0.1.0',
+  [ActionType.SessionToolCallContentChanged]: '0.1.0',
+  [ActionType.SessionTurnComplete]: '0.1.0',
+  [ActionType.SessionTurnCancelled]: '0.1.0',
+  [ActionType.SessionError]: '0.1.0',
+  [ActionType.SessionTitleChanged]: '0.1.0',
+  [ActionType.SessionUsage]: '0.1.0',
+  [ActionType.SessionReasoning]: '0.1.0',
+  [ActionType.SessionModelChanged]: '0.1.0',
+  [ActionType.SessionServerToolsChanged]: '0.1.0',
+  [ActionType.SessionActiveClientChanged]: '0.1.0',
+  [ActionType.SessionActiveClientToolsChanged]: '0.1.0',
+  [ActionType.SessionPendingMessageSet]: '0.1.0',
+  [ActionType.SessionPendingMessageRemoved]: '0.1.0',
+  [ActionType.SessionQueuedMessagesReordered]: '0.1.0',
+  [ActionType.SessionInputRequested]: '0.1.0',
+  [ActionType.SessionInputAnswerChanged]: '0.1.0',
+  [ActionType.SessionInputCompleted]: '0.1.0',
+  [ActionType.SessionCustomizationsChanged]: '0.1.0',
+  [ActionType.SessionCustomizationToggled]: '0.1.0',
+  [ActionType.SessionTruncated]: '0.1.0',
+  [ActionType.SessionIsReadChanged]: '0.1.0',
+  [ActionType.SessionIsArchivedChanged]: '0.1.0',
+  [ActionType.SessionActivityChanged]: '0.1.0',
+  [ActionType.SessionDiffsChanged]: '0.1.0',
+  [ActionType.SessionConfigChanged]: '0.1.0',
+  [ActionType.SessionMetaChanged]: '0.1.0',
+  [ActionType.RootTerminalsChanged]: '0.1.0',
+  [ActionType.RootConfigChanged]: '0.1.0',
+  [ActionType.TerminalData]: '0.1.0',
+  [ActionType.TerminalInput]: '0.1.0',
+  [ActionType.TerminalResized]: '0.1.0',
+  [ActionType.TerminalClaimed]: '0.1.0',
+  [ActionType.TerminalTitleChanged]: '0.1.0',
+  [ActionType.TerminalCwdChanged]: '0.1.0',
+  [ActionType.TerminalExited]: '0.1.0',
+  [ActionType.TerminalCleared]: '0.1.0',
+  [ActionType.TerminalCommandDetectionAvailable]: '0.1.0',
+  [ActionType.TerminalCommandExecuted]: '0.1.0',
+  [ActionType.TerminalCommandFinished]: '0.1.0',
 };
 
 /**
  * Returns whether the given action type is known to the specified protocol version.
  */
-export function isActionKnownToVersion(action: StateAction, clientVersion: number): boolean {
-  return ACTION_INTRODUCED_IN[action.type] <= clientVersion;
+export function isActionKnownToVersion(action: StateAction, clientVersion: string): boolean {
+  return compareProtocolVersions(ACTION_INTRODUCED_IN[action.type], clientVersion) <= 0;
 }
 
 // ─── Exhaustive Notification → Version Map ─────────────────────────────────
@@ -91,42 +123,19 @@ export function isActionKnownToVersion(action: StateAction, clientVersion: numbe
  * Maps every notification type to the protocol version that introduced it.
  * Adding a new notification to `ProtocolNotification` without adding it here
  * is a compile error.
+ *
+ * Versions are SemVer `MAJOR.MINOR.PATCH` strings (see `PROTOCOL_VERSION`).
  */
-export const NOTIFICATION_INTRODUCED_IN: { readonly [K in ProtocolNotification['type']]: number } = {
-  [NotificationType.SessionAdded]: 1,
-  [NotificationType.SessionRemoved]: 1,
-  [NotificationType.SessionSummaryChanged]: 1,
-  [NotificationType.AuthRequired]: 1,
+export const NOTIFICATION_INTRODUCED_IN: { readonly [K in ProtocolNotification['type']]: string } = {
+  [NotificationType.SessionAdded]: '0.1.0',
+  [NotificationType.SessionRemoved]: '0.1.0',
+  [NotificationType.SessionSummaryChanged]: '0.1.0',
+  [NotificationType.AuthRequired]: '0.1.0',
 };
 
 /**
  * Returns whether the given notification type is known to the specified protocol version.
  */
-export function isNotificationKnownToVersion(notification: ProtocolNotification, clientVersion: number): boolean {
-  return NOTIFICATION_INTRODUCED_IN[notification.type] <= clientVersion;
-}
-
-// ─── Capabilities ────────────────────────────────────────────────────────────
-
-/**
- * Feature capabilities gated by protocol version.
- */
-export interface ProtocolCapabilities {
-  /** v1 — always present */
-  readonly sessions: true;
-  /** v1 — always present */
-  readonly tools: true;
-  /** v1 — always present */
-  readonly permissions: true;
-}
-
-/**
- * Derives capabilities from a protocol version number.
- */
-export function capabilitiesForVersion(_version: number): ProtocolCapabilities {
-  return {
-    sessions: true,
-    tools: true,
-    permissions: true,
-  };
+export function isNotificationKnownToVersion(notification: ProtocolNotification, clientVersion: string): boolean {
+  return compareProtocolVersions(NOTIFICATION_INTRODUCED_IN[notification.type], clientVersion) <= 0;
 }


### PR DESCRIPTION
The protocolVersion field is now a SemVer MAJOR.MINOR.PATCH string instead of an integer, and the initialize handshake negotiates the version like a WebSocket subprotocol: the client sends `protocolVersions: string[]` ordered by preference, and the server selects one to return as `InitializeResult.protocolVersion`. If the server cannot speak any of the offered versions it returns UnsupportedProtocolVersion (-32005).

- types/commands.ts: protocolVersion -> protocolVersions[] on InitializeParams; InitializeResult carries the selected version.
- types/version/registry.ts: PROTOCOL_VERSION = '0.1.0'; drop MIN_PROTOCOL_VERSION; add compareProtocolVersions; ACTION_INTRODUCED_IN and NOTIFICATION_INTRODUCED_IN now map to SemVer strings.
- docs/specification/versioning.md: rewrite for the protocol-consumer audience — explain SemVer compatibility, capability-gated rollout, and the negotiation handshake.
- Update lifecycle, subscriptions, getting-started, and copilot-plugin examples to match the new wire shape.
- Hand-written Rust and Swift clients accept Vec<String> / [String] for protocolVersions; regenerate Rust and Swift bindings and JSON Schemas.