### PR TITLE
Rust SDK: port multi-host feedback from Swift PR #129

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "ahp-ws",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/clients/rust/crates/ahp/Cargo.toml
+++ b/clients/rust/crates/ahp/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }
 ahp-ws = { path = "../ahp-ws" }
 tracing-subscriber = "0.3"
+tempfile = "3"
 
 [[example]]
 name = "connect_ws"

--- a/clients/rust/crates/ahp/src/client.rs
+++ b/clients/rust/crates/ahp/src/client.rs
@@ -173,7 +173,14 @@ pub struct DispatchHandle {
 type PendingMap = HashMap<u64, oneshot::Sender<Result<Value, JsonRpcError>>>;
 
 struct Shared {
-    pending: Mutex<PendingMap>,
+    /// Pending requests keyed by id. Backed by a sync `std::sync::Mutex`
+    /// (rather than `tokio::sync::Mutex`) so the [`PendingGuard`] drop
+    /// glue can clean up the entry without `await`. The critical
+    /// section never holds the lock across an `await`, so a sync mutex
+    /// is strictly better — and lets us guarantee no orphaned entries
+    /// even when a caller drops the request future before the response
+    /// arrives.
+    pending: std::sync::Mutex<PendingMap>,
     subscriptions: Mutex<HashMap<String, broadcast::Sender<SubscriptionEvent>>>,
     /// Top-level all-events broadcast.
     ///
@@ -187,6 +194,48 @@ struct Shared {
     next_id: AtomicU64,
     next_client_seq: AtomicU64,
     config: ClientConfig,
+}
+
+/// RAII guard that removes its pending entry from
+/// [`Shared::pending`] on drop unless [`PendingGuard::disarm`] is
+/// called first.
+///
+/// Without this, dropping a request future before the response
+/// arrives (e.g. a caller `select!`-ing the request against
+/// cancellation) leaks the pending entry until the server eventually
+/// responds — or forever if no response is ever sent. The guard
+/// makes the cleanup deterministic.
+struct PendingGuard {
+    id: u64,
+    shared: Arc<Shared>,
+    armed: bool,
+}
+
+impl PendingGuard {
+    fn new(id: u64, shared: Arc<Shared>) -> Self {
+        Self {
+            id,
+            shared,
+            armed: true,
+        }
+    }
+
+    /// Mark the guard inactive so it doesn't remove the entry on drop.
+    /// Called when the response (or timeout) has already taken the
+    /// entry, so the drop cleanup is a no-op.
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PendingGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            if let Ok(mut pending) = self.shared.pending.lock() {
+                pending.remove(&self.id);
+            }
+        }
+    }
 }
 
 enum Outbound {
@@ -228,7 +277,7 @@ impl Client {
         let (outbound_tx, outbound_rx) = mpsc::channel::<Outbound>(64);
         let (all_events_tx, _) = broadcast::channel::<ClientEvent>(config.subscription_buffer);
         let shared = Arc::new(Shared {
-            pending: Mutex::new(HashMap::new()),
+            pending: std::sync::Mutex::new(HashMap::new()),
             subscriptions: Mutex::new(HashMap::new()),
             all_events: std::sync::Mutex::new(Some(all_events_tx)),
             outbound: outbound_tx,
@@ -251,8 +300,15 @@ impl Client {
     pub async fn shutdown(&self) {
         let _ = self.shared.outbound.send(Outbound::Shutdown).await;
         // Fail any pending in-flight requests.
-        let mut pending = self.shared.pending.lock().await;
-        for (_, tx) in pending.drain() {
+        let drained: Vec<_> = {
+            let mut pending = self
+                .shared
+                .pending
+                .lock()
+                .expect("client pending map poisoned");
+            pending.drain().collect()
+        };
+        for (_, tx) in drained {
             let _ = tx.send(Err(JsonRpcError {
                 code: -32000,
                 message: "client shut down".into(),
@@ -262,6 +318,15 @@ impl Client {
     }
 
     /// Send a JSON-RPC request and await its result.
+    ///
+    /// # Cancellation
+    ///
+    /// Cancel-safe via the standard Rust mechanism — drop the future
+    /// to cancel the local wait. An RAII guard removes the pending
+    /// entry from the request map immediately on drop, so abandoned
+    /// requests can't accumulate even if the server never responds.
+    /// **Cancellation only cancels the local wait** — it does not
+    /// abort the server's execution of the request.
     pub async fn request<P, R>(&self, method: &str, params: P) -> Result<R, ClientError>
     where
         P: Serialize,
@@ -283,9 +348,16 @@ impl Client {
 
         let (tx, rx) = oneshot::channel();
         {
-            let mut pending = self.shared.pending.lock().await;
+            let mut pending = self
+                .shared
+                .pending
+                .lock()
+                .expect("client pending map poisoned");
             pending.insert(id, tx);
         }
+        // Arm the cleanup guard before any await point so a dropped
+        // future removes the pending entry deterministically.
+        let guard = PendingGuard::new(id, self.shared.clone());
 
         if self
             .shared
@@ -294,7 +366,7 @@ impl Client {
             .await
             .is_err()
         {
-            self.shared.pending.lock().await.remove(&id);
+            // Guard's Drop will remove the entry; just return.
             return Err(ClientError::Shutdown);
         }
 
@@ -302,12 +374,16 @@ impl Client {
             Some(dur) => match tokio::time::timeout(dur, rx).await {
                 Ok(r) => r,
                 Err(_) => {
-                    self.shared.pending.lock().await.remove(&id);
+                    // Guard's Drop removes the entry; surface timeout.
                     return Err(ClientError::Cancelled);
                 }
             },
             None => rx.await,
         };
+
+        // Response (or shutdown) took the entry out of the map already
+        // — disarm the guard so its Drop is a no-op.
+        guard.disarm();
 
         match result {
             Ok(Ok(value)) => Ok(serde_json::from_value(value)?),
@@ -457,6 +533,20 @@ impl Client {
         .await?;
         Ok(DispatchHandle { client_seq })
     }
+
+    /// Number of in-flight requests currently awaiting a response.
+    ///
+    /// Exposed for diagnostics and tests — production code should not
+    /// depend on the absolute value (the count is racy across
+    /// in-flight cancellations) but tests can assert "0 leaked entries
+    /// after dropping the future".
+    pub fn pending_request_count(&self) -> usize {
+        self.shared
+            .pending
+            .lock()
+            .map(|p| p.len())
+            .unwrap_or_default()
+    }
 }
 
 async fn drive_transport<T: Transport>(
@@ -501,8 +591,11 @@ async fn drive_transport<T: Transport>(
     }
 
     // Teardown: close everything so waiters see Shutdown.
-    let mut pending = shared.pending.lock().await;
-    for (_, tx) in pending.drain() {
+    let drained: Vec<_> = {
+        let mut pending = shared.pending.lock().expect("client pending map poisoned");
+        pending.drain().collect()
+    };
+    for (_, tx) in drained {
         let _ = tx.send(Err(JsonRpcError {
             code: -32000,
             message: "transport closed".into(),
@@ -523,12 +616,20 @@ async fn drive_transport<T: Transport>(
 async fn dispatch_inbound(shared: &Shared, msg: JsonRpcMessage) {
     match msg {
         JsonRpcMessage::SuccessResponse(r) => {
-            if let Some(tx) = shared.pending.lock().await.remove(&r.id) {
+            let tx = {
+                let mut pending = shared.pending.lock().expect("client pending map poisoned");
+                pending.remove(&r.id)
+            };
+            if let Some(tx) = tx {
                 let _ = tx.send(Ok(r.result));
             }
         }
         JsonRpcMessage::ErrorResponse(r) => {
-            if let Some(tx) = shared.pending.lock().await.remove(&r.id) {
+            let tx = {
+                let mut pending = shared.pending.lock().expect("client pending map poisoned");
+                pending.remove(&r.id)
+            };
+            if let Some(tx) = tx {
                 let _ = tx.send(Err(r.error));
             }
         }

--- a/clients/rust/crates/ahp/src/hosts/client_id_store.rs
+++ b/clients/rust/crates/ahp/src/hosts/client_id_store.rs
@@ -1,0 +1,547 @@
+//! Persistence hooks for stable per-host `clientId`s.
+//!
+//! Each host in [`super::MultiHostClient`] needs a stable `clientId`
+//! so the AHP `reconnect` flow can replay missed actions on the next
+//! launch. By default [`super::MultiHostClient`] is wired with an
+//! [`InMemoryClientIdStore`] — session-stable but not durable. For
+//! cross-launch identity (which the reconnect flow needs to be
+//! useful across process restarts), supply a persistent
+//! implementation via [`super::MultiHostClient::with_client_id_store`]:
+//! [`FileClientIdStore`] is shipped here; consumers wanting a
+//! keychain/secure-enclave backing should implement [`ClientIdStore`]
+//! themselves.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use thiserror::Error;
+use tokio::sync::Mutex as AsyncMutex;
+
+use super::types::HostId;
+
+/// Errors returned by a [`ClientIdStore`].
+///
+/// The trait surfaces I/O failures rather than swallowing them so
+/// callers can tell the difference between "no stored id yet" and
+/// "we tried to read it but the disk is full" — without that
+/// distinction, a flaky filesystem silently degrades to "fresh
+/// `clientId` on every launch" and the reconnect flow stops working
+/// without warning.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ClientIdStoreError {
+    /// Underlying I/O failure (filesystem, OS keychain, …).
+    #[error("client id store io error: {0}")]
+    Io(String),
+
+    /// The store rejected the host id (e.g. illegal characters that
+    /// the backing store can't escape).
+    #[error("client id store rejected host id {host}: {reason}")]
+    InvalidHostId {
+        /// Host id the store could not accept.
+        host: HostId,
+        /// Human-readable reason from the implementation.
+        reason: String,
+    },
+}
+
+/// Persistence hook for stable `clientId`s per host.
+///
+/// [`super::MultiHostClient`] consults this store on every
+/// [`super::MultiHostClient::add_host`]: if the store returns
+/// `Some(id)`, that id is reused (so the server treats the new
+/// connection as the same client and the AHP `reconnect` flow can
+/// replay missed actions); on `None`, the SDK generates a fresh id
+/// and writes it back through [`ClientIdStore::store`].
+///
+/// Implementations must be `Send + Sync + 'static` so they can be
+/// shared across the multi-host facade and the per-host runtimes.
+/// Both methods take an immutable receiver — internal mutability
+/// (e.g. a mutex) is the implementation's responsibility.
+///
+/// # Implementing
+///
+/// The methods return `Pin<Box<dyn Future<...>>>` rather than
+/// `async fn` so the trait is dyn-compatible (the SDK holds a
+/// `Box<dyn ClientIdStore>`). This matches the
+/// [`super::HostTransportFactory`] pattern used elsewhere in the
+/// crate; implementations can be written with `Box::pin(async move
+/// { ... })`.
+///
+/// ```
+/// use ahp::hosts::{ClientIdStore, ClientIdStoreError, HostId};
+/// use std::pin::Pin;
+/// use std::future::Future;
+///
+/// struct Noop;
+///
+/// impl ClientIdStore for Noop {
+///     fn load(
+///         &self,
+///         _host_id: &HostId,
+///     ) -> Pin<Box<dyn Future<Output = Result<Option<String>, ClientIdStoreError>> + Send + '_>> {
+///         Box::pin(async { Ok(None) })
+///     }
+///
+///     fn store(
+///         &self,
+///         _host_id: &HostId,
+///         _client_id: &str,
+///     ) -> Pin<Box<dyn Future<Output = Result<(), ClientIdStoreError>> + Send + '_>> {
+///         Box::pin(async { Ok(()) })
+///     }
+/// }
+/// ```
+pub trait ClientIdStore: Send + Sync + 'static {
+    /// Look up the stored `clientId` for `host_id`, if any.
+    ///
+    /// Returns `Ok(None)` when the store has no entry for that host;
+    /// `Err(_)` when the lookup itself failed (e.g. I/O error).
+    fn load(
+        &self,
+        host_id: &HostId,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, ClientIdStoreError>> + Send + '_>>;
+
+    /// Persist `client_id` for `host_id`, overwriting any previous
+    /// value.
+    fn store(
+        &self,
+        host_id: &HostId,
+        client_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ClientIdStoreError>> + Send + '_>>;
+}
+
+/// In-process [`ClientIdStore`] backed by an in-memory map.
+///
+/// Session-stable: the assigned id survives reconnects within the same
+/// process but is lost on restart. Fine for tests, ephemeral CLIs,
+/// and as a starting point. Production apps that want reconnect to
+/// keep working across launches should swap in [`FileClientIdStore`]
+/// (or a keychain-backed implementation of their own).
+#[derive(Default)]
+pub struct InMemoryClientIdStore {
+    entries: AsyncMutex<HashMap<HostId, String>>,
+}
+
+impl InMemoryClientIdStore {
+    /// Build an empty in-memory store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl std::fmt::Debug for InMemoryClientIdStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InMemoryClientIdStore")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ClientIdStore for InMemoryClientIdStore {
+    fn load(
+        &self,
+        host_id: &HostId,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, ClientIdStoreError>> + Send + '_>> {
+        let host_id = host_id.clone();
+        Box::pin(async move {
+            let entries = self.entries.lock().await;
+            Ok(entries.get(&host_id).cloned())
+        })
+    }
+
+    fn store(
+        &self,
+        host_id: &HostId,
+        client_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ClientIdStoreError>> + Send + '_>> {
+        let host_id = host_id.clone();
+        let client_id = client_id.to_owned();
+        Box::pin(async move {
+            let mut entries = self.entries.lock().await;
+            entries.insert(host_id, client_id);
+            Ok(())
+        })
+    }
+}
+
+/// Filesystem-backed [`ClientIdStore`] that survives process
+/// restarts.
+///
+/// Stores one file per host id under a configurable directory.
+/// Writes go through a unique `<file>.<pid>.<counter>.tmp` staging
+/// path followed by an atomic-replace rename on Unix; on Windows the
+/// rename is best-effort (a previous file is removed first if it
+/// exists, with a small race window). Files are restricted to owner
+/// read/write (`0o600`) and the directory to owner read/write/exec
+/// (`0o700`) on POSIX platforms; these calls are no-ops on Windows.
+///
+/// Filenames are derived from each host id via percent-encoding so
+/// arbitrary characters in [`HostId`] (`:`, `/`, spaces, …) map to
+/// safe filesystem paths. The reverse direction isn't needed — only
+/// the writer reads its own files, by the same key.
+///
+/// **iOS Keychain / OS keyring note:** for the strongest-security
+/// profile (Keychain on Apple platforms, libsecret on Linux, DPAPI
+/// on Windows) implement [`ClientIdStore`] yourself in your app.
+/// [`FileClientIdStore`] is a reasonable default for desktop apps,
+/// command-line tools, and development builds that don't want to
+/// take on a platform-secrets dependency.
+pub struct FileClientIdStore {
+    directory: PathBuf,
+    /// Per-process monotonic counter that disambiguates concurrent
+    /// store calls so two writers for the same host id stage to
+    /// distinct `.tmp` files. The final `rename` is the only point
+    /// of contention; on Unix it's atomic-replace, on Windows it's
+    /// remove-then-rename.
+    counter: std::sync::atomic::AtomicU64,
+}
+
+impl FileClientIdStore {
+    /// Build a store rooted at `directory`.
+    ///
+    /// The directory is created lazily on first write if missing.
+    /// The caller is responsible for picking a writable location
+    /// (e.g. `dirs::data_dir().unwrap().join("my-app")` on Apple/Linux,
+    /// `%LOCALAPPDATA%\my-app` on Windows).
+    pub fn new(directory: impl Into<PathBuf>) -> Self {
+        Self {
+            directory: directory.into(),
+            counter: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Path the store reads/writes for `host_id`. Public for tests
+    /// and for callers that want to back up / migrate the file.
+    pub fn path_for(&self, host_id: &HostId) -> PathBuf {
+        self.directory
+            .join(format!("{}.clientid", encode_host_id(host_id)))
+    }
+}
+
+impl std::fmt::Debug for FileClientIdStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileClientIdStore")
+            .field("directory", &self.directory)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ClientIdStore for FileClientIdStore {
+    fn load(
+        &self,
+        host_id: &HostId,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, ClientIdStoreError>> + Send + '_>> {
+        let path = self.path_for(host_id);
+        Box::pin(async move {
+            // Run the blocking I/O off the async runtime. On Windows
+            // (remove+rename fallback) a concurrent reader may
+            // transiently observe a `NotFound` if it interleaves
+            // between the remove and the rename — that surfaces as
+            // `Ok(None)` and the caller treats it as "no stored id
+            // yet", which is acceptable because the next write will
+            // re-establish the file.
+            let result = tokio::task::spawn_blocking(move || load_blocking(&path))
+                .await
+                .map_err(|e| ClientIdStoreError::Io(format!("spawn_blocking join: {e}")))?;
+            result
+        })
+    }
+
+    fn store(
+        &self,
+        host_id: &HostId,
+        client_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ClientIdStoreError>> + Send + '_>> {
+        let path = self.path_for(host_id);
+        let directory = self.directory.clone();
+        let client_id = client_id.to_owned();
+        // Unique-per-call tmp path so two concurrent writers for the
+        // same host id don't clobber each other's staging file. The
+        // process id + a monotonic counter is enough on every
+        // platform; the actual `rename` is still the single point of
+        // contention.
+        let suffix = format!(
+            "{}.{}.tmp",
+            std::process::id(),
+            self.counter
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        let tmp_path = path.with_extension(format!("clientid.{suffix}"));
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                store_blocking(&directory, &path, &tmp_path, &client_id)
+            })
+            .await
+            .map_err(|e| ClientIdStoreError::Io(format!("spawn_blocking join: {e}")))?
+        })
+    }
+}
+
+fn load_blocking(path: &Path) -> Result<Option<String>, ClientIdStoreError> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_owned()))
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(ClientIdStoreError::Io(format!(
+            "read {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+fn store_blocking(
+    directory: &Path,
+    path: &Path,
+    tmp_path: &Path,
+    client_id: &str,
+) -> Result<(), ClientIdStoreError> {
+    ensure_directory(directory)?;
+    // Write the payload + perms to the temp file, then rename. On
+    // Unix `rename` is atomic-replace; on Windows it errors when
+    // the destination already exists, so we fall back to
+    // `remove_file + rename` there. The race window on Windows is
+    // limited to the single brief instant between the two calls.
+    std::fs::write(tmp_path, client_id)
+        .map_err(|e| ClientIdStoreError::Io(format!("write {}: {e}", tmp_path.display())))?;
+    restrict_file_perms(tmp_path);
+
+    match std::fs::rename(tmp_path, path) {
+        Ok(()) => Ok(()),
+        Err(_) if cfg!(windows) => {
+            // Best-effort: try removing the destination and retrying.
+            // If this fails too, surface the rename error.
+            let _ = std::fs::remove_file(path);
+            std::fs::rename(tmp_path, path).map_err(|e| {
+                ClientIdStoreError::Io(format!(
+                    "rename {} -> {}: {e}",
+                    tmp_path.display(),
+                    path.display()
+                ))
+            })
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(tmp_path);
+            Err(ClientIdStoreError::Io(format!(
+                "rename {} -> {}: {e}",
+                tmp_path.display(),
+                path.display()
+            )))
+        }
+    }
+}
+
+fn ensure_directory(directory: &Path) -> Result<(), ClientIdStoreError> {
+    if directory.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(directory).map_err(|e| {
+        ClientIdStoreError::Io(format!("create_dir_all {}: {e}", directory.display()))
+    })?;
+    restrict_dir_perms(directory);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_file_perms(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn restrict_file_perms(_path: &Path) {
+    // No-op on non-Unix platforms; callers picking a per-user
+    // directory (e.g. AppData on Windows) get OS-level ACL
+    // restrictions for free.
+}
+
+#[cfg(unix)]
+fn restrict_dir_perms(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+}
+
+#[cfg(not(unix))]
+fn restrict_dir_perms(_path: &Path) {}
+
+/// Percent-encode characters that aren't safe in filesystem paths.
+///
+/// Allowed set is the unreserved-URL-character set (`A-Z`, `a-z`,
+/// `0-9`, `-`, `_`, `.`, `~`); everything else is encoded as `%XX`.
+/// Cheap reimplementation rather than pulling in `percent-encoding`
+/// — the crate is deliberately dependency-light.
+fn encode_host_id(host_id: &HostId) -> String {
+    let mut out = String::with_capacity(host_id.as_str().len());
+    for byte in host_id.as_str().as_bytes() {
+        let c = *byte;
+        let unreserved =
+            c.is_ascii_alphanumeric() || c == b'-' || c == b'_' || c == b'.' || c == b'~';
+        if unreserved {
+            out.push(c as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{c:02X}"));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("create temp dir")
+    }
+
+    #[tokio::test]
+    async fn in_memory_load_returns_none_for_unknown_host() {
+        let store = InMemoryClientIdStore::new();
+        let value = store.load(&HostId::new("missing")).await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn in_memory_round_trip() {
+        let store = InMemoryClientIdStore::new();
+        store.store(&HostId::new("alpha"), "abc-123").await.unwrap();
+        let value = store.load(&HostId::new("alpha")).await.unwrap();
+        assert_eq!(value.as_deref(), Some("abc-123"));
+    }
+
+    #[tokio::test]
+    async fn in_memory_overwrite_keeps_most_recent_value() {
+        let store = InMemoryClientIdStore::new();
+        store.store(&HostId::new("h"), "first").await.unwrap();
+        store.store(&HostId::new("h"), "second").await.unwrap();
+        let value = store.load(&HostId::new("h")).await.unwrap();
+        assert_eq!(value.as_deref(), Some("second"));
+    }
+
+    #[tokio::test]
+    async fn file_load_returns_none_for_unknown_host() {
+        let dir = temp_dir();
+        let store = FileClientIdStore::new(dir.path());
+        let value = store.load(&HostId::new("missing")).await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn file_round_trip() {
+        let dir = temp_dir();
+        let store = FileClientIdStore::new(dir.path());
+        store.store(&HostId::new("alpha"), "abc-123").await.unwrap();
+        let value = store.load(&HostId::new("alpha")).await.unwrap();
+        assert_eq!(value.as_deref(), Some("abc-123"));
+    }
+
+    #[tokio::test]
+    async fn file_persists_across_instances() {
+        let dir = temp_dir();
+        let writer = FileClientIdStore::new(dir.path());
+        writer
+            .store(&HostId::new("h1"), "preserved-id")
+            .await
+            .unwrap();
+        // Simulate a restart: build a fresh store rooted at the
+        // same directory and verify the prior write is observable.
+        let reader = FileClientIdStore::new(dir.path());
+        let value = reader.load(&HostId::new("h1")).await.unwrap();
+        assert_eq!(value.as_deref(), Some("preserved-id"));
+    }
+
+    #[tokio::test]
+    async fn file_keys_per_host() {
+        let dir = temp_dir();
+        let store = FileClientIdStore::new(dir.path());
+        store.store(&HostId::new("a"), "id-a").await.unwrap();
+        store.store(&HostId::new("b"), "id-b").await.unwrap();
+        assert_eq!(
+            store.load(&HostId::new("a")).await.unwrap().as_deref(),
+            Some("id-a")
+        );
+        assert_eq!(
+            store.load(&HostId::new("b")).await.unwrap().as_deref(),
+            Some("id-b")
+        );
+    }
+
+    #[tokio::test]
+    async fn file_overwrites() {
+        let dir = temp_dir();
+        let store = FileClientIdStore::new(dir.path());
+        store.store(&HostId::new("h"), "first").await.unwrap();
+        store.store(&HostId::new("h"), "second").await.unwrap();
+        let value = store.load(&HostId::new("h")).await.unwrap();
+        assert_eq!(value.as_deref(), Some("second"));
+    }
+
+    #[tokio::test]
+    async fn file_persists_host_ids_with_unsafe_characters() {
+        let dir = temp_dir();
+        let store = FileClientIdStore::new(dir.path());
+        let tricky = HostId::new("copilot://tunnel/foo bar?baz=1");
+        store.store(&tricky, "tricky-id").await.unwrap();
+        let value = store.load(&tricky).await.unwrap();
+        assert_eq!(value.as_deref(), Some("tricky-id"));
+    }
+
+    #[tokio::test]
+    async fn file_concurrent_stores_do_not_corrupt() {
+        let dir = temp_dir();
+        let store = std::sync::Arc::new(FileClientIdStore::new(dir.path()));
+        let mut handles = Vec::new();
+        for i in 0..32 {
+            let store = store.clone();
+            handles.push(tokio::spawn(async move {
+                store
+                    .store(&HostId::new(format!("h-{i}")), &format!("id-{i}"))
+                    .await
+                    .unwrap();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        for i in 0..32 {
+            let value = store.load(&HostId::new(format!("h-{i}"))).await.unwrap();
+            assert_eq!(value.as_deref(), Some(format!("id-{i}").as_str()));
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn file_is_restricted_to_owner_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = temp_dir();
+        let store = FileClientIdStore::new(dir.path());
+        store.store(&HostId::new("h"), "value").await.unwrap();
+        let path = store.path_for(&HostId::new("h"));
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn encode_host_id_preserves_unreserved_set() {
+        let id = HostId::new("local-host_42.example~ok");
+        assert_eq!(encode_host_id(&id), "local-host_42.example~ok");
+    }
+
+    #[test]
+    fn encode_host_id_escapes_path_separators_and_specials() {
+        let id = HostId::new("copilot://tunnel/foo bar?baz=1");
+        let encoded = encode_host_id(&id);
+        assert!(!encoded.contains('/'));
+        assert!(!encoded.contains(':'));
+        assert!(!encoded.contains(' '));
+        assert!(!encoded.contains('?'));
+        assert!(encoded.contains("%2F"));
+    }
+}

--- a/clients/rust/crates/ahp/src/hosts/mod.rs
+++ b/clients/rust/crates/ahp/src/hosts/mod.rs
@@ -31,10 +31,27 @@
 //! # `clientId`
 //!
 //! Each host needs a stable `clientId` so the AHP `reconnect` flow
-//! works. [`HostConfig::new`] generates a session-stable UUID by
-//! default; for cross-launch identity persist the value yourself (e.g.
-//! in your app's keychain) and pass it via
-//! [`HostConfig::with_client_id`] on subsequent launches.
+//! works. [`MultiHostClient`] consults a pluggable [`ClientIdStore`]
+//! on every [`MultiHostClient::add_host`]: an explicit
+//! [`HostConfig::with_client_id`] always wins; otherwise the store is
+//! looked up; on miss, a fresh UUID is generated and persisted. The
+//! default store is [`InMemoryClientIdStore`] (session-stable, lost
+//! on process restart). For cross-launch reconnect identity, wire
+//! [`FileClientIdStore`] (or your own keychain-backed implementation
+//! of [`ClientIdStore`]) via
+//! [`MultiHostClient::with_client_id_store`].
+//!
+//! # Per-`(host, uri)` event streams
+//!
+//! [`MultiHostClient::events`] is a cross-host fan-in backed by a
+//! lossy broadcast — slow consumers see `Lagged` and skip events.
+//! For reducer-critical action envelopes (which can't be dropped
+//! without desyncing downstream state mirrors) use
+//! [`MultiHostClient::events_for`] instead: it returns a
+//! [`PerResourceStream`] backed by an unbounded mpsc channel that
+//! is owned by [`MultiHostClient`] (not by any single
+//! [`crate::Client`] generation), so replayed envelopes from a
+//! reconnect reach the stream too.
 //!
 //! # Quickstart (single-host)
 //!
@@ -90,16 +107,21 @@
 
 #![allow(clippy::module_inception)]
 
+mod client_id_store;
 mod factory;
 mod multi;
 mod policy;
 mod runtime;
 mod types;
 
+pub use client_id_store::{
+    ClientIdStore, ClientIdStoreError, FileClientIdStore, InMemoryClientIdStore,
+};
 pub use factory::HostTransportFactory;
 pub use multi::MultiHostClient;
 pub use policy::{Backoff, ReconnectPolicy};
 pub use types::{
-    HostClientHandle, HostConfig, HostError, HostEvent, HostEventStream, HostHandle, HostId,
-    HostState, HostSubscriptionEvent, HostSubscriptionStream, HostedAgent, HostedSessionSummary,
+    generate_client_id, HostClientHandle, HostConfig, HostError, HostEvent, HostEventStream,
+    HostHandle, HostId, HostState, HostSubscriptionEvent, HostSubscriptionStream, HostedAgent,
+    HostedSessionSummary, PerResourceStream,
 };

--- a/clients/rust/crates/ahp/src/hosts/multi.rs
+++ b/clients/rust/crates/ahp/src/hosts/multi.rs
@@ -154,11 +154,16 @@ impl MultiInner {
     /// Called from [`PerResourceStream`]'s `Drop` so dropping a stream
     /// releases its registry slot promptly rather than waiting for
     /// the host to be removed.
+    ///
+    /// Recovers gracefully on a poisoned lock: a panic inside `Drop`
+    /// during unwinding would abort the process, and a leaked listener
+    /// slot is strictly less bad than that. The next event for the
+    /// host with no live listener has its dead sender pruned by
+    /// [`MultiInner::fan_event`] anyway.
     pub(super) fn remove_per_resource_listener(&self, host: &HostId, listener_id: u64) {
-        let mut listeners = self
-            .per_resource_listeners
-            .write()
-            .expect("poisoned listener lock");
+        let Ok(mut listeners) = self.per_resource_listeners.write() else {
+            return;
+        };
         if let Some(bucket) = listeners.get_mut(host) {
             bucket.remove(&listener_id);
             if bucket.is_empty() {

--- a/clients/rust/crates/ahp/src/hosts/multi.rs
+++ b/clients/rust/crates/ahp/src/hosts/multi.rs
@@ -1,15 +1,18 @@
 //! `MultiHostClient` facade.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock as StdRwLock};
 
-use tokio::sync::{broadcast, RwLock};
+use tokio::sync::{broadcast, mpsc, RwLock};
 
-use super::runtime::{spawn, HostHandleTx};
+use super::client_id_store::{ClientIdStore, InMemoryClientIdStore};
+use super::runtime::{spawn, EventSink, HostHandleTx};
 use super::types::{
-    HostClientHandle, HostConfig, HostError, HostEvent, HostEventStream, HostHandle, HostId,
-    HostState, HostSubscriptionEvent, HostSubscriptionStream, HostedAgent, HostedSessionSummary,
+    generate_client_id, HostClientHandle, HostConfig, HostError, HostEvent, HostEventStream,
+    HostHandle, HostId, HostState, HostSubscriptionEvent, HostSubscriptionStream, HostedAgent,
+    HostedSessionSummary, PerResourceStream,
 };
+use crate::SubscriptionEvent;
 
 /// Buffer size for the cross-host fan-in broadcasts.
 const DEFAULT_EVENT_BUFFER: usize = 1024;
@@ -25,6 +28,10 @@ const DEFAULT_EVENT_BUFFER: usize = 1024;
 /// - [`MultiHostClient::single`] — one-line single-host constructor.
 /// - [`MultiHostClient::add_host`] / [`MultiHostClient::remove_host`].
 /// - [`MultiHostClient::events`] / [`MultiHostClient::host_events`].
+/// - [`MultiHostClient::events_for`] — reliable per-`(host, uri)`
+///   event stream that survives reconnects.
+/// - [`MultiHostClient::reconnect_all_unavailable`] — bulk wake
+///   helper.
 /// - [`MultiHostClient::aggregated_sessions`] /
 ///   [`MultiHostClient::aggregated_agents`].
 #[derive(Clone)]
@@ -32,22 +39,179 @@ pub struct MultiHostClient {
     inner: Arc<MultiInner>,
 }
 
-struct MultiInner {
-    hosts: RwLock<HashMap<HostId, HostHandleTx>>,
-    fan_out: broadcast::Sender<HostSubscriptionEvent>,
-    host_events: broadcast::Sender<HostEvent>,
+pub(super) struct MultiInner {
+    pub(super) hosts: RwLock<HashMap<HostId, HostHandleTx>>,
+    /// Insertion order of hosts. Used by aggregated views for
+    /// deterministic tie-breaking when sorting by `modified_at` (or
+    /// for stable agent ordering across calls). Held in an
+    /// `StdRwLock` because mutations are tiny vec ops with no `await`
+    /// points in scope.
+    pub(super) host_order: StdRwLock<Vec<HostId>>,
+    /// Host ids reserved by an in-flight `add_host` call. Held
+    /// synchronously across the async `ClientIdStore` lookup so two
+    /// concurrent `add_host` calls for the same id can't both pass
+    /// the duplicate check. Wrapped in an RAII guard so a cancelled
+    /// `add_host` future doesn't leak the reservation.
+    pub(super) pending_host_ids: StdRwLock<HashSet<HostId>>,
+    pub(super) fan_out: broadcast::Sender<HostSubscriptionEvent>,
+    pub(super) host_events: broadcast::Sender<HostEvent>,
+    /// Per-`(HostId, listener_id)` registry of unbounded mpsc senders
+    /// that back [`MultiHostClient::events_for`]. Lossless by
+    /// construction — slow consumers retain an unbounded backlog
+    /// rather than dropping events, mirroring the Swift SDK's
+    /// `events(host:uri:)` semantics.
+    pub(super) per_resource_listeners:
+        StdRwLock<HashMap<HostId, HashMap<u64, PerResourceListener>>>,
+    pub(super) next_listener_id: std::sync::atomic::AtomicU64,
+    pub(super) client_id_store: Arc<dyn ClientIdStore>,
+}
+
+pub(super) struct PerResourceListener {
+    pub(super) uri: String,
+    pub(super) tx: mpsc::UnboundedSender<SubscriptionEvent>,
+}
+
+/// RAII guard that holds the `pending_host_ids` reservation for a
+/// host id and releases it on drop. Without this, a cancelled
+/// `add_host` future would leak the reservation and permanently lock
+/// out future adds for the same id.
+struct PendingReservation {
+    inner: Arc<MultiInner>,
+    id: HostId,
+}
+
+impl PendingReservation {
+    fn new(inner: Arc<MultiInner>, id: HostId) -> Self {
+        Self { inner, id }
+    }
+}
+
+impl Drop for PendingReservation {
+    fn drop(&mut self) {
+        if let Ok(mut pending) = self.inner.pending_host_ids.write() {
+            pending.remove(&self.id);
+        }
+    }
+}
+
+impl MultiInner {
+    /// Synchronous fan-out: invoked from the per-host runtime on the
+    /// hot event path. Writes the event to the lossy broadcast (which
+    /// backs [`MultiHostClient::events`]) AND to every matching
+    /// per-`(host, uri)` listener (which backs
+    /// [`MultiHostClient::events_for`]).
+    ///
+    /// Protocol notifications (events with `resource: None`) fan to
+    /// every listener for the host because they're cross-resource by
+    /// design (auth required, session added/removed/changed).
+    pub(super) fn fan_event(&self, event: HostSubscriptionEvent) {
+        // 1. Lossy broadcast fan-in.
+        let _ = self.fan_out.send(event.clone());
+
+        // 2. Lossless per-`(host, uri)` fan-out. We take a read lock
+        //    on the registry; per-listener `mpsc::UnboundedSender::send`
+        //    is cheap and never blocks. Dead listeners (receiver
+        //    dropped without unregistering — shouldn't happen because
+        //    `PerResourceStream::Drop` unregisters, but defence in
+        //    depth) are collected and pruned under the write lock so
+        //    `per_resource_listeners` doesn't grow indefinitely.
+        let mut dead: Vec<(HostId, u64)> = Vec::new();
+        {
+            let listeners = self
+                .per_resource_listeners
+                .read()
+                .expect("poisoned listener lock");
+            let Some(bucket) = listeners.get(&event.host_id) else {
+                return;
+            };
+            for (id, listener) in bucket {
+                let deliver = match &event.resource {
+                    Some(uri) => listener.uri == *uri,
+                    None => true,
+                };
+                if deliver && listener.tx.send(event.event.clone()).is_err() {
+                    dead.push((event.host_id.clone(), *id));
+                }
+            }
+        }
+        if !dead.is_empty() {
+            let mut listeners = self
+                .per_resource_listeners
+                .write()
+                .expect("poisoned listener lock");
+            for (host_id, listener_id) in dead {
+                if let Some(bucket) = listeners.get_mut(&host_id) {
+                    bucket.remove(&listener_id);
+                    if bucket.is_empty() {
+                        listeners.remove(&host_id);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove a single per-`(host, uri)` listener from the registry.
+    /// Called from [`PerResourceStream`]'s `Drop` so dropping a stream
+    /// releases its registry slot promptly rather than waiting for
+    /// the host to be removed.
+    pub(super) fn remove_per_resource_listener(&self, host: &HostId, listener_id: u64) {
+        let mut listeners = self
+            .per_resource_listeners
+            .write()
+            .expect("poisoned listener lock");
+        if let Some(bucket) = listeners.get_mut(host) {
+            bucket.remove(&listener_id);
+            if bucket.is_empty() {
+                listeners.remove(host);
+            }
+        }
+    }
+
+    /// Drop every per-`(host, uri)` listener registered for `host` and
+    /// remove the bucket. Called on `remove_host` / `shutdown` so any
+    /// consumer holding the matching [`PerResourceStream`] observes a
+    /// clean close on its next `recv()`.
+    fn drop_per_resource_listeners_for(&self, host: &HostId) {
+        let mut listeners = self
+            .per_resource_listeners
+            .write()
+            .expect("poisoned listener lock");
+        listeners.remove(host);
+    }
 }
 
 impl MultiHostClient {
-    /// Build an empty multi-host client.
+    /// Build an empty multi-host client backed by an
+    /// [`InMemoryClientIdStore`].
+    ///
+    /// In-memory client ids are session-stable but lost on process
+    /// restart. For cross-launch reconnect identity, use
+    /// [`MultiHostClient::with_client_id_store`] with a persistent
+    /// store like [`super::FileClientIdStore`].
     pub fn new() -> Self {
+        Self::with_client_id_store(InMemoryClientIdStore::new())
+    }
+
+    /// Build an empty multi-host client wired to a custom
+    /// [`ClientIdStore`].
+    ///
+    /// The store is consulted whenever a host is added without an
+    /// explicit [`HostConfig::client_id`]: a stored value is reused;
+    /// a miss generates a fresh id which is then written back through
+    /// [`ClientIdStore::store`].
+    pub fn with_client_id_store(store: impl ClientIdStore) -> Self {
         let (fan_out, _) = broadcast::channel(DEFAULT_EVENT_BUFFER);
         let (host_events, _) = broadcast::channel(DEFAULT_EVENT_BUFFER);
         Self {
             inner: Arc::new(MultiInner {
                 hosts: RwLock::new(HashMap::new()),
+                host_order: StdRwLock::new(Vec::new()),
+                pending_host_ids: StdRwLock::new(HashSet::new()),
                 fan_out,
                 host_events,
+                per_resource_listeners: StdRwLock::new(HashMap::new()),
+                next_listener_id: std::sync::atomic::AtomicU64::new(1),
+                client_id_store: Arc::new(store),
             }),
         }
     }
@@ -70,6 +234,19 @@ impl MultiHostClient {
         Ok((multi, handle))
     }
 
+    /// Like [`MultiHostClient::single`] but lets the caller plug a
+    /// custom [`ClientIdStore`] in the same call, which is the
+    /// natural shape for desktop apps wiring a persistent file-backed
+    /// store at startup.
+    pub async fn single_with_client_id_store(
+        config: HostConfig,
+        store: impl ClientIdStore,
+    ) -> Result<(Self, HostHandle), HostError> {
+        let multi = Self::with_client_id_store(store);
+        let handle = multi.add_host(config).await?;
+        Ok((multi, handle))
+    }
+
     /// Register a new host and start its supervisor task.
     ///
     /// The supervisor immediately attempts to open a transport via
@@ -86,27 +263,115 @@ impl MultiHostClient {
     /// hung transport factory therefore cannot block other registry
     /// operations.
     ///
+    /// # `clientId` resolution
+    ///
+    /// If `config.client_id` is `Some(_)`, that value is used and
+    /// also written back to the configured [`ClientIdStore`] so the
+    /// store reflects the host's current identity. If `None`, the
+    /// store is consulted; on miss, a fresh id is generated and
+    /// stored. A failure to read or write the store is surfaced as
+    /// [`HostError::ClientIdStore`] without registering the host.
+    ///
     /// Returns [`HostError::DuplicateHost`] if the host id is already in
-    /// use; remove the existing host first.
+    /// use or a concurrent `add_host` is mid-flight for the same id;
+    /// remove the existing host first.
     pub async fn add_host(&self, config: HostConfig) -> Result<HostHandle, HostError> {
         let id = config.id.clone();
+
+        // Reserve the id synchronously so two concurrent `add_host`
+        // calls for the same id can't both pass the duplicate check
+        // across the awaited store lookups. Held in an RAII guard so
+        // that a cancelled `add_host` future doesn't leak the
+        // reservation and permanently lock out future adds for `id`.
+        let _reservation = {
+            let hosts = self.inner.hosts.read().await;
+            if hosts.contains_key(&id) {
+                return Err(HostError::DuplicateHost(id));
+            }
+            let mut pending = self
+                .inner
+                .pending_host_ids
+                .write()
+                .expect("poisoned pending lock");
+            if pending.contains(&id) {
+                return Err(HostError::DuplicateHost(id));
+            }
+            pending.insert(id.clone());
+            PendingReservation::new(self.inner.clone(), id.clone())
+        };
+
+        self.add_host_inner(config).await
+    }
+
+    async fn add_host_inner(&self, mut config: HostConfig) -> Result<HostHandle, HostError> {
+        let id = config.id.clone();
+
+        // Resolve the clientId: explicit > stored > freshly generated.
+        // Always write the resolved value back to the store so the
+        // next launch sees it.
+        let client_id = match config.client_id.take() {
+            Some(explicit) => {
+                self.inner
+                    .client_id_store
+                    .store(&id, &explicit)
+                    .await
+                    .map_err(HostError::ClientIdStore)?;
+                explicit
+            }
+            None => {
+                let stored = self
+                    .inner
+                    .client_id_store
+                    .load(&id)
+                    .await
+                    .map_err(HostError::ClientIdStore)?;
+                let resolved = stored.unwrap_or_else(generate_client_id);
+                self.inner
+                    .client_id_store
+                    .store(&id, &resolved)
+                    .await
+                    .map_err(HostError::ClientIdStore)?;
+                resolved
+            }
+        };
+
+        // Construct the per-runtime event sink. The closure holds a
+        // `Weak<MultiInner>` so it doesn't keep `MultiHostClient`
+        // alive past the consumer dropping every clone — a drop is
+        // observable via `Weak::upgrade` returning `None`.
+        let inner_weak = Arc::downgrade(&self.inner);
+        let event_sink: EventSink = Arc::new(move |event: HostSubscriptionEvent| {
+            if let Some(inner) = inner_weak.upgrade() {
+                inner.fan_event(event);
+            }
+        });
+
         let shared = {
-            // Reserve the id atomically — release the write lock before
-            // awaiting anything so a slow connect path can't block other
-            // registry operations behind us.
             let mut hosts = self.inner.hosts.write().await;
+            // Re-check duplicate inside the write lock in case a
+            // racing `remove_host` left a stale `pending_host_ids`
+            // entry plus a fresh real host.
             if hosts.contains_key(&id) {
                 return Err(HostError::DuplicateHost(id));
             }
             let tx = spawn(
                 config,
-                self.inner.fan_out.clone(),
+                client_id,
+                event_sink,
                 self.inner.host_events.clone(),
             );
             let shared = tx.shared.clone();
-            hosts.insert(id, tx);
+            hosts.insert(id.clone(), tx);
+            // Append to insertion-order list for deterministic
+            // aggregated views.
+            self.inner
+                .host_order
+                .write()
+                .expect("poisoned host_order lock")
+                .push(id.clone());
             shared
         };
+
         // Snapshot directly from per-host shared state. Doing this via
         // the supervisor's command channel would block here when the
         // supervisor is busy in `connect_once` (e.g. a hung transport
@@ -120,7 +385,8 @@ impl MultiHostClient {
     ///
     /// Any outstanding [`HostClientHandle`]s for this host become stale
     /// and will return [`HostError::HostShutDown`] from subsequent
-    /// dispatches.
+    /// dispatches. Any [`PerResourceStream`]s for this host are closed
+    /// so consumers' `recv()` loops exit cleanly.
     pub async fn remove_host(&self, id: &HostId) -> Result<(), HostError> {
         let entry = {
             let mut hosts = self.inner.hosts.write().await;
@@ -128,6 +394,12 @@ impl MultiHostClient {
         };
         match entry {
             Some(tx) => {
+                self.inner
+                    .host_order
+                    .write()
+                    .expect("poisoned host_order lock")
+                    .retain(|h| h != id);
+                self.inner.drop_per_resource_listeners_for(id);
                 tx.shutdown().await;
                 let _ = self.inner.host_events.send(HostEvent::Removed {
                     host_id: id.clone(),
@@ -136,6 +408,51 @@ impl MultiHostClient {
             }
             None => Err(HostError::UnknownHost(id.clone())),
         }
+    }
+
+    /// Tear down every registered host's supervisor and drop every
+    /// per-`(host, uri)` listener.
+    ///
+    /// Safe to call multiple times. The receiving half of any
+    /// existing [`PerResourceStream`] will resolve to `None` on its
+    /// next `recv()`. The cross-host broadcast streams returned by
+    /// [`MultiHostClient::events`] and
+    /// [`MultiHostClient::host_events`] are kept alive by their
+    /// senders inside the still-held [`MultiInner`]; they close
+    /// naturally when the last [`MultiHostClient`] clone is dropped.
+    ///
+    /// Mirrors Swift's `MultiHostClient.shutdown()` so consumers have
+    /// a deterministic lifecycle anchor for app teardown / sign-out.
+    pub async fn shutdown(&self) {
+        // Drain the host map so concurrent callers can't see the
+        // hosts in a partially-torn-down state.
+        let entries: Vec<HostHandleTx> = {
+            let mut hosts = self.inner.hosts.write().await;
+            self.inner
+                .host_order
+                .write()
+                .expect("poisoned host_order lock")
+                .clear();
+            hosts.drain().map(|(_, tx)| tx).collect()
+        };
+        // Drop every per-URI listener so consumers exit their loops.
+        {
+            let mut listeners = self
+                .inner
+                .per_resource_listeners
+                .write()
+                .expect("poisoned listener lock");
+            listeners.clear();
+        }
+        // Shut down each supervisor. Concurrent shutdowns let a slow
+        // transport teardown not block the others.
+        let mut tasks = tokio::task::JoinSet::new();
+        for tx in entries {
+            tasks.spawn(async move {
+                tx.shutdown().await;
+            });
+        }
+        while tasks.join_next().await.is_some() {}
     }
 
     /// Trigger a manual reconnect for `id`. Cancels the current
@@ -158,6 +475,79 @@ impl MultiHostClient {
             .await
             .map_err(|_| HostError::HostShutDown(id.clone()))?;
         Ok(())
+    }
+
+    /// Trigger a manual reconnect on every registered host that is
+    /// **not** currently `Connected` or `Connecting` — i.e., hosts in
+    /// `Disconnected`, `Reconnecting`, or `Failed`. Hosts already
+    /// connected (or actively connecting) are skipped.
+    ///
+    /// Designed for the scene-phase / network-change pattern: on
+    /// `ScenePhase.active` (or a network reachability flip), call
+    /// this to wake every host the user has been away from instead
+    /// of writing the loop in every consumer. Particularly useful
+    /// for `Failed` hosts whose reconnect policy is exhausted — a
+    /// manual reconnect bypasses the policy and starts a fresh
+    /// attempt.
+    ///
+    /// Per-host reconnect requests are dispatched concurrently; the
+    /// returned map contains one entry per host whose reconnect
+    /// failed. An empty map means every selected host acknowledged
+    /// its reconnect request.
+    pub async fn reconnect_all_unavailable(&self) -> HashMap<HostId, HostError> {
+        // Snapshot the candidate list under the read lock to avoid
+        // holding it across the per-host snapshot / reconnect awaits.
+        let candidates: Vec<(HostId, mpsc::Sender<super::runtime::HostCommand>)> = {
+            let hosts = self.inner.hosts.read().await;
+            hosts
+                .iter()
+                .map(|(id, tx)| (id.clone(), tx.cmd_tx.clone()))
+                .collect()
+        };
+
+        let mut pending: Vec<(HostId, mpsc::Sender<super::runtime::HostCommand>)> = Vec::new();
+        for (id, cmd_tx) in candidates {
+            let snap = match self.host(&id).await {
+                Some(s) => s,
+                None => continue, // removed between read and snapshot
+            };
+            match snap.state {
+                HostState::Connected | HostState::Connecting => continue,
+                HostState::Disconnected
+                | HostState::Reconnecting { .. }
+                | HostState::Failed { .. } => pending.push((id, cmd_tx)),
+            }
+        }
+
+        // Fire all reconnects concurrently.
+        let mut tasks = tokio::task::JoinSet::new();
+        for (id, cmd_tx) in pending {
+            tasks.spawn(async move {
+                let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+                let send_result = cmd_tx
+                    .send(super::runtime::HostCommand::Reconnect { reply: reply_tx })
+                    .await;
+                let outcome = match send_result {
+                    Ok(()) => match reply_rx.await {
+                        Ok(()) => Ok(()),
+                        Err(_) => Err(HostError::HostShutDown(id.clone())),
+                    },
+                    Err(_) => Err(HostError::HostShutDown(id.clone())),
+                };
+                (id, outcome)
+            });
+        }
+
+        let mut errors = HashMap::new();
+        while let Some(join) = tasks.join_next().await {
+            // A `JoinError` here means the task itself panicked; we
+            // shouldn't reach this since the task only sends/recvs.
+            // Surface it as a `HostShutDown` error rather than panic.
+            if let Ok((id, Err(err))) = join {
+                errors.insert(id, err);
+            }
+        }
+        errors
     }
 
     /// Snapshot the current state of `id`.
@@ -224,6 +614,21 @@ impl MultiHostClient {
     }
 
     /// Convenience: subscribe to `uri` on `host_id`.
+    ///
+    /// Returns the server's [`ahp_types::commands::SubscribeResult`]
+    /// (the initial snapshot the server pushes back). To consume the
+    /// live stream of action envelopes for `uri`, call
+    /// [`MultiHostClient::events_for`] separately — typically
+    /// **before** this call, so envelopes the server pushes between
+    /// the subscribe response and the consumer's first `recv()`
+    /// aren't dropped on the floor:
+    ///
+    /// ```ignore
+    /// let mut stream = multi.events_for(&host_id, uri.clone()).await
+    ///     .expect("host registered");
+    /// let snapshot = multi.subscribe(&host_id, uri.clone()).await?;
+    /// while let Some(event) = stream.recv().await { /* ... */ }
+    /// ```
     pub async fn subscribe(
         &self,
         host_id: &HostId,
@@ -252,6 +657,14 @@ impl MultiHostClient {
     /// Subscribe to a fan-in stream of every inbound event from every
     /// registered host. Each call returns a fresh receiver — multiple
     /// consumers can listen independently.
+    ///
+    /// **This stream is lossy by design.** Slow consumers see
+    /// `broadcast::error::RecvError::Lagged` and skip ahead, dropping
+    /// older events. Use it for advisory / notification-style
+    /// consumption (e.g. counters, UI badges). For reducer-critical
+    /// per-URI action streams use [`MultiHostClient::events_for`]
+    /// instead — that surface uses unbounded per-listener buffering
+    /// and survives reconnects.
     pub fn events(&self) -> HostSubscriptionStream {
         HostSubscriptionStream {
             rx: self.inner.fan_out.subscribe(),
@@ -266,37 +679,161 @@ impl MultiHostClient {
         }
     }
 
+    /// Per-`(host, uri)` event stream — the reliable channel for
+    /// reducer-critical action envelopes.
+    ///
+    /// Returns a [`PerResourceStream`] that delivers every event
+    /// scoped to `uri` on `host` — both live envelopes and envelopes
+    /// replayed during reconnect via `apply_reconnect_result`. The
+    /// stream is unbounded (no buffer drop) because losing an action
+    /// envelope desyncs downstream state mirrors irreversibly.
+    ///
+    /// Unlike [`crate::SessionSubscription`] (bound to one underlying
+    /// [`crate::Client`] generation), this stream is owned by
+    /// [`MultiHostClient`] and **survives reconnects** — replayed
+    /// envelopes from the per-host supervisor's reconnect path reach
+    /// this stream too. Protocol-level notifications (auth required,
+    /// session added/removed/changed) are also fanned to every active
+    /// per-URI listener for the host because they're cross-resource
+    /// by design.
+    ///
+    /// **Subscription registration is independent from subscribing
+    /// on the server.** Calling `events_for` does NOT send a
+    /// `subscribe` request. Attach the listener **before** calling
+    /// [`MultiHostClient::subscribe`] to avoid missing the initial
+    /// post-subscribe events:
+    ///
+    /// ```ignore
+    /// let mut stream = multi.events_for(&host_id, uri.clone()).await
+    ///     .expect("host registered");
+    /// multi.subscribe(&host_id, uri.clone()).await?;
+    /// while let Some(event) = stream.recv().await { /* ... */ }
+    /// ```
+    ///
+    /// **Consume promptly.** The stream is unbounded — a stalled
+    /// consumer retains an unbounded backlog. Process events on a
+    /// fast loop and dispatch reducer work asynchronously if needed.
+    ///
+    /// Returns `None` if `host` is not registered.
+    pub async fn events_for(&self, host: &HostId, uri: String) -> Option<PerResourceStream> {
+        // Hold the hosts `read()` lock across listener registration
+        // so a concurrent `remove_host` (which takes the `write()`
+        // lock and then calls `drop_per_resource_listeners_for(host)`)
+        // can't slip between our presence check and our insert,
+        // leaving a listener registered against a removed host.
+        let listener_id = self
+            .inner
+            .next_listener_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let (tx, rx) = mpsc::unbounded_channel();
+        {
+            let hosts = self.inner.hosts.read().await;
+            if !hosts.contains_key(host) {
+                return None;
+            }
+            let mut listeners = self
+                .inner
+                .per_resource_listeners
+                .write()
+                .expect("poisoned listener lock");
+            let bucket = listeners.entry(host.clone()).or_default();
+            bucket.insert(listener_id, PerResourceListener { uri, tx });
+        }
+        Some(PerResourceStream {
+            rx,
+            // Hold a Weak reference so dropping the stream doesn't
+            // keep `MultiInner` alive past its last clone.
+            registry: Arc::downgrade(&self.inner),
+            host: host.clone(),
+            listener_id,
+        })
+    }
+
     /// Aggregated session summaries across every registered host,
     /// sorted by `summary.modified_at` descending. Includes both the
     /// host id and label so consumers can render a unified inbox
     /// without losing host attribution.
+    ///
+    /// **Tie-breaking:** for equal `modified_at`, summaries are
+    /// ordered by host registration order, then by
+    /// `summary.resource`, so the result is deterministic across
+    /// calls (matches the Swift SDK).
     pub async fn aggregated_sessions(&self) -> Vec<HostedSessionSummary> {
+        let order = self
+            .inner
+            .host_order
+            .read()
+            .expect("poisoned host_order lock")
+            .clone();
+        let index: HashMap<HostId, usize> = order
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (id.clone(), i))
+            .collect();
         let mut out = Vec::new();
-        for handle in self.hosts().await {
-            for summary in handle.session_summaries.iter().cloned() {
+        for id in &order {
+            let shared = match self
+                .inner
+                .hosts
+                .read()
+                .await
+                .get(id)
+                .map(|e| e.shared.clone())
+            {
+                Some(s) => s,
+                None => continue,
+            };
+            let snap = shared.lock().await.snapshot();
+            for summary in snap.session_summaries.iter().cloned() {
                 out.push(HostedSessionSummary {
-                    host_id: handle.id.clone(),
-                    host_label: handle.label.clone(),
+                    host_id: snap.id.clone(),
+                    host_label: snap.label.clone(),
                     summary,
                 });
             }
         }
-        // Sort by `modified_at` descending. `sort_by_key` requires a
-        // total order on the key, which `Reverse` provides while
-        // preserving the insertion order for equal keys.
-        out.sort_by_key(|item| std::cmp::Reverse(item.summary.modified_at));
+        out.sort_by(|lhs, rhs| {
+            rhs.summary
+                .modified_at
+                .cmp(&lhs.summary.modified_at)
+                .then_with(|| {
+                    let li = index.get(&lhs.host_id).copied().unwrap_or(usize::MAX);
+                    let ri = index.get(&rhs.host_id).copied().unwrap_or(usize::MAX);
+                    li.cmp(&ri)
+                })
+                .then_with(|| lhs.summary.resource.cmp(&rhs.summary.resource))
+        });
         out
     }
 
-    /// Aggregated agents across every registered host, in registration
-    /// order per host.
+    /// Aggregated agents across every registered host, in
+    /// registration order per host. Order is deterministic across
+    /// calls.
     pub async fn aggregated_agents(&self) -> Vec<HostedAgent> {
+        let order = self
+            .inner
+            .host_order
+            .read()
+            .expect("poisoned host_order lock")
+            .clone();
         let mut out = Vec::new();
-        for handle in self.hosts().await {
-            for agent in handle.agents.iter().cloned() {
+        for id in order {
+            let shared = match self
+                .inner
+                .hosts
+                .read()
+                .await
+                .get(&id)
+                .map(|e| e.shared.clone())
+            {
+                Some(s) => s,
+                None => continue,
+            };
+            let snap = shared.lock().await.snapshot();
+            for agent in snap.agents.iter().cloned() {
                 out.push(HostedAgent {
-                    host_id: handle.id.clone(),
-                    host_label: handle.label.clone(),
+                    host_id: snap.id.clone(),
+                    host_label: snap.label.clone(),
                     agent,
                 });
             }

--- a/clients/rust/crates/ahp/src/hosts/runtime.rs
+++ b/clients/rust/crates/ahp/src/hosts/runtime.rs
@@ -70,16 +70,29 @@ impl HostHandleTx {
     }
 }
 
+/// Type alias for the callback the multi-host facade passes to
+/// each runtime so the runtime can fan out subscription events
+/// without knowing about the facade's internals.
+///
+/// Implementations must be cheap and synchronous (the runtime calls
+/// this on the hot per-event path). The facade's standard
+/// implementation fans events into both the lossy broadcast that
+/// backs [`MultiHostClient::events`](super::MultiHostClient::events)
+/// and the per-`(host, uri)` listener registry that backs
+/// [`MultiHostClient::events_for`](super::MultiHostClient::events_for).
+pub(super) type EventSink = Arc<dyn Fn(HostSubscriptionEvent) + Send + Sync>;
+
 /// Spawn a runtime for `config` and return its inbox.
 pub(super) fn spawn(
     config: HostConfig,
-    fan_out: broadcast::Sender<HostSubscriptionEvent>,
+    client_id: String,
+    event_sink: EventSink,
     host_events: broadcast::Sender<HostEvent>,
 ) -> HostHandleTx {
     let initial = HostInternal {
         id: config.id.clone(),
         label: config.label.clone(),
-        client_id: config.client_id.clone(),
+        client_id: client_id.clone(),
         state: HostState::Disconnected,
         last_error: None,
         last_connected_at: None,
@@ -103,11 +116,11 @@ pub(super) fn spawn(
 
     let (cmd_tx, cmd_rx) = mpsc::channel(32);
     let runtime = HostRuntime {
-        client_id: config.client_id.clone(),
+        client_id,
         config,
         cmd_rx,
         shared: shared.clone(),
-        fan_out,
+        event_sink,
         host_events,
         shutdown_signal: shutdown_signal.clone(),
     };
@@ -126,7 +139,7 @@ struct HostRuntime {
     client_id: String,
     cmd_rx: mpsc::Receiver<HostCommand>,
     shared: Arc<HostShared>,
-    fan_out: broadcast::Sender<HostSubscriptionEvent>,
+    event_sink: EventSink,
     host_events: broadcast::Sender<HostEvent>,
     shutdown_signal: Arc<Notify>,
 }
@@ -397,7 +410,7 @@ impl HostRuntime {
                         resource: Some(resource),
                         event: SubscriptionEvent::Action(envelope),
                     };
-                    let _ = self.fan_out.send(host_event);
+                    (self.event_sink)(host_event);
                 }
                 if !replay.missing.is_empty() {
                     let mut state = self.shared.lock().await;
@@ -556,7 +569,7 @@ impl HostRuntime {
             resource: event.resource,
             event: event.event,
         };
-        let _ = self.fan_out.send(host_event);
+        (self.event_sink)(host_event);
     }
 
     async fn apply_action(&self, envelope: &ActionEnvelope) {

--- a/clients/rust/crates/ahp/src/hosts/types.rs
+++ b/clients/rust/crates/ahp/src/hosts/types.rs
@@ -103,17 +103,32 @@ impl PartialEq for HostState {
 /// # `client_id`
 ///
 /// Each host needs a stable `clientId` so the AHP `reconnect` flow
-/// works across launches. By default [`HostConfig::new`] generates a
-/// session-stable UUID; pass [`HostConfig::with_client_id`] (typically
-/// loaded from your app's keychain or settings store) for a value that
-/// survives restarts.
+/// works across launches. The resolution order on
+/// [`super::MultiHostClient::add_host`] is:
+///
+/// 1. Explicit value set via [`HostConfig::with_client_id`] (always wins).
+/// 2. The host id's prior entry in the configured
+///    [`super::ClientIdStore`].
+/// 3. A freshly generated UUID-shaped string (and written back to the
+///    store so subsequent launches see it).
+///
+/// To keep `clientId`s stable across process restarts, wire a
+/// persistent store via
+/// [`super::MultiHostClient::with_client_id_store`] (e.g.
+/// [`super::FileClientIdStore`]). The default
+/// [`super::InMemoryClientIdStore`] only survives within a single
+/// process.
 pub struct HostConfig {
     /// Stable host identifier.
     pub id: HostId,
     /// Human-readable label. Surfaced through [`HostHandle::label`].
     pub label: String,
-    /// `clientId` sent to this host on `initialize` / `reconnect`.
-    pub client_id: String,
+    /// Explicit `clientId` to send on `initialize` / `reconnect`.
+    ///
+    /// `None` means defer to the configured [`super::ClientIdStore`]
+    /// at [`super::MultiHostClient::add_host`] time. `Some(_)` is an
+    /// explicit override that always wins over the store.
+    pub client_id: Option<String>,
     /// URIs to include in the `initialize` handshake. Defaults to
     /// `["agenthost:/root"]` so root state is always tracked.
     pub initial_subscriptions: Vec<String>,
@@ -128,10 +143,10 @@ pub struct HostConfig {
 impl HostConfig {
     /// Build a [`HostConfig`] with sensible defaults.
     ///
-    /// Generates a fresh, session-stable `clientId`. If you want
-    /// reconnect identity to survive process restarts, persist the id
-    /// you supply here yourself and pass it via
-    /// [`HostConfig::with_client_id`] on subsequent launches.
+    /// `client_id` is left unset; the multi-host client will look it
+    /// up in the configured [`super::ClientIdStore`] (or generate one
+    /// and persist it) when the host is added. To force an explicit
+    /// id, chain [`HostConfig::with_client_id`].
     pub fn new(
         id: impl Into<HostId>,
         label: impl Into<String>,
@@ -140,7 +155,7 @@ impl HostConfig {
         Self {
             id: id.into(),
             label: label.into(),
-            client_id: generate_client_id(),
+            client_id: None,
             initial_subscriptions: vec![ahp_types::ROOT_RESOURCE_URI.to_string()],
             client_config: ClientConfig::default(),
             transport_factory: Arc::new(transport_factory),
@@ -148,9 +163,10 @@ impl HostConfig {
         }
     }
 
-    /// Override the `clientId` for this host.
+    /// Set an explicit `clientId` for this host. Bypasses the
+    /// [`super::ClientIdStore`] lookup entirely.
     pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
-        self.client_id = client_id.into();
+        self.client_id = Some(client_id.into());
         self
     }
 
@@ -278,6 +294,12 @@ pub enum HostError {
     /// A request bubbled up an error from the underlying [`Client`].
     #[error(transparent)]
     Client(#[from] ClientError),
+
+    /// The configured [`super::ClientIdStore`] failed during
+    /// [`super::MultiHostClient::add_host`]. The host is not
+    /// registered; resolve the underlying I/O issue and retry.
+    #[error(transparent)]
+    ClientIdStore(#[from] super::client_id_store::ClientIdStoreError),
 }
 
 /// Generation-checked handle to the underlying single-host [`Client`].
@@ -375,12 +397,26 @@ pub struct HostSubscriptionEvent {
 /// Stream of [`HostSubscriptionEvent`]s.
 ///
 /// Returned by [`super::MultiHostClient::events`]. Each call returns a
-/// fresh receiver — multiple consumers can listen independently. Slow
-/// consumers that lag past the buffer skip the gap and keep going,
-/// matching [`crate::SessionSubscription`] semantics.
+/// fresh receiver — multiple consumers can listen independently.
+///
+/// # Lossiness
+///
+/// This stream is backed by a Tokio broadcast channel and is **lossy
+/// by design** — slow consumers that lag past the buffer skip the
+/// gap (`broadcast::error::RecvError::Lagged`) and keep going,
+/// matching [`crate::SessionSubscription`] semantics. **Do not use
+/// this stream for reducer-critical [`ActionEnvelope`]s** because
+/// dropped envelopes desync downstream state mirrors irreversibly.
+/// For guaranteed-delivery per-URI action streams use
+/// [`super::MultiHostClient::events_for`] instead — that surface uses
+/// unbounded buffering per URI and survives reconnects.
+///
+/// # Ordering
 ///
 /// Ordering is **only** guaranteed within a single host. There is no
 /// cross-host total order — different hosts run independently.
+///
+/// [`ActionEnvelope`]: ahp_types::actions::ActionEnvelope
 pub struct HostSubscriptionStream {
     pub(super) rx: broadcast::Receiver<HostSubscriptionEvent>,
 }
@@ -450,6 +486,77 @@ impl HostEventStream {
                 Err(broadcast::error::RecvError::Lagged(_)) => continue,
             }
         }
+    }
+}
+
+/// Per-`(hostId, uri)` event stream — the reliable channel for
+/// reducer-critical action envelopes.
+///
+/// Returned by [`super::MultiHostClient::events_for`]. Delivers every
+/// [`SubscriptionEvent`] scoped to `uri` on `host` — both live
+/// envelopes and envelopes replayed during reconnect — through an
+/// unbounded mpsc channel, so a slow consumer holds an unbounded
+/// backlog rather than dropping events (which would desync downstream
+/// state mirrors).
+///
+/// Unlike [`crate::SessionSubscription`] (which is bound to one
+/// underlying [`crate::Client`] generation), the per-URI stream is
+/// owned by [`super::MultiHostClient`] and **survives reconnects** —
+/// the per-host supervisor fans replayed envelopes from
+/// `apply_reconnect_result` through this stream too. Protocol-level
+/// notifications (auth required, session added/removed/changed) also
+/// fan to every active per-URI listener for that host because they're
+/// cross-resource by design.
+///
+/// Subscribing here is independent from sending a `subscribe` request
+/// to the server. Attach the stream **before** calling
+/// [`super::MultiHostClient::subscribe`] so envelopes the server
+/// pushes between the subscribe response and your first `recv()`
+/// aren't sitting in a closed channel:
+///
+/// ```ignore
+/// let mut stream = multi.events_for(&host_id, "copilot:/s1".into()).await
+///     .expect("host registered");
+/// multi.subscribe(&host_id, "copilot:/s1".into()).await?;
+/// while let Some(event) = stream.recv().await {
+///     // ...
+/// }
+/// ```
+pub struct PerResourceStream {
+    pub(super) rx: tokio::sync::mpsc::UnboundedReceiver<SubscriptionEvent>,
+    /// Weak back-reference to the multi-host registry so dropping
+    /// this stream releases its listener slot immediately rather
+    /// than waiting for the host to be removed. `Weak` (not `Arc`)
+    /// so a stream lying around doesn't keep the multi-host client
+    /// alive past its last clone.
+    pub(super) registry: std::sync::Weak<super::multi::MultiInner>,
+    pub(super) host: HostId,
+    pub(super) listener_id: u64,
+}
+
+impl PerResourceStream {
+    /// Await the next event. Returns `None` when the listener has
+    /// been dropped from the registry (host removed, multi-host
+    /// client shut down, or this stream was dropped — `recv` on a
+    /// dropped receiver returns `None` immediately).
+    pub async fn recv(&mut self) -> Option<SubscriptionEvent> {
+        self.rx.recv().await
+    }
+}
+
+impl Drop for PerResourceStream {
+    fn drop(&mut self) {
+        if let Some(inner) = self.registry.upgrade() {
+            inner.remove_per_resource_listener(&self.host, self.listener_id);
+        }
+    }
+}
+
+impl std::fmt::Debug for PerResourceStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PerResourceStream")
+            .field("host", &self.host)
+            .finish_non_exhaustive()
     }
 }
 
@@ -555,10 +662,15 @@ pub(super) fn server_seq_from_envelope(env: &ActionEnvelope) -> i64 {
     env.server_seq as i64
 }
 
-/// Generate a session-stable UUIDv4-shaped string for use as a default
-/// `clientId`. Consumers that want cross-launch stability should
-/// persist the id themselves and pass it via [`HostConfig::with_client_id`].
-pub(super) fn generate_client_id() -> String {
+/// Generate a UUIDv4-shaped string suitable for use as a default
+/// `clientId`.
+///
+/// The multi-host SDK calls this internally when [`HostConfig::client_id`]
+/// is `None` and the configured [`super::ClientIdStore`] has no entry
+/// for the host. Public so consumers building their own
+/// [`super::ClientIdStore`] implementations can mint fresh ids in the
+/// same shape the SDK uses.
+pub fn generate_client_id() -> String {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/clients/rust/crates/ahp/src/lib.rs
+++ b/clients/rust/crates/ahp/src/lib.rs
@@ -148,6 +148,7 @@ pub mod client;
 pub mod error;
 pub mod hosts;
 pub mod reducers;
+pub mod state_mirror;
 pub mod transport;
 
 pub use ahp_types;
@@ -160,4 +161,5 @@ pub use error::{ClientError, TransportError};
 pub use reducers::{
     apply_action_to_root, apply_action_to_session, apply_action_to_terminal, ReduceOutcome,
 };
+pub use state_mirror::{HostedResourceKey, MultiHostStateMirror};
 pub use transport::{BoxedTransport, DynTransport, Transport, TransportMessage};

--- a/clients/rust/crates/ahp/src/state_mirror.rs
+++ b/clients/rust/crates/ahp/src/state_mirror.rs
@@ -1,0 +1,244 @@
+//! Host-aware state mirror for multi-host consumers.
+//!
+//! Single-host consumers can build their state by running each
+//! [`ActionEnvelope`](ahp_types::actions::ActionEnvelope)'s payload
+//! through the pure reducers ([`crate::apply_action_to_root`],
+//! [`crate::apply_action_to_session`],
+//! [`crate::apply_action_to_terminal`]) directly, keyed by URI. That
+//! falls apart for multi-host consumers because URIs are per-host
+//! scoped — `copilot:/s1` on Host A and `copilot:/s1` on Host B are
+//! different sessions that must not clobber each other in a shared
+//! map.
+//!
+//! [`MultiHostStateMirror`] wraps those reducers behind a façade
+//! keyed by [`HostedResourceKey`] (`(HostId, uri)`), eliminating the
+//! cross-host collision. Drop-in for any multi-host consumer; can be
+//! fed directly from [`crate::hosts::MultiHostClient::events_for`]
+//! (the lossless per-`(host, uri)` stream) or from individual
+//! [`crate::hosts::HostSubscriptionEvent`]s via [`Self::apply`].
+//!
+//! **Feed from the reliable per-resource stream.** Pump events into
+//! the mirror from
+//! [`crate::hosts::MultiHostClient::events_for`](crate::hosts::MultiHostClient::events_for)
+//! — which is unbounded, delivers replayed envelopes, and survives
+//! reconnects — **not** from
+//! [`crate::hosts::MultiHostClient::events`](crate::hosts::MultiHostClient::events)
+//! (which is lossy by design). Dropping action envelopes desyncs the
+//! mirror irreversibly.
+
+use std::collections::HashMap;
+
+use ahp_types::actions::{ActionEnvelope, StateAction};
+use ahp_types::state::{RootState, SessionState, Snapshot, SnapshotState, TerminalState};
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use crate::hosts::{HostId, HostSubscriptionEvent};
+use crate::reducers::{apply_action_to_root, apply_action_to_session, apply_action_to_terminal};
+use crate::SubscriptionEvent;
+
+/// Compound key tagging a resource URI with the host that produced
+/// it.
+///
+/// Session and terminal URIs aren't globally unique across hosts —
+/// `copilot:/s1` on Host A and `copilot:/s1` on Host B are different
+/// resources. Use this struct as the key in any multi-host state
+/// map.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct HostedResourceKey {
+    /// Host the resource belongs to.
+    pub host_id: HostId,
+    /// Resource URI, scoped to the host.
+    pub uri: String,
+}
+
+impl HostedResourceKey {
+    /// Build a key from a host id and URI.
+    pub fn new(host_id: impl Into<HostId>, uri: impl Into<String>) -> Self {
+        Self {
+            host_id: host_id.into(),
+            uri: uri.into(),
+        }
+    }
+}
+
+/// In-memory mirror of root/session/terminal state, fed by
+/// [`ActionEnvelope`]s and [`Snapshot`]s tagged with their host of
+/// origin.
+///
+/// Single-host consumers can keep using the pure reducers directly;
+/// this type adds the host dimension necessary for multi-host UIs.
+/// Apply [`HostSubscriptionEvent`]s directly via [`Self::apply`], or
+/// feed individual envelopes / snapshots via [`Self::apply_envelope`]
+/// and [`Self::apply_snapshot`].
+///
+/// Cheaply cloneable — the inner storage is `Arc`-shared, so all
+/// clones observe the same mirror state.
+#[derive(Default)]
+pub struct MultiHostStateMirror {
+    inner: RwLock<MirrorInner>,
+}
+
+#[derive(Default)]
+struct MirrorInner {
+    root_states: HashMap<HostId, RootState>,
+    sessions: HashMap<HostedResourceKey, SessionState>,
+    terminals: HashMap<HostedResourceKey, TerminalState>,
+}
+
+impl MultiHostStateMirror {
+    /// Construct an empty mirror.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply a [`HostSubscriptionEvent`] produced by
+    /// [`crate::hosts::MultiHostClient::events`] or
+    /// [`crate::hosts::MultiHostClient::events_for`].
+    ///
+    /// Action envelopes are routed through the reducer; protocol
+    /// notifications are dropped (they don't affect reducer state).
+    pub async fn apply(&self, event: &HostSubscriptionEvent) {
+        if let SubscriptionEvent::Action(envelope) = &event.event {
+            self.apply_envelope(&event.host_id, envelope).await;
+        }
+    }
+
+    /// Apply a single action envelope, scoped to `host`.
+    ///
+    /// Routing rules mirror
+    /// [`crate::SubscriptionEvent::Action`]'s server semantics: the
+    /// reducer is dispatched based on the action's `session` /
+    /// `terminal` field (root if neither is present). If no
+    /// snapshot has seeded the matching `(host, uri)` slot yet, the
+    /// action is a no-op for session/terminal — the reducer can't
+    /// invent a state from scratch. The root state is initialised
+    /// on demand (empty agents list) because the protocol guarantees
+    /// every host eventually publishes a root state.
+    pub async fn apply_envelope(&self, host: &HostId, envelope: &ActionEnvelope) {
+        let mut state = self.inner.write().await;
+        if let Some(session_uri) = action_session_uri(&envelope.action) {
+            let key = HostedResourceKey::new(host.clone(), session_uri);
+            if let Some(session) = state.sessions.get_mut(&key) {
+                apply_action_to_session(session, &envelope.action);
+            }
+            return;
+        }
+        if let Some(terminal_uri) = action_terminal_uri(&envelope.action) {
+            let key = HostedResourceKey::new(host.clone(), terminal_uri);
+            if let Some(terminal) = state.terminals.get_mut(&key) {
+                apply_action_to_terminal(terminal, &envelope.action);
+            }
+            return;
+        }
+        let root = state
+            .root_states
+            .entry(host.clone())
+            .or_insert_with(|| RootState {
+                agents: vec![],
+                active_sessions: None,
+                terminals: None,
+                config: None,
+            });
+        apply_action_to_root(root, &envelope.action);
+    }
+
+    /// Seed the mirror from a [`Snapshot`] scoped to `host` — root,
+    /// session, or terminal as the snapshot's `state` discriminator
+    /// dictates.
+    pub async fn apply_snapshot(&self, host: &HostId, snapshot: &Snapshot) {
+        let mut state = self.inner.write().await;
+        match &snapshot.state {
+            SnapshotState::Root(root) => {
+                state
+                    .root_states
+                    .insert(host.clone(), root.as_ref().clone());
+            }
+            SnapshotState::Session(session) => {
+                let key = HostedResourceKey::new(host.clone(), snapshot.resource.clone());
+                state.sessions.insert(key, session.as_ref().clone());
+            }
+            SnapshotState::Terminal(terminal) => {
+                let key = HostedResourceKey::new(host.clone(), snapshot.resource.clone());
+                state.terminals.insert(key, terminal.as_ref().clone());
+            }
+        }
+    }
+
+    /// Reset every slot for `host` — drops the root state, all
+    /// sessions keyed under that host, and all terminals keyed under
+    /// that host. Other hosts are untouched.
+    pub async fn reset_host(&self, host: &HostId) {
+        let mut state = self.inner.write().await;
+        state.root_states.remove(host);
+        state.sessions.retain(|key, _| &key.host_id != host);
+        state.terminals.retain(|key, _| &key.host_id != host);
+    }
+
+    /// Reset every slot across every host.
+    pub async fn reset(&self) {
+        let mut state = self.inner.write().await;
+        state.root_states.clear();
+        state.sessions.clear();
+        state.terminals.clear();
+    }
+
+    /// Clone the root state for `host`, if any.
+    pub async fn root(&self, host: &HostId) -> Option<RootState> {
+        self.inner.read().await.root_states.get(host).cloned()
+    }
+
+    /// Clone the session state for `(host, uri)`, if any.
+    pub async fn session(&self, host: &HostId, uri: &str) -> Option<SessionState> {
+        let key = HostedResourceKey::new(host.clone(), uri.to_owned());
+        self.inner.read().await.sessions.get(&key).cloned()
+    }
+
+    /// Clone the terminal state for `(host, uri)`, if any.
+    pub async fn terminal(&self, host: &HostId, uri: &str) -> Option<TerminalState> {
+        let key = HostedResourceKey::new(host.clone(), uri.to_owned());
+        self.inner.read().await.terminals.get(&key).cloned()
+    }
+
+    /// Snapshot every root state. Order is unspecified.
+    pub async fn root_states(&self) -> HashMap<HostId, RootState> {
+        self.inner.read().await.root_states.clone()
+    }
+
+    /// Snapshot every session state. Order is unspecified.
+    pub async fn sessions(&self) -> HashMap<HostedResourceKey, SessionState> {
+        self.inner.read().await.sessions.clone()
+    }
+
+    /// Snapshot every terminal state. Order is unspecified.
+    pub async fn terminals(&self) -> HashMap<HostedResourceKey, TerminalState> {
+        self.inner.read().await.terminals.clone()
+    }
+}
+
+impl std::fmt::Debug for MultiHostStateMirror {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultiHostStateMirror")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Extract the action's `session` URI, if it carries one.
+///
+/// Uses serde rather than enumerating every variant so new actions
+/// route correctly without an SDK update. Mirrors the helper inside
+/// the hosts runtime.
+fn action_session_uri(action: &StateAction) -> Option<String> {
+    let val = serde_json::to_value(action).ok()?;
+    val.get("session")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+/// Extract the action's `terminal` URI, if it carries one.
+fn action_terminal_uri(action: &StateAction) -> Option<String> {
+    let val = serde_json::to_value(action).ok()?;
+    val.get("terminal")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}

--- a/clients/rust/crates/ahp/src/state_mirror.rs
+++ b/clients/rust/crates/ahp/src/state_mirror.rs
@@ -27,6 +27,7 @@
 //! mirror irreversibly.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use ahp_types::actions::{ActionEnvelope, StateAction};
 use ahp_types::state::{RootState, SessionState, Snapshot, SnapshotState, TerminalState};
@@ -74,9 +75,9 @@ impl HostedResourceKey {
 ///
 /// Cheaply cloneable — the inner storage is `Arc`-shared, so all
 /// clones observe the same mirror state.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct MultiHostStateMirror {
-    inner: RwLock<MirrorInner>,
+    inner: Arc<RwLock<MirrorInner>>,
 }
 
 #[derive(Default)]
@@ -84,6 +85,30 @@ struct MirrorInner {
     root_states: HashMap<HostId, RootState>,
     sessions: HashMap<HostedResourceKey, SessionState>,
     terminals: HashMap<HostedResourceKey, TerminalState>,
+}
+
+/// Routing classification for an [`ActionEnvelope`] payload.
+///
+/// Computed via a single `serde_json::to_value` before the mirror
+/// acquires its write lock, so the lock's critical section stays
+/// short (only the reducer call holds the lock).
+enum ActionRoute {
+    Session(String),
+    Terminal(String),
+    Root,
+}
+
+fn route_action(action: &StateAction) -> ActionRoute {
+    let Ok(val) = serde_json::to_value(action) else {
+        return ActionRoute::Root;
+    };
+    if let Some(uri) = val.get("session").and_then(Value::as_str) {
+        return ActionRoute::Session(uri.to_owned());
+    }
+    if let Some(uri) = val.get("terminal").and_then(Value::as_str) {
+        return ActionRoute::Terminal(uri.to_owned());
+    }
+    ActionRoute::Root
 }
 
 impl MultiHostStateMirror {
@@ -116,31 +141,37 @@ impl MultiHostStateMirror {
     /// on demand (empty agents list) because the protocol guarantees
     /// every host eventually publishes a root state.
     pub async fn apply_envelope(&self, host: &HostId, envelope: &ActionEnvelope) {
+        // Classify outside the lock so the single `serde_json::to_value`
+        // call doesn't block readers/writers — and so we never serialise
+        // the same action twice on the no-session/terminal fallthrough.
+        let route = route_action(&envelope.action);
         let mut state = self.inner.write().await;
-        if let Some(session_uri) = action_session_uri(&envelope.action) {
-            let key = HostedResourceKey::new(host.clone(), session_uri);
-            if let Some(session) = state.sessions.get_mut(&key) {
-                apply_action_to_session(session, &envelope.action);
+        match route {
+            ActionRoute::Session(uri) => {
+                let key = HostedResourceKey::new(host.clone(), uri);
+                if let Some(session) = state.sessions.get_mut(&key) {
+                    apply_action_to_session(session, &envelope.action);
+                }
             }
-            return;
-        }
-        if let Some(terminal_uri) = action_terminal_uri(&envelope.action) {
-            let key = HostedResourceKey::new(host.clone(), terminal_uri);
-            if let Some(terminal) = state.terminals.get_mut(&key) {
-                apply_action_to_terminal(terminal, &envelope.action);
+            ActionRoute::Terminal(uri) => {
+                let key = HostedResourceKey::new(host.clone(), uri);
+                if let Some(terminal) = state.terminals.get_mut(&key) {
+                    apply_action_to_terminal(terminal, &envelope.action);
+                }
             }
-            return;
+            ActionRoute::Root => {
+                let root = state
+                    .root_states
+                    .entry(host.clone())
+                    .or_insert_with(|| RootState {
+                        agents: vec![],
+                        active_sessions: None,
+                        terminals: None,
+                        config: None,
+                    });
+                apply_action_to_root(root, &envelope.action);
+            }
         }
-        let root = state
-            .root_states
-            .entry(host.clone())
-            .or_insert_with(|| RootState {
-                agents: vec![],
-                active_sessions: None,
-                terminals: None,
-                config: None,
-            });
-        apply_action_to_root(root, &envelope.action);
     }
 
     /// Seed the mirror from a [`Snapshot`] scoped to `host` — root,
@@ -221,24 +252,4 @@ impl std::fmt::Debug for MultiHostStateMirror {
         f.debug_struct("MultiHostStateMirror")
             .finish_non_exhaustive()
     }
-}
-
-/// Extract the action's `session` URI, if it carries one.
-///
-/// Uses serde rather than enumerating every variant so new actions
-/// route correctly without an SDK update. Mirrors the helper inside
-/// the hosts runtime.
-fn action_session_uri(action: &StateAction) -> Option<String> {
-    let val = serde_json::to_value(action).ok()?;
-    val.get("session")
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-}
-
-/// Extract the action's `terminal` URI, if it carries one.
-fn action_terminal_uri(action: &StateAction) -> Option<String> {
-    let val = serde_json::to_value(action).ok()?;
-    val.get("terminal")
-        .and_then(Value::as_str)
-        .map(str::to_owned)
 }

--- a/clients/rust/crates/ahp/tests/client_roundtrip.rs
+++ b/clients/rust/crates/ahp/tests/client_roundtrip.rs
@@ -158,7 +158,7 @@ async fn request_response_and_action_fanout() {
 
 /// Cancelling a request future via `select!` against another branch
 /// must drop the pending entry immediately rather than leaking it
-/// until (or beyond) the server response. The Phase 7 RAII guard on
+/// until (or beyond) the server response. The RAII `PendingGuard` on
 /// `Client::request` is what enforces that — without it, the pending
 /// map would grow on every cancelled typeahead / debounce request.
 #[tokio::test]

--- a/clients/rust/crates/ahp/tests/client_roundtrip.rs
+++ b/clients/rust/crates/ahp/tests/client_roundtrip.rs
@@ -155,3 +155,62 @@ async fn request_response_and_action_fanout() {
     client.shutdown().await;
     server.await.unwrap();
 }
+
+/// Cancelling a request future via `select!` against another branch
+/// must drop the pending entry immediately rather than leaking it
+/// until (or beyond) the server response. The Phase 7 RAII guard on
+/// `Client::request` is what enforces that — without it, the pending
+/// map would grow on every cancelled typeahead / debounce request.
+#[tokio::test]
+async fn cancelled_request_future_clears_pending_entry() {
+    let (client_side, mut server_side) = pair();
+    let client = Client::connect(client_side, ClientConfig::default())
+        .await
+        .expect("connect");
+
+    // Server drains messages but never replies — so the only way
+    // for the request future to resolve is the caller cancelling it.
+    let drain = tokio::spawn(async move {
+        loop {
+            match server_side.recv().await {
+                Ok(Some(_)) => continue,
+                Ok(None) | Err(_) => return,
+            }
+        }
+    });
+
+    // Spawn the request on a task we can abort.
+    let client_clone = client.clone();
+    let request_task = tokio::spawn(async move {
+        let _: Result<serde_json::Value, _> = client_clone
+            .request("never-replied", serde_json::Value::Null)
+            .await;
+    });
+
+    // Give the client time to push the outbound message + insert the
+    // pending entry, then verify the entry is there.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        client.pending_request_count(),
+        1,
+        "request should have inserted a pending entry"
+    );
+
+    // Cancel the request by aborting the task. The guard's Drop should
+    // remove the pending entry deterministically; without the guard
+    // the entry would linger until the server eventually replied (it
+    // never will) or until `Client::shutdown`.
+    request_task.abort();
+    let _ = request_task.await;
+
+    // Allow the abort + drop glue to run.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        client.pending_request_count(),
+        0,
+        "cancelled request must clean up its pending entry"
+    );
+
+    client.shutdown().await;
+    let _ = drain.await;
+}

--- a/clients/rust/crates/ahp/tests/hosts.rs
+++ b/clients/rust/crates/ahp/tests/hosts.rs
@@ -712,9 +712,9 @@ async fn shutdown_is_not_blocked_by_a_hung_transport_factory() {
     );
 }
 
-// ─── New phase tests (Phase 2 / 4 / 5 / 6 / 7 parity with Swift PR #129) ────
+// ─── Multi-host registry tests: client_id store, reconnect-all, per-URI streams ─
 
-/// Phase 5: stored `clientId` is reused across `add_host` cycles.
+/// Stored `clientId` is reused across `add_host` cycles.
 ///
 /// The default in-memory store keeps the resolved id keyed by HostId,
 /// so removing and re-adding a host (without an explicit
@@ -756,7 +756,7 @@ async fn client_id_persists_across_add_remove_add_when_unset() {
     );
 }
 
-/// Phase 5: explicit `with_client_id` always wins over the store.
+/// Explicit `with_client_id` always wins over the store.
 #[tokio::test]
 async fn explicit_client_id_overrides_store_and_is_persisted() {
     let multi = MultiHostClient::new();
@@ -811,7 +811,7 @@ async fn explicit_client_id_overrides_store_and_is_persisted() {
     );
 }
 
-/// Phase 6: `reconnect_all_unavailable` skips connected hosts and
+/// `reconnect_all_unavailable` skips connected hosts and
 /// kicks any host not in `Connected`/`Connecting`.
 #[tokio::test]
 async fn reconnect_all_unavailable_skips_connected_and_wakes_failed() {
@@ -894,7 +894,7 @@ async fn reconnect_all_unavailable_skips_connected_and_wakes_failed() {
     );
 }
 
-/// Phase 6: empty map when every host is Connected.
+/// `reconnect_all_unavailable` returns an empty map when every host is `Connected`.
 #[tokio::test]
 async fn reconnect_all_unavailable_returns_empty_when_all_connected() {
     let multi = MultiHostClient::new();
@@ -911,9 +911,8 @@ async fn reconnect_all_unavailable_returns_empty_when_all_connected() {
     assert!(errors.is_empty());
 }
 
-/// Phase 2: per-`(host, uri)` stream delivers a live action envelope
-/// scoped to the requested resource and ignores envelopes for other
-/// resources.
+/// `events_for` delivers a live action envelope scoped to the
+/// requested resource and ignores envelopes for other resources.
 #[tokio::test]
 async fn events_for_delivers_live_action_envelopes_scoped_to_uri() {
     use ahp_types::actions::{SessionTitleChangedAction, StateAction};
@@ -1030,7 +1029,7 @@ async fn events_for_delivers_live_action_envelopes_scoped_to_uri() {
     );
 }
 
-/// Phase 2: `events_for` returns `None` for an unregistered host.
+/// `events_for` returns `None` for an unregistered host.
 #[tokio::test]
 async fn events_for_returns_none_for_unknown_host() {
     let multi = MultiHostClient::new();
@@ -1040,7 +1039,7 @@ async fn events_for_returns_none_for_unknown_host() {
     assert!(stream.is_none());
 }
 
-/// Phase 2: removing a host closes the per-`(host, uri)` stream so
+/// Removing a host closes the per-`(host, uri)` stream so
 /// the consumer's `recv()` loop exits cleanly.
 #[tokio::test]
 async fn events_for_closes_when_host_is_removed() {
@@ -1072,12 +1071,13 @@ async fn events_for_closes_when_host_is_removed() {
     );
 }
 
-/// Phase 2 (correctness): the per-`(host, uri)` stream must receive
-/// **replayed** action envelopes too — not just live ones. This is
-/// the headline bug the Swift PR #129 / Phase 2 fix addresses for
-/// consumers that use the per-URI stream as their reducer feed: the
-/// runtime fans replay actions through the same path as live
-/// envelopes, and `events_for` was wired to capture both.
+/// The per-`(host, uri)` stream must receive **replayed** action
+/// envelopes too, not just live ones. The runtime fans replay
+/// actions through the same sink as live envelopes, and
+/// `events_for` is wired to capture both; a regression that
+/// detached the per-URI listeners from the replay path would
+/// silently break consumers that use the per-URI stream as their
+/// reducer feed.
 #[tokio::test]
 async fn events_for_receives_replayed_envelopes_across_reconnect() {
     use ahp_types::actions::{RootActiveSessionsChangedAction, StateAction};
@@ -1119,8 +1119,9 @@ async fn events_for_receives_replayed_envelopes_across_reconnect() {
         .expect("reconnect");
 
     // Pull from the per-URI stream until we see the replayed
-    // RootActiveSessionsChanged. Without Phase 2 wiring the runtime's
-    // fan-out to per-URI listeners, this would time out.
+    // RootActiveSessionsChanged. If the runtime stopped fanning
+    // replay envelopes through the per-URI registry, this would
+    // time out.
     let deadline = tokio::time::Instant::now() + Duration::from_millis(2500);
     let mut saw_it = false;
     while tokio::time::Instant::now() < deadline {
@@ -1140,16 +1141,12 @@ async fn events_for_receives_replayed_envelopes_across_reconnect() {
             _ => break,
         }
     }
-    assert!(
-        saw_it,
-        "events_for must deliver replayed action envelopes — Phase 2 correctness fix"
-    );
+    assert!(saw_it, "events_for must deliver replayed action envelopes");
 }
 
-/// Phase 2 (drop semantics): dropping a `PerResourceStream`
-/// unregisters its listener slot from the registry immediately, so
-/// long-running consumers that create + drop streams in a loop
-/// don't leak per-listener state.
+/// Dropping a `PerResourceStream` unregisters its listener slot
+/// from the registry immediately, so long-running consumers that
+/// create + drop streams in a loop don't leak per-listener state.
 #[tokio::test]
 async fn dropping_events_for_stream_releases_listener_slot() {
     let multi = MultiHostClient::new();
@@ -1198,8 +1195,8 @@ async fn dropping_events_for_stream_releases_listener_slot() {
     // If we got here without OOMing or panicking, the cleanup works.
 }
 
-/// Phase 6 / lifecycle: `MultiHostClient::shutdown()` tears down
-/// every host's supervisor and closes any open per-URI streams.
+/// `MultiHostClient::shutdown()` tears down every host's
+/// supervisor and closes any open per-URI streams.
 #[tokio::test]
 async fn shutdown_tears_down_all_hosts_and_closes_listeners() {
     let multi = MultiHostClient::new();
@@ -1247,8 +1244,8 @@ async fn shutdown_tears_down_all_hosts_and_closes_listeners() {
     multi.shutdown().await;
 }
 
-/// Phase 6 / cancellation safety: a cancelled `add_host` future
-/// must not leak the `pending_host_ids` reservation. Without the
+/// A cancelled `add_host` future must not leak the
+/// `pending_host_ids` reservation. Without the
 /// RAII guard, a subsequent `add_host` for the same id would
 /// permanently return `DuplicateHost`.
 ///

--- a/clients/rust/crates/ahp/tests/hosts.rs
+++ b/clients/rust/crates/ahp/tests/hosts.rs
@@ -712,6 +712,654 @@ async fn shutdown_is_not_blocked_by_a_hung_transport_factory() {
     );
 }
 
+// ─── New phase tests (Phase 2 / 4 / 5 / 6 / 7 parity with Swift PR #129) ────
+
+/// Phase 5: stored `clientId` is reused across `add_host` cycles.
+///
+/// The default in-memory store keeps the resolved id keyed by HostId,
+/// so removing and re-adding a host (without an explicit
+/// `with_client_id`) should yield the same id — proof that the store
+/// resolution path actually runs and persists what it resolves.
+#[tokio::test]
+async fn client_id_persists_across_add_remove_add_when_unset() {
+    let multi = MultiHostClient::new();
+
+    multi
+        .add_host(HostConfig::new(
+            "h",
+            "Host",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+    let first_id = multi.host(&HostId::new("h")).await.unwrap().client_id;
+    assert!(
+        !first_id.is_empty(),
+        "client_id should be generated, not empty"
+    );
+
+    multi.remove_host(&HostId::new("h")).await.unwrap();
+    multi
+        .add_host(HostConfig::new(
+            "h",
+            "Host",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+    let second_id = multi.host(&HostId::new("h")).await.unwrap().client_id;
+    assert_eq!(
+        first_id, second_id,
+        "store should resolve the same client_id on the second add"
+    );
+}
+
+/// Phase 5: explicit `with_client_id` always wins over the store.
+#[tokio::test]
+async fn explicit_client_id_overrides_store_and_is_persisted() {
+    let multi = MultiHostClient::new();
+
+    // Seed the store via an unset add — store now holds whatever was
+    // generated.
+    multi
+        .add_host(HostConfig::new(
+            "h",
+            "Host",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+    let generated = multi.host(&HostId::new("h")).await.unwrap().client_id;
+
+    multi.remove_host(&HostId::new("h")).await.unwrap();
+
+    // Re-add with an explicit client id — must win over the store.
+    multi
+        .add_host(
+            HostConfig::new("h", "Host", make_basic_factory(FakeHostState::new()))
+                .with_client_id("explicit-id"),
+        )
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+    assert_eq!(
+        multi.host(&HostId::new("h")).await.unwrap().client_id,
+        "explicit-id"
+    );
+
+    // Removing and re-adding without an explicit id should now return
+    // the *explicit* id (the store was overwritten on the previous
+    // add).
+    multi.remove_host(&HostId::new("h")).await.unwrap();
+    multi
+        .add_host(HostConfig::new(
+            "h",
+            "Host",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+    let after_overwrite = multi.host(&HostId::new("h")).await.unwrap().client_id;
+    assert_eq!(after_overwrite, "explicit-id");
+    assert_ne!(
+        after_overwrite, generated,
+        "the explicit id should have replaced the originally generated one"
+    );
+}
+
+/// Phase 6: `reconnect_all_unavailable` skips connected hosts and
+/// kicks any host not in `Connected`/`Connecting`.
+#[tokio::test]
+async fn reconnect_all_unavailable_skips_connected_and_wakes_failed() {
+    // Host A: connects normally on first try (stays Connected).
+    let counter_a = Arc::new(AtomicU32::new(0));
+    let counter_a_clone = counter_a.clone();
+    let factory_a = move |_id: HostId| {
+        let counter = counter_a_clone.clone();
+        Box::pin(async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            let (client_side, server_side) = pair();
+            tokio::spawn(drive_fake_host_basic(server_side, FakeHostState::new()));
+            Ok(BoxedTransport::new(client_side))
+        })
+            as std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<BoxedTransport, TransportError>> + Send,
+                >,
+            >
+    };
+
+    // Host B: first attempt fails (driving the host to Failed because
+    // policy is `disabled`), subsequent attempts succeed.
+    let did_first_fail = Arc::new(AtomicBool::new(false));
+    let counter_b = Arc::new(AtomicU32::new(0));
+    let counter_b_clone = counter_b.clone();
+    let did_first_fail_clone = did_first_fail.clone();
+    let factory_b = move |_id: HostId| {
+        let counter = counter_b_clone.clone();
+        let flag = did_first_fail_clone.clone();
+        Box::pin(async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            if !flag.swap(true, Ordering::SeqCst) {
+                return Err(TransportError::Io(
+                    "intentional first-attempt failure".into(),
+                ));
+            }
+            let (client_side, server_side) = pair();
+            tokio::spawn(drive_fake_host_basic(server_side, FakeHostState::new()));
+            Ok(BoxedTransport::new(client_side))
+        })
+            as std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<BoxedTransport, TransportError>> + Send,
+                >,
+            >
+    };
+
+    let multi = MultiHostClient::new();
+    multi
+        .add_host(HostConfig::new("a", "A", factory_a))
+        .await
+        .unwrap();
+    multi
+        .add_host(
+            HostConfig::new("b", "B", factory_b).with_reconnect_policy(ReconnectPolicy::disabled()),
+        )
+        .await
+        .unwrap();
+
+    wait_for_state(&multi, &HostId::new("a"), |s| s.is_connected(), 2000).await;
+    wait_for_state(&multi, &HostId::new("b"), |s| s.is_failed(), 2000).await;
+
+    let a_count_before = counter_a.load(Ordering::SeqCst);
+    assert_eq!(a_count_before, 1);
+
+    let errors = multi.reconnect_all_unavailable().await;
+    assert!(
+        errors.is_empty(),
+        "expected acks without error, got {errors:?}"
+    );
+
+    wait_for_state(&multi, &HostId::new("b"), |s| s.is_connected(), 2000).await;
+    let a_count_after = counter_a.load(Ordering::SeqCst);
+    let b_count_after = counter_b.load(Ordering::SeqCst);
+    assert_eq!(a_count_after, 1, "host A should not have been re-connected");
+    assert_eq!(
+        b_count_after, 2,
+        "host B should have re-attempted exactly once"
+    );
+}
+
+/// Phase 6: empty map when every host is Connected.
+#[tokio::test]
+async fn reconnect_all_unavailable_returns_empty_when_all_connected() {
+    let multi = MultiHostClient::new();
+    multi
+        .add_host(HostConfig::new(
+            "x",
+            "X",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("x"), |s| s.is_connected(), 2000).await;
+    let errors = multi.reconnect_all_unavailable().await;
+    assert!(errors.is_empty());
+}
+
+/// Phase 2: per-`(host, uri)` stream delivers a live action envelope
+/// scoped to the requested resource and ignores envelopes for other
+/// resources.
+#[tokio::test]
+async fn events_for_delivers_live_action_envelopes_scoped_to_uri() {
+    use ahp_types::actions::{SessionTitleChangedAction, StateAction};
+
+    // Custom factory: respond to subscribe + push an action envelope
+    // targeting copilot:/s1 a moment later.
+    let factory = move |_id: HostId| {
+        Box::pin(async move {
+            let (client_side, server_side) = pair();
+            tokio::spawn(async move {
+                let mut t = server_side;
+                let mut handled_subscribe = false;
+                loop {
+                    let frame = match t.recv().await {
+                        Ok(Some(f)) => f,
+                        _ => return,
+                    };
+                    let parsed = match frame.into_parsed() {
+                        Ok(m) => m,
+                        Err(_) => continue,
+                    };
+                    if let JsonRpcMessage::Request(req) = parsed {
+                        let result = handle_request(&req, &FakeHostState::new());
+                        let resp = JsonRpcMessage::SuccessResponse(JsonRpcSuccessResponse {
+                            jsonrpc: JsonRpcVersion::V2,
+                            id: req.id,
+                            result: ahp_types::common::AnyValue::from(result),
+                        });
+                        if t.send(TransportMessage::encode(&resp).unwrap())
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                        if req.method == "subscribe" && !handled_subscribe {
+                            handled_subscribe = true;
+                            // Push a couple of action envelopes: one for the
+                            // subscribed URI, one for a different URI. Only
+                            // the first should reach the per-URI stream.
+                            for (resource, title, seq) in [
+                                ("copilot:/s1", "live", 11i64),
+                                ("copilot:/s2", "other", 12i64),
+                            ] {
+                                let envelope = serde_json::json!({
+                                    "action": {
+                                        "type": "session/titleChanged",
+                                        "session": resource,
+                                        "title": title,
+                                    },
+                                    "serverSeq": seq,
+                                });
+                                let notif = JsonRpcMessage::Notification(JsonRpcNotification {
+                                    jsonrpc: JsonRpcVersion::V2,
+                                    method: "action".into(),
+                                    params: Some(ahp_types::common::AnyValue::from(envelope)),
+                                });
+                                let _ = t.send(TransportMessage::encode(&notif).unwrap()).await;
+                            }
+                        }
+                    }
+                }
+            });
+            Ok(BoxedTransport::new(client_side))
+        })
+            as std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<BoxedTransport, TransportError>> + Send,
+                >,
+            >
+    };
+
+    let multi = MultiHostClient::new();
+    multi
+        .add_host(HostConfig::new("h", "Host", factory))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+
+    // Register the per-URI stream BEFORE subscribing.
+    let mut stream = multi
+        .events_for(&HostId::new("h"), "copilot:/s1".into())
+        .await
+        .expect("host is registered");
+    multi
+        .subscribe(&HostId::new("h"), "copilot:/s1".into())
+        .await
+        .expect("subscribe");
+
+    // Pull events; first matching should be the live action for /s1.
+    let event = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .expect("timeout")
+        .expect("channel closed");
+    match event {
+        ahp::SubscriptionEvent::Action(env) => {
+            assert_eq!(env.server_seq, 11);
+            match env.action {
+                StateAction::SessionTitleChanged(SessionTitleChangedAction { session, title }) => {
+                    assert_eq!(session, "copilot:/s1");
+                    assert_eq!(title, "live");
+                }
+                other => panic!("unexpected action: {other:?}"),
+            }
+        }
+        ahp::SubscriptionEvent::Notification(_) => panic!("expected an Action event"),
+    }
+
+    // A short grace window: nothing else should arrive on the
+    // per-URI stream (the /s2 envelope is for a different URI).
+    let next = tokio::time::timeout(Duration::from_millis(150), stream.recv()).await;
+    assert!(
+        next.is_err(),
+        "stream should not deliver events for other URIs; got {next:?}"
+    );
+}
+
+/// Phase 2: `events_for` returns `None` for an unregistered host.
+#[tokio::test]
+async fn events_for_returns_none_for_unknown_host() {
+    let multi = MultiHostClient::new();
+    let stream = multi
+        .events_for(&HostId::new("never-added"), "copilot:/s1".into())
+        .await;
+    assert!(stream.is_none());
+}
+
+/// Phase 2: removing a host closes the per-`(host, uri)` stream so
+/// the consumer's `recv()` loop exits cleanly.
+#[tokio::test]
+async fn events_for_closes_when_host_is_removed() {
+    let multi = MultiHostClient::new();
+    multi
+        .add_host(HostConfig::new(
+            "h",
+            "Host",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+
+    let mut stream = multi
+        .events_for(&HostId::new("h"), "copilot:/s1".into())
+        .await
+        .expect("host is registered");
+
+    multi.remove_host(&HostId::new("h")).await.unwrap();
+
+    // The receiver should resolve to None (channel closed).
+    let next = tokio::time::timeout(Duration::from_millis(500), stream.recv())
+        .await
+        .expect("stream did not close after host removal");
+    assert!(
+        next.is_none(),
+        "per-uri stream should report end-of-stream after host removal; got {next:?}"
+    );
+}
+
+/// Phase 2 (correctness): the per-`(host, uri)` stream must receive
+/// **replayed** action envelopes too — not just live ones. This is
+/// the headline bug the Swift PR #129 / Phase 2 fix addresses for
+/// consumers that use the per-URI stream as their reducer feed: the
+/// runtime fans replay actions through the same path as live
+/// envelopes, and `events_for` was wired to capture both.
+#[tokio::test]
+async fn events_for_receives_replayed_envelopes_across_reconnect() {
+    use ahp_types::actions::{RootActiveSessionsChangedAction, StateAction};
+
+    let drop_after_init = Arc::new(AtomicBool::new(false));
+    let return_replay = Arc::new(Mutex::new(false));
+    let state = FakeHostState::new();
+
+    let multi = MultiHostClient::new();
+    // Subscribe to the per-URI stream BEFORE adding the host so the
+    // first connect's replay (when it eventually happens) can't race
+    // ahead of our registration.
+    multi
+        .add_host(HostConfig::new(
+            "h",
+            "Host",
+            make_replay_factory(state, drop_after_init.clone(), return_replay.clone()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+
+    // The replay envelope targets the ROOT_RESOURCE_URI (it's a
+    // RootActiveSessionsChanged action). Subscribe the per-URI
+    // stream to that URI.
+    let mut stream = multi
+        .events_for(&HostId::new("h"), ahp_types::ROOT_RESOURCE_URI.into())
+        .await
+        .expect("host registered");
+
+    // Flip the server to respond with a Replay on the next
+    // `reconnect`, then drop the existing connection so the
+    // supervisor kicks a new connect.
+    *return_replay.lock().await = true;
+    drop_after_init.store(true, Ordering::SeqCst);
+    multi
+        .reconnect_host(&HostId::new("h"))
+        .await
+        .expect("reconnect");
+
+    // Pull from the per-URI stream until we see the replayed
+    // RootActiveSessionsChanged. Without Phase 2 wiring the runtime's
+    // fan-out to per-URI listeners, this would time out.
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(2500);
+    let mut saw_it = false;
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.recv()).await {
+            Ok(Some(ahp::SubscriptionEvent::Action(env))) => {
+                if matches!(
+                    env.action,
+                    StateAction::RootActiveSessionsChanged(RootActiveSessionsChangedAction {
+                        active_sessions: 7
+                    })
+                ) {
+                    saw_it = true;
+                    break;
+                }
+            }
+            Ok(Some(_)) => continue,
+            _ => break,
+        }
+    }
+    assert!(
+        saw_it,
+        "events_for must deliver replayed action envelopes — Phase 2 correctness fix"
+    );
+}
+
+/// Phase 2 (drop semantics): dropping a `PerResourceStream`
+/// unregisters its listener slot from the registry immediately, so
+/// long-running consumers that create + drop streams in a loop
+/// don't leak per-listener state.
+#[tokio::test]
+async fn dropping_events_for_stream_releases_listener_slot() {
+    let multi = MultiHostClient::new();
+    multi
+        .add_host(HostConfig::new(
+            "h",
+            "Host",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("h"), |s| s.is_connected(), 2000).await;
+
+    // Create a stream, then drop it; the listener slot should be gone.
+    {
+        let _stream = multi
+            .events_for(&HostId::new("h"), "copilot:/s1".into())
+            .await
+            .expect("host registered");
+    }
+
+    // Give the Drop a moment.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Push an event by triggering a manual reconnect (cheap way to
+    // exercise the fan-out path). Then create a new stream and
+    // verify it observes a *fresh* listener id (the prior one is
+    // gone). We can't probe the registry directly, but we can probe
+    // indirectly: registering many streams in a loop and dropping
+    // them shouldn't exhaust memory — the previous implementation
+    // would have grown the per_resource_listeners bucket
+    // unboundedly. Smoke test: register and drop 100 streams, then
+    // register one more and observe a live event flows through.
+    for _ in 0..100 {
+        let _stream = multi
+            .events_for(&HostId::new("h"), "copilot:/s1".into())
+            .await
+            .expect("host registered");
+        // Stream dropped at end of scope.
+    }
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let _stream = multi
+        .events_for(&HostId::new("h"), "copilot:/s1".into())
+        .await
+        .expect("host registered");
+    // If we got here without OOMing or panicking, the cleanup works.
+}
+
+/// Phase 6 / lifecycle: `MultiHostClient::shutdown()` tears down
+/// every host's supervisor and closes any open per-URI streams.
+#[tokio::test]
+async fn shutdown_tears_down_all_hosts_and_closes_listeners() {
+    let multi = MultiHostClient::new();
+    multi
+        .add_host(HostConfig::new(
+            "a",
+            "A",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    multi
+        .add_host(HostConfig::new(
+            "b",
+            "B",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await
+        .unwrap();
+    wait_for_state(&multi, &HostId::new("a"), |s| s.is_connected(), 2000).await;
+    wait_for_state(&multi, &HostId::new("b"), |s| s.is_connected(), 2000).await;
+
+    let mut stream_a = multi
+        .events_for(&HostId::new("a"), "copilot:/s1".into())
+        .await
+        .expect("host A registered");
+
+    multi.shutdown().await;
+
+    // Per-URI stream should report end-of-stream.
+    let next = tokio::time::timeout(Duration::from_millis(500), stream_a.recv())
+        .await
+        .expect("stream did not close after shutdown");
+    assert!(
+        next.is_none(),
+        "expected per-URI stream to close on shutdown"
+    );
+
+    // Hosts should be gone.
+    assert!(multi.host(&HostId::new("a")).await.is_none());
+    assert!(multi.host(&HostId::new("b")).await.is_none());
+    assert_eq!(multi.hosts().await.len(), 0);
+
+    // shutdown() should be idempotent.
+    multi.shutdown().await;
+}
+
+/// Phase 6 / cancellation safety: a cancelled `add_host` future
+/// must not leak the `pending_host_ids` reservation. Without the
+/// RAII guard, a subsequent `add_host` for the same id would
+/// permanently return `DuplicateHost`.
+///
+/// We exercise the cancellation path by plugging a [`ClientIdStore`]
+/// that takes forever to `load()`, so `add_host_inner` parks
+/// awaiting the store with the reservation still held. When the
+/// outer task is aborted, the reservation's `Drop` must fire.
+#[tokio::test]
+async fn cancelled_add_host_releases_pending_reservation() {
+    use ahp::hosts::{ClientIdStore, ClientIdStoreError};
+    use std::pin::Pin;
+
+    /// Store that blocks forever inside `load` so we can park
+    /// `add_host_inner` mid-resolution and then cancel it.
+    struct ParkingStore;
+    impl ClientIdStore for ParkingStore {
+        fn load(
+            &self,
+            _host_id: &HostId,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<String>, ClientIdStoreError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                Ok(None)
+            })
+        }
+        fn store(
+            &self,
+            _host_id: &HostId,
+            _client_id: &str,
+        ) -> Pin<Box<dyn std::future::Future<Output = Result<(), ClientIdStoreError>> + Send + '_>>
+        {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    let multi = MultiHostClient::with_client_id_store(ParkingStore);
+
+    // Kick off add_host on a task; it will park inside store.load.
+    // Note we use a factory that would only run AFTER add_host_inner
+    // returns Ok, so it never actually executes here — the
+    // reservation is held while we're stuck in store.load.
+    let multi_clone = multi.clone();
+    let task = tokio::spawn(async move {
+        let _ = multi_clone
+            .add_host(HostConfig::new(
+                "h",
+                "Host",
+                make_basic_factory(FakeHostState::new()),
+            ))
+            .await;
+    });
+    // Brief pause so the task gets to the parked store.load.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Confirm the reservation IS in place — a second add_host for
+    // the same id should fail until the first is cancelled.
+    let racing = multi
+        .add_host(HostConfig::new(
+            "h",
+            "Other",
+            make_basic_factory(FakeHostState::new()),
+        ))
+        .await;
+    assert!(
+        matches!(racing, Err(HostError::DuplicateHost(_))),
+        "expected DuplicateHost while reservation is held; got {racing:?}"
+    );
+
+    // Cancel the parked add and wait for the abort + Drop chain.
+    task.abort();
+    let _ = task.await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Switch to a multi-host client built without the parking store
+    // for the recovery add, since the original is still wired to
+    // ParkingStore (which would re-park). Instead, take a fresh
+    // MultiHostClient with default store and confirm the path works
+    // in isolation. The reservation-release behaviour we're
+    // verifying is observable on `multi` itself — after the abort
+    // the pending_host_ids set should not contain "h".
+    //
+    // We probe `multi` indirectly: a fresh add_host on `multi` for
+    // the same id would re-enter the parking store, but at least
+    // the reservation check should pass. So spawn another and
+    // verify it parks rather than fast-fails with DuplicateHost.
+    let multi_clone2 = multi.clone();
+    let probe = tokio::spawn(async move {
+        multi_clone2
+            .add_host(HostConfig::new(
+                "h",
+                "Probe",
+                make_basic_factory(FakeHostState::new()),
+            ))
+            .await
+    });
+    // Give the probe a tick to either fail or park.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !probe.is_finished(),
+        "second add_host should have passed the reservation check and parked in the store"
+    );
+    probe.abort();
+    let _ = probe.await;
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 fn make_summary(uri: &str, title: &str, modified_at: i64) -> ahp_types::state::SessionSummary {

--- a/clients/rust/crates/ahp/tests/state_mirror.rs
+++ b/clients/rust/crates/ahp/tests/state_mirror.rs
@@ -1,0 +1,347 @@
+//! Tests for [`ahp::MultiHostStateMirror`].
+//!
+//! The mirror is the host-aware reducer façade — its core invariant
+//! is that two hosts can legitimately advertise the same resource URI
+//! without clobbering each other. These tests pin down the
+//! reducer-routing behaviour, the per-host snapshot semantics, and
+//! the reset helpers.
+
+use ahp::hosts::HostId;
+use ahp::{HostedResourceKey, MultiHostStateMirror};
+use ahp_types::actions::{
+    ActionEnvelope, RootAgentsChangedAction, SessionTitleChangedAction, StateAction,
+};
+use ahp_types::state::{
+    AgentInfo, RootState, SessionLifecycle, SessionState, SessionSummary, Snapshot, SnapshotState,
+};
+
+fn agent(provider: &str) -> AgentInfo {
+    AgentInfo {
+        provider: provider.into(),
+        display_name: provider.into(),
+        description: String::new(),
+        models: vec![],
+        protected_resources: None,
+        customizations: None,
+    }
+}
+
+fn empty_root() -> RootState {
+    RootState {
+        agents: vec![],
+        active_sessions: None,
+        terminals: None,
+        config: None,
+    }
+}
+
+fn session_state(uri: &str, title: &str) -> SessionState {
+    SessionState {
+        summary: SessionSummary {
+            resource: uri.into(),
+            provider: "copilot".into(),
+            title: title.into(),
+            status: 0,
+            activity: None,
+            created_at: 1,
+            modified_at: 1,
+            project: None,
+            model: None,
+            working_directory: None,
+            diffs: None,
+        },
+        lifecycle: SessionLifecycle::Ready,
+        creation_error: None,
+        server_tools: None,
+        active_client: None,
+        turns: vec![],
+        active_turn: None,
+        steering_message: None,
+        queued_messages: None,
+        input_requests: None,
+        config: None,
+        customizations: None,
+        meta: None,
+    }
+}
+
+#[tokio::test]
+async fn root_states_are_isolated_per_host() {
+    let mirror = MultiHostStateMirror::new();
+    mirror
+        .apply_snapshot(
+            &HostId::new("alpha"),
+            &Snapshot {
+                resource: ahp_types::ROOT_RESOURCE_URI.into(),
+                state: SnapshotState::Root(Box::new(RootState {
+                    agents: vec![agent("a")],
+                    ..empty_root()
+                })),
+                from_seq: 0,
+            },
+        )
+        .await;
+    mirror
+        .apply_snapshot(
+            &HostId::new("beta"),
+            &Snapshot {
+                resource: ahp_types::ROOT_RESOURCE_URI.into(),
+                state: SnapshotState::Root(Box::new(RootState {
+                    agents: vec![agent("b")],
+                    ..empty_root()
+                })),
+                from_seq: 0,
+            },
+        )
+        .await;
+
+    let alpha = mirror.root(&HostId::new("alpha")).await.unwrap();
+    let beta = mirror.root(&HostId::new("beta")).await.unwrap();
+    assert_eq!(alpha.agents.first().map(|a| a.provider.as_str()), Some("a"));
+    assert_eq!(beta.agents.first().map(|a| a.provider.as_str()), Some("b"));
+}
+
+#[tokio::test]
+async fn session_uri_collision_across_hosts_does_not_clobber() {
+    // The core multi-host invariant: two hosts can legitimately
+    // advertise the same session URI; the mirror MUST key by
+    // (hostId, uri) so they don't overwrite each other.
+    let mirror = MultiHostStateMirror::new();
+    let uri = "copilot:/s1";
+
+    mirror
+        .apply_snapshot(
+            &HostId::new("alpha"),
+            &Snapshot {
+                resource: uri.into(),
+                state: SnapshotState::Session(Box::new(session_state(uri, "A title"))),
+                from_seq: 0,
+            },
+        )
+        .await;
+    mirror
+        .apply_snapshot(
+            &HostId::new("beta"),
+            &Snapshot {
+                resource: uri.into(),
+                state: SnapshotState::Session(Box::new(session_state(uri, "B title"))),
+                from_seq: 0,
+            },
+        )
+        .await;
+
+    let alpha_session = mirror.session(&HostId::new("alpha"), uri).await.unwrap();
+    let beta_session = mirror.session(&HostId::new("beta"), uri).await.unwrap();
+    assert_eq!(alpha_session.summary.title, "A title");
+    assert_eq!(beta_session.summary.title, "B title");
+
+    let key_alpha = HostedResourceKey::new("alpha", uri);
+    let key_beta = HostedResourceKey::new("beta", uri);
+    assert_ne!(key_alpha, key_beta);
+}
+
+#[tokio::test]
+async fn apply_root_action_updates_only_target_host() {
+    let mirror = MultiHostStateMirror::new();
+    mirror
+        .apply_snapshot(
+            &HostId::new("alpha"),
+            &Snapshot {
+                resource: ahp_types::ROOT_RESOURCE_URI.into(),
+                state: SnapshotState::Root(Box::new(empty_root())),
+                from_seq: 0,
+            },
+        )
+        .await;
+    mirror
+        .apply_snapshot(
+            &HostId::new("beta"),
+            &Snapshot {
+                resource: ahp_types::ROOT_RESOURCE_URI.into(),
+                state: SnapshotState::Root(Box::new(empty_root())),
+                from_seq: 0,
+            },
+        )
+        .await;
+
+    let envelope = ActionEnvelope {
+        action: StateAction::RootAgentsChanged(RootAgentsChangedAction {
+            agents: vec![agent("new")],
+        }),
+        server_seq: 5,
+        origin: None,
+        rejection_reason: None,
+    };
+    mirror
+        .apply_envelope(&HostId::new("alpha"), &envelope)
+        .await;
+
+    let alpha = mirror.root(&HostId::new("alpha")).await.unwrap();
+    let beta = mirror.root(&HostId::new("beta")).await.unwrap();
+    assert_eq!(alpha.agents.len(), 1);
+    assert_eq!(alpha.agents[0].provider, "new");
+    assert_eq!(
+        beta.agents.len(),
+        0,
+        "applying a root action to alpha must not touch beta's root state"
+    );
+}
+
+#[tokio::test]
+async fn apply_session_action_updates_only_target_session() {
+    let mirror = MultiHostStateMirror::new();
+    let uri = "copilot:/s1";
+    mirror
+        .apply_snapshot(
+            &HostId::new("alpha"),
+            &Snapshot {
+                resource: uri.into(),
+                state: SnapshotState::Session(Box::new(session_state(uri, "Old"))),
+                from_seq: 0,
+            },
+        )
+        .await;
+    mirror
+        .apply_snapshot(
+            &HostId::new("beta"),
+            &Snapshot {
+                resource: uri.into(),
+                state: SnapshotState::Session(Box::new(session_state(uri, "Old"))),
+                from_seq: 0,
+            },
+        )
+        .await;
+
+    let envelope = ActionEnvelope {
+        action: StateAction::SessionTitleChanged(SessionTitleChangedAction {
+            session: uri.into(),
+            title: "New on alpha".into(),
+        }),
+        server_seq: 7,
+        origin: None,
+        rejection_reason: None,
+    };
+    mirror
+        .apply_envelope(&HostId::new("alpha"), &envelope)
+        .await;
+
+    let alpha = mirror.session(&HostId::new("alpha"), uri).await.unwrap();
+    let beta = mirror.session(&HostId::new("beta"), uri).await.unwrap();
+    assert_eq!(alpha.summary.title, "New on alpha");
+    assert_eq!(
+        beta.summary.title, "Old",
+        "applying a session action to alpha must not touch beta's session state"
+    );
+}
+
+#[tokio::test]
+async fn session_action_without_prior_snapshot_is_noop() {
+    // The reducers can't invent a SessionState from scratch — only
+    // applySnapshot can seed one. Confirm an action that arrives
+    // before any snapshot is silently dropped rather than panicking
+    // or creating a placeholder.
+    let mirror = MultiHostStateMirror::new();
+    let envelope = ActionEnvelope {
+        action: StateAction::SessionTitleChanged(SessionTitleChangedAction {
+            session: "copilot:/missing".into(),
+            title: "anything".into(),
+        }),
+        server_seq: 1,
+        origin: None,
+        rejection_reason: None,
+    };
+    mirror
+        .apply_envelope(&HostId::new("alpha"), &envelope)
+        .await;
+    assert!(mirror
+        .session(&HostId::new("alpha"), "copilot:/missing")
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn root_action_initialises_empty_root_when_no_snapshot_seen() {
+    // Root actions land on every host eventually — the protocol
+    // guarantees an initial root snapshot, but if a consumer wires
+    // the mirror up partway through (or before the snapshot lands),
+    // a root action should still update the in-memory root rather
+    // than be lost. Matches the runtime's behaviour where root
+    // state is held with default values until a snapshot replaces
+    // them.
+    let mirror = MultiHostStateMirror::new();
+    let envelope = ActionEnvelope {
+        action: StateAction::RootAgentsChanged(RootAgentsChangedAction {
+            agents: vec![agent("a")],
+        }),
+        server_seq: 1,
+        origin: None,
+        rejection_reason: None,
+    };
+    mirror.apply_envelope(&HostId::new("h"), &envelope).await;
+    let root = mirror.root(&HostId::new("h")).await.unwrap();
+    assert_eq!(root.agents.len(), 1);
+}
+
+#[tokio::test]
+async fn reset_host_drops_only_that_hosts_slots() {
+    let mirror = MultiHostStateMirror::new();
+    let uri = "copilot:/s1";
+    for host in ["alpha", "beta"] {
+        mirror
+            .apply_snapshot(
+                &HostId::new(host),
+                &Snapshot {
+                    resource: ahp_types::ROOT_RESOURCE_URI.into(),
+                    state: SnapshotState::Root(Box::new(empty_root())),
+                    from_seq: 0,
+                },
+            )
+            .await;
+        mirror
+            .apply_snapshot(
+                &HostId::new(host),
+                &Snapshot {
+                    resource: uri.into(),
+                    state: SnapshotState::Session(Box::new(session_state(uri, host))),
+                    from_seq: 0,
+                },
+            )
+            .await;
+    }
+
+    mirror.reset_host(&HostId::new("alpha")).await;
+
+    assert!(mirror.root(&HostId::new("alpha")).await.is_none());
+    assert!(mirror.session(&HostId::new("alpha"), uri).await.is_none());
+    assert!(mirror.root(&HostId::new("beta")).await.is_some());
+    assert!(mirror.session(&HostId::new("beta"), uri).await.is_some());
+}
+
+#[tokio::test]
+async fn reset_clears_every_host() {
+    let mirror = MultiHostStateMirror::new();
+    let uri = "copilot:/s1";
+    mirror
+        .apply_snapshot(
+            &HostId::new("alpha"),
+            &Snapshot {
+                resource: uri.into(),
+                state: SnapshotState::Session(Box::new(session_state(uri, "A"))),
+                from_seq: 0,
+            },
+        )
+        .await;
+    mirror
+        .apply_snapshot(
+            &HostId::new("beta"),
+            &Snapshot {
+                resource: ahp_types::ROOT_RESOURCE_URI.into(),
+                state: SnapshotState::Root(Box::new(empty_root())),
+                from_seq: 0,
+            },
+        )
+        .await;
+    mirror.reset().await;
+    assert!(mirror.sessions().await.is_empty());
+    assert!(mirror.root_states().await.is_empty());
+}

--- a/clients/rust/crates/ahp/tests/state_mirror.rs
+++ b/clients/rust/crates/ahp/tests/state_mirror.rs
@@ -345,3 +345,34 @@ async fn reset_clears_every_host() {
     assert!(mirror.sessions().await.is_empty());
     assert!(mirror.root_states().await.is_empty());
 }
+
+/// `MultiHostStateMirror` is `Clone` and all clones share the same
+/// underlying storage — proving the docstring's "Cheaply cloneable —
+/// inner storage is `Arc`-shared" claim. A consumer can hand a clone
+/// to a reducer task and to a UI store and have both observe the
+/// same writes.
+#[tokio::test]
+async fn clones_share_inner_storage() {
+    let mirror = MultiHostStateMirror::new();
+    let clone = mirror.clone();
+
+    clone
+        .apply_snapshot(
+            &HostId::new("alpha"),
+            &Snapshot {
+                resource: ahp_types::ROOT_RESOURCE_URI.into(),
+                state: SnapshotState::Root(Box::new(RootState {
+                    agents: vec![agent("from-clone")],
+                    active_sessions: None,
+                    terminals: None,
+                    config: None,
+                })),
+                from_seq: 0,
+            },
+        )
+        .await;
+
+    let observed = mirror.root(&HostId::new("alpha")).await.unwrap();
+    assert_eq!(observed.agents.len(), 1);
+    assert_eq!(observed.agents[0].provider, "from-clone");
+}

--- a/docs/guide/clients-multi-host.md
+++ b/docs/guide/clients-multi-host.md
@@ -129,7 +129,76 @@ handle.check_alive().await?;
 # Ok(()) }
 ```
 
-Configuration knobs live on `HostConfig` (`with_client_id`, `with_initial_subscriptions`, `with_client_config`, `with_reconnect_policy`) and on `ReconnectPolicy::{disabled, immediate_forever, exponential}`. For persistent identity across launches, persist the `clientId` you pass to [`HostConfig::with_client_id`](https://docs.rs/ahp/latest/ahp/hosts/struct.HostConfig.html#method.with_client_id) yourself (e.g. in your app's keychain or settings store) and supply it on subsequent launches.
+Configuration knobs live on `HostConfig` (`with_client_id`, `with_initial_subscriptions`, `with_client_config`, `with_reconnect_policy`) and on `ReconnectPolicy::{disabled, immediate_forever, exponential}`.
+
+### Per-`(host, uri)` event streams (reliable feed)
+
+`MultiHostClient::events()` is a cross-host fan-in backed by a lossy broadcast — slow consumers see `Lagged` and skip events. **That's unsafe for reducer-critical action envelopes**, which can't be dropped without desyncing downstream state mirrors. For reliable per-URI streams, use `events_for(&host_id, uri)` instead:
+
+```rust
+# use ahp::hosts::{HostId, MultiHostClient};
+# async fn run(multi: MultiHostClient) -> Result<(), Box<dyn std::error::Error>> {
+let host_id = HostId::new("local");
+// Attach the listener BEFORE subscribing on the server so initial
+// post-subscribe envelopes aren't dropped.
+let mut stream = multi
+    .events_for(&host_id, "copilot:/s1".into())
+    .await
+    .expect("host registered");
+multi.subscribe(&host_id, "copilot:/s1".into()).await?;
+while let Some(event) = stream.recv().await {
+    // Includes envelopes replayed across reconnects.
+    println!("{event:?}");
+}
+# Ok(()) }
+```
+
+The per-URI stream is owned by `MultiHostClient` (not by any single underlying `Client` generation), so envelopes replayed by the reconnect path reach it too. Cross-resource protocol notifications (auth required, session added/removed/changed) also fan to every active per-URI listener for the host.
+
+### Persistent `clientId` across launches
+
+The SDK ships a `ClientIdStore` trait with two implementations:
+
+- `InMemoryClientIdStore` — session-stable, lost on restart (the default).
+- `FileClientIdStore` — one file per host under a configurable directory, atomic writes, owner-only perms on POSIX.
+
+Wire a persistent store via `MultiHostClient::with_client_id_store` (or `single_with_client_id_store` for single-host consumers) and let `HostConfig::client_id` default to `None`; the SDK will reuse the stored value on subsequent launches:
+
+```rust
+# use ahp::hosts::{FileClientIdStore, HostConfig, MultiHostClient};
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let dir = dirs::data_dir().unwrap().join("my-app").join("client-ids");
+let multi = MultiHostClient::with_client_id_store(FileClientIdStore::new(dir));
+multi
+    .add_host(HostConfig::new("local", "Local", open_local))
+    .await?;
+# async fn open_local(_: ahp::hosts::HostId) -> Result<ahp::transport::BoxedTransport, ahp::TransportError> { unimplemented!() }
+# Ok(()) }
+```
+
+For the strongest-security profile (Keychain on Apple, libsecret on Linux, DPAPI on Windows), implement `ClientIdStore` yourself in your app — the trait is dyn-compatible.
+
+### Waking idle hosts in bulk
+
+After a network change or scene-phase resume, call `reconnect_all_unavailable()` to fire concurrent reconnects on every host not currently `Connected` or `Connecting`. The call returns a `HashMap<HostId, HostError>` of per-host failures; an empty map means every selected host acknowledged its reconnect request. This bypasses the policy's exhausted-attempts state, so `Failed` hosts get a fresh chance too.
+
+### Host-aware state mirror
+
+`MultiHostStateMirror` is the host-aware counterpart to the pure reducers — keyed by `HostedResourceKey { host_id, uri }` so two hosts that legitimately advertise the same session URI don't clobber each other. Feed it from `events_for` (the lossless per-URI stream) for reducer correctness:
+
+```rust
+# use ahp::hosts::{HostId, MultiHostClient};
+# use ahp::MultiHostStateMirror;
+# async fn run(multi: MultiHostClient, host: HostId) -> Result<(), Box<dyn std::error::Error>> {
+let mirror = MultiHostStateMirror::new();
+let mut stream = multi.events_for(&host, "copilot:/s1".into()).await.unwrap();
+while let Some(event) = stream.recv().await {
+    if let ahp::SubscriptionEvent::Action(env) = event {
+        mirror.apply_envelope(&host, &env).await;
+    }
+}
+# Ok(()) }
+```
 
 See the `ahp::hosts` rustdoc and `crates/ahp/tests/hosts.rs` for the full surface.
 


### PR DESCRIPTION
Addresses 6 items of Rust parity with [PR #129](https://github.com/microsoft/agent-host-protocol/pull/129) (the Swift consumer-feedback PR) — the four explicitly-deferred Rust items, the cancellation-parity investigation, plus Phase 2 (per-URI streams that survive reconnect) promoted into scope after observing a real correctness gap in the github-app consumer's pump.

**Tests:** 74 pass — 24 unit + 22 hosts + 8 state_mirror + 2 client_roundtrip + 18 doctests/other (was 58 baseline; 16 new).

## What & why

| # | Feedback (from PR #129) | Fix |
|---|---|---|
| 1 | `applyReconnectResult` correctness | **Already in Rust** (`apply_reconnect_result`) — Swift was catching up. No-op here. |
| 2 | Per-URI stream that survives reconnect | `MultiHostClient::events_for(&host, uri) -> Option<PerResourceStream>`, backed by an unbounded `mpsc` per listener and owned by `MultiHostClient` (not by any underlying `Client` generation). Replaced the runtime's `fan_out: broadcast::Sender` parameter with a callback `event_sink: Arc<dyn Fn(HostSubscriptionEvent) + Send + Sync>` that fans events to **both** the lossy cross-host broadcast and the per-`(host, uri)` registry. Replayed envelopes from `apply_reconnect_result` flow through the same sink, so consumers using `events_for` get them too — closing the consumer pattern of "restart pump on `HostEvent::Connected`" that silently missed replay. |
| 3 | Lossy `events()` warning | Strong docstring on `MultiHostClient::events()` and `HostSubscriptionStream` pointing reducer-critical consumers at `events_for`. |
| 4 | `MultiHostStateMirror` keyed by `(host, uri)` | New top-level `ahp::MultiHostStateMirror` + `HostedResourceKey { host_id, uri }`. Session/terminal actions are no-ops without a prior snapshot (the reducer can't invent state); root actions initialise an empty `RootState` on demand. Routing via `serde_json::to_value(&action)["session"|"terminal"]` matches the runtime's existing helper. |
| 5 | `ClientIdStore` + `FileClientIdStore` | New `ahp::hosts::ClientIdStore` trait (dyn-compatible via `Pin<Box<dyn Future>>`, matches `HostTransportFactory`). `InMemoryClientIdStore` is the default for `MultiHostClient::new()`. `FileClientIdStore` writes one file per host, percent-encoded id → safe filename, unique-per-call `.tmp` + atomic-replace rename on Unix, remove-then-rename fallback on Windows, `0o600` / `0o700` perms on `#[cfg(unix)]`. `MultiHostClient::with_client_id_store(store)` and `single_with_client_id_store(config, store)` for the wiring. Errors surface as `HostError::ClientIdStore(ClientIdStoreError)` rather than being silently swallowed. |
| 6 | `reconnect_all_unavailable()` | `MultiHostClient::reconnect_all_unavailable() -> HashMap<HostId, HostError>`. Iterates the registry, skips `Connected`/`Connecting`, fires concurrent reconnects via `tokio::task::JoinSet`. Designed for scene-phase / network-reachability bulk-wake patterns. |
| 7 | Cancellation parity (`Task.isCancelled`) | Rust handles cancellation natively via future-drop, but the pending map was leaking entries between cancel and the server's response. Switched `Shared::pending` from `tokio::sync::Mutex` to `std::sync::Mutex` (no awaits under the lock anyway) and added an RAII `PendingGuard` that removes the entry on drop unless `disarm()` is called. Drop-on-cancel test verifies the pending count goes to 0 after `task.abort()`. |
| 8 | Live `sessionSummaries` / `hostSnapshots` streams | Out of scope. Same shape as Phase 2 but lower payoff. Deferred to a follow-up. |
| 9 | `requestRaw` escape hatch | Out of scope. Rust has no Swift-6 actor-isolation analog; `Client::request` already accepts `serde_json::Value` for `P`/`R`. |

## Drive-by improvements (rubber-duck-flagged)

- **`MultiHostClient::shutdown()`** for deterministic lifecycle parity with Swift. Concurrent per-supervisor teardown so a slow transport close doesn't block the others. Closes all per-URI streams. Idempotent.
- **Deterministic aggregated views.** Added `host_order: Vec<HostId>` tracking registration order. `aggregated_sessions()` now ties-break equal `modified_at` by registration order, then by `resource` — matches Swift PR #129's behaviour and gives consumers (and tests) stable ordering across calls.
- **`PerResourceStream` drop unregistration.** Dropping a stream releases its registry slot immediately rather than waiting for `remove_host`. `fan_event` also prunes dead senders as defence-in-depth.
- **`add_host` cancellation safety.** Wrapped the `pending_host_ids` reservation in an RAII `PendingReservation` so a cancelled `add_host` future doesn't leak the reservation. Without this, a cancelled future would permanently lock out future adds for that host id.

## Breaking changes

- **`HostConfig::client_id: String` → `Option<String>`.** `HostConfig::new` sets `None`; `with_client_id` sets `Some(_)`. Resolution at `add_host` time: explicit → `store.load` → generate (and always written back). The github-app consumer (the only known consumer) uses `HostConfig::new` and never reads the field directly, so impact is minimal. The crate is `0.1.0` and the field landed in PRs #121/#124, so it's still pre-stable.

## Design notes

- **Per-URI listener ownership** lives on `MultiHostClient`'s `MultiInner` (not inside `HostRuntime`) so listeners outlive any single `Client` instance and naturally pick up replayed envelopes via `fan_event`. The runtime calls into `MultiInner::fan_event` through an `Arc<dyn Fn(HostSubscriptionEvent)>` callback that captures `Weak<MultiInner>` — so dropping every `MultiHostClient` clone makes the closure a no-op without keeping the inner alive past its consumers.
- **Reconnect ordering.** The existing runtime ordering is preserved (install client + bump generation → `apply_reconnect_result` → emit `HostEvent::Connected`), so a consumer waking on `Connected` already sees the post-reconnect state — and replayed envelopes have already fanned through the per-URI registry.
- **`add_host` reservation** is held synchronously across the awaited store lookups via a `std::sync::RwLock<HashSet<HostId>>`, then released by RAII guard regardless of success / error / cancellation.
- **`FileClientIdStore` Windows write race.** Limited to the brief instant between `remove_file` and `rename` (and even then, a concurrent reader observes "no entry" not corruption). The next write re-establishes the file.

## Validation

- `cargo test --workspace` — 74 pass, run twice back-to-back for flake check.
- `cargo clippy --workspace --all-targets` — clean except 3 pre-existing reducers.rs `redundant_closure` warnings unrelated to this PR.
- `cargo fmt --all -- --check` — clean.
- Rubber-duck pass before implementation (caught Phase 2 correctness gap) and after implementation (caught `add_host` cancellation leak, missing `shutdown()`, listener Drop unregistration, race in `events_for` registration, nondeterministic aggregation — all addressed).

## Out of scope (deferred follow-ups)

- Phase 8 — live `sessionSummaries(host)` / `hostSnapshots(host)` streams.
- Phase 9 — `requestRaw` escape hatch.
