### PR TITLE
feat: add support for custom agent selection in session actions and state

### DIFF
--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::state::{
-    AgentInfo, ConfirmationOption, ErrorInfo, FileEdit, ModelSelection, PendingMessageKind,
-    ResponsePart, SessionActiveClient, SessionCustomization, SessionInputAnswer,
-    SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo,
+    AgentInfo, AgentSelection, ConfirmationOption, ErrorInfo, FileEdit, ModelSelection,
+    PendingMessageKind, ResponsePart, SessionActiveClient, SessionCustomization,
+    SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo,
     ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallResult, ToolDefinition,
     ToolResultContent, UsageInfo, UserMessage,
 };
@@ -66,6 +66,8 @@ pub enum ActionType {
     SessionReasoning,
     #[serde(rename = "session/modelChanged")]
     SessionModelChanged,
+    #[serde(rename = "session/agentChanged")]
+    SessionAgentChanged,
     #[serde(rename = "session/serverToolsChanged")]
     SessionServerToolsChanged,
     #[serde(rename = "session/activeClientChanged")]
@@ -527,6 +529,17 @@ pub struct SessionModelChangedAction {
     pub session: Uri,
     /// New model selection
     pub model: ModelSelection,
+}
+
+/// Custom agent changed for this session.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionAgentChangedAction {
+    /// Session URI
+    pub session: Uri,
+    /// New agent selection, or `undefined` to clear the selection
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentSelection>,
 }
 
 /// The read state of the session changed.
@@ -1049,6 +1062,8 @@ pub enum StateAction {
     SessionReasoning(SessionReasoningAction),
     #[serde(rename = "session/modelChanged")]
     SessionModelChanged(SessionModelChangedAction),
+    #[serde(rename = "session/agentChanged")]
+    SessionAgentChanged(SessionAgentChangedAction),
     #[serde(rename = "session/isReadChanged")]
     SessionIsReadChanged(SessionIsReadChangedAction),
     #[serde(rename = "session/isArchivedChanged")]

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -15,8 +15,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::actions::{ActionEnvelope, StateAction};
 #[allow(unused_imports)]
 use crate::state::{
-    MessageAttachment, ModelSelection, SessionActiveClient, SessionConfigSchema, SessionSummary,
-    Snapshot, SnapshotState, TerminalClaim, Turn,
+    AgentSelection, MessageAttachment, ModelSelection, SessionActiveClient, SessionConfigSchema,
+    SessionSummary, Snapshot, SnapshotState, TerminalClaim, Turn,
 };
 
 // ─── Enums ────────────────────────────────────────────────────────────
@@ -185,6 +185,9 @@ pub struct CreateSessionParams {
     /// Model selection (ID and optional model-specific configuration)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<ModelSelection>,
+    /// Custom agent selection (name) — selects a customization-pipeline agent for this session
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentSelection>,
     /// Working directory for the session
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<Uri>,

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[allow(unused_imports)]
-use crate::state::{FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary};
+use crate::state::{
+    AgentSelection, FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary,
+};
 
 // ─── Enums ────────────────────────────────────────────────────────────
 
@@ -148,6 +150,9 @@ pub struct PartialSessionSummary {
     /// Currently selected model
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<ModelSelection>,
+    /// Currently selected custom agent
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentSelection>,
     /// The working directory URI for this session
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<Uri>,

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -490,6 +490,20 @@ pub struct ModelSelection {
     pub config: Option<std::collections::HashMap<String, String>>,
 }
 
+/// An agent selection: the URI of the chosen agent's source `.agent.md`
+/// file (matching `INamedPluginResource.uri` / `ICustomAgent.uri` in the
+/// customization pipeline). URIs are unique by construction, so selection is
+/// unambiguous even when two plugins contribute agents with the same `name`.
+/// Selection is opaque to the protocol — providers translate the URI to their
+/// backend's representation (e.g. the Copilot SDK addresses agents by `name`,
+/// so the Copilot provider does a URI → name lookup at its SDK boundary).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSelection {
+    /// URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`).
+    pub id: Uri,
+}
+
 /// A JSON Schema-compatible property descriptor with display extensions.
 ///
 /// Standard JSON Schema fields (`type`, `title`, `description`, `default`,
@@ -657,6 +671,9 @@ pub struct SessionSummary {
     /// Currently selected model
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<ModelSelection>,
+    /// Currently selected custom agent
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentSelection>,
     /// The working directory URI for this session
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<Uri>,

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -549,6 +549,11 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
             touch_modified(state);
             ReduceOutcome::Applied
         }
+        StateAction::SessionAgentChanged(a) => {
+            state.summary.agent = a.agent.clone();
+            touch_modified(state);
+            ReduceOutcome::Applied
+        }
         StateAction::SessionIsReadChanged(a) => {
             state.summary.status =
                 with_status_flag(state.summary.status, SessionStatus::IsRead, a.is_read);
@@ -1113,6 +1118,7 @@ mod tests {
                 modified_at: 0,
                 project: None,
                 model: None,
+                agent: None,
                 working_directory: None,
                 diffs: None,
             },

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -27,6 +27,7 @@ public enum ActionType: String, Codable, Sendable {
     case sessionUsage = "session/usage"
     case sessionReasoning = "session/reasoning"
     case sessionModelChanged = "session/modelChanged"
+    case sessionAgentChanged = "session/agentChanged"
     case sessionServerToolsChanged = "session/serverToolsChanged"
     case sessionActiveClientChanged = "session/activeClientChanged"
     case sessionActiveClientToolsChanged = "session/activeClientToolsChanged"
@@ -704,6 +705,24 @@ public struct SessionModelChangedAction: Codable, Sendable {
         self.type = type
         self.session = session
         self.model = model
+    }
+}
+
+public struct SessionAgentChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// New agent selection, or `undefined` to clear the selection
+    public var agent: AgentSelection?
+
+    public init(
+        type: ActionType,
+        session: String,
+        agent: AgentSelection? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.agent = agent
     }
 }
 
@@ -1386,6 +1405,7 @@ public enum StateAction: Codable, Sendable {
     case sessionUsage(SessionUsageAction)
     case sessionReasoning(SessionReasoningAction)
     case sessionModelChanged(SessionModelChangedAction)
+    case sessionAgentChanged(SessionAgentChangedAction)
     case sessionIsReadChanged(SessionIsReadChangedAction)
     case sessionIsArchivedChanged(SessionIsArchivedChangedAction)
     case sessionActivityChanged(SessionActivityChangedAction)
@@ -1467,6 +1487,8 @@ public enum StateAction: Codable, Sendable {
             self = .sessionReasoning(try SessionReasoningAction(from: decoder))
         case "session/modelChanged":
             self = .sessionModelChanged(try SessionModelChangedAction(from: decoder))
+        case "session/agentChanged":
+            self = .sessionAgentChanged(try SessionAgentChangedAction(from: decoder))
         case "session/isReadChanged":
             self = .sessionIsReadChanged(try SessionIsReadChangedAction(from: decoder))
         case "session/isArchivedChanged":
@@ -1558,6 +1580,7 @@ public enum StateAction: Codable, Sendable {
         case .sessionUsage(let v): try v.encode(to: encoder)
         case .sessionReasoning(let v): try v.encode(to: encoder)
         case .sessionModelChanged(let v): try v.encode(to: encoder)
+        case .sessionAgentChanged(let v): try v.encode(to: encoder)
         case .sessionIsReadChanged(let v): try v.encode(to: encoder)
         case .sessionIsArchivedChanged(let v): try v.encode(to: encoder)
         case .sessionActivityChanged(let v): try v.encode(to: encoder)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -189,6 +189,8 @@ public struct CreateSessionParams: Codable, Sendable {
     public var provider: String?
     /// Model selection (ID and optional model-specific configuration)
     public var model: ModelSelection?
+    /// Custom agent selection (name) — selects a customization-pipeline agent for this session
+    public var agent: AgentSelection?
     /// Working directory for the session
     public var workingDirectory: String?
     /// Fork from an existing session. The new session is populated with content
@@ -209,6 +211,7 @@ public struct CreateSessionParams: Codable, Sendable {
         session: String,
         provider: String? = nil,
         model: ModelSelection? = nil,
+        agent: AgentSelection? = nil,
         workingDirectory: String? = nil,
         fork: SessionForkSource? = nil,
         config: [String: AnyCodable]? = nil,
@@ -217,6 +220,7 @@ public struct CreateSessionParams: Codable, Sendable {
         self.session = session
         self.provider = provider
         self.model = model
+        self.agent = agent
         self.workingDirectory = workingDirectory
         self.fork = fork
         self.config = config

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -110,6 +110,8 @@ public struct PartialSessionSummary: Codable, Sendable {
     public var project: ProjectInfo?
     /// Currently selected model
     public var model: ModelSelection?
+    /// Currently selected custom agent
+    public var agent: AgentSelection?
     /// The working directory URI for this session
     public var workingDirectory: String?
     /// Files changed during this session with diff statistics
@@ -125,6 +127,7 @@ public struct PartialSessionSummary: Codable, Sendable {
         modifiedAt: Int? = nil,
         project: ProjectInfo? = nil,
         model: ModelSelection? = nil,
+        agent: AgentSelection? = nil,
         workingDirectory: String? = nil,
         diffs: [FileEdit]? = nil
     ) {
@@ -137,6 +140,7 @@ public struct PartialSessionSummary: Codable, Sendable {
         self.modifiedAt = modifiedAt
         self.project = project
         self.model = model
+        self.agent = agent
         self.workingDirectory = workingDirectory
         self.diffs = diffs
     }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -478,6 +478,17 @@ public struct ModelSelection: Codable, Sendable {
     }
 }
 
+public struct AgentSelection: Codable, Sendable {
+    /// URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`).
+    public var id: String
+
+    public init(
+        id: String
+    ) {
+        self.id = id
+    }
+}
+
 public final class ConfigPropertySchema: Codable, @unchecked Sendable {
     /// JSON Schema: property type
     public var type: String
@@ -701,6 +712,8 @@ public struct SessionSummary: Codable, Sendable {
     public var project: ProjectInfo?
     /// Currently selected model
     public var model: ModelSelection?
+    /// Currently selected custom agent
+    public var agent: AgentSelection?
     /// The working directory URI for this session
     public var workingDirectory: String?
     /// Files changed during this session with diff statistics
@@ -716,6 +729,7 @@ public struct SessionSummary: Codable, Sendable {
         modifiedAt: Int,
         project: ProjectInfo? = nil,
         model: ModelSelection? = nil,
+        agent: AgentSelection? = nil,
         workingDirectory: String? = nil,
         diffs: [FileEdit]? = nil
     ) {
@@ -728,6 +742,7 @@ public struct SessionSummary: Codable, Sendable {
         self.modifiedAt = modifiedAt
         self.project = project
         self.model = model
+        self.agent = agent
         self.workingDirectory = workingDirectory
         self.diffs = diffs
     }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
@@ -405,6 +405,10 @@ public struct AHPSessionReducer: Reducer {
             state.summary.model = a.model
             state.summary.modifiedAt = currentTimestamp()
 
+        case .sessionAgentChanged(let a):
+            state.summary.agent = a.agent
+            state.summary.modifiedAt = currentTimestamp()
+
         case .sessionActivityChanged(let a):
             state.summary.activity = a.activity
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -362,6 +362,12 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
         next.summary.modifiedAt = currentTimestamp()
         return next
 
+    case .sessionAgentChanged(let a):
+        var next = state
+        next.summary.agent = a.agent
+        next.summary.modifiedAt = currentTimestamp()
+        return next
+
     case .sessionActivityChanged(let a):
         var next = state
         next.summary.activity = a.activity
@@ -579,7 +585,7 @@ public func isClientDispatchable(_ action: StateAction) -> Bool {
     switch action {
     case .sessionTurnStarted, .sessionToolCallConfirmed, .sessionToolCallComplete,
          .sessionToolCallResultConfirmed, .sessionTurnCancelled,
-         .sessionModelChanged, .sessionActiveClientChanged,
+         .sessionModelChanged, .sessionAgentChanged, .sessionActiveClientChanged,
          .sessionActiveClientToolsChanged, .sessionPendingMessageSet,
          .sessionPendingMessageRemoved, .sessionQueuedMessagesReordered,
          .sessionInputAnswerChanged, .sessionInputCompleted,

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -840,6 +840,28 @@
         "model"
       ]
     },
+    "SessionAgentChangedAction": {
+      "type": "object",
+      "description": "Custom agent changed for this session.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionAgentChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "New agent selection, or `undefined` to clear the selection"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "agent"
+      ]
+    },
     "SessionIsReadChangedAction": {
       "type": "object",
       "description": "The read state of the session changed.\n\nDispatched by a client to mark a session as read (e.g. after viewing it)\nor unread (e.g. after new activity since the client last looked at it).",
@@ -1817,6 +1839,19 @@
         "id"
       ]
     },
+    "AgentSelection": {
+      "type": "object",
+      "description": "An agent selection: the URI of the chosen agent's source `.agent.md`\nfile (matching `INamedPluginResource.uri` / `ICustomAgent.uri` in the\ncustomization pipeline). URIs are unique by construction, so selection is\nunambiguous even when two plugins contribute agents with the same `name`.\nSelection is opaque to the protocol — providers translate the URI to their\nbackend's representation (e.g. the Copilot SDK addresses agents by `name`,\nso the Copilot provider does a URI → name lookup at its SDK boundary).",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`)."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
     "PendingMessage": {
       "type": "object",
       "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
@@ -2002,6 +2037,10 @@
         "model": {
           "$ref": "#/$defs/ModelSelection",
           "description": "Currently selected model"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "Currently selected custom agent"
         },
         "workingDirectory": {
           "$ref": "#/$defs/URI",
@@ -4534,6 +4573,9 @@
         },
         {
           "$ref": "#/$defs/SessionModelChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionAgentChangedAction"
         },
         {
           "$ref": "#/$defs/SessionServerToolsChangedAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -209,6 +209,10 @@
           "$ref": "#/$defs/ModelSelection",
           "description": "Model selection (ID and optional model-specific configuration)"
         },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "Custom agent selection (name) — selects a customization-pipeline agent for this session"
+        },
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Working directory for the session"
@@ -1066,6 +1070,19 @@
         "id"
       ]
     },
+    "AgentSelection": {
+      "type": "object",
+      "description": "An agent selection: the URI of the chosen agent's source `.agent.md`\nfile (matching `INamedPluginResource.uri` / `ICustomAgent.uri` in the\ncustomization pipeline). URIs are unique by construction, so selection is\nunambiguous even when two plugins contribute agents with the same `name`.\nSelection is opaque to the protocol — providers translate the URI to their\nbackend's representation (e.g. the Copilot SDK addresses agents by `name`,\nso the Copilot provider does a URI → name lookup at its SDK boundary).",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`)."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
     "PendingMessage": {
       "type": "object",
       "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
@@ -1251,6 +1268,10 @@
         "model": {
           "$ref": "#/$defs/ModelSelection",
           "description": "Currently selected model"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "Currently selected custom agent"
         },
         "workingDirectory": {
           "$ref": "#/$defs/URI",
@@ -4367,6 +4388,28 @@
         "type",
         "session",
         "model"
+      ]
+    },
+    "SessionAgentChangedAction": {
+      "type": "object",
+      "description": "Custom agent changed for this session.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionAgentChanged"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "New agent selection, or `undefined` to clear the selection"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "agent"
       ]
     },
     "SessionIsReadChangedAction": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -343,6 +343,19 @@
         "id"
       ]
     },
+    "AgentSelection": {
+      "type": "object",
+      "description": "An agent selection: the URI of the chosen agent's source `.agent.md`\nfile (matching `INamedPluginResource.uri` / `ICustomAgent.uri` in the\ncustomization pipeline). URIs are unique by construction, so selection is\nunambiguous even when two plugins contribute agents with the same `name`.\nSelection is opaque to the protocol — providers translate the URI to their\nbackend's representation (e.g. the Copilot SDK addresses agents by `name`,\nso the Copilot provider does a URI → name lookup at its SDK boundary).",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`)."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
     "PendingMessage": {
       "type": "object",
       "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
@@ -528,6 +541,10 @@
         "model": {
           "$ref": "#/$defs/ModelSelection",
           "description": "Currently selected model"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "Currently selected custom agent"
         },
         "workingDirectory": {
           "$ref": "#/$defs/URI",
@@ -3014,6 +3031,10 @@
         "model": {
           "$ref": "#/$defs/ModelSelection",
           "description": "Model selection (ID and optional model-specific configuration)"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "Custom agent selection (name) — selects a customization-pipeline agent for this session"
         },
         "workingDirectory": {
           "$ref": "#/$defs/URI",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -89,6 +89,10 @@
               "$ref": "#/$defs/ModelSelection",
               "description": "Currently selected model"
             },
+            "agent": {
+              "$ref": "#/$defs/AgentSelection",
+              "description": "Currently selected custom agent"
+            },
             "workingDirectory": {
               "$ref": "#/$defs/URI",
               "description": "The working directory URI for this session"
@@ -397,6 +401,19 @@
         "id"
       ]
     },
+    "AgentSelection": {
+      "type": "object",
+      "description": "An agent selection: the URI of the chosen agent's source `.agent.md`\nfile (matching `INamedPluginResource.uri` / `ICustomAgent.uri` in the\ncustomization pipeline). URIs are unique by construction, so selection is\nunambiguous even when two plugins contribute agents with the same `name`.\nSelection is opaque to the protocol — providers translate the URI to their\nbackend's representation (e.g. the Copilot SDK addresses agents by `name`,\nso the Copilot provider does a URI → name lookup at its SDK boundary).",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`)."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
     "PendingMessage": {
       "type": "object",
       "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
@@ -582,6 +599,10 @@
         "model": {
           "$ref": "#/$defs/ModelSelection",
           "description": "Currently selected model"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "Currently selected custom agent"
         },
         "workingDirectory": {
           "$ref": "#/$defs/URI",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -254,6 +254,19 @@
         "id"
       ]
     },
+    "AgentSelection": {
+      "type": "object",
+      "description": "An agent selection: the URI of the chosen agent's source `.agent.md`\nfile (matching `INamedPluginResource.uri` / `ICustomAgent.uri` in the\ncustomization pipeline). URIs are unique by construction, so selection is\nunambiguous even when two plugins contribute agents with the same `name`.\nSelection is opaque to the protocol — providers translate the URI to their\nbackend's representation (e.g. the Copilot SDK addresses agents by `name`,\nso the Copilot provider does a URI → name lookup at its SDK boundary).",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/URI",
+          "description": "URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`)."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
     "PendingMessage": {
       "type": "object",
       "description": "A message queued for future delivery to the agent.\n\nSteering messages are injected into the current turn mid-flight.\nQueued messages are automatically started as new turns after the\ncurrent turn naturally finishes.",
@@ -439,6 +452,10 @@
         "model": {
           "$ref": "#/$defs/ModelSelection",
           "description": "Currently selected model"
+        },
+        "agent": {
+          "$ref": "#/$defs/AgentSelection",
+          "description": "Currently selected custom agent"
         },
         "workingDirectory": {
           "$ref": "#/$defs/URI",

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -534,6 +534,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'AgentInfo' },
   { name: 'SessionModelInfo' },
   { name: 'ModelSelection' },
+  { name: 'AgentSelection' },
   { name: 'ConfigPropertySchema' },
   { name: 'ConfigSchema' },
   { name: 'PendingMessage' },
@@ -813,6 +814,7 @@ const ACTION_VARIANTS: {
   { type: 'session/usage', variantName: 'SessionUsage', tsInterface: 'SessionUsageAction' },
   { type: 'session/reasoning', variantName: 'SessionReasoning', tsInterface: 'SessionReasoningAction' },
   { type: 'session/modelChanged', variantName: 'SessionModelChanged', tsInterface: 'SessionModelChangedAction' },
+  { type: 'session/agentChanged', variantName: 'SessionAgentChanged', tsInterface: 'SessionAgentChangedAction' },
   { type: 'session/isReadChanged', variantName: 'SessionIsReadChanged', tsInterface: 'SessionIsReadChangedAction' },
   { type: 'session/isArchivedChanged', variantName: 'SessionIsArchivedChanged', tsInterface: 'SessionIsArchivedChangedAction' },
   { type: 'session/activityChanged', variantName: 'SessionActivityChanged', tsInterface: 'SessionActivityChangedAction' },
@@ -883,7 +885,7 @@ pub struct SessionToolCallConfirmedAction {
 function generateActionsFile(project: Project): string {
   const sf = project.getSourceFiles().find(f => f.getBaseName() === 'actions.ts')!;
   const lines: string[] = [GENERATED_HEADER];
-  lines.push('use crate::state::{AgentInfo, ConfirmationOption, ErrorInfo, FileEdit, ModelSelection, ResponsePart, SessionActiveClient, SessionCustomization, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, UserMessage, PendingMessageKind};');
+  lines.push('use crate::state::{AgentInfo, ConfirmationOption, ErrorInfo, FileEdit, ModelSelection, AgentSelection, ResponsePart, SessionActiveClient, SessionCustomization, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, UserMessage, PendingMessageKind};');
   lines.push('');
 
   // ActionType enum
@@ -996,7 +998,7 @@ function generateCommandsFile(project: Project): string {
   lines.push('#[allow(unused_imports)]');
   lines.push('use crate::actions::{ActionEnvelope, StateAction};');
   lines.push('#[allow(unused_imports)]');
-  lines.push('use crate::state::{MessageAttachment, ModelSelection, SessionActiveClient, SessionConfigSchema, SessionSummary, Snapshot, SnapshotState, TerminalClaim, Turn};');
+  lines.push('use crate::state::{MessageAttachment, ModelSelection, AgentSelection, SessionActiveClient, SessionConfigSchema, SessionSummary, Snapshot, SnapshotState, TerminalClaim, Turn};');
   lines.push('');
 
   lines.push('// ─── Enums ────────────────────────────────────────────────────────────\n');
@@ -1058,7 +1060,7 @@ function generateNotificationsFile(project: Project): string {
   const sf = project.getSourceFiles().find(f => f.getBaseName() === 'notifications.ts')!;
   const lines: string[] = [GENERATED_HEADER];
   lines.push('#[allow(unused_imports)]');
-  lines.push('use crate::state::{FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary};');
+  lines.push('use crate::state::{AgentSelection, FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary};');
   lines.push('');
 
   lines.push('// ─── Enums ────────────────────────────────────────────────────────────\n');

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -487,7 +487,7 @@ const STATE_ENUMS = [
 
 const STATE_STRUCTS = [
   'Icon', 'ProtectedResourceMetadata', 'RootState', 'RootConfigState', 'AgentInfo',
-  'SessionModelInfo', 'ModelSelection', 'ConfigPropertySchema', 'ConfigSchema',
+  'SessionModelInfo', 'ModelSelection', 'AgentSelection', 'ConfigPropertySchema', 'ConfigSchema',
   'PendingMessage', 'SessionState', 'SessionActiveClient',
   'SessionSummary', 'ProjectInfo', 'SessionConfigState', 'Turn', 'ActiveTurn', 'UserMessage',
   'SessionInputOption',
@@ -800,6 +800,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'session/usage', caseName: 'sessionUsage', tsInterface: 'SessionUsageAction' },
   { type: 'session/reasoning', caseName: 'sessionReasoning', tsInterface: 'SessionReasoningAction' },
   { type: 'session/modelChanged', caseName: 'sessionModelChanged', tsInterface: 'SessionModelChangedAction' },
+  { type: 'session/agentChanged', caseName: 'sessionAgentChanged', tsInterface: 'SessionAgentChangedAction' },
   { type: 'session/isReadChanged', caseName: 'sessionIsReadChanged', tsInterface: 'SessionIsReadChangedAction' },
   { type: 'session/isArchivedChanged', caseName: 'sessionIsArchivedChanged', tsInterface: 'SessionIsArchivedChangedAction' },
   { type: 'session/activityChanged', caseName: 'sessionActivityChanged', tsInterface: 'SessionActivityChangedAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -26,6 +26,7 @@ import type {
   SessionUsageAction,
   SessionReasoningAction,
   SessionModelChangedAction,
+  SessionAgentChangedAction,
   SessionServerToolsChangedAction,
   SessionActiveClientChangedAction,
   SessionActiveClientToolsChangedAction,
@@ -102,6 +103,7 @@ export type SessionAction =
   | SessionUsageAction
   | SessionReasoningAction
   | SessionModelChangedAction
+  | SessionAgentChangedAction
   | SessionServerToolsChangedAction
   | SessionActiveClientChangedAction
   | SessionActiveClientToolsChangedAction
@@ -132,6 +134,7 @@ export type ClientSessionAction =
   | SessionTurnCancelledAction
   | SessionTitleChangedAction
   | SessionModelChangedAction
+  | SessionAgentChangedAction
   | SessionActiveClientChangedAction
   | SessionActiveClientToolsChangedAction
   | SessionPendingMessageSetAction
@@ -231,6 +234,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.SessionUsage]: false,
   [ActionType.SessionReasoning]: false,
   [ActionType.SessionModelChanged]: true,
+  [ActionType.SessionAgentChanged]: true,
   [ActionType.SessionServerToolsChanged]: false,
   [ActionType.SessionActiveClientChanged]: true,
   [ActionType.SessionActiveClientToolsChanged]: true,

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -12,6 +12,7 @@ import type {
   AgentInfo,
   ErrorInfo,
   ModelSelection,
+  AgentSelection,
   UserMessage,
   ResponsePart,
   ToolCallResult,
@@ -60,6 +61,7 @@ export const enum ActionType {
   SessionUsage = 'session/usage',
   SessionReasoning = 'session/reasoning',
   SessionModelChanged = 'session/modelChanged',
+  SessionAgentChanged = 'session/agentChanged',
   SessionServerToolsChanged = 'session/serverToolsChanged',
   SessionActiveClientChanged = 'session/activeClientChanged',
   SessionActiveClientToolsChanged = 'session/activeClientToolsChanged',
@@ -584,6 +586,21 @@ export interface SessionModelChangedAction {
   session: URI;
   /** New model selection */
   model: ModelSelection;
+}
+
+/**
+ * Custom agent changed for this session.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface SessionAgentChangedAction {
+  type: ActionType.SessionAgentChanged;
+  /** Session URI */
+  session: URI;
+  /** New agent selection, or `undefined` to clear the selection */
+  agent: AgentSelection | undefined;
 }
 
 /**
@@ -1186,6 +1203,7 @@ export type StateAction =
   | SessionUsageAction
   | SessionReasoningAction
   | SessionModelChangedAction
+  | SessionAgentChangedAction
   | SessionServerToolsChangedAction
   | SessionActiveClientChangedAction
   | SessionActiveClientToolsChangedAction

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -6,7 +6,7 @@
  * They return a result or a JSON-RPC error.
  */
 
-import type { URI, Snapshot, SessionConfigSchema, SessionSummary, ModelSelection, Turn, TerminalClaim, SessionActiveClient, MessageAttachment } from './state.js';
+import type { URI, Snapshot, SessionConfigSchema, SessionSummary, ModelSelection, AgentSelection, Turn, TerminalClaim, SessionActiveClient, MessageAttachment } from './state.js';
 import type { ActionEnvelope, StateAction } from './actions.js';
 
 export type { ConfigPropertySchema, ConfigSchema, SessionConfigPropertySchema, SessionConfigSchema } from './state.js';
@@ -221,6 +221,8 @@ export interface CreateSessionParams {
   provider?: string;
   /** Model selection (ID and optional model-specific configuration) */
   model?: ModelSelection;
+  /** Custom agent selection (name) — selects a customization-pipeline agent for this session */
+  agent?: AgentSelection;
   /** Working directory for the session */
   workingDirectory?: URI;
   /**

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -566,6 +566,12 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
         summary: { ...state.summary, model: action.model, modifiedAt: Date.now() },
       };
 
+    case ActionType.SessionAgentChanged:
+      return {
+        ...state,
+        summary: { ...state.summary, agent: action.agent, modifiedAt: Date.now() },
+      };
+
     case ActionType.SessionIsReadChanged:
       return {
         ...state,

--- a/types/state.ts
+++ b/types/state.ts
@@ -235,6 +235,22 @@ export interface ModelSelection {
   config?: Record<string, string>;
 }
 
+/**
+ * An agent selection: the URI of the chosen agent's source `.agent.md`
+ * file (matching `INamedPluginResource.uri` / `ICustomAgent.uri` in the
+ * customization pipeline). URIs are unique by construction, so selection is
+ * unambiguous even when two plugins contribute agents with the same `name`.
+ * Selection is opaque to the protocol — providers translate the URI to their
+ * backend's representation (e.g. the Copilot SDK addresses agents by `name`,
+ * so the Copilot provider does a URI → name lookup at its SDK boundary).
+ *
+ * @category Root State
+ */
+export interface AgentSelection {
+  /** URI of the agent's source file (a stringified URI; same shape as `ModelSelection.id`). */
+  id: URI;
+}
+
 // ─── Pending Message Types ───────────────────────────────────────────────────
 
 /**
@@ -400,6 +416,8 @@ export interface SessionSummary {
   project?: ProjectInfo;
   /** Currently selected model */
   model?: ModelSelection;
+  /** Currently selected custom agent */
+  agent?: AgentSelection;
   /** The working directory URI for this session */
   workingDirectory?: URI;
   /** Files changed during this session with diff statistics */

--- a/types/test-cases/reducers/136-session-agentchanged-updates-agent.json
+++ b/types/test-cases/reducers/136-session-agentchanged-updates-agent.json
@@ -1,0 +1,40 @@
+{
+  "description": "session/agentChanged updates agent",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/agentChanged",
+      "session": "copilot:/test-session",
+      "agent": {
+        "id": "file:///agents/reviewer.agent.md"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 9999,
+      "agent": {
+        "id": "file:///agents/reviewer.agent.md"
+      }
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/137-session-agentchanged-clears-agent.json
+++ b/types/test-cases/reducers/137-session-agentchanged-clears-agent.json
@@ -1,0 +1,39 @@
+{
+  "description": "session/agentChanged with undefined clears agent",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000,
+    "agent": {
+        "id": "file:///agents/reviewer.agent.md"
+    }
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/agentChanged",
+      "session": "copilot:/test-session",
+      "agent": null
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 9999,
+      "agent": null
+    },
+    "lifecycle": "creating",
+    "turns": []
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -77,6 +77,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string
   [ActionType.SessionUsage]: '0.1.0',
   [ActionType.SessionReasoning]: '0.1.0',
   [ActionType.SessionModelChanged]: '0.1.0',
+  [ActionType.SessionAgentChanged]: '0.1.0',
   [ActionType.SessionServerToolsChanged]: '0.1.0',
   [ActionType.SessionActiveClientChanged]: '0.1.0',
   [ActionType.SessionActiveClientToolsChanged]: '0.1.0',

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -15,6 +15,7 @@ import type {
   AgentInfo,
   SessionModelInfo,
   ModelSelection,
+  AgentSelection,
   ProtectedResourceMetadata,
   StringOrMarkdown,
   SessionState,
@@ -217,6 +218,7 @@ type V1_IAgentInfo = AgentInfo;
 type V1_IProtectedResourceMetadata = ProtectedResourceMetadata;
 type V1_ISessionModelInfo = SessionModelInfo;
 type V1_IModelSelection = ModelSelection;
+type V1_IAgentSelection = AgentSelection;
 type V1_ISessionState = SessionState;
 type V1_ISessionSummary = SessionSummary;
 type V1_ISessionConfigState = SessionConfigState;
@@ -393,6 +395,8 @@ type _CheckAgentInfo = AssertCompatible<V1_IAgentInfo, AgentInfo>;
 type _CheckSessionModelInfo = AssertCompatible<V1_ISessionModelInfo, SessionModelInfo>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckModelSelection = AssertCompatible<V1_IModelSelection, ModelSelection>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckAgentSelection = AssertCompatible<V1_IAgentSelection, AgentSelection>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckSessionState = AssertCompatible<V1_ISessionState, SessionState>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
- Introduced `SessionAgentChangedAction` to handle changes in agent selection.
- Updated `StateAction` enum to include `SessionAgentChanged`.
- Added `AgentSelection` struct to represent the selected agent's URI.
- Modified session state to include agent information.
- Updated reducers to apply agent changes to the session state.
- Enhanced command and notification schemas to support agent selection.
- Added tests for agent selection changes in session state.