### PR TITLE
docs: enable GitHub Pages base path

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,8 +4,7 @@ import { withMermaid } from 'vitepress-plugin-mermaid'
 export default withMermaid(defineConfig({
   title: 'Agent Host Protocol',
   description: 'Documentation for the Agent Host Protocol — a synchronized, multi-client state protocol for AI agent sessions',
-  // todo: reenable when GH pages is public
-  // base: '/agent-host-protocol/',
+  base: '/agent-host-protocol/',
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/agent-host-protocol/logo.svg' }],


### PR DESCRIPTION
- Re-enables the base path configuration for GitHub Pages deployment that was previously commented out as a TODO. This allows the documentation site to be properly served from the /agent-host-protocol/ path.

(Commit message generated by Copilot)