### PR TITLE
Add ping command for protocol-level liveness

### DIFF
--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -74,6 +74,11 @@
         "snapshots"
       ]
     },
+    "PingParams": {
+      "type": "object",
+      "description": "Measures end-to-end protocol responsiveness.\n\nApplication-level liveness over the AHP transport (WebSocket, SSH relay,\ntunnel relay) — not WebSocket ping frames. The server MUST respond\nregardless of whether the client has completed `initialize` or holds any\nsubscriptions. Request/response correlation is handled by the JSON-RPC\n`id` field; ping carries no payload in either direction.",
+      "properties": {}
+    },
     "ReconnectParams": {
       "type": "object",
       "description": "Re-establishes a dropped connection. The server replays missed actions or\nprovides fresh snapshots.",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -76,7 +76,7 @@
     },
     "PingParams": {
       "type": "object",
-      "description": "Measures end-to-end protocol responsiveness.\n\nApplication-level liveness over the AHP transport (WebSocket, SSH relay,\ntunnel relay) — not WebSocket ping frames. The server MUST respond\nregardless of whether the client has completed `initialize` or holds any\nsubscriptions. Request/response correlation is handled by the JSON-RPC\n`id` field; ping carries no payload in either direction.",
+      "description": "Verifies that the AHP connection is still alive and keeps it from being\nclosed by idle-timeout intermediaries (proxies, load balancers, etc.).\n\nThe server MUST respond regardless of whether the client has completed\n`initialize` or holds any subscriptions. Ping carries no payload in either\ndirection; the response itself is the signal.",
       "properties": {}
     },
     "ReconnectParams": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2928,7 +2928,7 @@
     },
     "PingParams": {
       "type": "object",
-      "description": "Measures end-to-end protocol responsiveness.\n\nApplication-level liveness over the AHP transport (WebSocket, SSH relay,\ntunnel relay) — not WebSocket ping frames. The server MUST respond\nregardless of whether the client has completed `initialize` or holds any\nsubscriptions. Request/response correlation is handled by the JSON-RPC\n`id` field; ping carries no payload in either direction.",
+      "description": "Verifies that the AHP connection is still alive and keeps it from being\nclosed by idle-timeout intermediaries (proxies, load balancers, etc.).\n\nThe server MUST respond regardless of whether the client has completed\n`initialize` or holds any subscriptions. Ping carries no payload in either\ndirection; the response itself is the signal.",
       "properties": {}
     },
     "ReconnectParams": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2926,6 +2926,11 @@
         "snapshots"
       ]
     },
+    "PingParams": {
+      "type": "object",
+      "description": "Measures end-to-end protocol responsiveness.\n\nApplication-level liveness over the AHP transport (WebSocket, SSH relay,\ntunnel relay) — not WebSocket ping frames. The server MUST respond\nregardless of whether the client has completed `initialize` or holds any\nsubscriptions. Request/response correlation is handled by the JSON-RPC\n`id` field; ping carries no payload in either direction.",
+      "properties": {}
+    },
     "ReconnectParams": {
       "type": "object",
       "description": "Re-establishes a dropped connection. The server replays missed actions or\nprovides fresh snapshots.",

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -78,6 +78,24 @@ export interface InitializeResult {
   completionTriggerCharacters?: string[];
 }
 
+// ─── ping ────────────────────────────────────────────────────────────────────
+
+/**
+ * Measures end-to-end protocol responsiveness.
+ *
+ * Application-level liveness over the AHP transport. The server MUST respond
+ * regardless of whether the client has completed `initialize` or holds any
+ * subscriptions. Ping carries no payload in either direction.
+ *
+ * @category Commands
+ * @method ping
+ * @direction Client → Server
+ * @messageType Request
+ * @version 0.1.0
+ */
+export interface PingParams {
+}
+
 // ─── reconnect ───────────────────────────────────────────────────────────────
 
 /**

--- a/types/commands.ts
+++ b/types/commands.ts
@@ -81,11 +81,12 @@ export interface InitializeResult {
 // ─── ping ────────────────────────────────────────────────────────────────────
 
 /**
- * Measures end-to-end protocol responsiveness.
+ * Verifies that the AHP connection is still alive and keeps it from being
+ * closed by idle-timeout intermediaries (proxies, load balancers, etc.).
  *
- * Application-level liveness over the AHP transport. The server MUST respond
- * regardless of whether the client has completed `initialize` or holds any
- * subscriptions. Ping carries no payload in either direction.
+ * The server MUST respond regardless of whether the client has completed
+ * `initialize` or holds any subscriptions. Ping carries no payload in either
+ * direction; the response itself is the signal.
  *
  * @category Commands
  * @method ping

--- a/types/index.ts
+++ b/types/index.ts
@@ -194,6 +194,7 @@ export {
 export type {
   InitializeParams,
   InitializeResult,
+  PingParams,
   ReconnectParams,
   ReconnectReplayResult,
   ReconnectSnapshotResult,

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -10,6 +10,7 @@
 import type {
   InitializeParams,
   InitializeResult,
+  PingParams,
   ReconnectParams,
   ReconnectResult,
   SubscribeParams,
@@ -114,6 +115,7 @@ export interface JsonRpcNotification {
  */
 export interface CommandMap {
   'initialize': { params: InitializeParams; result: InitializeResult };
+  'ping': { params: PingParams; result: null };
   'reconnect': { params: ReconnectParams; result: ReconnectResult };
   'subscribe': { params: SubscribeParams; result: SubscribeResult };
   'createSession': { params: CreateSessionParams; result: null };

--- a/types/version/message-checks.ts
+++ b/types/version/message-checks.ts
@@ -25,6 +25,7 @@ type _Exact<A, B> = [A] extends [B] ? [B] extends [A] ? true : never : never;
 /** All methods annotated `@messageType Request` in commands.ts. */
 type _ExpectedCommands =
   | 'initialize'
+  | 'ping'
   | 'reconnect'
   | 'subscribe'
   | 'createSession'


### PR DESCRIPTION
Adds a `ping` request the client can send to keep the AHP connection alive and verify it's still up.

- No payload in either direction (`PingParams = {}`, result `null`).
- Server MUST respond regardless of `initialize` state or subscriptions.
- Purpose is connection liveness — keep idle-timeout intermediaries (proxies, load balancers, etc.) from closing the connection, and let the client detect a dead transport. Not a measure of end-to-end responsiveness.

The vscode side will use this for a periodic keep-alive on remote agent host connections (replacing the previous per-request timeout). PR there to follow.

(Written by Copilot)