### PR TITLE
Add `AgentHostProtocolClient` SwiftPM product (single-host)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,16 +22,30 @@ let package = Package(
             name: "AgentHostProtocol",
             targets: ["AgentHostProtocol"]
         ),
+        .library(
+            name: "AgentHostProtocolClient",
+            targets: ["AgentHostProtocolClient"]
+        ),
     ],
     targets: [
         .target(
             name: "AgentHostProtocol",
             path: "clients/swift/AgentHostProtocol/Sources/AgentHostProtocol"
         ),
+        .target(
+            name: "AgentHostProtocolClient",
+            dependencies: ["AgentHostProtocol"],
+            path: "clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient"
+        ),
         .testTarget(
             name: "AgentHostProtocolTests",
             dependencies: ["AgentHostProtocol"],
             path: "clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests"
+        ),
+        .testTarget(
+            name: "AgentHostProtocolClientTests",
+            dependencies: ["AgentHostProtocolClient"],
+            path: "clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests"
         ),
     ]
 )

--- a/clients/swift/AgentHostProtocol/README.md
+++ b/clients/swift/AgentHostProtocol/README.md
@@ -1,0 +1,150 @@
+# AgentHostProtocol Swift Package
+
+This package contains the Swift libraries for the Agent Host Protocol (AHP). The package manifest lives at the repository root because Swift Package Manager resolves remote packages from the root `Package.swift`, while the Swift sources live under `clients/swift/AgentHostProtocol/`.
+
+## Products
+
+- `AgentHostProtocol` provides generated protocol types, commands, notifications, actions, and reducers. Use this product when you only need to decode protocol data or apply state reducers yourself.
+- `AgentHostProtocolClient` provides a reusable single-host client on top of `AgentHostProtocol`. It owns JSON-RPC request correlation, subscription fan-out, transport integration, and typed helpers for `initialize`, `reconnect`, `subscribe`, `unsubscribe`, `dispatch`, and arbitrary requests.
+
+The client product is intentionally a protocol/client layer, not a full app store. App-specific policy such as server selection, authentication, retry timing, reconnect UX, session summary caches, and optimistic outbound action replay should live in the app or in a higher-level supervisor.
+
+## Installation
+
+Add this repository as a SwiftPM dependency:
+
+```swift
+.package(url: "https://github.com/microsoft/agent-host-protocol.git", from: "0.1.0")
+```
+
+Then depend on one or both products:
+
+```swift
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "AgentHostProtocol", package: "agent-host-protocol"),
+        .product(name: "AgentHostProtocolClient", package: "agent-host-protocol"),
+    ]
+)
+```
+
+## Minimal Single-Host Client
+
+This example opens one WebSocket connection, subscribes to the root resource during `initialize`, applies the returned snapshots, and then applies subsequent action events.
+
+```swift
+import AgentHostProtocol
+import AgentHostProtocolClient
+import Foundation
+
+let transport = URLSessionWebSocketTransport(url: URL(string: "wss://example.com/ahp")!)
+let client = AHPClient(transport: transport)
+let mirror = AHPStateMirror()
+
+// Attach event streams before connecting so notifications delivered during the
+// initialize window are not missed.
+let events = await client.events
+
+Task {
+    for await event in events {
+        switch event.event {
+        case .action(let envelope):
+            await mirror.apply(envelope)
+        case .notification(let notification):
+            // Protocol notifications are ephemeral and are not replayed on
+            // reconnect. Apps commonly refresh listSessions() after reconnect.
+            print("notification: \(notification)")
+        }
+    }
+}
+
+try await client.connect()
+
+let initialized = try await client.initialize(
+    clientId: "my-client-id",
+    protocolVersions: ["0.1.0"],
+    initialSubscriptions: [RootResourceURI]
+)
+
+for snapshot in initialized.snapshots {
+    await mirror.applySnapshot(snapshot)
+}
+```
+
+`AHPStateMirror` is a convenience for simple consumers. Larger apps can keep their own state store and route snapshots/actions through the generated reducers directly.
+
+## Reconnect Layering
+
+`AHPClient.reconnect(...)` sends the typed AHP `reconnect` request on an already-open transport. It does not decide when to reconnect, how often to retry, whether to fall back to `initialize`, whether authentication errors are terminal, or how to update UI while reconnecting.
+
+A typical app-level reconnect flow is:
+
+1. Open a fresh transport and `AHPClient`.
+2. Attach event streams before the handshake.
+3. Call `connect()`.
+4. Call `reconnect(clientId:lastSeenServerSeq:subscriptions:)`.
+5. Apply the returned replay actions or snapshots to the app store.
+6. Re-fetch `listSessions` or other ephemeral data because protocol notifications are not replayed.
+7. Resume any app-owned pending outbound actions that were not acknowledged.
+
+The future multi-host layer may own this supervisor policy per host, but the single-host client keeps it explicit.
+
+## Dispatch And App-Owned Outboxes
+
+`dispatchAction` is a fire-and-forget notification. The server acknowledgement comes later when a live or replayed `ActionEnvelope` includes the same `origin.clientId` and `origin.clientSeq`.
+
+`AHPClient.dispatch(_:)` is a convenience for simple clients; it assigns `clientSeq` internally and returns a `DispatchHandle` with the sequence that was sent.
+
+Apps that need to replay unacknowledged local actions after reconnect should own their outbound queue and send explicit `clientSeq` values:
+
+```swift
+struct PendingOutboundAction {
+    let clientSeq: Int
+    let action: StateAction
+}
+
+var nextClientSeq = 1
+var pendingOutboundActions: [PendingOutboundAction] = []
+
+func dispatchFromApp(_ action: StateAction, client: AHPClient) async throws {
+    let seq = nextClientSeq
+    nextClientSeq += 1
+    pendingOutboundActions.append(PendingOutboundAction(clientSeq: seq, action: action))
+
+    try await client.dispatch(action, clientSeq: seq)
+}
+
+func acknowledge(_ envelope: ActionEnvelope, clientId: String) {
+    guard let origin = envelope.origin,
+          origin.clientId == clientId,
+          pendingOutboundActions.first?.clientSeq == origin.clientSeq else { return }
+    pendingOutboundActions.removeFirst()
+}
+```
+
+This stays outside the low-level client because replay policy is app-specific. A chat message, terminal resize, terminal input, and transient UI toggle may all have different replay/coalescing behavior.
+
+## Subscription Ownership
+
+`subscribe(uri)` returns the server snapshot plus a stream of subsequent events for that resource URI.
+
+`unsubscribe(uri)` is resource-wide: it sends `unsubscribe` to the server and finishes all local streams for that URI. It is not a per-view cancellation handle and it does not maintain listener reference counts.
+
+Apps should normally centralize protocol subscriptions in one owner, such as an app store or host supervisor, and let views observe state from that owner. A future higher-level API can add refcounted subscription handles if multiple independent components need to subscribe to the same URI directly.
+
+## Transport Choice
+
+`AHPTransport` is the transport abstraction. The default `URLSessionWebSocketTransport` is suitable for many `wss://` deployments and simple clients.
+
+For iOS/macOS local development, LAN, and Tailscale-style `ws://` targets, a native `NWConnection` transport can be a better fit because it avoids `URLSession` ATS behavior and can expose explicit WebSocket handshake and ping behavior. The example iOS app currently uses a native transport for this reason. A reusable native transport is a good follow-up for this package.
+
+Prefer inbound `.text` or `.binary` frames from transports. Inbound `.parsed` frames may bypass the client's raw JSON parsing path that preserves Apple `NSNumber` Bool/Int distinctions.
+
+## Next Steps For This Client
+
+- Add or promote a reusable native `NWConnection` WebSocket transport.
+- Add optional keepalive/liveness configuration for transports that support ping.
+- Add tests and docs for app-owned dispatch outboxes and explicit `clientSeq` replay.
+- Add protocol transcript fixtures, similar in spirit to the reducer fixture tests, to validate client/server flows across languages.
+- Migrate the example iOS app through an adapter around `AHPClient` while keeping app policy in `AppStore`.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
@@ -349,11 +349,26 @@ public actor AHPClient {
     public func dispatch(_ action: StateAction) async throws -> DispatchHandle {
         let seq = nextClientSeq
         nextClientSeq += 1
+        return try await dispatch(action, clientSeq: seq)
+    }
+
+    /// Fire a write-ahead `dispatchAction` notification with a caller-owned
+    /// `clientSeq`.
+    ///
+    /// Use this overload when a higher layer owns an outbound action queue and
+    /// needs to replay unacknowledged actions across reconnects with stable
+    /// sequence numbers. The convenience `dispatch(_:)` overload remains
+    /// suitable for simple fire-and-forget clients.
+    @discardableResult
+    public func dispatch(_ action: StateAction, clientSeq: Int) async throws -> DispatchHandle {
+        if clientSeq >= nextClientSeq {
+            nextClientSeq = clientSeq + 1
+        }
         try await notify(
             method: "dispatchAction",
-            params: DispatchActionParams(clientSeq: seq, action: action)
+            params: DispatchActionParams(clientSeq: clientSeq, action: action)
         )
-        return DispatchHandle(clientSeq: seq)
+        return DispatchHandle(clientSeq: clientSeq)
     }
 
     // MARK: - Generic request

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
@@ -495,8 +495,12 @@ public actor AHPClient {
             case .binary(let d):
                 data = d
             case .parsed(let parsed):
-                // Slow path: re-serialize and re-parse so the rest of the
-                // pipeline only deals with raw bytes.
+                // Slow path: re-serialize via Codable so the rest of the
+                // pipeline only deals with raw bytes. Note that any
+                // `AnyCodable`-wrapped payload inside `parsed` may already
+                // have been corrupted by an earlier `JSONDecoder` pass —
+                // see `TransportMessage` docs and microsoft/agent-host-protocol#123.
+                // Transports SHOULD prefer `.text`/`.binary` for inbound frames.
                 guard let d = try? encoder.encode(parsed) else {
                     #if DEBUG
                     print("[AHPClient] dropped unencodable parsed frame")
@@ -550,9 +554,15 @@ public actor AHPClient {
             guard let resultAny = object["result"] else {
                 return nil
             }
-            let resultData = (try? JSONSerialization.data(
+            // If we can't re-serialize the value we just parsed (e.g. an
+            // exotic NSObject snuck in), drop the whole frame rather than
+            // silently coercing the result to JSON `null`. A `null` would
+            // resolve the pending request with a value the peer never sent.
+            guard let resultData = try? JSONSerialization.data(
                 withJSONObject: resultAny, options: [.fragmentsAllowed]
-            )) ?? Data("null".utf8)
+            ) else {
+                return nil
+            }
             return .successResponse(id: id, result: resultData)
         }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
@@ -1,0 +1,823 @@
+// AHPClient — single-host JSON-RPC client over a pluggable `AHPTransport`.
+//
+// Owns request/response correlation, per-URI subscription fan-out, a top-level
+// `events` multicast tap, and connection-state notifications. Modelled after
+// the Rust `ahp::Client` but structured around Swift actors and AsyncStreams.
+
+import Foundation
+import AgentHostProtocol
+
+/// Async JSON-RPC client driving a pluggable `AHPTransport`.
+///
+/// Lifecycle:
+///
+/// ```swift
+/// let transport = URLSessionWebSocketTransport(url: url)
+/// let client = AHPClient(transport: transport)
+///
+/// // Attach taps BEFORE `connect()` so handshake notifications aren't missed.
+/// let events = await client.events
+/// let states = await client.stateChanges
+///
+/// try await client.connect()
+/// let init = try await client.initialize(
+///     clientId: "my-client",
+///     protocolVersions: ["0.1.0"],
+///     initialSubscriptions: [RootResourceURI]
+/// )
+/// // ... use client ...
+/// await client.shutdown()
+/// ```
+///
+/// `AHPClient` is a *single-shot* connection — reopening a dropped transport
+/// and replaying subscriptions belongs to a higher layer. `reconnect(...)` is
+/// only the typed JSON-RPC handshake on the current transport.
+public actor AHPClient {
+
+    // MARK: - Stored state
+
+    private let transport: AHPTransport
+    private let config: AHPClientConfig
+
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        // Server is JSON-typed; default settings are correct.
+        return e
+    }()
+    private let decoder: JSONDecoder = JSONDecoder()
+
+    // ── Sequence numbers ─────────────────────────────────────────────────
+    private var nextRequestId: Int = 1
+    private var nextClientSeq: Int = 1
+
+    // ── Pending request continuations ────────────────────────────────────
+    /// In-flight JSON-RPC requests keyed by id. Resolves with the raw `result`
+    /// AnyCodable on success or fails with `AHPClientError` on error/timeout/
+    /// shutdown.
+    private var pending: [Int: PendingEntry] = [:]
+
+    // ── Subscription registry ────────────────────────────────────────────
+    /// Per-URI listeners. Each entry holds one or more `AsyncStream` continuations
+    /// for `attachSubscription`/`subscribe` callers. Streams are unbounded —
+    /// dropping action envelopes desyncs the consumer's reducer mirror.
+    private var perUriListeners: [String: [SubscriptionListener]] = [:]
+
+    // ── Top-level multicast taps ─────────────────────────────────────────
+    /// Multicast listeners for `events` (top-level fan-out tagged with resource).
+    private var eventListeners: [EventListener] = []
+    /// Multicast listeners for `stateChanges`.
+    private var stateListeners: [StateListener] = []
+
+    // ── Outbound writer ──────────────────────────────────────────────────
+    /// Outbound channel carries raw JSON bytes. Going via JSONSerialization
+    /// preserves the NSNumber Bool/Int distinction that AnyCodable would
+    /// otherwise erase on Apple platforms.
+    private var outboundContinuation: AsyncStream<Data>.Continuation?
+    private var writerTask: Task<Void, Never>?
+
+    // ── Receive loop ─────────────────────────────────────────────────────
+    private var receiveTask: Task<Void, Never>?
+
+    // ── State ────────────────────────────────────────────────────────────
+    public private(set) var connectionState: ConnectionState = .disconnected
+    public private(set) var lastSeenServerSeq: Int = 0
+    private var didShutdown: Bool = false
+
+    // MARK: - Init
+
+    public init(transport: AHPTransport, config: AHPClientConfig = .default) {
+        self.transport = transport
+        self.config = config
+    }
+
+    // MARK: - Lifecycle
+
+    /// Start the receive and writer loops over the transport.
+    ///
+    /// The transport is treated as already-open; connect failures (TLS,
+    /// handshake) are the transport's concern. After `connect()` returns,
+    /// `connectionState == .connected` and the next call should typically be
+    /// `initialize(...)` (or `reconnect(...)`).
+    ///
+    /// You should attach `events` and `stateChanges` taps *before* calling
+    /// `connect()` if you need to observe handshake-time notifications.
+    public func connect() async throws {
+        if didShutdown {
+            throw AHPClientError.shutdown
+        }
+        if connectionState == .connected {
+            return
+        }
+        await transition(to: .connecting)
+
+        // Set up the writer pipeline. Sends are pushed onto `outboundContinuation`
+        // from inside the actor and the writer Task drains and serializes them
+        // to `transport.send`. This avoids two `await transport.send` calls
+        // racing under actor reentrancy.
+        var cont: AsyncStream<Data>.Continuation!
+        let outbound = AsyncStream<Data>(bufferingPolicy: .unbounded) { c in
+            cont = c
+        }
+        self.outboundContinuation = cont
+        let transport = self.transport
+        self.writerTask = Task { [weak self] in
+            for await data in outbound {
+                guard let text = String(data: data, encoding: .utf8) else {
+                    await self?.handleTransportFailure(
+                        TransportError.protocol("outbound bytes are not valid UTF-8")
+                    )
+                    return
+                }
+                do {
+                    try await transport.send(.text(text))
+                } catch {
+                    await self?.handleTransportFailure(error)
+                    return
+                }
+            }
+        }
+
+        // Start the receive loop.
+        self.receiveTask = Task { [weak self] in
+            await self?.runReceiveLoop()
+        }
+
+        await transition(to: .connected)
+    }
+
+    /// Shut the client down: cancel loops, close the transport, fail pending
+    /// requests with `AHPClientError.shutdown`, and finish all subscription
+    /// streams.
+    public func shutdown() async {
+        if didShutdown { return }
+        didShutdown = true
+
+        // Stop the writer (no more sends). Order matters: finishing the
+        // outbound stream lets the writer loop exit naturally; cancelling the
+        // receive task aborts the inbound loop.
+        outboundContinuation?.finish()
+        outboundContinuation = nil
+        writerTask?.cancel()
+        writerTask = nil
+
+        receiveTask?.cancel()
+        receiveTask = nil
+
+        try? await transport.close()
+
+        failAllPending(with: .shutdown)
+        finishAllSubscriptions()
+        finishAllEventListeners()
+        // Final state transition (also fans out).
+        await transition(to: .disconnected)
+        finishAllStateListeners()
+    }
+
+    // MARK: - Multicast taps
+
+    /// A multicast stream of every event delivered to any subscription on
+    /// this client, tagged with the resource URI (if known).
+    ///
+    /// Each call returns a *fresh* stream. To capture handshake notifications,
+    /// call this property *before* `connect()` and `initialize(...)` so the
+    /// receive loop has a continuation to deliver into.
+    ///
+    /// The stream uses `.bufferingNewest(config.subscriptionBufferSize)`; slow
+    /// consumers will lose advisory events. For a delivery-guaranteed stream
+    /// of action envelopes, use `subscribe(uri)` instead.
+    public var events: AsyncStream<ClientEvent> {
+        let bufferSize = config.subscriptionBufferSize
+        let listenerId = nextListenerId()
+        return AsyncStream<ClientEvent>(bufferingPolicy: .bufferingNewest(bufferSize)) { cont in
+            let listener = EventListener(id: listenerId, continuation: cont)
+            self.eventListeners.append(listener)
+            cont.onTermination = { [weak self] _ in
+                Task { [weak self] in
+                    await self?.removeEventListener(id: listenerId)
+                }
+            }
+        }
+    }
+
+    /// A multicast stream of `ConnectionState` transitions.
+    ///
+    /// Each call returns a *fresh* stream. The current value is available
+    /// synchronously via `connectionState`; this stream only delivers
+    /// *future* changes after attachment.
+    public var stateChanges: AsyncStream<ConnectionState> {
+        let bufferSize = max(8, config.subscriptionBufferSize)
+        let listenerId = nextListenerId()
+        return AsyncStream<ConnectionState>(bufferingPolicy: .bufferingNewest(bufferSize)) { cont in
+            let listener = StateListener(id: listenerId, continuation: cont)
+            self.stateListeners.append(listener)
+            cont.onTermination = { [weak self] _ in
+                Task { [weak self] in
+                    await self?.removeStateListener(id: listenerId)
+                }
+            }
+        }
+    }
+
+    // MARK: - Protocol commands
+
+    /// Issue the `initialize` handshake.
+    @discardableResult
+    public func initialize(
+        clientId: String,
+        protocolVersions: [String],
+        initialSubscriptions: [String] = []
+    ) async throws -> InitializeResult {
+        let params = InitializeParams(
+            protocolVersions: protocolVersions,
+            clientId: clientId,
+            initialSubscriptions: initialSubscriptions.isEmpty ? nil : initialSubscriptions
+        )
+        let result: InitializeResult = try await request(method: "initialize", params: params)
+        if result.serverSeq > lastSeenServerSeq {
+            lastSeenServerSeq = result.serverSeq
+        }
+        return result
+    }
+
+    /// Re-establish identity on a fresh transport with `reconnect`.
+    ///
+    /// This is *only* the typed handshake on the current connection — opening a
+    /// new transport, backoff, and generation tracking belong to a higher
+    /// layer.
+    @discardableResult
+    public func reconnect(
+        clientId: String,
+        lastSeenServerSeq: Int,
+        subscriptions: [String]
+    ) async throws -> ReconnectResult {
+        let params = ReconnectParams(
+            clientId: clientId,
+            lastSeenServerSeq: lastSeenServerSeq,
+            subscriptions: subscriptions
+        )
+        let result: ReconnectResult = try await request(method: "reconnect", params: params)
+        switch result {
+        case .replay(let r):
+            if let last = r.actions.last, last.serverSeq > self.lastSeenServerSeq {
+                self.lastSeenServerSeq = last.serverSeq
+            }
+        case .snapshot(let r):
+            let maxSeq = r.snapshots.map(\.fromSeq).max() ?? self.lastSeenServerSeq
+            if maxSeq > self.lastSeenServerSeq {
+                self.lastSeenServerSeq = maxSeq
+            }
+        }
+        return result
+    }
+
+    /// Subscribe to a resource URI. Returns the snapshot the server provides
+    /// and a fresh stream of subsequent events.
+    ///
+    /// If the request fails (RPC error, timeout, transport drop), the local
+    /// listener is removed and its stream finished — callers don't need to
+    /// clean up the partially-attached subscription.
+    public func subscribe(_ uri: String) async throws -> (SubscribeResult, AsyncStream<SubscriptionEvent>) {
+        let (stream, listenerId) = attachSubscriptionInternal(uri)
+        do {
+            let result: SubscribeResult = try await request(
+                method: "subscribe",
+                params: SubscribeParams(resource: uri)
+            )
+            return (result, stream)
+        } catch {
+            removeAndFinishSubscriptionListener(uri: uri, id: listenerId)
+            throw error
+        }
+    }
+
+    /// Attach a subscription stream for `uri` *without* sending a `subscribe`
+    /// request. Useful when the URI was included in
+    /// `initialize(initialSubscriptions:)`.
+    public func attachSubscription(_ uri: String) -> AsyncStream<SubscriptionEvent> {
+        let (stream, _) = attachSubscriptionInternal(uri)
+        return stream
+    }
+
+    /// Internal variant exposing the listener id so callers can detach the
+    /// listener if a follow-up wire request fails.
+    private func attachSubscriptionInternal(
+        _ uri: String
+    ) -> (AsyncStream<SubscriptionEvent>, UInt64) {
+        let listenerId = nextListenerId()
+        let stream = AsyncStream<SubscriptionEvent>(bufferingPolicy: .unbounded) { cont in
+            let listener = SubscriptionListener(id: listenerId, continuation: cont)
+            var listeners = self.perUriListeners[uri, default: []]
+            listeners.append(listener)
+            self.perUriListeners[uri] = listeners
+            cont.onTermination = { [weak self] _ in
+                Task { [weak self] in
+                    await self?.removeSubscriptionListener(uri: uri, id: listenerId)
+                }
+            }
+        }
+        return (stream, listenerId)
+    }
+
+    /// Synchronously remove a subscription listener and finish its stream.
+    /// Used by `subscribe()` to roll back a failed attachment.
+    private func removeAndFinishSubscriptionListener(uri: String, id: UInt64) {
+        guard var listeners = perUriListeners[uri] else { return }
+        if let idx = listeners.firstIndex(where: { $0.id == id }) {
+            let listener = listeners.remove(at: idx)
+            listener.continuation.finish()
+            if listeners.isEmpty {
+                perUriListeners.removeValue(forKey: uri)
+            } else {
+                perUriListeners[uri] = listeners
+            }
+        }
+    }
+
+    /// Send `unsubscribe` to the server and finish *all* per-URI streams for
+    /// this URI. This is the nuclear option — there is no per-listener
+    /// detach. Higher-layer reference counting belongs in a multi-host
+    /// runtime.
+    public func unsubscribe(_ uri: String) async throws {
+        let listeners = perUriListeners.removeValue(forKey: uri) ?? []
+        for l in listeners { l.continuation.finish() }
+        try await notify(method: "unsubscribe", params: UnsubscribeParams(resource: uri))
+    }
+
+    /// Fire a write-ahead `dispatchAction` notification. Returns a handle
+    /// carrying the assigned `clientSeq`.
+    @discardableResult
+    public func dispatch(_ action: StateAction) async throws -> DispatchHandle {
+        let seq = nextClientSeq
+        nextClientSeq += 1
+        try await notify(
+            method: "dispatchAction",
+            params: DispatchActionParams(clientSeq: seq, action: action)
+        )
+        return DispatchHandle(clientSeq: seq)
+    }
+
+    // MARK: - Generic request
+
+    /// Send a JSON-RPC request and await its decoded result.
+    public func request<P: Encodable & Sendable, R: Decodable & Sendable>(
+        method: String,
+        params: P
+    ) async throws -> R {
+        if didShutdown { throw AHPClientError.shutdown }
+        guard let cont = outboundContinuation else {
+            throw AHPClientError.shutdown
+        }
+
+        // Order matters: register the pending entry BEFORE pushing the
+        // outbound message, so an immediate response (which a fast in-memory
+        // transport could deliver before this method returns) finds the
+        // continuation in the map.
+        let id = nextRequestId
+        nextRequestId += 1
+
+        let resultData: Data = try await withCheckedThrowingContinuation { continuation in
+            let entry = PendingEntry(continuation: continuation)
+            pending[id] = entry
+
+            let wireData: Data
+            do {
+                wireData = try buildRequestWire(id: id, method: method, params: params)
+            } catch {
+                pending.removeValue(forKey: id)
+                continuation.resume(throwing: AHPClientError.decoding(
+                    "failed to encode params for \(method): \(error)"
+                ))
+                return
+            }
+            cont.yield(wireData)
+
+            // Schedule a timeout. The timeout task races against the response;
+            // whichever resolves first wins. The task is tracked on the entry
+            // so a successful response can cancel the sleep instead of letting
+            // it accumulate at high request rates.
+            let timeoutDuration = config.requestTimeout
+            entry.timeoutTask = Task { [weak self] in
+                try? await Task.sleep(for: timeoutDuration)
+                if Task.isCancelled { return }
+                await self?.timeoutPending(id: id)
+            }
+        }
+
+        do {
+            return try decoder.decode(R.self, from: resultData)
+        } catch {
+            throw AHPClientError.decoding(
+                "failed to decode result for \(method): \(error)"
+            )
+        }
+    }
+
+    /// Send a JSON-RPC notification (fire-and-forget).
+    public func notify<P: Encodable & Sendable>(method: String, params: P) async throws {
+        if didShutdown { throw AHPClientError.shutdown }
+        guard let cont = outboundContinuation else {
+            throw AHPClientError.shutdown
+        }
+        let wireData: Data
+        do {
+            wireData = try buildNotificationWire(method: method, params: params)
+        } catch {
+            throw AHPClientError.decoding("failed to encode params for \(method): \(error)")
+        }
+        cont.yield(wireData)
+    }
+
+    // MARK: - Private: wire-building
+
+    /// Build a JSON-RPC request frame as raw JSON bytes. Going through
+    /// JSONSerialization for the assembly preserves the NSNumber Bool/Int
+    /// distinction that AnyCodable would otherwise erase.
+    private func buildRequestWire<P: Encodable>(
+        id: Int, method: String, params: P
+    ) throws -> Data {
+        let paramsData = try encoder.encode(params)
+        let paramsAny = try JSONSerialization.jsonObject(
+            with: paramsData, options: [.fragmentsAllowed]
+        )
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": paramsAny,
+        ]
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private func buildNotificationWire<P: Encodable>(
+        method: String, params: P
+    ) throws -> Data {
+        let paramsData = try encoder.encode(params)
+        let paramsAny = try JSONSerialization.jsonObject(
+            with: paramsData, options: [.fragmentsAllowed]
+        )
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": paramsAny,
+        ]
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+
+    // MARK: - Private: receive loop
+
+    private func runReceiveLoop() async {
+        while !Task.isCancelled {
+            let msg: TransportMessage?
+            do {
+                msg = try await transport.recv()
+            } catch {
+                await handleTransportFailure(error)
+                return
+            }
+            guard let msg else {
+                // Clean close.
+                await handleTransportFailure(nil)
+                return
+            }
+            // Convert to raw bytes once. Going through JSONSerialization (vs
+            // JSONDecoder + AnyCodable) preserves the Bool/Int distinction
+            // that NSNumber bridging in JSONDecoder otherwise erases.
+            let data: Data
+            switch msg {
+            case .text(let s):
+                guard let d = s.data(using: .utf8) else {
+                    #if DEBUG
+                    print("[AHPClient] dropped malformed text frame")
+                    #endif
+                    continue
+                }
+                data = d
+            case .binary(let d):
+                data = d
+            case .parsed(let parsed):
+                // Slow path: re-serialize and re-parse so the rest of the
+                // pipeline only deals with raw bytes.
+                guard let d = try? encoder.encode(parsed) else {
+                    #if DEBUG
+                    print("[AHPClient] dropped unencodable parsed frame")
+                    #endif
+                    continue
+                }
+                data = d
+            }
+            guard let frame = parseRawFrame(from: data) else {
+                #if DEBUG
+                print("[AHPClient] dropped malformed frame")
+                #endif
+                continue
+            }
+            await dispatchInbound(frame)
+        }
+    }
+
+    /// Internal frame representation that keeps payload sub-trees as raw JSON
+    /// bytes. We can then `JSONDecoder.decode` typed values straight from
+    /// those bytes — avoiding the round-trip through `AnyCodable`, which on
+    /// Apple platforms erases the Bool/Int distinction due to NSNumber
+    /// bridging.
+    private enum RawFrame {
+        case request(id: Int, method: String, params: Data?)
+        case successResponse(id: Int, result: Data)
+        case errorResponse(id: Int, error: JsonRpcError)
+        case notification(method: String, params: Data?)
+    }
+
+    private func parseRawFrame(from data: Data) -> RawFrame? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let id = object["id"] as? Int
+        let method = object["method"] as? String
+
+        if let id, method == nil {
+            if let errorAny = object["error"] {
+                guard let errData = try? JSONSerialization.data(
+                    withJSONObject: errorAny, options: [.fragmentsAllowed]
+                ),
+                      let err = try? decoder.decode(JsonRpcError.self, from: errData)
+                else { return nil }
+                return .errorResponse(id: id, error: err)
+            }
+            // A response MUST carry either `result` (possibly null) or `error`.
+            // A frame with neither is malformed; drop it. Note: a missing key
+            // and an explicit `null` result are different — the latter shows
+            // up as `NSNull` in the dict.
+            guard let resultAny = object["result"] else {
+                return nil
+            }
+            let resultData = (try? JSONSerialization.data(
+                withJSONObject: resultAny, options: [.fragmentsAllowed]
+            )) ?? Data("null".utf8)
+            return .successResponse(id: id, result: resultData)
+        }
+
+        if let method {
+            let paramsData: Data? = object["params"].flatMap { paramsAny in
+                try? JSONSerialization.data(
+                    withJSONObject: paramsAny, options: [.fragmentsAllowed]
+                )
+            }
+            if let id {
+                return .request(id: id, method: method, params: paramsData)
+            }
+            return .notification(method: method, params: paramsData)
+        }
+
+        return nil
+    }
+
+    private func dispatchInbound(_ frame: RawFrame) async {
+        switch frame {
+        case .successResponse(let id, let resultData):
+            if let entry = pending.removeValue(forKey: id) {
+                entry.timeoutTask?.cancel()
+                entry.continuation.resume(returning: resultData)
+            }
+        case .errorResponse(let id, let error):
+            if let entry = pending.removeValue(forKey: id) {
+                entry.timeoutTask?.cancel()
+                entry.continuation.resume(throwing: AHPClientError.rpc(
+                    code: error.code, message: error.message, data: error.data
+                ))
+            }
+        case .notification(let method, let params):
+            await handleNotification(method: method, paramsData: params)
+        case .request(let id, _, _):
+            // We don't yet implement server-initiated requests. Reply with
+            // a JSON-RPC `method not found` so the peer's pending map doesn't
+            // grow unbounded for buggy implementations.
+            await sendMethodNotFound(forId: id)
+        }
+    }
+
+    private func handleNotification(method: String, paramsData: Data?) async {
+        switch method {
+        case "action":
+            await handleActionNotification(paramsData: paramsData)
+        case "notification":
+            await handleProtocolNotification(paramsData: paramsData)
+        default:
+            #if DEBUG
+            print("[AHPClient] unhandled notification: \(method)")
+            #endif
+        }
+    }
+
+    private func handleActionNotification(paramsData: Data?) async {
+        guard let paramsData else { return }
+        let envelope: ActionEnvelope
+        do {
+            envelope = try decoder.decode(ActionEnvelope.self, from: paramsData)
+        } catch {
+            #if DEBUG
+            print("[AHPClient] failed to decode action envelope: \(error)")
+            #endif
+            return
+        }
+        if envelope.serverSeq > lastSeenServerSeq {
+            lastSeenServerSeq = envelope.serverSeq
+        }
+        let resource = actionResource(for: envelope.action)
+        let event = SubscriptionEvent.action(envelope)
+        if let resource, let listeners = perUriListeners[resource] {
+            for l in listeners { l.continuation.yield(event) }
+        }
+        broadcast(ClientEvent(resource: resource, event: event))
+    }
+
+    private func handleProtocolNotification(paramsData: Data?) async {
+        guard let paramsData else { return }
+        let wrapped: NotificationMethodParams
+        do {
+            wrapped = try decoder.decode(NotificationMethodParams.self, from: paramsData)
+        } catch {
+            #if DEBUG
+            print("[AHPClient] failed to decode protocol notification: \(error)")
+            #endif
+            return
+        }
+        let event = SubscriptionEvent.notification(wrapped.notification)
+        // Protocol notifications are cross-resource; fan to every subscription
+        // and to the top-level events tap (with no resource tag).
+        for listeners in perUriListeners.values {
+            for l in listeners { l.continuation.yield(event) }
+        }
+        broadcast(ClientEvent(resource: nil, event: event))
+    }
+
+    // MARK: - Private: failure / cleanup
+
+    /// Invoked when the receive loop terminates (clean close: `error == nil`,
+    /// abnormal: `error != nil`) or the writer hits a send failure.
+    private func handleTransportFailure(_ error: Error?) async {
+        if didShutdown { return }
+        let clientError: AHPClientError
+        if let transportError = error as? TransportError {
+            clientError = .transport(transportError)
+        } else if let error {
+            clientError = .transport(.io("\(error)"))
+        } else {
+            clientError = .shutdown
+        }
+
+        outboundContinuation?.finish()
+        outboundContinuation = nil
+        writerTask?.cancel()
+        writerTask = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        try? await transport.close()
+
+        failAllPending(with: clientError)
+        finishAllSubscriptions()
+        // Top-level taps stay alive after a transport drop so consumers can
+        // observe later state transitions (in this single-shot client, only
+        // `.disconnected` will follow).
+        await transition(to: .disconnected)
+    }
+
+    private func failAllPending(with error: AHPClientError) {
+        let entries = pending
+        pending.removeAll()
+        for (_, entry) in entries {
+            entry.timeoutTask?.cancel()
+            entry.continuation.resume(throwing: error)
+        }
+    }
+
+    private func timeoutPending(id: Int) {
+        if let entry = pending.removeValue(forKey: id) {
+            entry.timeoutTask = nil
+            entry.continuation.resume(throwing: AHPClientError.requestTimeout)
+        }
+    }
+
+    /// Send a JSON-RPC error response back to the peer. Used for unsolicited
+    /// server-initiated requests so the peer's pending map doesn't grow
+    /// unbounded.
+    private func sendMethodNotFound(forId id: Int) async {
+        guard let cont = outboundContinuation else { return }
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": [
+                "code": -32601,
+                "message": "method not found",
+            ] as [String: Any],
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: dict) else { return }
+        cont.yield(data)
+    }
+
+    private func finishAllSubscriptions() {
+        let listeners = perUriListeners
+        perUriListeners.removeAll()
+        for (_, ls) in listeners {
+            for l in ls { l.continuation.finish() }
+        }
+    }
+
+    private func finishAllEventListeners() {
+        for l in eventListeners { l.continuation.finish() }
+        eventListeners.removeAll()
+    }
+
+    private func finishAllStateListeners() {
+        for l in stateListeners { l.continuation.finish() }
+        stateListeners.removeAll()
+    }
+
+    private func broadcast(_ event: ClientEvent) {
+        for l in eventListeners { l.continuation.yield(event) }
+    }
+
+    private func transition(to newState: ConnectionState) async {
+        connectionState = newState
+        for l in stateListeners { l.continuation.yield(newState) }
+    }
+
+    // MARK: - Private: listener bookkeeping
+
+    private var nextListenerSeq: UInt64 = 1
+    private func nextListenerId() -> UInt64 {
+        let id = nextListenerSeq
+        nextListenerSeq += 1
+        return id
+    }
+
+    private func removeEventListener(id: UInt64) {
+        eventListeners.removeAll { $0.id == id }
+    }
+
+    private func removeStateListener(id: UInt64) {
+        stateListeners.removeAll { $0.id == id }
+    }
+
+    private func removeSubscriptionListener(uri: String, id: UInt64) {
+        guard var listeners = perUriListeners[uri] else { return }
+        listeners.removeAll { $0.id == id }
+        if listeners.isEmpty {
+            perUriListeners.removeValue(forKey: uri)
+        } else {
+            perUriListeners[uri] = listeners
+        }
+    }
+
+    // MARK: - Private: helpers
+
+    /// Determine the resource URI an action is scoped to, mirroring the Rust
+    /// fallback: serialize the payload, look up `session` then `terminal`,
+    /// fall back to `RootResourceURI`.
+    private func actionResource(for action: StateAction) -> String? {
+        guard let data = try? encoder.encode(action),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return RootResourceURI
+        }
+        if let session = object["session"] as? String { return session }
+        if let terminal = object["terminal"] as? String { return terminal }
+        return RootResourceURI
+    }
+    // MARK: - Internal test hooks
+
+    /// Internal accessor used by tests to confirm listener cleanup. Counts
+    /// the number of per-URI subscription listeners attached for `uri`.
+    internal func _listenerCount(forUri uri: String) -> Int {
+        return perUriListeners[uri]?.count ?? 0
+    }
+
+    /// Internal accessor used by tests. Counts the in-flight pending
+    /// requests.
+    internal func _pendingCount() -> Int {
+        return pending.count
+    }
+}
+
+private final class PendingEntry: @unchecked Sendable {
+    let continuation: CheckedContinuation<Data, Error>
+    var timeoutTask: Task<Void, Never>?
+
+    init(continuation: CheckedContinuation<Data, Error>) {
+        self.continuation = continuation
+    }
+}
+
+private struct SubscriptionListener {
+    let id: UInt64
+    let continuation: AsyncStream<SubscriptionEvent>.Continuation
+}
+
+private struct EventListener {
+    let id: UInt64
+    let continuation: AsyncStream<ClientEvent>.Continuation
+}
+
+private struct StateListener {
+    let id: UInt64
+    let continuation: AsyncStream<ConnectionState>.Continuation
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientConfig.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientConfig.swift
@@ -1,0 +1,29 @@
+// AHPClientConfig — knobs for an `AHPClient` instance.
+
+import Foundation
+
+/// Tunable settings for an `AHPClient` instance.
+public struct AHPClientConfig: Sendable {
+    /// Maximum time a `request` will wait for its response before failing
+    /// with `AHPClientError.requestTimeout`. Defaults to 30 seconds.
+    public var requestTimeout: Duration
+
+    /// Buffer size for the multicast `events` and `stateChanges` streams.
+    /// When a consumer falls behind by more than this many items, the oldest
+    /// items are dropped (`.bufferingNewest`). Per-URI subscription streams
+    /// are *unbounded* regardless of this value, since dropping action
+    /// envelopes desyncs the consumer's reducer mirror.
+    ///
+    /// Defaults to 256.
+    public var subscriptionBufferSize: Int
+
+    public init(
+        requestTimeout: Duration = .seconds(30),
+        subscriptionBufferSize: Int = 256
+    ) {
+        self.requestTimeout = requestTimeout
+        self.subscriptionBufferSize = subscriptionBufferSize
+    }
+
+    public static let `default` = AHPClientConfig()
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientConfig.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientConfig.swift
@@ -14,6 +14,9 @@ public struct AHPClientConfig: Sendable {
     /// are *unbounded* regardless of this value, since dropping action
     /// envelopes desyncs the consumer's reducer mirror.
     ///
+    /// Values less than 1 are silently clamped to 1 by the initializer so
+    /// the buffering policy always retains at least the most recent item.
+    ///
     /// Defaults to 256.
     public var subscriptionBufferSize: Int
 
@@ -22,7 +25,10 @@ public struct AHPClientConfig: Sendable {
         subscriptionBufferSize: Int = 256
     ) {
         self.requestTimeout = requestTimeout
-        self.subscriptionBufferSize = subscriptionBufferSize
+        // `.bufferingNewest(0)` means "buffer nothing" and `.bufferingNewest`
+        // with a negative count is undefined; clamp to 1 so the public API
+        // never lets the consumer reach those edges by accident.
+        self.subscriptionBufferSize = max(1, subscriptionBufferSize)
     }
 
     public static let `default` = AHPClientConfig()

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientError.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientError.swift
@@ -1,0 +1,36 @@
+// AHPClientError — errors raised by `AHPClient`.
+
+import Foundation
+import AgentHostProtocol
+
+/// Errors raised by `AHPClient`.
+public enum AHPClientError: Error, Sendable {
+    /// Underlying transport failure.
+    case transport(TransportError)
+    /// JSON-RPC error response from the peer.
+    case rpc(code: Int, message: String, data: AnyCodable?)
+    /// Failed to decode a response or notification payload.
+    case decoding(String)
+    /// The client was shut down (cleanly or by transport close) before the
+    /// operation completed.
+    case shutdown
+    /// A request didn't resolve before `requestTimeout`.
+    case requestTimeout
+}
+
+extension AHPClientError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .transport(let e):
+            return "transport error: \(e)"
+        case .rpc(let code, let message, _):
+            return "JSON-RPC error \(code): \(message)"
+        case .decoding(let detail):
+            return "failed to decode: \(detail)"
+        case .shutdown:
+            return "client was shut down"
+        case .requestTimeout:
+            return "request timed out"
+        }
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientEvents.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientEvents.swift
@@ -15,9 +15,9 @@ public enum SubscriptionEvent: Sendable {
 
 /// One event delivered by `AHPClient.events` — the top-level multicast tap.
 ///
-/// `resource` is `Some(uri)` for action envelopes (the URI the action is
-/// scoped to) and `None` for cross-resource protocol notifications. Mirrors
-/// the shape planned for the Rust `Client::events()` method.
+/// `resource` is non-nil for action envelopes (carrying the URI the action is
+/// scoped to) and nil for cross-resource protocol notifications. Mirrors the
+/// shape planned for the Rust `Client::events()` method.
 public struct ClientEvent: Sendable {
     public let resource: String?
     public let event: SubscriptionEvent

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientEvents.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClientEvents.swift
@@ -1,0 +1,53 @@
+// AHPClientEvents — event and state types fanned out by `AHPClient`.
+
+import Foundation
+import AgentHostProtocol
+
+/// One event delivered by a per-URI subscription.
+///
+/// `Action` envelopes carry the write-ahead mutation stream for a resource;
+/// `Notification` frames carry protocol-level signals the server broadcasts
+/// (session added/removed, summary changed, auth required).
+public enum SubscriptionEvent: Sendable {
+    case action(ActionEnvelope)
+    case notification(ProtocolNotification)
+}
+
+/// One event delivered by `AHPClient.events` — the top-level multicast tap.
+///
+/// `resource` is `Some(uri)` for action envelopes (the URI the action is
+/// scoped to) and `None` for cross-resource protocol notifications. Mirrors
+/// the shape planned for the Rust `Client::events()` method.
+public struct ClientEvent: Sendable {
+    public let resource: String?
+    public let event: SubscriptionEvent
+
+    public init(resource: String?, event: SubscriptionEvent) {
+        self.resource = resource
+        self.event = event
+    }
+}
+
+/// Connection state observable on `AHPClient.connectionState` and the
+/// `stateChanges` stream.
+public enum ConnectionState: Sendable, Equatable {
+    /// No active receive loop; the transport may or may not be open.
+    case disconnected
+    /// `connect()` is in progress.
+    case connecting
+    /// Receive loop is running; the transport is treated as live.
+    case connected
+}
+
+/// Handle returned from `AHPClient.dispatch`.
+///
+/// Dispatch is fire-and-forget by design; the handle records the
+/// client-assigned `clientSeq` so callers can correlate optimistic local
+/// updates with server echoes (`ActionEnvelope.origin.clientSeq`).
+public struct DispatchHandle: Sendable, Equatable {
+    public let clientSeq: Int
+
+    public init(clientSeq: Int) {
+        self.clientSeq = clientSeq
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPStateMirror.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPStateMirror.swift
@@ -1,0 +1,78 @@
+// AHPStateMirror — thin reducer façade for an in-memory state copy.
+//
+// Wraps the existing pure reducers (`rootReducer`, `sessionReducer`) so a
+// consumer can keep an in-memory mirror by just routing every inbound
+// `ActionEnvelope` (and any seed `Snapshot`) through `apply` /
+// `applySnapshot`. Multi-host runtimes can compose a mirror per host.
+
+import Foundation
+import AgentHostProtocol
+
+/// In-memory mirror of root/session/terminal state, fed by `ActionEnvelope`
+/// and `Snapshot` values from `AHPClient`.
+public actor AHPStateMirror {
+    public private(set) var rootState: RootState = RootState(agents: [])
+    public private(set) var sessions: [String: SessionState] = [:]
+    public private(set) var terminals: [String: TerminalState] = [:]
+
+    public init() {}
+
+    /// Apply a single action envelope, routing by `action.session` /
+    /// `action.terminal` (root state if neither is present).
+    public func apply(_ envelope: ActionEnvelope) {
+        let action = envelope.action
+        if let sessionURI = sessionURI(for: action) {
+            // If we have no session state for this URI yet, the reducer
+            // can't initialise one — only `applySnapshot` can do that.
+            if var session = sessions[sessionURI] {
+                session = sessionReducer(state: session, action: action)
+                sessions[sessionURI] = session
+            }
+            return
+        }
+        if terminalURI(for: action) != nil {
+            // Terminals don't have a hand-written reducer in the Swift
+            // package today; just leave the slot as the latest snapshot.
+            // (Native reducer + state shape will be wired up when
+            // terminal lifecycle reducers ship.)
+            return
+        }
+        rootState = rootReducer(state: rootState, action: action)
+    }
+
+    /// Seed the mirror from a `Snapshot` — root, session, or terminal as
+    /// the snapshot's `state` discriminator dictates.
+    public func applySnapshot(_ snapshot: Snapshot) {
+        switch snapshot.state {
+        case .root(let state):
+            rootState = state
+        case .session(let state):
+            sessions[snapshot.resource] = state
+        case .terminal(let state):
+            terminals[snapshot.resource] = state
+        }
+    }
+
+    /// Reset the mirror to its initial empty state.
+    public func reset() {
+        rootState = RootState(agents: [])
+        sessions.removeAll()
+        terminals.removeAll()
+    }
+
+    // MARK: - Helpers
+
+    private func sessionURI(for action: StateAction) -> String? {
+        guard let data = try? JSONEncoder().encode(action),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object["session"] as? String
+    }
+
+    private func terminalURI(for action: StateAction) -> String? {
+        guard let data = try? JSONEncoder().encode(action),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object["terminal"] as? String
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AgentHostProtocolClient.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AgentHostProtocolClient.swift
@@ -1,0 +1,26 @@
+// AgentHostProtocolClient — single-host JSON-RPC client for the Agent Host Protocol.
+//
+// This module ships:
+//   - `AHPTransport`: a pluggable async transport protocol (text/binary/parsed framing).
+//   - `URLSessionWebSocketTransport`: default WebSocket implementation.
+//   - `InMemoryTransport`: paired in-memory transport for tests.
+//   - `AHPClient`: an actor that owns request/response correlation, subscription
+//     fan-out, a top-level `events` tap, and connection-state changes.
+//   - `AHPStateMirror`: a thin reducer façade for keeping an in-memory state copy.
+//
+// Multi-host abstractions, reconnect policy with backoff, generation-checked
+// handles, observable façade, and `ClientIdStore` are deliberately *not* in
+// this module — they belong on a higher layer (planned as a follow-up
+// `MultiHostClient`).
+
+import Foundation
+
+/// Well-known resource URI for root-state subscriptions and snapshots.
+///
+/// The protocol-level value referenced throughout the spec, docs, and the
+/// example app's initial subscriptions. Defined here as a constant so the
+/// JSON-RPC client doesn't string-match the URI inline.
+///
+/// TODO(codegen): Source this from `AgentHostProtocol` once codegen exposes a
+/// shared constant (TypeScript/Rust/Swift would all benefit).
+public let RootResourceURI: String = "agenthost:/root"

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/AHPTransport.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/AHPTransport.swift
@@ -95,6 +95,19 @@ extension JsonRpcMessage: Codable {
 /// when one is naturally available (e.g. an in-memory pair); otherwise text
 /// or binary frames carry the JSON-encoded payload and the client decodes
 /// them itself.
+///
+/// **Prefer `.text` or `.binary` for inbound frames.** `AHPClient` decodes
+/// inbound JSON via `JSONSerialization` to preserve the NSNumber
+/// `Bool`/`Int` distinction that `JSONDecoder`+`AnyCodable` collapses on
+/// Apple platforms (tracked as
+/// [microsoft/agent-host-protocol#123](https://github.com/microsoft/agent-host-protocol/issues/123)).
+/// Inbound `.parsed` messages bypass that path: the client must re-encode
+/// them to recover bytes, and any `AnyCodable`-wrapped payload inside them
+/// may already have been corrupted before reaching the client. `.parsed` is
+/// safe for outbound sends (the writer encodes to `.text` itself) and for
+/// transports that construct `JsonRpcMessage` values without going through
+/// `AnyCodable`/`JSONDecoder`. The in-memory test transport in this package
+/// only emits `.text`.
 public enum TransportMessage: Sendable {
     /// A pre-decoded JSON-RPC message.
     case parsed(JsonRpcMessage)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/AHPTransport.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/AHPTransport.swift
@@ -1,0 +1,188 @@
+// AHPTransport — pluggable async transport for the JSON-RPC client.
+//
+// Inspired by the Rust `Transport` trait (`clients/rust/crates/ahp/src/transport.rs`)
+// but uses Swift's `async throws` directly. Implementations may be backed by
+// WebSocket, stdio, an in-memory pair for tests, or anything else that
+// delivers framed JSON-RPC messages.
+
+import Foundation
+import AgentHostProtocol
+
+// MARK: - JSON-RPC message union
+
+/// A typed JSON-RPC 2.0 message.
+///
+/// The Swift types library ships per-kind generics (`JsonRpcRequest<P>`,
+/// `JsonRpcSuccessResponse<R>`, `JsonRpcErrorResponse`, `JsonRpcNotification<P>`)
+/// but no enum to discriminate them on the wire. This local union closes that
+/// gap for transports and the client without forcing the types library to
+/// take any new dependency.
+public enum JsonRpcMessage: Sendable {
+    /// JSON-RPC request (has `id` and `method`).
+    case request(id: Int, method: String, params: AnyCodable?)
+    /// Successful JSON-RPC response (has `id` and `result`).
+    case successResponse(id: Int, result: AnyCodable)
+    /// JSON-RPC error response (has `id` and `error`).
+    case errorResponse(id: Int, error: JsonRpcError)
+    /// JSON-RPC notification (has `method` but no `id`).
+    case notification(method: String, params: AnyCodable?)
+}
+
+extension JsonRpcMessage: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case jsonrpc, id, method, params, result, error
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = try container.decodeIfPresent(Int.self, forKey: .id)
+        let method = try container.decodeIfPresent(String.self, forKey: .method)
+
+        if let id, method == nil {
+            // Response (success or error).
+            if let error = try container.decodeIfPresent(JsonRpcError.self, forKey: .error) {
+                self = .errorResponse(id: id, error: error)
+            } else if let result = try container.decodeIfPresent(AnyCodable.self, forKey: .result) {
+                self = .successResponse(id: id, result: result)
+            } else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .result, in: container,
+                    debugDescription: "JSON-RPC response missing both result and error"
+                )
+            }
+        } else if let method, let id {
+            // Server → client request (rare, but spec-permitted).
+            let params = try container.decodeIfPresent(AnyCodable.self, forKey: .params)
+            self = .request(id: id, method: method, params: params)
+        } else if let method {
+            // Notification.
+            let params = try container.decodeIfPresent(AnyCodable.self, forKey: .params)
+            self = .notification(method: method, params: params)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .method, in: container,
+                debugDescription: "JSON-RPC message has neither method nor id"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("2.0", forKey: .jsonrpc)
+        switch self {
+        case .request(let id, let method, let params):
+            try container.encode(id, forKey: .id)
+            try container.encode(method, forKey: .method)
+            try container.encodeIfPresent(params, forKey: .params)
+        case .successResponse(let id, let result):
+            try container.encode(id, forKey: .id)
+            try container.encode(result, forKey: .result)
+        case .errorResponse(let id, let error):
+            try container.encode(id, forKey: .id)
+            try container.encode(error, forKey: .error)
+        case .notification(let method, let params):
+            try container.encode(method, forKey: .method)
+            try container.encodeIfPresent(params, forKey: .params)
+        }
+    }
+}
+
+// MARK: - TransportMessage
+
+/// One message flowing in or out over an `AHPTransport`.
+///
+/// Transports may hand the client an already-decoded message via `.parsed`
+/// when one is naturally available (e.g. an in-memory pair); otherwise text
+/// or binary frames carry the JSON-encoded payload and the client decodes
+/// them itself.
+public enum TransportMessage: Sendable {
+    /// A pre-decoded JSON-RPC message.
+    case parsed(JsonRpcMessage)
+    /// A text frame whose payload is a JSON-RPC message encoded as UTF-8.
+    case text(String)
+    /// A binary frame carrying a JSON-RPC message encoded as UTF-8.
+    case binary(Data)
+
+    /// Decode this message into a typed `JsonRpcMessage`.
+    public func intoParsed() throws -> JsonRpcMessage {
+        switch self {
+        case .parsed(let m):
+            return m
+        case .text(let s):
+            guard let data = s.data(using: .utf8) else {
+                throw TransportError.protocol("text frame is not valid UTF-8")
+            }
+            do {
+                return try JSONDecoder().decode(JsonRpcMessage.self, from: data)
+            } catch {
+                throw TransportError.protocol("failed to decode text frame: \(error)")
+            }
+        case .binary(let data):
+            do {
+                return try JSONDecoder().decode(JsonRpcMessage.self, from: data)
+            } catch {
+                throw TransportError.protocol("failed to decode binary frame: \(error)")
+            }
+        }
+    }
+
+    /// Encode a `JsonRpcMessage` into a text-frame `TransportMessage`.
+    public static func encode(_ message: JsonRpcMessage) throws -> TransportMessage {
+        do {
+            let data = try JSONEncoder().encode(message)
+            guard let s = String(data: data, encoding: .utf8) else {
+                throw TransportError.protocol("encoded message is not valid UTF-8")
+            }
+            return .text(s)
+        } catch let error as TransportError {
+            throw error
+        } catch {
+            throw TransportError.protocol("failed to encode message: \(error)")
+        }
+    }
+}
+
+// MARK: - TransportError
+
+/// Errors raised by an `AHPTransport` implementation.
+public enum TransportError: Error, Sendable, Equatable {
+    /// The transport was closed before the operation could complete.
+    case closed
+    /// I/O failure (network error, broken pipe, etc.).
+    case io(String)
+    /// Protocol-level error (bad framing, decode failure, malformed UTF-8).
+    case `protocol`(String)
+}
+
+// MARK: - AHPTransport
+
+/// Pluggable transport for the JSON-RPC client.
+///
+/// `AHPClient` calls `send` and `recv` *serially* — implementations are not
+/// required to support reentrant `send` from multiple tasks. The receive loop
+/// runs concurrently with the writer, so `send` and `recv` can overlap, but
+/// neither is invoked from multiple tasks simultaneously by the client.
+///
+/// `close` MUST be idempotent — `AHPClient` may call it from both its
+/// `shutdown()` path and its abnormal-disconnect handler, possibly back to
+/// back if the two interleave.
+///
+/// Transports are expected to be full-duplex and half-closable: the client
+/// will keep sending until the underlying connection closes, and `recv`
+/// signals a clean close by returning `nil`.
+public protocol AHPTransport: AnyObject, Sendable {
+    /// Send a single message.
+    ///
+    /// Errors thrown here are typically fatal for the transport; `AHPClient`
+    /// will surface them to in-flight requests and tear down.
+    func send(_ message: TransportMessage) async throws
+
+    /// Receive the next inbound message.
+    ///
+    /// Returns `nil` when the remote half has cleanly closed. Errors are
+    /// treated as abnormal closure.
+    func recv() async throws -> TransportMessage?
+
+    /// Close the transport and release any underlying resources.
+    func close() async throws
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/InMemoryTransport.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/InMemoryTransport.swift
@@ -1,0 +1,125 @@
+// InMemoryTransport — paired in-memory transport for tests.
+//
+// Two halves connected by AsyncStreams. Mirrors the `MemTransport` pattern
+// in the Rust integration tests (`crates/ahp/tests/client_roundtrip.rs`).
+
+import Foundation
+
+/// One half of an in-memory transport pair.
+///
+/// Calls to `send` on one half are observed by `recv` on the other.
+/// `close()` on either half finishes both inbound queues so both peers see
+/// `recv() == nil` shortly afterward.
+///
+/// `recv()` is single-consumer — it is called from a single task at a time
+/// (the `AHPClient` receive loop) and is not safe to invoke concurrently
+/// from multiple tasks. `send()` and `close()` are safe to call concurrently.
+public final class InMemoryTransport: AHPTransport, @unchecked Sendable {
+    /// Continuation that delivers into our peer's inbound queue.
+    private let peerInboundContinuation: AsyncStream<TransportMessage>.Continuation
+    /// Continuation that delivers into our own inbound queue.
+    private let ownInboundContinuation: AsyncStream<TransportMessage>.Continuation
+    /// Storage cell for the iterator over our own inbound queue.
+    private let iteratorBox: IteratorBox
+
+    private let lock = NSLock()
+    private var closed = false
+
+    private init(
+        peerInboundContinuation: AsyncStream<TransportMessage>.Continuation,
+        ownInbound: AsyncStream<TransportMessage>,
+        ownInboundContinuation: AsyncStream<TransportMessage>.Continuation
+    ) {
+        self.peerInboundContinuation = peerInboundContinuation
+        self.ownInboundContinuation = ownInboundContinuation
+        self.iteratorBox = IteratorBox(iterator: ownInbound.makeAsyncIterator())
+    }
+
+    /// Create a connected pair of in-memory transports.
+    public static func pair() -> (InMemoryTransport, InMemoryTransport) {
+        var aInCont: AsyncStream<TransportMessage>.Continuation!
+        let aIn = AsyncStream<TransportMessage>(bufferingPolicy: .unbounded) { cont in
+            aInCont = cont
+        }
+        var bInCont: AsyncStream<TransportMessage>.Continuation!
+        let bIn = AsyncStream<TransportMessage>(bufferingPolicy: .unbounded) { cont in
+            bInCont = cont
+        }
+        let a = InMemoryTransport(
+            peerInboundContinuation: bInCont,
+            ownInbound: aIn,
+            ownInboundContinuation: aInCont
+        )
+        let b = InMemoryTransport(
+            peerInboundContinuation: aInCont,
+            ownInbound: bIn,
+            ownInboundContinuation: bInCont
+        )
+        return (a, b)
+    }
+
+    public func send(_ message: TransportMessage) async throws {
+        if isClosedSync() {
+            throw TransportError.closed
+        }
+        peerInboundContinuation.yield(message)
+    }
+
+    public func recv() async throws -> TransportMessage? {
+        return await iteratorBox.next()
+    }
+
+    public func close() async throws {
+        if !markClosed() { return }
+        peerInboundContinuation.finish()
+        ownInboundContinuation.finish()
+    }
+
+    // MARK: - Lock helpers (sync to avoid holding the lock across `await`).
+
+    private func isClosedSync() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return closed
+    }
+
+    /// Atomically transitions to the closed state. Returns `true` if this is
+    /// the *first* close (the caller should run cleanup), `false` if the
+    /// transport was already closed.
+    private func markClosed() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if closed { return false }
+        closed = true
+        return true
+    }
+}
+
+/// Single-consumer iterator wrapper. Locks are taken only synchronously, never
+/// across an `await`. Concurrent calls to `next()` are unsupported and may
+/// crash.
+private final class IteratorBox: @unchecked Sendable {
+    private var iterator: AsyncStream<TransportMessage>.AsyncIterator?
+    private let lock = NSLock()
+
+    init(iterator: AsyncStream<TransportMessage>.AsyncIterator) {
+        self.iterator = iterator
+    }
+
+    func next() async -> TransportMessage? {
+        guard var iter = takeIterator() else { return nil }
+        let item = await iter.next()
+        returnIterator(iter)
+        return item
+    }
+
+    private func takeIterator() -> AsyncStream<TransportMessage>.AsyncIterator? {
+        lock.lock(); defer { lock.unlock() }
+        let iter = iterator
+        iterator = nil
+        return iter
+    }
+
+    private func returnIterator(_ iter: AsyncStream<TransportMessage>.AsyncIterator) {
+        lock.lock(); defer { lock.unlock() }
+        iterator = iter
+    }
+}

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/InMemoryTransport.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/InMemoryTransport.swift
@@ -93,33 +93,72 @@ public final class InMemoryTransport: AHPTransport, @unchecked Sendable {
     }
 }
 
-/// Single-consumer iterator wrapper. Locks are taken only synchronously, never
-/// across an `await`. Concurrent calls to `next()` are unsupported and may
-/// crash.
+/// Single-consumer iterator wrapper. Locks are taken only synchronously,
+/// never across an `await`. Concurrent calls to `next()` are unsupported and
+/// trip a `preconditionFailure` — they would otherwise look like a clean
+/// close to one of the racing callers.
 private final class IteratorBox: @unchecked Sendable {
-    private var iterator: AsyncStream<TransportMessage>.AsyncIterator?
+    private enum State {
+        /// Iterator is sitting in the box, ready for the next caller.
+        case available(AsyncStream<TransportMessage>.AsyncIterator)
+        /// A caller has taken the iterator and is awaiting its next item.
+        case inFlight
+        /// The stream has finished; future `next()` calls return nil.
+        case finished
+    }
+
+    private var state: State
     private let lock = NSLock()
 
     init(iterator: AsyncStream<TransportMessage>.AsyncIterator) {
-        self.iterator = iterator
+        self.state = .available(iterator)
     }
 
     func next() async -> TransportMessage? {
-        guard var iter = takeIterator() else { return nil }
+        var iter = takeIterator()
         let item = await iter.next()
+        if item == nil {
+            markFinished()
+            return nil
+        }
         returnIterator(iter)
         return item
     }
 
-    private func takeIterator() -> AsyncStream<TransportMessage>.AsyncIterator? {
+    private func takeIterator() -> AsyncStream<TransportMessage>.AsyncIterator {
         lock.lock(); defer { lock.unlock() }
-        let iter = iterator
-        iterator = nil
-        return iter
+        switch state {
+        case .available(let iter):
+            state = .inFlight
+            return iter
+        case .inFlight:
+            preconditionFailure(
+                "InMemoryTransport.recv() is single-consumer; concurrent calls are not supported"
+            )
+        case .finished:
+            // Hand out a no-op iterator. The caller will pump it once and
+            // see `nil`, then we'll re-enter `markFinished` (idempotent).
+            return AsyncStream<TransportMessage> { _ in }.makeAsyncIterator()
+        }
     }
 
     private func returnIterator(_ iter: AsyncStream<TransportMessage>.AsyncIterator) {
         lock.lock(); defer { lock.unlock() }
-        iterator = iter
+        // The state may have transitioned to .finished concurrently if the
+        // stream finished between our `await iter.next()` and this call;
+        // honour that and don't resurrect the iterator.
+        switch state {
+        case .inFlight:
+            state = .available(iter)
+        case .finished:
+            break
+        case .available:
+            preconditionFailure("IteratorBox.returnIterator called without takeIterator")
+        }
+    }
+
+    private func markFinished() {
+        lock.lock(); defer { lock.unlock() }
+        state = .finished
     }
 }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/URLSessionWebSocketTransport.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/Transport/URLSessionWebSocketTransport.swift
@@ -1,0 +1,138 @@
+// URLSessionWebSocketTransport — default WebSocket transport.
+//
+// Wraps `URLSessionWebSocketTask`. Suitable for `wss://` deployments and
+// `ws://` targets where ATS isn't a problem; consumers that need to bypass
+// ATS for `ws://` LAN/Tailscale targets should provide their own
+// `AHPTransport` (the example app uses a native `NWConnection` impl for that
+// reason).
+
+import Foundation
+
+/// Default WebSocket transport built on `URLSessionWebSocketTask`.
+public final class URLSessionWebSocketTransport: AHPTransport, @unchecked Sendable {
+    private let url: URL
+    private let headers: [String: String]
+    private let session: URLSession
+
+    private let lock = NSLock()
+    private var task: URLSessionWebSocketTask?
+    private var closed = false
+
+    /// Creates a new WebSocket transport. The connection is opened lazily on
+    /// the first call to `send` or `recv`.
+    public init(
+        url: URL,
+        headers: [String: String] = [:],
+        session: URLSession = .shared
+    ) {
+        self.url = url
+        self.headers = headers
+        self.session = session
+    }
+
+    public func send(_ message: TransportMessage) async throws {
+        let task = try ensureTask()
+        let wsMessage: URLSessionWebSocketTask.Message
+        switch message {
+        case .text(let s):
+            wsMessage = .string(s)
+        case .binary(let data):
+            wsMessage = .data(data)
+        case .parsed(let parsed):
+            // Re-encode and send as text. WebSocket peers vary in whether they
+            // accept text vs binary JSON; text is the lowest-friction choice.
+            let encoded = try TransportMessage.encode(parsed)
+            try await send(encoded)
+            return
+        }
+        do {
+            try await task.send(wsMessage)
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    public func recv() async throws -> TransportMessage? {
+        let task = try ensureTask()
+        do {
+            let message = try await task.receive()
+            switch message {
+            case .data(let data):
+                return .binary(data)
+            case .string(let s):
+                return .text(s)
+            @unknown default:
+                throw TransportError.protocol("unknown WebSocket frame kind")
+            }
+        } catch {
+            // Distinguish a clean close from an abnormal one. URLSession
+            // throws on close instead of returning nil.
+            if isCleanClose(error: error, task: task) {
+                return nil
+            }
+            throw mapError(error)
+        }
+    }
+
+    public func close() async throws {
+        let task = clearTaskAndMarkClosed()
+        // 1000 (normal closure) is the conventional value for client-initiated
+        // close. Leaving the reason empty is fine.
+        task?.cancel(with: .normalClosure, reason: nil)
+    }
+
+    // MARK: - Helpers
+
+    private func clearTaskAndMarkClosed() -> URLSessionWebSocketTask? {
+        lock.lock(); defer { lock.unlock() }
+        let task = self.task
+        self.task = nil
+        closed = true
+        return task
+    }
+
+    private func ensureTask() throws -> URLSessionWebSocketTask {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { throw TransportError.closed }
+        if let task { return task }
+        var request = URLRequest(url: url)
+        for (k, v) in headers {
+            request.setValue(v, forHTTPHeaderField: k)
+        }
+        let task = session.webSocketTask(with: request)
+        task.resume()
+        self.task = task
+        return task
+    }
+
+    private func isCleanClose(error: Error, task: URLSessionWebSocketTask) -> Bool {
+        // Our own `close()` cancels the task with `.normalClosure`; that
+        // surfaces as `URLError(.cancelled)` from `receive()`.
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+            return true
+        }
+        // The peer closing also surfaces as a thrown error; check the close
+        // code. Only whitelist explicitly-clean codes — everything else is an
+        // abnormal closure that the consumer should treat as a transport
+        // failure (e.g. so a higher-layer reconnect supervisor can retry).
+        switch task.closeCode {
+        case .normalClosure, .goingAway, .noStatusReceived:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func mapError(_ error: Error) -> TransportError {
+        if let transportError = error as? TransportError {
+            return transportError
+        }
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+            return .closed
+        }
+        return .io(nsError.localizedDescription)
+    }
+}

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTestHelpers.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTestHelpers.swift
@@ -1,0 +1,86 @@
+// AHPClientTestHelpers — utilities shared across the client test suite.
+
+import Foundation
+import AgentHostProtocol
+@testable import AgentHostProtocolClient
+
+extension TransportMessage {
+    /// Convenience: encode a JSON-RPC message into a text frame for tests.
+    static func encoded(_ message: JsonRpcMessage) -> TransportMessage {
+        return try! TransportMessage.encode(message)
+    }
+}
+
+/// Build a wire-format JSON-RPC notification that preserves NSNumber Bool/Int
+/// fidelity (which AnyCodable's encode order otherwise erases). The path is
+/// `typed → JSONEncoder → JSONSerialization → re-serialized JSON Data`.
+func makeNotificationWire<P: Encodable>(
+    method: String, params: P
+) throws -> TransportMessage {
+    let paramsBytes = try JSONEncoder().encode(params)
+    let paramsAny = try JSONSerialization.jsonObject(
+        with: paramsBytes, options: [.fragmentsAllowed]
+    )
+    let dict: [String: Any] = [
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": paramsAny,
+    ]
+    let wireBytes = try JSONSerialization.data(withJSONObject: dict)
+    guard let text = String(data: wireBytes, encoding: .utf8) else {
+        throw TestHelperError.encoding("failed to UTF-8-encode wire bytes")
+    }
+    return .text(text)
+}
+
+func makeResponseWire<R: Encodable>(
+    id: Int, result: R
+) throws -> TransportMessage {
+    let resultBytes = try JSONEncoder().encode(result)
+    let resultAny = try JSONSerialization.jsonObject(
+        with: resultBytes, options: [.fragmentsAllowed]
+    )
+    let dict: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": resultAny,
+    ]
+    let wireBytes = try JSONSerialization.data(withJSONObject: dict)
+    guard let text = String(data: wireBytes, encoding: .utf8) else {
+        throw TestHelperError.encoding("failed to UTF-8-encode wire bytes")
+    }
+    return .text(text)
+}
+
+enum TestHelperError: Error, LocalizedError {
+    case encoding(String)
+    var errorDescription: String? {
+        switch self {
+        case .encoding(let s): return s
+        }
+    }
+}
+
+/// Wait for the next value from an AsyncStream iterator with a timeout.
+func nextWithTimeout<E>(
+    _ iterator: inout AsyncStream<E>.AsyncIterator,
+    _ timeout: Duration = .seconds(2)
+) async throws -> E? where E: Sendable {
+    try await withThrowingTaskGroup(of: E?.self) { group in
+        group.addTask { [iterator = iterator] in
+            var iter = iterator
+            return await iter.next()
+        }
+        group.addTask {
+            try await Task.sleep(for: timeout)
+            throw TimeoutError()
+        }
+        defer { group.cancelAll() }
+        return try await group.next()!
+    }
+}
+
+struct TimeoutError: Error, LocalizedError {
+    var errorDescription: String? { "operation timed out in test" }
+}
+

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTests.swift
@@ -226,6 +226,32 @@ final class AHPClientTests: XCTestCase {
         await client.shutdown()
     }
 
+    func testUnsubscribeFinishesAllStreamsForUri() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        let firstStream = await client.attachSubscription("copilot:/s1")
+        let secondStream = await client.attachSubscription("copilot:/s1")
+
+        let serverTask = Task {
+            _ = try await readNotification(from: serverSide, expectedMethod: "unsubscribe")
+        }
+
+        try await client.unsubscribe("copilot:/s1")
+
+        var firstIter = firstStream.makeAsyncIterator()
+        let firstEvent = try await nextWithTimeout(&firstIter)
+        XCTAssertNil(firstEvent)
+
+        var secondIter = secondStream.makeAsyncIterator()
+        let secondEvent = try await nextWithTimeout(&secondIter)
+        XCTAssertNil(secondEvent)
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
     // MARK: - shutdown finishes streams
 
     func testShutdownTerminatesAllStreams() async throws {
@@ -303,6 +329,37 @@ final class AHPClientTests: XCTestCase {
         await client.shutdown()
     }
 
+    // MARK: - dispatch supports caller-owned clientSeq
+
+    func testDispatchCanUseExplicitClientSeq() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        let action = StateAction.sessionTitleChanged(SessionTitleChangedAction(
+            type: .sessionTitleChanged,
+            session: "copilot:/s1",
+            title: "From app outbox"
+        ))
+
+        let serverTask = Task {
+            let first = try await readDispatchNotification(from: serverSide)
+            XCTAssertEqual(first.clientSeq, 42)
+
+            let second = try await readDispatchNotification(from: serverSide)
+            XCTAssertEqual(second.clientSeq, 43)
+        }
+
+        let explicit = try await client.dispatch(action, clientSeq: 42)
+        XCTAssertEqual(explicit.clientSeq, 42)
+
+        let automatic = try await client.dispatch(action)
+        XCTAssertEqual(automatic.clientSeq, 43)
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
 
     private struct ParsedRequest { let id: Int; let method: String; let params: AnyCodable? }
 
@@ -334,6 +391,14 @@ final class AHPClientTests: XCTestCase {
         }
         XCTAssertEqual(method, expectedMethod)
         return params
+    }
+
+    private func readDispatchNotification(from transport: InMemoryTransport) async throws -> DispatchActionParams {
+        guard let params = try await readNotification(from: transport, expectedMethod: "dispatchAction") else {
+            throw TestError.unexpectedMessage("dispatchAction notification missing params")
+        }
+        let data = try JSONEncoder().encode(params)
+        return try JSONDecoder().decode(DispatchActionParams.self, from: data)
     }
 
     private func respond<R: Encodable>(

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTests.swift
@@ -1,0 +1,361 @@
+// AHPClientTests — request/response, subscription fan-out, events tap,
+// unsubscribe, and shutdown behaviour for `AHPClient`.
+
+import XCTest
+import AgentHostProtocol
+@testable import AgentHostProtocolClient
+
+final class AHPClientTests: XCTestCase {
+
+    // MARK: - request_response_round_trip
+
+    func testInitializeHandshakeRoundTrip() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        // Server task: respond to `initialize`.
+        let serverTask = Task {
+            let request = try await readRequest(from: serverSide, expectedMethod: "initialize")
+            let result = InitializeResult(
+                protocolVersion: "0.1.0",
+                serverSeq: 0,
+                snapshots: []
+            )
+            try await respond(to: request.id, with: result, on: serverSide)
+        }
+
+        let init1 = try await client.initialize(
+            clientId: "test-client",
+            protocolVersions: ["0.1.0"],
+            initialSubscriptions: []
+        )
+        XCTAssertEqual(init1.protocolVersion, "0.1.0")
+        XCTAssertEqual(init1.serverSeq, 0)
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
+    // MARK: - subscribe_streams_actions
+
+    func testSubscribeStreamsActions() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        let serverTask = Task {
+            // Respond to subscribe with an empty root snapshot.
+            let request = try await readRequest(from: serverSide, expectedMethod: "subscribe")
+            let snap = SubscribeResult(snapshot: Snapshot(
+                resource: "copilot:/s1",
+                state: .session(SessionState(
+                    summary: SessionSummary(
+                        resource: "copilot:/s1",
+                        provider: "test",
+                        title: "T",
+                        status: .idle,
+                        createdAt: 1, modifiedAt: 1
+                    ),
+                    lifecycle: .ready,
+                    turns: []
+                )),
+                fromSeq: 0
+            ))
+            try await respond(to: request.id, with: snap, on: serverSide)
+
+            // Push an action notification scoped to the subscribed URI.
+            let envelope = ActionEnvelope(
+                action: .sessionTitleChanged(SessionTitleChangedAction(
+                    type: .sessionTitleChanged,
+                    session: "copilot:/s1",
+                    title: "Hello"
+                )),
+                serverSeq: 1
+            )
+            try await pushNotification(
+                method: "action",
+                params: envelope,
+                on: serverSide
+            )
+        }
+
+        let (_, stream) = try await client.subscribe("copilot:/s1")
+        var iter = stream.makeAsyncIterator()
+        let event = try await nextWithTimeout(&iter)
+        guard case .action(let envelope) = event else {
+            XCTFail("expected an action event, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(envelope.serverSeq, 1)
+        guard case .sessionTitleChanged(let action) = envelope.action else {
+            XCTFail("unexpected action variant")
+            return
+        }
+        XCTAssertEqual(action.session, "copilot:/s1")
+        XCTAssertEqual(action.title, "Hello")
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
+    // MARK: - events_tap_captures_handshake_notifications
+
+    func testEventsTapCapturesHandshakeNotifications() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+
+        // Attach the events tap BEFORE connect so the receive loop has a
+        // continuation to deliver into. This is the contract that guards
+        // against the bug PR 1 caught (handshake notifications dropped when
+        // the events stream isn't attached early).
+        let events = await client.events
+        var eventIter = events.makeAsyncIterator()
+
+        try await client.connect()
+
+        let serverTask = Task {
+            let request = try await readRequest(from: serverSide, expectedMethod: "initialize")
+            let result = InitializeResult(
+                protocolVersion: "0.1.0",
+                serverSeq: 0,
+                snapshots: []
+            )
+            try await respond(to: request.id, with: result, on: serverSide)
+
+            // Push a protocol notification *during* the handshake window.
+            let notification = ProtocolNotification.sessionAdded(SessionAddedNotification(
+                type: .sessionAdded,
+                summary: SessionSummary(
+                    resource: "copilot:/s1",
+                    provider: "test",
+                    title: "T",
+                    status: .idle,
+                    createdAt: 1, modifiedAt: 1
+                )
+            ))
+            let wrapped = NotificationMethodParams(notification: notification)
+            try await pushNotification(
+                method: "notification",
+                params: wrapped,
+                on: serverSide
+            )
+        }
+
+        _ = try await client.initialize(
+            clientId: "test-client",
+            protocolVersions: ["0.1.0"],
+            initialSubscriptions: []
+        )
+
+        let event = try await nextWithTimeout(&eventIter)
+        guard let event else {
+            XCTFail("events stream finished before delivering the notification")
+            return
+        }
+        XCTAssertNil(event.resource, "protocol notifications carry no resource URI")
+        guard case .notification(let proto) = event.event,
+              case .sessionAdded = proto else {
+            XCTFail("expected sessionAdded notification, got \(event.event)")
+            return
+        }
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
+    // MARK: - unexpected_close_fails_pending_requests
+
+    func testUnexpectedCloseFailsPendingRequests() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        // Server side closes before responding.
+        let serverTask = Task {
+            // Wait for the request to arrive but don't reply.
+            _ = try await readRequest(from: serverSide, expectedMethod: "initialize")
+            try await serverSide.close()
+        }
+
+        do {
+            _ = try await client.initialize(
+                clientId: "test-client",
+                protocolVersions: ["0.1.0"],
+                initialSubscriptions: []
+            )
+            XCTFail("expected an error from initialize")
+        } catch let error as AHPClientError {
+            switch error {
+            case .shutdown, .transport:
+                break
+            default:
+                XCTFail("expected .shutdown or .transport, got \(error)")
+            }
+        }
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
+    // MARK: - unsubscribe_drops_per_uri_stream
+
+    func testUnsubscribeFinishesPerUriStream() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        let stream = await client.attachSubscription("copilot:/s1")
+
+        // Server task: drain the unsubscribe notification so the writer
+        // doesn't park forever when the test ends.
+        let serverTask = Task {
+            _ = try await readNotification(from: serverSide, expectedMethod: "unsubscribe")
+        }
+
+        try await client.unsubscribe("copilot:/s1")
+
+        // Drain the stream: it should finish cleanly.
+        var collected: [SubscriptionEvent] = []
+        for await event in stream {
+            collected.append(event)
+        }
+        XCTAssertTrue(collected.isEmpty, "expected stream to finish without delivering events")
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
+    // MARK: - shutdown finishes streams
+
+    func testShutdownTerminatesAllStreams() async throws {
+        let (clientSide, _) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        let events = await client.events
+        let stateChanges = await client.stateChanges
+        let subStream = await client.attachSubscription("copilot:/s1")
+
+        await client.shutdown()
+
+        var subCollected = 0
+        for await _ in subStream { subCollected += 1 }
+        XCTAssertEqual(subCollected, 0)
+
+        var eventsCollected = 0
+        for await _ in events { eventsCollected += 1 }
+        XCTAssertEqual(eventsCollected, 0)
+
+        // stateChanges receives a final `.disconnected` then finishes.
+        var lastState: ConnectionState?
+        for await state in stateChanges {
+            lastState = state
+        }
+        XCTAssertEqual(lastState, .disconnected)
+    }
+
+    // MARK: - subscribe failure cleans up the listener
+
+    func testSubscribeFailureCleansUpListener() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        // Server task: respond to `subscribe` with a JSON-RPC error.
+        let serverTask = Task {
+            let request = try await readRequest(from: serverSide, expectedMethod: "subscribe")
+            let dict: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": request.id,
+                "error": [
+                    "code": -32602,
+                    "message": "no such resource",
+                ] as [String: Any],
+            ]
+            let bytes = try JSONSerialization.data(withJSONObject: dict)
+            try await serverSide.send(.text(String(data: bytes, encoding: .utf8)!))
+        }
+
+        do {
+            _ = try await client.subscribe("copilot:/missing")
+            XCTFail("expected an RPC error")
+        } catch let error as AHPClientError {
+            guard case .rpc(let code, _, _) = error else {
+                XCTFail("expected .rpc, got \(error)")
+                return
+            }
+            XCTAssertEqual(code, -32602)
+        }
+
+        try await serverTask.value
+
+        // The listener attached optimistically by `subscribe` must have been
+        // removed when the request failed. Otherwise it would accumulate
+        // unread events forever (the consumer never received the stream).
+        let count = await client._listenerCount(forUri: "copilot:/missing")
+        XCTAssertEqual(count, 0, "subscribe failure should clean up its listener")
+
+        // The pending continuation should also have been cleared.
+        let pendingCount = await client._pendingCount()
+        XCTAssertEqual(pendingCount, 0, "errored request must clear its pending entry")
+
+        await client.shutdown()
+    }
+
+
+    private struct ParsedRequest { let id: Int; let method: String; let params: AnyCodable? }
+
+    private func readRequest(
+        from transport: InMemoryTransport,
+        expectedMethod: String
+    ) async throws -> ParsedRequest {
+        guard let raw = try await transport.recv() else {
+            throw TestError.unexpectedClose
+        }
+        let parsed = try raw.intoParsed()
+        guard case .request(let id, let method, let params) = parsed else {
+            throw TestError.unexpectedMessage("expected request, got \(parsed)")
+        }
+        XCTAssertEqual(method, expectedMethod)
+        return ParsedRequest(id: id, method: method, params: params)
+    }
+
+    private func readNotification(
+        from transport: InMemoryTransport,
+        expectedMethod: String
+    ) async throws -> AnyCodable? {
+        guard let raw = try await transport.recv() else {
+            throw TestError.unexpectedClose
+        }
+        let parsed = try raw.intoParsed()
+        guard case .notification(let method, let params) = parsed else {
+            throw TestError.unexpectedMessage("expected notification, got \(parsed)")
+        }
+        XCTAssertEqual(method, expectedMethod)
+        return params
+    }
+
+    private func respond<R: Encodable>(
+        to id: Int,
+        with result: R,
+        on transport: InMemoryTransport
+    ) async throws {
+        let wire = try makeResponseWire(id: id, result: result)
+        try await transport.send(wire)
+    }
+
+    private func pushNotification<P: Encodable>(
+        method: String,
+        params: P,
+        on transport: InMemoryTransport
+    ) async throws {
+        let wire = try makeNotificationWire(method: method, params: params)
+        try await transport.send(wire)
+    }
+}
+
+private enum TestError: Error {
+    case unexpectedClose
+    case unexpectedMessage(String)
+}

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPStateMirrorTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPStateMirrorTests.swift
@@ -1,0 +1,111 @@
+// AHPStateMirrorTests — smoke test for the reducer façade.
+
+import XCTest
+import AgentHostProtocol
+@testable import AgentHostProtocolClient
+
+final class AHPStateMirrorTests: XCTestCase {
+
+    func testApplySnapshotSeedsRootState() async {
+        let mirror = AHPStateMirror()
+        let agents = [
+            AgentInfo(provider: "copilot", displayName: "Copilot", description: "", models: [])
+        ]
+        let snapshot = Snapshot(
+            resource: RootResourceURI,
+            state: .root(RootState(agents: agents)),
+            fromSeq: 0
+        )
+        await mirror.applySnapshot(snapshot)
+        let root = await mirror.rootState
+        XCTAssertEqual(root.agents.count, 1)
+        XCTAssertEqual(root.agents.first?.provider, "copilot")
+    }
+
+    func testApplySnapshotSeedsSessionState() async {
+        let mirror = AHPStateMirror()
+        let session = SessionState(
+            summary: SessionSummary(
+                resource: "copilot:/s1",
+                provider: "test",
+                title: "T",
+                status: .idle,
+                createdAt: 1, modifiedAt: 1
+            ),
+            lifecycle: .ready,
+            turns: []
+        )
+        let snapshot = Snapshot(
+            resource: "copilot:/s1",
+            state: .session(session),
+            fromSeq: 0
+        )
+        await mirror.applySnapshot(snapshot)
+        let sessions = await mirror.sessions
+        XCTAssertNotNil(sessions["copilot:/s1"])
+    }
+
+    func testApplyRootActionUpdatesRoot() async {
+        let mirror = AHPStateMirror()
+        let agents = [
+            AgentInfo(provider: "x", displayName: "X", description: "", models: [])
+        ]
+        let envelope = ActionEnvelope(
+            action: .rootAgentsChanged(RootAgentsChangedAction(
+                type: .rootAgentsChanged,
+                agents: agents
+            )),
+            serverSeq: 1
+        )
+        await mirror.apply(envelope)
+        let root = await mirror.rootState
+        XCTAssertEqual(root.agents.count, 1)
+        XCTAssertEqual(root.agents.first?.provider, "x")
+    }
+
+    func testApplySessionActionUpdatesSession() async {
+        let mirror = AHPStateMirror()
+        let initial = SessionState(
+            summary: SessionSummary(
+                resource: "copilot:/s1",
+                provider: "test",
+                title: "Old",
+                status: .idle,
+                createdAt: 1, modifiedAt: 1
+            ),
+            lifecycle: .ready,
+            turns: []
+        )
+        await mirror.applySnapshot(Snapshot(
+            resource: "copilot:/s1",
+            state: .session(initial),
+            fromSeq: 0
+        ))
+
+        let envelope = ActionEnvelope(
+            action: .sessionTitleChanged(SessionTitleChangedAction(
+                type: .sessionTitleChanged,
+                session: "copilot:/s1",
+                title: "New"
+            )),
+            serverSeq: 1
+        )
+        await mirror.apply(envelope)
+        let sessions = await mirror.sessions
+        XCTAssertEqual(sessions["copilot:/s1"]?.summary.title, "New")
+    }
+
+    func testResetClearsState() async {
+        let mirror = AHPStateMirror()
+        await mirror.applySnapshot(Snapshot(
+            resource: RootResourceURI,
+            state: .root(RootState(agents: [
+                AgentInfo(provider: "copilot", displayName: "Copilot", description: "", models: [])
+            ])),
+            fromSeq: 0
+        ))
+        await mirror.reset()
+        let root = await mirror.rootState
+        XCTAssertEqual(root.agents.count, 0)
+    }
+}

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/InMemoryTransportTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/InMemoryTransportTests.swift
@@ -1,0 +1,115 @@
+// InMemoryTransportTests — basic round-trip and close behaviour for the
+// paired in-memory transport.
+
+import XCTest
+import AgentHostProtocol
+@testable import AgentHostProtocolClient
+
+final class InMemoryTransportTests: XCTestCase {
+
+    func testPairDeliversMessagesBothDirections() async throws {
+        let (a, b) = InMemoryTransport.pair()
+
+        let aToB = TransportMessage.text("a→b")
+        try await a.send(aToB)
+        let received1 = try await b.recv()
+        XCTAssertEqual(stringPayload(of: received1), "a→b")
+
+        let bToA = TransportMessage.text("b→a")
+        try await b.send(bToA)
+        let received2 = try await a.recv()
+        XCTAssertEqual(stringPayload(of: received2), "b→a")
+    }
+
+    func testCloseEndsBothPeersRecv() async throws {
+        let (a, b) = InMemoryTransport.pair()
+        try await a.close()
+        let aRecv = try await a.recv()
+        let bRecv = try await b.recv()
+        XCTAssertNil(aRecv, "a should observe its own close as nil recv")
+        XCTAssertNil(bRecv, "b should observe peer close as nil recv")
+    }
+
+    func testSendAfterCloseThrows() async throws {
+        let (a, _) = InMemoryTransport.pair()
+        try await a.close()
+        do {
+            try await a.send(.text("doomed"))
+            XCTFail("expected closed error")
+        } catch let error as TransportError {
+            XCTAssertEqual(error, .closed)
+        }
+    }
+
+    func testTransportMessageRoundTripEncodingPreservesNotification() throws {
+        let original = JsonRpcMessage.notification(
+            method: "ping",
+            params: AnyCodable(["k": "v"])
+        )
+        let encoded = try TransportMessage.encode(original)
+        let parsed = try encoded.intoParsed()
+        guard case .notification(let method, let params) = parsed else {
+            XCTFail("expected notification, got \(parsed)")
+            return
+        }
+        XCTAssertEqual(method, "ping")
+        XCTAssertEqual(params, AnyCodable(["k": "v"]))
+    }
+
+    func testTransportMessageRoundTripPreservesSuccessResponse() throws {
+        let original = JsonRpcMessage.successResponse(
+            id: 42,
+            result: AnyCodable(["ok": true])
+        )
+        let encoded = try TransportMessage.encode(original)
+        let parsed = try encoded.intoParsed()
+        guard case .successResponse(let id, let result) = parsed else {
+            XCTFail("expected successResponse, got \(parsed)")
+            return
+        }
+        XCTAssertEqual(id, 42)
+        XCTAssertEqual(result, AnyCodable(["ok": true]))
+    }
+
+    func testTransportMessageRoundTripPreservesErrorResponse() throws {
+        let original = JsonRpcMessage.errorResponse(
+            id: 7,
+            error: JsonRpcError(code: -32000, message: "boom", data: nil)
+        )
+        let encoded = try TransportMessage.encode(original)
+        let parsed = try encoded.intoParsed()
+        guard case .errorResponse(let id, let error) = parsed else {
+            XCTFail("expected errorResponse, got \(parsed)")
+            return
+        }
+        XCTAssertEqual(id, 7)
+        XCTAssertEqual(error.code, -32000)
+        XCTAssertEqual(error.message, "boom")
+    }
+
+    func testTransportMessageRoundTripPreservesRequest() throws {
+        let original = JsonRpcMessage.request(
+            id: 1,
+            method: "subscribe",
+            params: AnyCodable(["resource": "agenthost:/root"])
+        )
+        let encoded = try TransportMessage.encode(original)
+        let parsed = try encoded.intoParsed()
+        guard case .request(let id, let method, let params) = parsed else {
+            XCTFail("expected request, got \(parsed)")
+            return
+        }
+        XCTAssertEqual(id, 1)
+        XCTAssertEqual(method, "subscribe")
+        XCTAssertEqual(params, AnyCodable(["resource": "agenthost:/root"]))
+    }
+
+    private func stringPayload(of message: TransportMessage?) -> String? {
+        guard let message else { return nil }
+        switch message {
+        case .text(let s): return s
+        case .binary(let d): return String(data: d, encoding: .utf8)
+        case .parsed: return nil
+        }
+    }
+}

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/InMemoryTransportTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/InMemoryTransportTests.swift
@@ -113,3 +113,27 @@ final class InMemoryTransportTests: XCTestCase {
         }
     }
 }
+
+final class AHPClientConfigTests: XCTestCase {
+
+    func testSubscriptionBufferSizeClampsToOne() {
+        let config = AHPClientConfig(subscriptionBufferSize: 0)
+        XCTAssertEqual(config.subscriptionBufferSize, 1)
+    }
+
+    func testSubscriptionBufferSizeClampsNegativeToOne() {
+        let config = AHPClientConfig(subscriptionBufferSize: -42)
+        XCTAssertEqual(config.subscriptionBufferSize, 1)
+    }
+
+    func testSubscriptionBufferSizePreservesPositive() {
+        let config = AHPClientConfig(subscriptionBufferSize: 64)
+        XCTAssertEqual(config.subscriptionBufferSize, 64)
+    }
+
+    func testDefaultsAreReasonable() {
+        let config = AHPClientConfig.default
+        XCTAssertEqual(config.subscriptionBufferSize, 256)
+        XCTAssertEqual(config.requestTimeout, .seconds(30))
+    }
+}


### PR DESCRIPTION
## Why

The Swift package today ships only generated types and pure reducers — there's no client primitive to drive a transport, manage subscriptions, or correlate JSON-RPC traffic. Every consumer (the example iOS app, future macOS/Tauri integrations, the upcoming `MultiHostClient`) has to reimplement that layer; the example app's `AHPConnection` (~1100 lines) shows the shape and pain.

This is **PR 2 of a 3-PR series** adding multi-host client support across the AHP SDKs:

- **PR 1** — Rust `ahp::hosts` multi-host SDK ([open as #121](https://github.com/microsoft/agent-host-protocol/pull/121)). Establishes the API shape this Swift work mirrors.
- **PR 2** — *this PR* — single-host Swift client.
- **PR 3** — Swift `MultiHostClient` (per-host runtime/supervisor, generation-checked handles, reconnect policy, observable façade, `ClientIdStore`, aggregated views). Will stack on top of this product.
- **PR 4** (separate) — refactor the example `AHPClient` iOS app onto the new library.

Splitting PR 2 out keeps the JSON-RPC plumbing reviewable on its own and lets it bake before the multi-host wrapper goes on top.

## What

A new SwiftPM library product **`AgentHostProtocolClient`** that depends on the existing `AgentHostProtocol` types library. Surface:

- **`AHPTransport`** — pluggable async transport protocol (`send`/`recv`/`close`). `AHPClient` calls these serially; transports are not required to be reentrant-safe. `close()` MUST be idempotent.
- **`TransportMessage`** — `.parsed(JsonRpcMessage)` / `.text(String)` / `.binary(Data)` framing enum.
- **`JsonRpcMessage`** — local JSON-RPC 2.0 union (request/successResponse/errorResponse/notification). Lives only in this product so the types-only library stays dependency-free.
- **`URLSessionWebSocketTransport`** — default WebSocket transport. Maps `URLError(.cancelled)` and clean WebSocket close codes (`1000`, `1001`, `1005`) to `recv() -> nil`; everything else is `TransportError.io`.
- **`InMemoryTransport.pair()`** — paired in-memory transport for tests, mirroring the Rust `MemTransport` pattern in `client_roundtrip.rs`.
- **`AHPClient`** — actor with `init(transport:, config:)`, `connect`, `shutdown`, `initialize`, `reconnect`, `subscribe`, `attachSubscription`, `unsubscribe`, `dispatch`, generic `request<P, R>`. Exposes `events: AsyncStream<ClientEvent>` (top-level multicast tap tagged with `resource: String?`), `stateChanges: AsyncStream<ConnectionState>` (multicast), and a sync `connectionState`/`lastSeenServerSeq` accessor.
- **`AHPStateMirror`** — small actor that wraps the existing `rootReducer`/`sessionReducer` so consumers can keep an in-memory state mirror without hand-writing the dispatch loop.
- **`AgentHostProtocolClient.RootResourceURI`** — the `agenthost:/root` constant used throughout the spec, docs, and example app.

### Notable design choices

- **Send serialization via writer Task.** Outbound messages are pushed onto an `AsyncStream<Data>` channel from inside the actor; a single writer Task drains it and calls `transport.send` serially. Avoids two `await transport.send` calls racing under actor reentrancy.
- **Per-URI subscription streams are unbounded.** Top-level `events`/`stateChanges` are bounded with `.bufferingNewest(N)` and documented as advisory. Dropping an action envelope would silently desync the consumer's reducer mirror — unacceptable.
- **`events` tap registered before the handshake.** Documented contract: attach `events`/`stateChanges` *before* `connect()` if you need handshake-time notifications. Guarded by the `testEventsTapCapturesHandshakeNotifications` test (this is the bug PR #121's `runtime.rs` had a comment about).
- **Receive loop bypasses `AnyCodable`.** `AnyCodable` on Apple platforms collapses NSNumber Bool/Int distinction (the encoder/decoder accepts `1` as `Bool` and `true` as `Int`), which was corrupting `Int` fields like `serverSeq`. The receive loop now parses raw JSON via `JSONSerialization`, extracts payload sub-trees as raw `Data` slices, and decodes typed values directly via `JSONDecoder`. The outbound writer assembles the wire bytes the same way. The public `JsonRpcMessage` enum is unchanged for transport authors that want to inspect parsed messages.
- **`subscribe` cleans up on failure.** If the round-trip fails, the optimistically-attached per-URI listener is removed — no orphan listeners accumulate when the server rejects a subscribe.
- **Unsolicited server-initiated requests are answered with `-32601`.** Prevents a buggy peer from accumulating pending entries forever.
- **No `@MainActor` in the library.** UI threading is the consumer's concern. PR 3 will add an observable façade on top.

## Tests

`AgentHostProtocolClientTests` (XCTest, matching the existing `AgentHostProtocolTests` convention):

- `InMemoryTransportTests` — pair delivery both ways, close on either half ends both peers' `recv`, encoding round-trips for all four `JsonRpcMessage` variants.
- `AHPClientTests` — `initialize` round trip, `subscribe` + action notification fan-out, **events tap capturing notifications during the initialize window** (the bug PR #121 caught), unexpected close failing pending requests, `unsubscribe` finishing per-URI streams, `shutdown` terminating all multicast streams, **subscribe-failure listener cleanup**.
- `AHPStateMirrorTests` — apply root snapshot, apply session snapshot, root action updates root, session action updates session, reset.

`swift build` clean (zero warnings); `swift test` runs 33 tests, 0 failures (the existing 14 reducer tests still pass alongside the 19 new tests).

## Out of scope (PR 3 territory)

- Multi-host `MultiHostClient` / `HostRuntime` / `HostHandle`
- Generation-checked `HostClientHandle` for safe escape-hatch access across reconnects
- `ReconnectPolicy` (backoff, jitter, max-attempts) and supervisor-driven reopen
- `ClientIdStore` with persistent backends (Keychain, file)
- Aggregated cross-host views (`HostedSessionSummary`, `HostedAgent`)
- Per-host root + summary cache
- `@Observable` SwiftUI façade
- Refactoring the example `AHPClient` iOS app onto this library (PR 4)
- Per-listener subscribe refcounting — `unsubscribe(uri)` is the nuclear option here; reference counting belongs on the `HostRuntime` layer

## Compatibility

No protocol or wire changes. The existing `AgentHostProtocol` types library is untouched (no edits, no new dependencies). The example `AHPClient` iOS app keeps using its own `AHPConnection`. Adding the new product alongside the existing one is purely additive — no breaking changes for current consumers.