### PR TITLE
Make the top-level tab highlight persistent

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,9 +14,9 @@ export default withMermaid(defineConfig({
     logo: '/logo.svg',
 
     nav: [
-      { text: 'Guide', link: '/guide/what-is-ahp' },
-      { text: 'Specification', link: '/specification/overview' },
-      { text: 'Reference', link: '/reference/common' },
+      { text: 'Guide', link: '/guide/what-is-ahp', activeMatch: '^/guide/' },
+      { text: 'Specification', link: '/specification/overview', activeMatch: '^/specification/' },
+      { text: 'Reference', link: '/reference/common', activeMatch: '^/reference/' },
     ],
 
     sidebar: {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,3 @@
+.VPNavBarMenu .VPNavBarMenuLink.active {
+  font-weight: 700;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,9 @@
+/// <reference path="./styles.d.ts" />
+
+import DefaultTheme from 'vitepress/theme'
+
+import './custom.css'
+
+export default {
+  extends: DefaultTheme,
+}

--- a/docs/.vitepress/theme/styles.d.ts
+++ b/docs/.vitepress/theme/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'


### PR DESCRIPTION
It should always be highlighted even when navigating to a sub page