### PR TITLE
Add provider metadata to UsageInfo

### DIFF
--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -1908,8 +1908,7 @@ pub struct UsageInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_read_tokens: Option<i64>,
     /// Additional provider-specific metadata for this usage report.
-    /// Clients MAY look for well-known optional keys here to provide enhanced UI,
-    /// but MUST ignore keys they do not understand.
+    /// Clients MAY look for well-known optional keys here to provide enhanced UI.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<JsonObject>,
 }

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -1907,6 +1907,11 @@ pub struct UsageInfo {
     /// Tokens read from cache
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_read_tokens: Option<i64>,
+    /// Additional provider-specific metadata for this usage report.
+    /// Clients MAY look for well-known optional keys here to provide enhanced UI,
+    /// but MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -2524,17 +2524,31 @@ public struct UsageInfo: Codable, Sendable {
     public var model: String?
     /// Tokens read from cache
     public var cacheReadTokens: Int?
+    /// Additional provider-specific metadata for this usage report.
+    /// Clients MAY look for well-known optional keys here to provide enhanced UI,
+    /// but MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case inputTokens
+        case outputTokens
+        case model
+        case cacheReadTokens
+        case meta = "_meta"
+    }
 
     public init(
         inputTokens: Int? = nil,
         outputTokens: Int? = nil,
         model: String? = nil,
-        cacheReadTokens: Int? = nil
+        cacheReadTokens: Int? = nil,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
         self.model = model
         self.cacheReadTokens = cacheReadTokens
+        self.meta = meta
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -2525,8 +2525,7 @@ public struct UsageInfo: Codable, Sendable {
     /// Tokens read from cache
     public var cacheReadTokens: Int?
     /// Additional provider-specific metadata for this usage report.
-    /// Clients MAY look for well-known optional keys here to provide enhanced UI,
-    /// but MUST ignore keys they do not understand.
+    /// Clients MAY look for well-known optional keys here to provide enhanced UI.
     public var meta: [String: AnyCodable]?
 
     enum CodingKeys: String, CodingKey {

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -363,7 +363,7 @@ UsageInfo {
 }
 ```
 
-`_meta` carries provider-specific metadata for the usage report. Clients may inspect well-known optional keys to provide enhanced UI, but must ignore keys they do not understand.
+`_meta` carries provider-specific metadata for the usage report. Clients may inspect well-known optional keys to provide enhanced UI.
 
 ## Session List
 

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -359,8 +359,11 @@ UsageInfo {
   outputTokens?: number
   model?: string
   cacheReadTokens?: number
+  _meta?: Record<string, unknown>
 }
 ```
+
+`_meta` carries provider-specific metadata for the usage report. Clients may inspect well-known optional keys to provide enhanced UI, but must ignore keys they do not understand.
 
 ## Session List
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -4269,6 +4269,11 @@
         "cacheReadTokens": {
           "type": "number",
           "description": "Tokens read from cache"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
         }
       }
     },

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -4273,7 +4273,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI."
         }
       }
     },

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -3518,6 +3518,11 @@
         "cacheReadTokens": {
           "type": "number",
           "description": "Tokens read from cache"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
         }
       }
     },

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -3522,7 +3522,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI."
         }
       }
     },

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2795,6 +2795,11 @@
         "cacheReadTokens": {
           "type": "number",
           "description": "Tokens read from cache"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
         }
       }
     },

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2799,7 +2799,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI."
         }
       }
     },

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -2853,7 +2853,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI."
         }
       }
     },

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -2849,6 +2849,11 @@
         "cacheReadTokens": {
           "type": "number",
           "description": "Tokens read from cache"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
         }
       }
     },

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -2710,7 +2710,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI."
         }
       }
     },

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -2706,6 +2706,11 @@
         "cacheReadTokens": {
           "type": "number",
           "description": "Tokens read from cache"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this usage report.\nClients MAY look for well-known optional keys here to provide enhanced UI,\nbut MUST ignore keys they do not understand."
         }
       }
     },

--- a/types/state.ts
+++ b/types/state.ts
@@ -1836,6 +1836,12 @@ export interface UsageInfo {
   model?: string;
   /** Tokens read from cache */
   cacheReadTokens?: number;
+  /**
+   * Additional provider-specific metadata for this usage report.
+   * Clients MAY look for well-known optional keys here to provide enhanced UI,
+   * but MUST ignore keys they do not understand.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**

--- a/types/state.ts
+++ b/types/state.ts
@@ -1838,8 +1838,7 @@ export interface UsageInfo {
   cacheReadTokens?: number;
   /**
    * Additional provider-specific metadata for this usage report.
-   * Clients MAY look for well-known optional keys here to provide enhanced UI,
-   * but MUST ignore keys they do not understand.
+   * Clients MAY look for well-known optional keys here to provide enhanced UI.
    */
   _meta?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Add optional `UsageInfo._meta?: Record<string, unknown>` for provider-specific usage metadata
- Document that clients may inspect well-known optional metadata keys for enhanced UI
- Regenerate JSON schema plus Swift and Rust client artifacts

## Validation
- `npm run generate`
- `npm run test`
- `git diff --check`

This keeps Copilot-specific usage details inside `_meta` rather than adding provider-specific top-level fields.