### PR TITLE
errors: add UnsupportedProtocolVersionErrorData

### DIFF
--- a/clients/rust/crates/ahp-types/src/errors.rs
+++ b/clients/rust/crates/ahp-types/src/errors.rs
@@ -80,3 +80,14 @@ pub struct PermissionDeniedErrorData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request: Option<ResourceRequestParams>,
 }
+
+/// Details carried in the `data` field of an `UnsupportedProtocolVersion`
+/// (-32005) error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnsupportedProtocolVersionErrorData {
+    /// Protocol versions the server is willing to speak. Each entry is
+    /// either a SemVer `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`) or a
+    /// SemVer range constraint (e.g. `">=0.1.0 <0.3.0"` or `"^0.2.0"`).
+    pub supported_versions: Vec<String>,
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
@@ -67,3 +67,18 @@ public struct PermissionDeniedErrorData: Codable, Sendable {
         self.request = request
     }
 }
+
+public struct UnsupportedProtocolVersionErrorData: Codable, Sendable {
+    /// Protocol versions the server is willing to speak.
+    /// 
+    /// Each entry is either a [SemVer](https://semver.org) `MAJOR.MINOR.PATCH`
+    /// string (e.g. `"0.1.0"`) or a [SemVer range](https://semver.org/#spec-item-11)
+    /// constraint (e.g. `">=0.1.0 <0.3.0"` or `"^0.2.0"`).
+    public var supportedVersions: [String]
+
+    public init(
+        supportedVersions: [String]
+    ) {
+        self.supportedVersions = supportedVersions
+    }
+}

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -58,6 +58,22 @@
         }
       }
     },
+    "UnsupportedProtocolVersionErrorData": {
+      "type": "object",
+      "description": "Details carried in the `data` field of an `UnsupportedProtocolVersion`\n(-32005) error.",
+      "properties": {
+        "supportedVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Protocol versions the server is willing to speak.\n\nEach entry is either a [SemVer](https://semver.org) `MAJOR.MINOR.PATCH`\nstring (e.g. `\"0.1.0\"`) or a [SemVer range](https://semver.org/#spec-item-11)\nconstraint (e.g. `\">=0.1.0 <0.3.0\"` or `\"^0.2.0\"`)."
+        }
+      },
+      "required": [
+        "supportedVersions"
+      ]
+    },
     "AhpErrorDetailsMap": {
       "type": "object",
       "description": "Maps each AHP error code that carries structured `data` to the type of\nthat data.\n\nError codes not present in this map either have no `data` payload or\ncarry an unspecified payload that callers SHOULD treat as `unknown`.",
@@ -67,11 +83,15 @@
         },
         "[AhpErrorCodes.PermissionDenied]": {
           "$ref": "#/$defs/PermissionDeniedErrorData"
+        },
+        "[AhpErrorCodes.UnsupportedProtocolVersion]": {
+          "$ref": "#/$defs/UnsupportedProtocolVersionErrorData"
         }
       },
       "required": [
         "[AhpErrorCodes.AuthRequired]",
-        "[AhpErrorCodes.PermissionDenied]"
+        "[AhpErrorCodes.PermissionDenied]",
+        "[AhpErrorCodes.UnsupportedProtocolVersion]"
       ]
     },
     "Icon": {

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1179,6 +1179,17 @@ pub struct PermissionDeniedErrorData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request: Option<ResourceRequestParams>,
 }
+
+/// Details carried in the \`data\` field of an \`UnsupportedProtocolVersion\`
+/// (-32005) error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnsupportedProtocolVersionErrorData {
+    /// Protocol versions the server is willing to speak. Each entry is
+    /// either a SemVer \`MAJOR.MINOR.PATCH\` string (e.g. \`"0.1.0"\`) or a
+    /// SemVer range constraint (e.g. \`">=0.1.0 <0.3.0"\` or \`"^0.2.0"\`).
+    pub supported_versions: Vec<String>,
+}
 `;
 }
 
@@ -1337,6 +1348,7 @@ function checkExhaustiveness(project: Project): void {
     'ReconnectResult',
     'AuthRequiredErrorData',
     'PermissionDeniedErrorData',
+    'UnsupportedProtocolVersionErrorData',
     'AhpError',
     'AhpErrorDetailsMap',
   ]);

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1163,7 +1163,7 @@ function generateErrorsFile(project: Project): string {
   lines.push('');
 
   lines.push('// MARK: - Error Detail Payloads\n');
-  for (const ifaceName of ['AuthRequiredErrorData', 'PermissionDeniedErrorData']) {
+  for (const ifaceName of ['AuthRequiredErrorData', 'PermissionDeniedErrorData', 'UnsupportedProtocolVersionErrorData']) {
     try {
       lines.push(generateStructFromInterface(project, ifaceName));
       lines.push('');
@@ -1473,6 +1473,7 @@ function checkExhaustiveness(project: Project): void {
     'MessageAttachmentBase',        // base interface, flattened into the variant structs via `extends`
     'AuthRequiredErrorData',        // emitted by generateErrorsFile()
     'PermissionDeniedErrorData',    // emitted by generateErrorsFile()
+    'UnsupportedProtocolVersionErrorData', // emitted by generateErrorsFile()
     'AhpError',                     // typed via JsonRpcError; not a Swift struct
     'AhpErrorDetailsMap',           // type-level mapping; not a Swift struct
     'ReconnectResult',              // RECONNECT_RESULT_UNION discriminated union

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -49,7 +49,9 @@ export const AhpErrorCodes = {
   TurnInProgress: -32004,
   /**
    * The server cannot speak any of the protocol versions offered by the
-   * client in `InitializeParams.protocolVersions`.
+   * client in `InitializeParams.protocolVersions`. The `data` field of the
+   * JSON-RPC error MAY be an `UnsupportedProtocolVersionErrorData` advertising
+   * the protocol versions the server is willing to speak.
    */
   UnsupportedProtocolVersion: -32005,
   /** The requested content URI does not exist */
@@ -127,6 +129,24 @@ export interface PermissionDeniedErrorData {
 }
 
 /**
+ * Details carried in the `data` field of an `UnsupportedProtocolVersion`
+ * (-32005) error.
+ *
+ * @category Error Details
+ * @version 1
+ */
+export interface UnsupportedProtocolVersionErrorData {
+  /**
+   * Protocol versions the server is willing to speak.
+   *
+   * Each entry is either a [SemVer](https://semver.org) `MAJOR.MINOR.PATCH`
+   * string (e.g. `"0.1.0"`) or a [SemVer range](https://semver.org/#spec-item-11)
+   * constraint (e.g. `">=0.1.0 <0.3.0"` or `"^0.2.0"`).
+   */
+  supportedVersions: string[];
+}
+
+/**
  * Maps each AHP error code that carries structured `data` to the type of
  * that data.
  *
@@ -139,6 +159,7 @@ export interface PermissionDeniedErrorData {
 export interface AhpErrorDetailsMap {
   [AhpErrorCodes.AuthRequired]: AuthRequiredErrorData;
   [AhpErrorCodes.PermissionDenied]: PermissionDeniedErrorData;
+  [AhpErrorCodes.UnsupportedProtocolVersion]: UnsupportedProtocolVersionErrorData;
 }
 
 /** AHP error codes that carry a structured `data` payload. */

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -189,6 +189,7 @@ import type {
   AhpErrorDetailsMap,
   AuthRequiredErrorData,
   PermissionDeniedErrorData,
+  UnsupportedProtocolVersionErrorData,
 } from '../errors.js';
 
 // ─── Bidirectional Assignability Check ───────────────────────────────────────
@@ -373,6 +374,7 @@ type V1_IAhpError = AhpError;
 type V1_IAhpErrorDetailsMap = AhpErrorDetailsMap;
 type V1_IAuthRequiredErrorData = AuthRequiredErrorData;
 type V1_IPermissionDeniedErrorData = PermissionDeniedErrorData;
+type V1_IUnsupportedProtocolVersionErrorData = UnsupportedProtocolVersionErrorData;
 
 // ─── Compatibility Assertions ────────────────────────────────────────────────
 
@@ -619,6 +621,8 @@ type _CheckAhpErrorDetailsMap = AssertCompatible<V1_IAhpErrorDetailsMap, AhpErro
 type _CheckAuthRequiredErrorData = AssertCompatible<V1_IAuthRequiredErrorData, AuthRequiredErrorData>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckPermissionDeniedErrorData = AssertCompatible<V1_IPermissionDeniedErrorData, PermissionDeniedErrorData>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckUnsupportedProtocolVersionErrorData = AssertCompatible<V1_IUnsupportedProtocolVersionErrorData, UnsupportedProtocolVersionErrorData>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckTerminalsChangedAction = AssertCompatible<V1_IRootTerminalsChangedAction, RootTerminalsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
errors: add UnsupportedProtocolVersionErrorData

Adds a structured `data` payload for the `UnsupportedProtocolVersion` (-32005) JSON-RPC error
so a server can advertise the protocol versions it is willing to speak when it rejects a client's
`initialize` offer.

- Add `UnsupportedProtocolVersionErrorData` interface with a `supportedVersions: string[]`
  field accepting SemVer versions or SemVer range constraints.
- Wire the new payload into `AhpErrorDetailsMap` so `AhpError` narrows `data` correctly when
  `code` is `UnsupportedProtocolVersion`.
- Update the `UnsupportedProtocolVersion` JSDoc to point at the new payload.
- Freeze the new type in `types/version/v1.ts` with an `AssertCompatible` check.
- Emit the new struct from the Rust and Swift generators and register it in their exhaustiveness
  lists; regenerate JSON schemas, docs, and the Rust/Swift client packages.

(Commit message generated by Copilot)

