### PR TITLE
session: add session/customizationUpdated upsert action

### DIFF
--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::state::{
-    AgentInfo, ConfirmationOption, ErrorInfo, FileEdit, ModelSelection, PendingMessageKind,
-    ResponsePart, SessionActiveClient, SessionCustomization, SessionInputAnswer,
-    SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo,
+    AgentInfo, ConfirmationOption, CustomizationRef, CustomizationStatus, ErrorInfo, FileEdit,
+    ModelSelection, PendingMessageKind, ResponsePart, SessionActiveClient, SessionCustomization,
+    SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo,
     ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallResult, ToolDefinition,
     ToolResultContent, UsageInfo, UserMessage,
 };
@@ -88,6 +88,8 @@ pub enum ActionType {
     SessionCustomizationsChanged,
     #[serde(rename = "session/customizationToggled")]
     SessionCustomizationToggled,
+    #[serde(rename = "session/customizationUpdated")]
+    SessionCustomizationUpdated,
     #[serde(rename = "session/truncated")]
     SessionTruncated,
     #[serde(rename = "session/isReadChanged")]
@@ -740,6 +742,36 @@ pub struct SessionCustomizationToggledAction {
     pub enabled: bool,
 }
 
+/// Upserts mutable fields on a single customization.
+///
+/// Dispatched by the server to update one or more fields on a customization,
+/// or to add a new customization to the session, without republishing the
+/// entire `customizations` list. The reducer locates the existing entry by
+/// `customization.uri`:
+///
+/// - If an entry exists, each provided field is assigned; absent (or
+///   `undefined`) fields are left unchanged. The stored `customization`
+///   ref is replaced with the one in the action.
+/// - If no entry exists, a new {@link SessionCustomization} is appended
+///   using the provided fields; `enabled` defaults to `false` when absent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCustomizationUpdatedAction {
+    /// Session URI
+    pub session: Uri,
+    /// The customization to update or insert (matched by `customization.uri`)
+    pub customization: CustomizationRef,
+    /// New enabled state (defaults to `false` on insert)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// New loading status
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<CustomizationStatus>,
+    /// New human-readable status detail
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_message: Option<String>,
+}
+
 /// Truncates a session's history. If `turnId` is provided, all turns after that
 /// turn are removed and the specified turn is kept. If `turnId` is omitted, all
 /// turns are removed.
@@ -1077,6 +1109,8 @@ pub enum StateAction {
     SessionCustomizationsChanged(SessionCustomizationsChangedAction),
     #[serde(rename = "session/customizationToggled")]
     SessionCustomizationToggled(SessionCustomizationToggledAction),
+    #[serde(rename = "session/customizationUpdated")]
+    SessionCustomizationUpdated(SessionCustomizationUpdatedAction),
     #[serde(rename = "session/truncated")]
     SessionTruncated(SessionTruncatedAction),
     #[serde(rename = "session/diffsChanged")]

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -55,10 +55,10 @@ use ahp_types::actions::{
 };
 use ahp_types::state::{
     ActiveTurn, ConfirmationOption, ErrorInfo, PendingMessage, PendingMessageKind, ResponsePart,
-    RootState, SessionInputRequest, SessionLifecycle, SessionState, SessionStatus,
-    TerminalCommandPart, TerminalContentPart, TerminalState, TerminalUnclassifiedPart,
-    ToolCallCancellationReason, ToolCallCancelledState, ToolCallCompletedState,
-    ToolCallConfirmationReason, ToolCallPendingConfirmationState,
+    RootState, SessionCustomization, SessionInputRequest, SessionLifecycle, SessionState,
+    SessionStatus, TerminalCommandPart, TerminalContentPart, TerminalState,
+    TerminalUnclassifiedPart, ToolCallCancellationReason, ToolCallCancelledState,
+    ToolCallCompletedState, ToolCallConfirmationReason, ToolCallPendingConfirmationState,
     ToolCallPendingResultConfirmationState, ToolCallResponsePart, ToolCallRunningState,
     ToolCallState, ToolCallStreamingState, Turn, TurnState,
 };
@@ -615,6 +615,30 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
                 return ReduceOutcome::NoOp;
             };
             list[idx].enabled = a.enabled;
+            ReduceOutcome::Applied
+        }
+        StateAction::SessionCustomizationUpdated(a) => {
+            let list = state.customizations.get_or_insert_with(Vec::new);
+            if let Some(idx) = list.iter().position(|c| c.customization.uri == a.customization.uri) {
+                list[idx].customization = a.customization.clone();
+                if let Some(enabled) = a.enabled {
+                    list[idx].enabled = enabled;
+                }
+                if let Some(status) = a.status.clone() {
+                    list[idx].status = Some(status);
+                }
+                if let Some(message) = a.status_message.clone() {
+                    list[idx].status_message = Some(message);
+                }
+            } else {
+                list.push(SessionCustomization {
+                    customization: a.customization.clone(),
+                    enabled: a.enabled.unwrap_or(false),
+                    client_id: None,
+                    status: a.status.clone(),
+                    status_message: a.status_message.clone(),
+                });
+            }
             ReduceOutcome::Applied
         }
         StateAction::SessionTruncated(a) => apply_truncated(state, a.turn_id.as_deref()),

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -624,7 +624,7 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
                 if let Some(enabled) = a.enabled {
                     list[idx].enabled = enabled;
                 }
-                if let Some(status) = a.status.clone() {
+                if let Some(status) = a.status {
                     list[idx].status = Some(status);
                 }
                 if let Some(message) = a.status_message.clone() {
@@ -635,7 +635,7 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
                     customization: a.customization.clone(),
                     enabled: a.enabled.unwrap_or(false),
                     client_id: None,
-                    status: a.status.clone(),
+                    status: a.status,
                     status_message: a.status_message.clone(),
                 });
             }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -38,6 +38,7 @@ public enum ActionType: String, Codable, Sendable {
     case sessionInputCompleted = "session/inputCompleted"
     case sessionCustomizationsChanged = "session/customizationsChanged"
     case sessionCustomizationToggled = "session/customizationToggled"
+    case sessionCustomizationUpdated = "session/customizationUpdated"
     case sessionTruncated = "session/truncated"
     case sessionIsReadChanged = "session/isReadChanged"
     case sessionIsArchivedChanged = "session/isArchivedChanged"
@@ -991,6 +992,36 @@ public struct SessionCustomizationToggledAction: Codable, Sendable {
     }
 }
 
+public struct SessionCustomizationUpdatedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Session URI
+    public var session: String
+    /// The customization to update or insert (matched by `customization.uri`)
+    public var customization: CustomizationRef
+    /// New enabled state (defaults to `false` on insert)
+    public var enabled: Bool?
+    /// New loading status
+    public var status: CustomizationStatus?
+    /// New human-readable status detail
+    public var statusMessage: String?
+
+    public init(
+        type: ActionType,
+        session: String,
+        customization: CustomizationRef,
+        enabled: Bool? = nil,
+        status: CustomizationStatus? = nil,
+        statusMessage: String? = nil
+    ) {
+        self.type = type
+        self.session = session
+        self.customization = customization
+        self.enabled = enabled
+        self.status = status
+        self.statusMessage = statusMessage
+    }
+}
+
 public struct SessionTruncatedAction: Codable, Sendable {
     public var type: ActionType
     /// Session URI
@@ -1400,6 +1431,7 @@ public enum StateAction: Codable, Sendable {
     case sessionInputCompleted(SessionInputCompletedAction)
     case sessionCustomizationsChanged(SessionCustomizationsChangedAction)
     case sessionCustomizationToggled(SessionCustomizationToggledAction)
+    case sessionCustomizationUpdated(SessionCustomizationUpdatedAction)
     case sessionTruncated(SessionTruncatedAction)
     case sessionDiffsChanged(SessionDiffsChangedAction)
     case sessionConfigChanged(SessionConfigChangedAction)
@@ -1495,6 +1527,8 @@ public enum StateAction: Codable, Sendable {
             self = .sessionCustomizationsChanged(try SessionCustomizationsChangedAction(from: decoder))
         case "session/customizationToggled":
             self = .sessionCustomizationToggled(try SessionCustomizationToggledAction(from: decoder))
+        case "session/customizationUpdated":
+            self = .sessionCustomizationUpdated(try SessionCustomizationUpdatedAction(from: decoder))
         case "session/truncated":
             self = .sessionTruncated(try SessionTruncatedAction(from: decoder))
         case "session/diffsChanged":
@@ -1572,6 +1606,7 @@ public enum StateAction: Codable, Sendable {
         case .sessionInputCompleted(let v): try v.encode(to: encoder)
         case .sessionCustomizationsChanged(let v): try v.encode(to: encoder)
         case .sessionCustomizationToggled(let v): try v.encode(to: encoder)
+        case .sessionCustomizationUpdated(let v): try v.encode(to: encoder)
         case .sessionTruncated(let v): try v.encode(to: encoder)
         case .sessionDiffsChanged(let v): try v.encode(to: encoder)
         case .sessionConfigChanged(let v): try v.encode(to: encoder)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
@@ -436,6 +436,31 @@ public struct AHPSessionReducer: Reducer {
             guard let idx = state.customizations?.firstIndex(where: { $0.customization.uri == a.uri }) else { return }
             state.customizations?[idx].enabled = a.enabled
 
+        case .sessionCustomizationUpdated(let a):
+            if state.customizations == nil {
+                state.customizations = []
+            }
+            if let idx = state.customizations?.firstIndex(where: { $0.customization.uri == a.customization.uri }) {
+                state.customizations?[idx].customization = a.customization
+                if let enabled = a.enabled {
+                    state.customizations?[idx].enabled = enabled
+                }
+                if let status = a.status {
+                    state.customizations?[idx].status = status
+                }
+                if let message = a.statusMessage {
+                    state.customizations?[idx].statusMessage = message
+                }
+            } else {
+                state.customizations?.append(SessionCustomization(
+                    customization: a.customization,
+                    enabled: a.enabled ?? false,
+                    clientId: nil,
+                    status: a.status,
+                    statusMessage: a.statusMessage
+                ))
+            }
+
         // ── Truncation ────────────────────────────────────────────────────────
 
         case .sessionTruncated(let a):

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -414,6 +414,32 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
         next.customizations = list
         return next
 
+    case .sessionCustomizationUpdated(let a):
+        var list = state.customizations ?? []
+        if let idx = list.firstIndex(where: { $0.customization.uri == a.customization.uri }) {
+            list[idx].customization = a.customization
+            if let enabled = a.enabled {
+                list[idx].enabled = enabled
+            }
+            if let status = a.status {
+                list[idx].status = status
+            }
+            if let message = a.statusMessage {
+                list[idx].statusMessage = message
+            }
+        } else {
+            list.append(SessionCustomization(
+                customization: a.customization,
+                enabled: a.enabled ?? false,
+                clientId: nil,
+                status: a.status,
+                statusMessage: a.statusMessage
+            ))
+        }
+        var next = state
+        next.customizations = list
+        return next
+
     // ── Truncation ────────────────────────────────────────────────────────
 
     case .sessionTruncated(let a):

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -148,6 +148,26 @@ sequenceDiagram
     Note over Server: customizations: [Plugin A (enabled), Plugin B (enabled)]
 ```
 
+## Reporting Customization Updates
+
+The server reports plugin state via the `enabled`, `status` (`loading` / `loaded` / `degraded` / `error`) and `statusMessage` fields on each `SessionCustomization`. To change one or more of these for a single plugin — for example, when a plugin finishes loading or fails — the server dispatches `session/customizationUpdated` instead of republishing the entire `customizations` list:
+
+```typescript
+{
+  type: 'session/customizationUpdated'
+  session: URI
+  customization: CustomizationRef // matched by `customization.uri`
+  enabled?: boolean               // omit to leave unchanged (defaults to false on insert)
+  status?: CustomizationStatus    // omit to leave unchanged
+  statusMessage?: string          // omit to leave unchanged
+}
+```
+
+This action is an upsert. The reducer locates the entry by `customization.uri`:
+
+- If found, the stored `customization` ref is replaced with the one in the action and each provided mutable field is assigned. Absent fields are left unchanged.
+- If not found, a new entry is appended using the provided fields. `enabled` defaults to `false` when absent.
+
 ## Client-Provided Tools
 
 AHP sessions can expose tools from two sources: **server tools** provided by the agent host, and **client tools** provided by the active client (e.g. an IDE). Client tools let the agent invoke capabilities that only the client has access to.
@@ -269,6 +289,7 @@ This ensures tool calls do not remain stuck in `running` state indefinitely.
 |---|---|---|
 | `session/customizationsChanged` | No | Server updated the session's customization list (full replacement) |
 | `session/customizationToggled` | **Yes** | Client toggled a customization on or off |
+| `session/customizationUpdated` | No | Server upserts mutable fields on a single customization |
 | `session/activeClientChanged` | **Yes** | Client claims/releases the active role (with tools + customizations) |
 | `session/activeClientToolsChanged` | **Yes** | Client updates its tool list without re-claiming |
 | `session/toolCallStart` | No | Server begins a tool call (sets `toolClientId` for client tools) |

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1060,6 +1060,40 @@
         "enabled"
       ]
     },
+    "SessionCustomizationUpdatedAction": {
+      "type": "object",
+      "description": "Upserts mutable fields on a single customization.\n\nDispatched by the server to update one or more fields on a customization,\nor to add a new customization to the session, without republishing the\nentire `customizations` list. The reducer locates the existing entry by\n`customization.uri`:\n\n- If an entry exists, each provided field is assigned; absent (or\n  `undefined`) fields are left unchanged. The stored `customization`\n  ref is replaced with the one in the action.\n- If no entry exists, a new {@link SessionCustomization} is appended\n  using the provided fields; `enabled` defaults to `false` when absent.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionCustomizationUpdated"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "customization": {
+          "$ref": "#/$defs/CustomizationRef",
+          "description": "The customization to update or insert (matched by `customization.uri`)"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "New enabled state (defaults to `false` on insert)"
+        },
+        "status": {
+          "$ref": "#/$defs/CustomizationStatus",
+          "description": "New loading status"
+        },
+        "statusMessage": {
+          "type": "string",
+          "description": "New human-readable status detail"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "customization"
+      ]
+    },
     "SessionConfigChangedAction": {
       "type": "object",
       "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
@@ -4613,6 +4647,9 @@
         },
         {
           "$ref": "#/$defs/SessionCustomizationToggledAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationUpdatedAction"
         },
         {
           "$ref": "#/$defs/SessionTruncatedAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -4640,6 +4640,40 @@
         "enabled"
       ]
     },
+    "SessionCustomizationUpdatedAction": {
+      "type": "object",
+      "description": "Upserts mutable fields on a single customization.\n\nDispatched by the server to update one or more fields on a customization,\nor to add a new customization to the session, without republishing the\nentire `customizations` list. The reducer locates the existing entry by\n`customization.uri`:\n\n- If an entry exists, each provided field is assigned; absent (or\n  `undefined`) fields are left unchanged. The stored `customization`\n  ref is replaced with the one in the action.\n- If no entry exists, a new {@link SessionCustomization} is appended\n  using the provided fields; `enabled` defaults to `false` when absent.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.SessionCustomizationUpdated"
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session URI"
+        },
+        "customization": {
+          "$ref": "#/$defs/CustomizationRef",
+          "description": "The customization to update or insert (matched by `customization.uri`)"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "New enabled state (defaults to `false` on insert)"
+        },
+        "status": {
+          "$ref": "#/$defs/CustomizationStatus",
+          "description": "New loading status"
+        },
+        "statusMessage": {
+          "type": "string",
+          "description": "New human-readable status detail"
+        }
+      },
+      "required": [
+        "type",
+        "session",
+        "customization"
+      ]
+    },
     "SessionConfigChangedAction": {
       "type": "object",
       "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -830,6 +830,7 @@ const ACTION_VARIANTS: {
   { type: 'session/inputCompleted', variantName: 'SessionInputCompleted', tsInterface: 'SessionInputCompletedAction' },
   { type: 'session/customizationsChanged', variantName: 'SessionCustomizationsChanged', tsInterface: 'SessionCustomizationsChangedAction' },
   { type: 'session/customizationToggled', variantName: 'SessionCustomizationToggled', tsInterface: 'SessionCustomizationToggledAction' },
+  { type: 'session/customizationUpdated', variantName: 'SessionCustomizationUpdated', tsInterface: 'SessionCustomizationUpdatedAction' },
   { type: 'session/truncated', variantName: 'SessionTruncated', tsInterface: 'SessionTruncatedAction' },
   { type: 'session/diffsChanged', variantName: 'SessionDiffsChanged', tsInterface: 'SessionDiffsChangedAction' },
   { type: 'session/configChanged', variantName: 'SessionConfigChanged', tsInterface: 'SessionConfigChangedAction' },
@@ -886,7 +887,7 @@ pub struct SessionToolCallConfirmedAction {
 function generateActionsFile(project: Project): string {
   const sf = project.getSourceFiles().find(f => f.getBaseName() === 'actions.ts')!;
   const lines: string[] = [GENERATED_HEADER];
-  lines.push('use crate::state::{AgentInfo, ConfirmationOption, ErrorInfo, FileEdit, ModelSelection, ResponsePart, SessionActiveClient, SessionCustomization, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, UserMessage, PendingMessageKind};');
+  lines.push('use crate::state::{AgentInfo, ConfirmationOption, CustomizationRef, CustomizationStatus, ErrorInfo, FileEdit, ModelSelection, ResponsePart, SessionActiveClient, SessionCustomization, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, UserMessage, PendingMessageKind};');
   lines.push('');
 
   // ActionType enum

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -815,6 +815,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'session/inputCompleted', caseName: 'sessionInputCompleted', tsInterface: 'SessionInputCompletedAction' },
   { type: 'session/customizationsChanged', caseName: 'sessionCustomizationsChanged', tsInterface: 'SessionCustomizationsChangedAction' },
   { type: 'session/customizationToggled', caseName: 'sessionCustomizationToggled', tsInterface: 'SessionCustomizationToggledAction' },
+  { type: 'session/customizationUpdated', caseName: 'sessionCustomizationUpdated', tsInterface: 'SessionCustomizationUpdatedAction' },
   { type: 'session/truncated', caseName: 'sessionTruncated', tsInterface: 'SessionTruncatedAction' },
   { type: 'session/diffsChanged', caseName: 'sessionDiffsChanged', tsInterface: 'SessionDiffsChangedAction' },
   { type: 'session/configChanged', caseName: 'sessionConfigChanged', tsInterface: 'SessionConfigChangedAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -37,6 +37,7 @@ import type {
   SessionInputCompletedAction,
   SessionCustomizationsChangedAction,
   SessionCustomizationToggledAction,
+  SessionCustomizationUpdatedAction,
   SessionTruncatedAction,
   SessionIsReadChangedAction,
   SessionIsArchivedChangedAction,
@@ -113,6 +114,7 @@ export type SessionAction =
   | SessionInputCompletedAction
   | SessionCustomizationsChangedAction
   | SessionCustomizationToggledAction
+  | SessionCustomizationUpdatedAction
   | SessionTruncatedAction
   | SessionIsReadChangedAction
   | SessionIsArchivedChangedAction
@@ -162,6 +164,7 @@ export type ServerSessionAction =
   | SessionServerToolsChangedAction
   | SessionInputRequestedAction
   | SessionCustomizationsChangedAction
+  | SessionCustomizationUpdatedAction
   | SessionActivityChangedAction
   | SessionDiffsChangedAction
   | SessionMetaChangedAction
@@ -242,6 +245,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.SessionInputCompleted]: true,
   [ActionType.SessionCustomizationsChanged]: false,
   [ActionType.SessionCustomizationToggled]: true,
+  [ActionType.SessionCustomizationUpdated]: false,
   [ActionType.SessionTruncated]: true,
   [ActionType.SessionIsReadChanged]: true,
   [ActionType.SessionIsArchivedChanged]: true,

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -20,6 +20,7 @@ import type {
   SessionActiveClient,
   UsageInfo,
   SessionCustomization,
+  CustomizationRef,
   FileEdit,
   SessionInputAnswer,
   SessionInputRequest,
@@ -27,6 +28,7 @@ import type {
   TerminalClaim,
   SessionInputResponseKind,
   ConfirmationOption,
+  CustomizationStatus,
 } from './state.js';
 
 import { ToolCallConfirmationReason, ToolCallCancellationReason, PendingMessageKind } from './state.js';
@@ -71,6 +73,7 @@ export const enum ActionType {
   SessionInputCompleted = 'session/inputCompleted',
   SessionCustomizationsChanged = 'session/customizationsChanged',
   SessionCustomizationToggled = 'session/customizationToggled',
+  SessionCustomizationUpdated = 'session/customizationUpdated',
   SessionTruncated = 'session/truncated',
   SessionIsReadChanged = 'session/isReadChanged',
   SessionIsArchivedChanged = 'session/isArchivedChanged',
@@ -750,6 +753,37 @@ export interface SessionCustomizationToggledAction {
   enabled: boolean;
 }
 
+/**
+ * Upserts mutable fields on a single customization.
+ *
+ * Dispatched by the server to update one or more fields on a customization,
+ * or to add a new customization to the session, without republishing the
+ * entire `customizations` list. The reducer locates the existing entry by
+ * `customization.uri`:
+ *
+ * - If an entry exists, each provided field is assigned; absent (or
+ *   `undefined`) fields are left unchanged. The stored `customization`
+ *   ref is replaced with the one in the action.
+ * - If no entry exists, a new {@link SessionCustomization} is appended
+ *   using the provided fields; `enabled` defaults to `false` when absent.
+ *
+ * @category Session Actions
+ * @version 1
+ */
+export interface SessionCustomizationUpdatedAction {
+  type: ActionType.SessionCustomizationUpdated;
+  /** Session URI */
+  session: URI;
+  /** The customization to update or insert (matched by `customization.uri`) */
+  customization: CustomizationRef;
+  /** New enabled state (defaults to `false` on insert) */
+  enabled?: boolean;
+  /** New loading status */
+  status?: CustomizationStatus;
+  /** New human-readable status detail */
+  statusMessage?: string;
+}
+
 // ─── Config Actions ──────────────────────────────────────────────────────────
 
 /**
@@ -1197,6 +1231,7 @@ export type StateAction =
   | SessionInputCompletedAction
   | SessionCustomizationsChangedAction
   | SessionCustomizationToggledAction
+  | SessionCustomizationUpdatedAction
   | SessionTruncatedAction
   | SessionIsReadChangedAction
   | SessionIsArchivedChangedAction

--- a/types/reducers.ts
+++ b/types/reducers.ts
@@ -5,7 +5,7 @@
  */
 
 import { ActionType } from './actions.js';
-import type { RootState, SessionInputRequest, SessionState, TerminalState, TerminalContentPart, ToolCallState, ResponsePart, ToolCallResponsePart, Turn, PendingMessage, ConfirmationOption } from './state.js';
+import type { RootState, SessionCustomization, SessionInputRequest, SessionState, TerminalState, TerminalContentPart, ToolCallState, ResponsePart, ToolCallResponsePart, Turn, PendingMessage, ConfirmationOption } from './state.js';
 import { SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallCancellationReason, ResponsePartKind, PendingMessageKind } from './state.js';
 import type { RootAction, ClientRootAction, SessionAction, ClientSessionAction, TerminalAction, ClientTerminalAction } from './action-origin.generated.js';
 import { IS_CLIENT_DISPATCHABLE } from './action-origin.generated.js';
@@ -643,6 +643,37 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
       }
       const updated = [...list];
       updated[idx] = { ...list[idx], enabled: action.enabled };
+      return { ...state, customizations: updated };
+    }
+
+    case ActionType.SessionCustomizationUpdated: {
+      const list = state.customizations ?? [];
+      const idx = list.findIndex(c => c.customization.uri === action.customization.uri);
+      if (idx < 0) {
+        const inserted: SessionCustomization = {
+          customization: action.customization,
+          enabled: action.enabled ?? false,
+        };
+        if (action.status !== undefined) {
+          inserted.status = action.status;
+        }
+        if (action.statusMessage !== undefined) {
+          inserted.statusMessage = action.statusMessage;
+        }
+        return { ...state, customizations: [...list, inserted] };
+      }
+      const updated = [...list];
+      const next = { ...list[idx], customization: action.customization };
+      if (action.enabled !== undefined) {
+        next.enabled = action.enabled;
+      }
+      if (action.status !== undefined) {
+        next.status = action.status;
+      }
+      if (action.statusMessage !== undefined) {
+        next.statusMessage = action.statusMessage;
+      }
+      updated[idx] = next;
       return { ...state, customizations: updated };
     }
 

--- a/types/test-cases/reducers/136-session-customizationupdated-updates-status.json
+++ b/types/test-cases/reducers/136-session-customizationupdated-updates-status.json
@@ -1,0 +1,77 @@
+{
+  "description": "session/customizationUpdated updates status and statusMessage by URI",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true,
+        "status": "loading"
+      },
+      {
+        "customization": {
+          "uri": "https://plugins.example/b",
+          "displayName": "Plugin B"
+        },
+        "enabled": true,
+        "status": "loaded"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/customizationUpdated",
+      "session": "copilot:/test-session",
+      "customization": {
+        "uri": "https://plugins.example/a",
+        "displayName": "Plugin A"
+      },
+      "status": "error",
+      "statusMessage": "Failed to load"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true,
+        "status": "error",
+        "statusMessage": "Failed to load"
+      },
+      {
+        "customization": {
+          "uri": "https://plugins.example/b",
+          "displayName": "Plugin B"
+        },
+        "enabled": true,
+        "status": "loaded"
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/137-session-customizationupdated-updates-multiple-fields.json
+++ b/types/test-cases/reducers/137-session-customizationupdated-updates-multiple-fields.json
@@ -1,0 +1,61 @@
+{
+  "description": "session/customizationUpdated updates enabled and statusMessage together",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true,
+        "status": "loaded"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/customizationUpdated",
+      "session": "copilot:/test-session",
+      "customization": {
+        "uri": "https://plugins.example/a",
+        "displayName": "Plugin A"
+      },
+      "enabled": false,
+      "statusMessage": "Disabled by user"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": false,
+        "status": "loaded",
+        "statusMessage": "Disabled by user"
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/138-session-customizationupdated-upserts-unknown-uri.json
+++ b/types/test-cases/reducers/138-session-customizationupdated-upserts-unknown-uri.json
@@ -1,0 +1,67 @@
+{
+  "description": "session/customizationUpdated upserts a new customization when the URI is unknown",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/customizationUpdated",
+      "session": "copilot:/test-session",
+      "customization": {
+        "uri": "https://plugins.example/new",
+        "displayName": "New Plugin"
+      },
+      "enabled": true,
+      "status": "loading"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true
+      },
+      {
+        "customization": {
+          "uri": "https://plugins.example/new",
+          "displayName": "New Plugin"
+        },
+        "enabled": true,
+        "status": "loading"
+      }
+    ]
+  }
+}
+

--- a/types/test-cases/reducers/139-session-customizationupdated-creates-list.json
+++ b/types/test-cases/reducers/139-session-customizationupdated-creates-list.json
@@ -1,0 +1,53 @@
+{
+  "description": "session/customizationUpdated creates the customizations list when absent",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "session/customizationUpdated",
+      "session": "copilot:/test-session",
+      "customization": {
+        "uri": "https://plugins.example/a",
+        "displayName": "Plugin A"
+      },
+      "enabled": true,
+      "status": "error",
+      "statusMessage": "Failed to load"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": true,
+        "status": "error",
+        "statusMessage": "Failed to load"
+      }
+    ]
+  }
+}
+

--- a/types/test-cases/reducers/140-session-customizationupdated-insert-defaults-enabled-false.json
+++ b/types/test-cases/reducers/140-session-customizationupdated-insert-defaults-enabled-false.json
@@ -1,0 +1,48 @@
+{
+  "description": "session/customizationUpdated insert defaults enabled to false when absent",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": []
+  },
+  "actions": [
+    {
+      "type": "session/customizationUpdated",
+      "session": "copilot:/test-session",
+      "customization": {
+        "uri": "https://plugins.example/a",
+        "displayName": "Plugin A"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 1,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "customizations": [
+      {
+        "customization": {
+          "uri": "https://plugins.example/a",
+          "displayName": "Plugin A"
+        },
+        "enabled": false
+      }
+    ]
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -88,6 +88,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string
   [ActionType.SessionInputCompleted]: '0.1.0',
   [ActionType.SessionCustomizationsChanged]: '0.1.0',
   [ActionType.SessionCustomizationToggled]: '0.1.0',
+  [ActionType.SessionCustomizationUpdated]: '0.1.0',
   [ActionType.SessionTruncated]: '0.1.0',
   [ActionType.SessionIsReadChanged]: '0.1.0',
   [ActionType.SessionIsArchivedChanged]: '0.1.0',

--- a/types/version/v1.ts
+++ b/types/version/v1.ts
@@ -108,6 +108,7 @@ import type {
   SessionQueuedMessagesReorderedAction,
   SessionCustomizationsChangedAction,
   SessionCustomizationToggledAction,
+  SessionCustomizationUpdatedAction,
   SessionTruncatedAction,
   SessionIsReadChangedAction,
   SessionIsArchivedChangedAction,
@@ -298,6 +299,7 @@ type V1_ISessionPendingMessageRemovedAction = SessionPendingMessageRemovedAction
 type V1_ISessionQueuedMessagesReorderedAction = SessionQueuedMessagesReorderedAction;
 type V1_ISessionCustomizationsChangedAction = SessionCustomizationsChangedAction;
 type V1_ISessionCustomizationToggledAction = SessionCustomizationToggledAction;
+type V1_ISessionCustomizationUpdatedAction = SessionCustomizationUpdatedAction;
 type V1_ISessionTruncatedAction = SessionTruncatedAction;
 type V1_ISessionIsReadChangedAction = SessionIsReadChangedAction;
 type V1_ISessionIsArchivedChangedAction = SessionIsArchivedChangedAction;
@@ -557,6 +559,8 @@ type _CheckSessionCustomization = AssertCompatible<V1_ISessionCustomization, Ses
 type _CheckCustomizationsChangedAction = AssertCompatible<V1_ISessionCustomizationsChangedAction, SessionCustomizationsChangedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckCustomizationToggledAction = AssertCompatible<V1_ISessionCustomizationToggledAction, SessionCustomizationToggledAction>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckCustomizationUpdatedAction = AssertCompatible<V1_ISessionCustomizationUpdatedAction, SessionCustomizationUpdatedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckTruncatedAction = AssertCompatible<V1_ISessionTruncatedAction, SessionTruncatedAction>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
- Avoids re-publishing the entire customizations array whenever a single customization's loading status or enabled flag changes; servers can now dispatch a targeted partial update instead.
- Generalizes the action to upsert semantics so servers can introduce a new customization mid-session without orchestrating a full customizationsChanged broadcast.
- Carries the full CustomizationRef on the action so the reducer has enough information to insert a new entry when no match exists, keeping the action self-sufficient rather than depending on prior state.

(PR description generated by Copilot)