### PR TITLE
spec: add message chunking primitive (ahp/messageSegment)

### DIFF
--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -51,6 +51,59 @@ pub enum CompletionItemKind {
 
 // ─── Command Payloads ─────────────────────────────────────────────────
 
+/// Receiver-side limits for the message-chunking primitive. A side that
+/// advertises `chunking` permits the peer to send oversized JSON-RPC
+/// messages as a sequence of `ahp/messageSegment` notifications.
+///
+/// See [Chunking](/specification/chunking) for the full sender and receiver
+/// behaviour, validation rules, and reconnection interaction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChunkingCapability {
+    /// Maximum size, in UTF-8 bytes, of any single transport frame this side
+    /// is willing to receive — for both unchunked JSON-RPC messages and
+    /// individual `ahp/messageSegment` notifications. Includes the JSON-RPC
+    /// envelope overhead. Senders MUST NOT emit a frame larger than this.
+    pub max_incoming_frame_bytes: i64,
+    /// Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message
+    /// this side is willing to receive. MUST be greater than or equal to
+    /// `maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message
+    /// whose reassembled payload would exceed this value.
+    pub max_incoming_message_bytes: i64,
+    /// Maximum number of concurrently in-flight reassembly groups this side
+    /// will hold open. MUST be at least 1. If omitted, the sender SHOULD use
+    /// an implementation-defined default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_incoming_groups: Option<i64>,
+    /// Maximum time, in milliseconds, this side will hold an incomplete
+    /// reassembly group before discarding it as abandoned. If omitted, the
+    /// sender SHOULD use an implementation-defined default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_timeout_ms: Option<i64>,
+}
+
+/// Capabilities advertised by the client during `initialize` (or
+/// `reconnect`). Each field is independently optional; omitting a field
+/// means the client does not support that feature.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCapabilities {
+    /// Chunking limits the server may apply when sending to this client.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunking: Option<ChunkingCapability>,
+}
+
+/// Capabilities advertised by the server in the `initialize` result. Each
+/// field is independently optional; omitting a field means the server does
+/// not support that feature.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerCapabilities {
+    /// Chunking limits the client may apply when sending to this server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunking: Option<ChunkingCapability>,
+}
+
 /// Establishes a new connection and negotiates the protocol version.
 /// This MUST be the first message sent by the client.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -76,6 +129,12 @@ pub struct InitializeParams {
     /// user-facing strings such as confirmation option labels.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
+    /// Client-side feature capabilities and the per-direction limits that
+    /// govern them. The client advertises what it is willing to *receive*; the
+    /// server's outbound behaviour respects these limits. Omitting a field
+    /// (or the entire object) means the client does not support that feature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<ClientCapabilities>,
 }
 
 /// Result of the `initialize` command.
@@ -105,6 +164,13 @@ pub struct InitializeResult {
     /// `'@'` or `'/'`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion_trigger_characters: Option<Vec<String>>,
+    /// Server-side feature capabilities and the per-direction limits that
+    /// govern them. The server advertises what it is willing to *receive*;
+    /// the client's outbound behaviour respects these limits. Omitting a
+    /// field (or the entire object) means the server does not support that
+    /// feature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<ServerCapabilities>,
 }
 
 /// Re-establishes a dropped connection. The server replays missed actions or
@@ -120,6 +186,13 @@ pub struct ReconnectParams {
     pub last_seen_server_seq: i64,
     /// URIs the client was subscribed to
     pub subscriptions: Vec<Uri>,
+    /// Client-side feature capabilities for the new transport connection.
+    /// `reconnect` runs over a fresh transport whose limits the server has no
+    /// other way to learn, so the client SHOULD re-advertise its capabilities
+    /// here whenever its limits have changed. If omitted, the server SHOULD
+    /// assume the previously-negotiated capabilities still apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<ClientCapabilities>,
 }
 
 /// Reconnect result when the server can replay from the requested sequence.

--- a/clients/rust/crates/ahp-types/src/lib.rs
+++ b/clients/rust/crates/ahp-types/src/lib.rs
@@ -68,6 +68,7 @@
 //!     client_id: "my-host/1.0".into(),
 //!     initial_subscriptions: Some(vec!["ahp-root://".into()]),
 //!     locale: Some("en".into()),
+//!     capabilities: None,
 //! };
 //!
 //! let req = JsonRpcMessage::Request(JsonRpcRequest {

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -118,6 +118,50 @@ pub struct AuthRequiredParams {
     pub reason: Option<AuthRequiredReason>,
 }
 
+/// Carries one segment of a JSON-RPC message that the sender has split to
+/// stay below a transport frame ceiling. Reassembled by the receiver's
+/// framing layer before normal JSON-RPC dispatch.
+///
+/// `ahp/messageSegment` is a **control** notification: it belongs to the
+/// framing layer, not to any subscribable resource, and is the only AHP
+/// notification that does **not** carry a top-level `channel: URI`. It is
+/// registered in {@link ControlNotificationMap} rather than the client- or
+/// server-direction notification maps; it MAY be sent in either direction.
+///
+/// Chunking is opt-in per direction: a sender MUST NOT emit
+/// `ahp/messageSegment` unless the receiver has advertised
+/// {@link ChunkingCapability} during `initialize` (or `reconnect`). See
+/// [Chunking](/specification/chunking) for the full lifecycle, sender and
+/// receiver behaviour, validation rules, and DoS limits.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageSegmentParams {
+    /// Opaque sender-chosen identifier that scopes one in-flight reassembly.
+    ///
+    /// MUST be a non-empty string of at most 128 UTF-8 bytes. Receivers MUST
+    /// NOT interpret the value. A `groupId` MUST be unique among the sender's
+    /// currently in-flight reassemblies on a single connection; it MAY be
+    /// reused once the receiver has either fully reassembled or discarded
+    /// that group. `groupId` and JSON-RPC `id` are independent namespaces.
+    pub group_id: String,
+    /// 0-based position of this segment within the group. MUST be a
+    /// non-negative integer strictly less than `total`. Receivers MUST reject
+    /// duplicate or out-of-order indices as a protocol error.
+    pub index: i64,
+    /// Total number of segments in this group. MUST be at least 1 and less
+    /// than 65 536. MUST be identical across every segment of the group; a
+    /// subsequent segment with a different `total` is a protocol error.
+    pub total: i64,
+    /// Base64-encoded slice of the UTF-8 bytes of the original JSON-RPC
+    /// message being reassembled. Uses the standard base64 alphabet
+    /// ([RFC 4648 §4](https://www.rfc-editor.org/rfc/rfc4648#section-4)) with
+    /// padding. Concatenating the decoded bytes of segments `0..total-1` in
+    /// order MUST produce a UTF-8 byte sequence that parses as exactly one
+    /// JSON-RPC request, response, or notification — which MUST NOT itself
+    /// be an `ahp/messageSegment` (no recursion).
+    pub data: String,
+}
+
 // ─── Partial Summaries ────────────────────────────────────────────────
 
 /// Partial equivalent of SessionSummary — every field is optional for delta updates.

--- a/clients/rust/crates/ahp-types/src/version.rs
+++ b/clients/rust/crates/ahp-types/src/version.rs
@@ -5,4 +5,4 @@
 #![allow(missing_docs)]
 
 /// Current protocol version (SemVer `MAJOR.MINOR.PATCH`).
-pub const PROTOCOL_VERSION: &str = "0.2.0";
+pub const PROTOCOL_VERSION: &str = "0.3.0";

--- a/clients/rust/crates/ahp/src/client.rs
+++ b/clients/rust/crates/ahp/src/client.rs
@@ -364,6 +364,7 @@ impl Client {
                 Some(initial_subscriptions)
             },
             locale: None,
+            capabilities: None,
         };
         self.request("initialize", params).await
     }
@@ -380,6 +381,7 @@ impl Client {
             client_id,
             last_seen_server_seq,
             subscriptions,
+            capabilities: None,
         };
         self.request("reconnect", params).await
     }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -26,6 +26,61 @@ public enum CompletionItemKind: String, Codable, Sendable {
 
 // MARK: - Command Types
 
+public struct ChunkingCapability: Codable, Sendable {
+    /// Maximum size, in UTF-8 bytes, of any single transport frame this side
+    /// is willing to receive — for both unchunked JSON-RPC messages and
+    /// individual `ahp/messageSegment` notifications. Includes the JSON-RPC
+    /// envelope overhead. Senders MUST NOT emit a frame larger than this.
+    public var maxIncomingFrameBytes: Int
+    /// Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message
+    /// this side is willing to receive. MUST be greater than or equal to
+    /// `maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message
+    /// whose reassembled payload would exceed this value.
+    public var maxIncomingMessageBytes: Int
+    /// Maximum number of concurrently in-flight reassembly groups this side
+    /// will hold open. MUST be at least 1. If omitted, the sender SHOULD use
+    /// an implementation-defined default.
+    public var maxIncomingGroups: Int?
+    /// Maximum time, in milliseconds, this side will hold an incomplete
+    /// reassembly group before discarding it as abandoned. If omitted, the
+    /// sender SHOULD use an implementation-defined default.
+    public var groupTimeoutMs: Int?
+
+    public init(
+        maxIncomingFrameBytes: Int,
+        maxIncomingMessageBytes: Int,
+        maxIncomingGroups: Int? = nil,
+        groupTimeoutMs: Int? = nil
+    ) {
+        self.maxIncomingFrameBytes = maxIncomingFrameBytes
+        self.maxIncomingMessageBytes = maxIncomingMessageBytes
+        self.maxIncomingGroups = maxIncomingGroups
+        self.groupTimeoutMs = groupTimeoutMs
+    }
+}
+
+public struct ClientCapabilities: Codable, Sendable {
+    /// Chunking limits the server may apply when sending to this client.
+    public var chunking: ChunkingCapability?
+
+    public init(
+        chunking: ChunkingCapability? = nil
+    ) {
+        self.chunking = chunking
+    }
+}
+
+public struct ServerCapabilities: Codable, Sendable {
+    /// Chunking limits the client may apply when sending to this server.
+    public var chunking: ChunkingCapability?
+
+    public init(
+        chunking: ChunkingCapability? = nil
+    ) {
+        self.chunking = chunking
+    }
+}
+
 public struct InitializeParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
@@ -45,19 +100,26 @@ public struct InitializeParams: Codable, Sendable {
     /// (e.g. `"en-US"`, `"ja"`). The server SHOULD use this to localise
     /// user-facing strings such as confirmation option labels.
     public var locale: String?
+    /// Client-side feature capabilities and the per-direction limits that
+    /// govern them. The client advertises what it is willing to *receive*; the
+    /// server's outbound behaviour respects these limits. Omitting a field
+    /// (or the entire object) means the client does not support that feature.
+    public var capabilities: ClientCapabilities?
 
     public init(
         channel: String,
         protocolVersions: [String],
         clientId: String,
         initialSubscriptions: [String]? = nil,
-        locale: String? = nil
+        locale: String? = nil,
+        capabilities: ClientCapabilities? = nil
     ) {
         self.channel = channel
         self.protocolVersions = protocolVersions
         self.clientId = clientId
         self.initialSubscriptions = initialSubscriptions
         self.locale = locale
+        self.capabilities = capabilities
     }
 }
 
@@ -77,19 +139,27 @@ public struct InitializeResult: Codable, Sendable {
     /// {@link CompletionItemKind.UserMessage}. Typically includes characters like
     /// `'@'` or `'/'`.
     public var completionTriggerCharacters: [String]?
+    /// Server-side feature capabilities and the per-direction limits that
+    /// govern them. The server advertises what it is willing to *receive*;
+    /// the client's outbound behaviour respects these limits. Omitting a
+    /// field (or the entire object) means the server does not support that
+    /// feature.
+    public var capabilities: ServerCapabilities?
 
     public init(
         protocolVersion: String,
         serverSeq: Int,
         snapshots: [Snapshot],
         defaultDirectory: String? = nil,
-        completionTriggerCharacters: [String]? = nil
+        completionTriggerCharacters: [String]? = nil,
+        capabilities: ServerCapabilities? = nil
     ) {
         self.protocolVersion = protocolVersion
         self.serverSeq = serverSeq
         self.snapshots = snapshots
         self.defaultDirectory = defaultDirectory
         self.completionTriggerCharacters = completionTriggerCharacters
+        self.capabilities = capabilities
     }
 }
 
@@ -102,17 +172,25 @@ public struct ReconnectParams: Codable, Sendable {
     public var lastSeenServerSeq: Int
     /// URIs the client was subscribed to
     public var subscriptions: [String]
+    /// Client-side feature capabilities for the new transport connection.
+    /// `reconnect` runs over a fresh transport whose limits the server has no
+    /// other way to learn, so the client SHOULD re-advertise its capabilities
+    /// here whenever its limits have changed. If omitted, the server SHOULD
+    /// assume the previously-negotiated capabilities still apply.
+    public var capabilities: ClientCapabilities?
 
     public init(
         channel: String,
         clientId: String,
         lastSeenServerSeq: Int,
-        subscriptions: [String]
+        subscriptions: [String],
+        capabilities: ClientCapabilities? = nil
     ) {
         self.channel = channel
         self.clientId = clientId
         self.lastSeenServerSeq = lastSeenServerSeq
         self.subscriptions = subscriptions
+        self.capabilities = capabilities
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -85,6 +85,45 @@ public struct AuthRequiredParams: Codable, Sendable {
     }
 }
 
+public struct MessageSegmentParams: Codable, Sendable {
+    /// Opaque sender-chosen identifier that scopes one in-flight reassembly.
+    /// 
+    /// MUST be a non-empty string of at most 128 UTF-8 bytes. Receivers MUST
+    /// NOT interpret the value. A `groupId` MUST be unique among the sender's
+    /// currently in-flight reassemblies on a single connection; it MAY be
+    /// reused once the receiver has either fully reassembled or discarded
+    /// that group. `groupId` and JSON-RPC `id` are independent namespaces.
+    public var groupId: String
+    /// 0-based position of this segment within the group. MUST be a
+    /// non-negative integer strictly less than `total`. Receivers MUST reject
+    /// duplicate or out-of-order indices as a protocol error.
+    public var index: Int
+    /// Total number of segments in this group. MUST be at least 1 and less
+    /// than 65 536. MUST be identical across every segment of the group; a
+    /// subsequent segment with a different `total` is a protocol error.
+    public var total: Int
+    /// Base64-encoded slice of the UTF-8 bytes of the original JSON-RPC
+    /// message being reassembled. Uses the standard base64 alphabet
+    /// ([RFC 4648 §4](https://www.rfc-editor.org/rfc/rfc4648#section-4)) with
+    /// padding. Concatenating the decoded bytes of segments `0..total-1` in
+    /// order MUST produce a UTF-8 byte sequence that parses as exactly one
+    /// JSON-RPC request, response, or notification — which MUST NOT itself
+    /// be an `ahp/messageSegment` (no recursion).
+    public var data: String
+
+    public init(
+        groupId: String,
+        index: Int,
+        total: Int,
+        data: String
+    ) {
+        self.groupId = groupId
+        self.index = index
+        self.total = total
+        self.data = data
+    }
+}
+
 // MARK: - Partial Summary Types
 
 public struct PartialSessionSummary: Codable, Sendable {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,7 @@ export default withMermaid(defineConfig({
             { text: 'Lifecycle', link: '/specification/lifecycle' },
             { text: 'Channels & Subscriptions', link: '/specification/subscriptions' },
             { text: 'Authentication', link: '/specification/authentication' },
+            { text: 'Chunking', link: '/specification/chunking' },
             { text: 'Versioning', link: '/specification/versioning' },
           ],
         },

--- a/docs/specification/chunking.md
+++ b/docs/specification/chunking.md
@@ -1,0 +1,303 @@
+# Chunking
+
+Some transports place a hard upper bound on the size of a single message — for example, [Azure Web PubSub](https://learn.microsoft.com/en-us/azure/azure-web-pubsub/) rejects any WebSocket frame larger than 1 MB. AHP's chunking primitive lets implementations split a single logical JSON-RPC message into multiple frames that fit under such a ceiling, and reassemble it on the receiving side before normal dispatch.
+
+Chunking is **opt-in per direction** and is negotiated through the [capability fields](#capability-negotiation) exchanged during [`initialize`](/specification/lifecycle#initialize-client-server) and [`reconnect`](/specification/lifecycle#reconnection). A peer that does not advertise the chunking capability MUST NOT receive `ahp/messageSegment` notifications, and the other side MUST NOT segment outbound messages to that peer.
+
+## Overview
+
+Chunking layers **above** JSON-RPC: from the application's point of view, nothing changes. A notification is still a notification; a response is still a response. The framing layer beneath the dispatcher hides reassembly:
+
+```mermaid
+sequenceDiagram
+    participant App as Application<br/>(reducer, handler)
+    participant Frame as Segmenting layer
+    participant Wire as Transport (1 frame ≤ N bytes)
+    participant FrameR as Segmenting layer
+    participant AppR as Application<br/>(reducer, handler)
+
+    App->>Frame: dispatch ActionEnvelope (3 MB)
+    Frame->>Frame: split into 4 base64 segments
+    Frame->>Wire: ahp/messageSegment #0
+    Frame->>Wire: ahp/messageSegment #1
+    Frame->>Wire: ahp/messageSegment #2
+    Frame->>Wire: ahp/messageSegment #3
+    Wire-->>FrameR: ahp/messageSegment #0..#3
+    FrameR->>FrameR: concat + base64-decode
+    FrameR->>AppR: dispatch reassembled ActionEnvelope
+```
+
+A small in-flight reassembly table on the receiver holds partial groups keyed by `groupId`. Once a group is complete the bytes are decoded, parsed as a single JSON-RPC message, and dispatched through the normal path.
+
+## Capability negotiation
+
+Chunking is enabled per direction by the **receiver** advertising a [`ChunkingCapability`](/reference/common#chunkingcapability):
+
+```ts
+interface ChunkingCapability {
+  maxIncomingFrameBytes: number;     // hard cap per transport frame
+  maxIncomingMessageBytes: number;   // hard cap per reassembled message
+  maxIncomingGroups?: number;        // concurrency cap on the receiver
+  groupTimeoutMs?: number;           // abandoned-group sweep interval
+}
+```
+
+Capabilities travel inside the `capabilities` field on three messages:
+
+- [`InitializeParams`](/reference/common#initializeparams) — `capabilities: ClientCapabilities`
+- [`InitializeResult`](/reference/common#initializeresult) — `capabilities: ServerCapabilities`
+- [`ReconnectParams`](/reference/common#reconnectparams) — `capabilities: ClientCapabilities` (re-advertised because `reconnect` runs over a fresh transport whose limits the server cannot otherwise learn)
+
+If both sides advertise `chunking`, segmenting is enabled. The sender in a given direction MUST respect the *receiver*'s `maxIncomingFrameBytes` for every frame it puts on the wire (segmented or not) and MUST NOT initiate a chunked message whose fully-reassembled payload would exceed the receiver's `maxIncomingMessageBytes`.
+
+If the receiver did not advertise `chunking`, the sender MUST NOT emit `ahp/messageSegment`. If it produces a message that would exceed the receiver's transport ceiling, it MUST follow the [fail-closed rules](#fail-closed-paths).
+
+## Wire format
+
+Segments travel as JSON-RPC notifications with the reserved method name `ahp/messageSegment` and params shape [`MessageSegmentParams`](/reference/common#ahpmessagesegment):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "ahp/messageSegment",
+  "params": {
+    "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
+    "index": 0,
+    "total": 3,
+    "data": "eyJqc29ucnBjIjoiMi4wIiwibWV0aG9kIjoiYWN0aW9uIiwic..."
+  }
+}
+```
+
+`ahp/messageSegment` is registered in [`ControlNotificationMap`](/reference/common#controlnotificationmap), the registry for framing-layer notifications. Unlike entries in `ClientNotificationMap` and `ServerNotificationMap`, control notifications do **not** carry a top-level `channel: URI` — they belong to the framing layer rather than to any subscribable resource and are consumed by the receiver before normal channel routing.
+
+### Base64, not raw text
+
+`data` is base64 of the message's UTF-8 bytes — not the raw JSON text. The trade-off is intentional:
+
+- Embedding raw JSON inside another JSON string re-escapes every `"`, `\`, and control character, so the same logical content can land at very different wire sizes depending on its contents. Base64 has a fixed 4:3 expansion factor and no escaping.
+- Splitting a JSON string at a UTF-8 byte boundary that falls inside a multi-byte codepoint is a bug source. Base64 sidesteps the question.
+
+The price is a flat ~33 % data-overhead inflation; that is an acceptable cost for a primitive that exists specifically to fit under a hard wire ceiling.
+
+## Sender behaviour
+
+For every outgoing JSON-RPC message *M* a chunking-aware sender MUST:
+
+1. Serialize *M* to UTF-8 bytes — call the result `B`.
+2. If `len(B)` (plus the surrounding transport overhead) is ≤ the receiver's `maxIncomingFrameBytes`, send *M* as a single frame and stop.
+3. Otherwise:
+    1. If the receiver did not advertise `chunking`, the sender MUST fail the local operation (see [§ Fail-closed paths](#fail-closed-paths)).
+    2. If `len(B) > maxIncomingMessageBytes`, the sender MUST fail the local operation.
+    3. Mint a unique `groupId` for the message.
+    4. Compute the per-segment payload size `S` such that, after base64 encoding and inclusion in a `MessageSegmentParams` envelope, the resulting frame fits within the receiver's `maxIncomingFrameBytes`. (Base64 expands by 4/3; allow for JSON envelope overhead.)
+    5. Split `B` into `ceil(len(B) / S)` segments, in order.
+    6. Encode each segment with base64 and send it as `ahp/messageSegment` with the correct `index`, `total`, and `groupId`.
+
+A sender MUST NOT segment an `ahp/messageSegment` (no recursion).
+
+### Interleaving
+
+A sender MAY interleave segments from different `groupId`s — for example, to keep a small, latency-sensitive `terminal/data` notification flowing while a multi-segment `session/customizationsChanged` is mid-transmission. A simple sender that always sends groups contiguously is conformant. Senders SHOULD:
+
+- Avoid starvation of small messages behind a bulk transfer.
+- Cap their concurrently-originated groups at the receiver's `maxIncomingGroups`.
+- Send segments of a single group in `index` order — the receiver requires this.
+
+## Receiver behaviour
+
+Receivers maintain a small reassembly table:
+
+```ts
+type ReassemblyTable = Map<string, {
+  total: number;
+  nextIndex: number;
+  bufferedBytes: number;
+  segments: Uint8Array[];
+  startedAt: number;
+}>;
+```
+
+On every `ahp/messageSegment` notification:
+
+1. Look up `groupId`.
+    - If absent and the table already holds `maxIncomingGroups` entries, reject as a protocol error.
+    - If absent, validate `index === 0` and `total ≥ 1`; insert a new entry.
+    - If present, validate that `total` matches the previously-recorded total and `index === nextIndex`.
+2. Decode `data` from base64. Reject if decoding fails or the decoded segment exceeds the receiver's own `maxIncomingFrameBytes`.
+3. Append the decoded bytes to the group's buffer. If accumulated `bufferedBytes` would exceed `maxIncomingMessageBytes`, reject.
+4. Increment `nextIndex`.
+5. If `nextIndex === total`:
+    1. Concatenate the segments into a single byte buffer.
+    2. Decode UTF-8 → JSON-RPC parse. Reject if either step fails.
+    3. Reject if the reassembled message is itself an `ahp/messageSegment`.
+    4. Dispatch the reassembled message through the normal handler path.
+    5. Remove the entry from the table.
+
+Receivers MUST sweep entries older than `groupTimeoutMs` periodically and discard them as abandoned (no protocol error — the sender will retry on reconnect). On transport disconnect, the receiver MUST drop the entire reassembly table.
+
+### Validation rules
+
+`ahp/messageSegment` is a notification, so there is no JSON-RPC response path for errors. Any of the following conditions are **protocol errors** and the receiver MUST close the transport with a defined close reason (e.g. WebSocket close code `4400` with reason `invalid messageSegment`). The client SHOULD reconnect.
+
+| Condition | Notes |
+|---|---|
+| `groupId` is missing, empty, or > 128 UTF-8 bytes | |
+| `index` is not a non-negative integer | |
+| `index >= total` | |
+| `index !== nextIndex` for an existing group | Out-of-order delivery is impossible under a reliable, ordered transport; this is either a sender bug or duplicate interleaving on the same `groupId` |
+| `total < 1` or `total >= 2^16` | |
+| `total` changes mid-group | |
+| `data` is missing or not a base64-encoded string | |
+| Decoded segment exceeds the receiver's `maxIncomingFrameBytes` | |
+| Accumulated bytes for the group exceed `maxIncomingMessageBytes` | |
+| Active groups exceed `maxIncomingGroups` | |
+| Reassembled bytes are not valid UTF-8, or do not parse as a single JSON-RPC message | |
+| Reassembled message is itself `ahp/messageSegment` | No recursion |
+| `groupId` already in flight when a new `index === 0` segment arrives | |
+
+## Reconnection
+
+Two cases interact with the existing [reconnection flow](/specification/lifecycle#reconnection):
+
+### Server → client `action` envelopes
+
+The server assigns `serverSeq` when it produces an [`ActionEnvelope`](/reference/common#actionenvelope). The client tracks `lastSeenServerSeq` and MUST update it **only after fully reassembling, parsing, and dispatching** the envelope — never on individual segment receipt.
+
+If the transport drops mid-group:
+
+1. The client's reassembly table is discarded.
+2. The client reconnects with `lastSeenServerSeq` still pointing at the last *fully* processed envelope.
+3. The server's existing replay path resends every action with `serverSeq > lastSeenServerSeq`, which includes the partially-delivered envelope. It will be segmented again on the new transport (possibly differently, since limits may have been re-negotiated).
+
+No per-segment acknowledgement is required.
+
+### Outstanding requests
+
+If a request is mid-segmentation when the transport drops, the request `id` is no longer meaningful on the new connection. The caller's outstanding promise MUST be rejected with a transport-disconnect error. Whether the request is safe to retry is the **caller's** responsibility — chunking adds no exactly-once guarantee for non-idempotent operations. Callers SHOULD NOT blindly retry `createSession`, `resourceWrite`, or any other state-mutating request without an idempotency mechanism appropriate to that command. This matches the pre-existing semantics for non-segmented requests across reconnect.
+
+## Fail-closed paths
+
+If a sender produces a message that would exceed the receiver's `maxIncomingFrameBytes` and the receiver has not advertised the `chunking` capability:
+
+- For **requests**, the sender MUST fail the local call with [`MessageTooLarge`](/reference/error-codes) (`-32011`) rather than send a frame the receiver would reject.
+- For **responses**, the sender MUST return a JSON-RPC error of code `-32011` (`MessageTooLarge`) to the requester in place of the oversized result.
+- For **notifications**, the sender MAY drop the notification and log; the receiver will fall back to the natural recovery mechanism for the affected channel (e.g. reconnect + state catch-up via `serverSeq` replay).
+
+## Recommended limits
+
+Implementation defaults — guidance, not normative requirements:
+
+| Limit | Default |
+|---|---|
+| `maxIncomingFrameBytes` | 900 KB on transports with a 1 MB ceiling; 4 MB elsewhere |
+| `maxIncomingMessageBytes` | 32 MB |
+| `maxIncomingGroups` | 8 |
+| `groupTimeoutMs` | 30 000 |
+| `groupId` length | ≤ 128 UTF-8 bytes |
+| `total` | `< 2^16` (65 536) |
+
+A peer that omits `maxIncomingGroups` or `groupTimeoutMs` is asking the other side to apply its own defaults; it is not asking for unbounded resources.
+
+## Examples
+
+### A chunked `action` envelope
+
+A 2.4 MB `session/toolCallComplete` action over a transport whose receiver advertised `{ maxIncomingFrameBytes: 900000, maxIncomingMessageBytes: 33554432, maxIncomingGroups: 8 }`:
+
+```json
+{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
+  "params": {
+    "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
+    "index": 0, "total": 3,
+    "data": "eyJqc29ucnBjIjoiMi4wIiwibWV0aG9kIjoiYWN0aW9uIiwicGFyYW1z..."
+  }
+}
+{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
+  "params": {
+    "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
+    "index": 1, "total": 3,
+    "data": "OiB7ImNoYW5uZWwiOiJhaHAtc2Vzc2lvbjovYWJjLTEyMyIsImFjdGlvbi..."
+  }
+}
+{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
+  "params": {
+    "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
+    "index": 2, "total": 3,
+    "data": "ifSwgInNlcnZlclNlcSI6NDIxLCAib3JpZ2luIjpudWxsfQ=="
+  }
+}
+```
+
+Concatenating the base64-decoded `data` payloads, in `index` order, produces the original UTF-8 bytes of:
+
+```json
+{ "jsonrpc": "2.0", "method": "action",
+  "params": { "channel": "ahp-session:/abc-123", "action": { /* … large */ }, "serverSeq": 421, "origin": null }
+}
+```
+
+which is then dispatched through the receiver's normal notification handler.
+
+### A chunked `reconnect` result
+
+A multi-megabyte `snapshot[]` produced by [`reconnect`](/specification/lifecycle#reconnection) is segmented the same way — the entire JSON-RPC response (including its correlation `id`) is the byte stream that gets split:
+
+```json
+{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
+  "params": { "groupId": "g7", "index": 0, "total": 5, "data": "..." }
+}
+{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
+  "params": { "groupId": "g7", "index": 4, "total": 5, "data": "..." }
+}
+```
+
+After reassembly the client's JSON-RPC layer sees a normal:
+
+```json
+{ "jsonrpc": "2.0", "id": 17, "result": { "type": "snapshot", "snapshots": [ /* … */ ] } }
+```
+
+and correlates it with the in-flight `reconnect` request `id: 17`.
+
+### Capability exchange
+
+```json
+// Client → Server
+{
+  "jsonrpc": "2.0", "id": 1, "method": "initialize",
+  "params": {
+    "channel": "ahp-root://",
+    "protocolVersions": ["0.3.0", "0.2.0"],
+    "clientId": "client-abc",
+    "capabilities": {
+      "chunking": {
+        "maxIncomingFrameBytes": 900000,
+        "maxIncomingMessageBytes": 33554432,
+        "maxIncomingGroups": 8,
+        "groupTimeoutMs": 30000
+      }
+    }
+  }
+}
+
+// Server → Client
+{
+  "jsonrpc": "2.0", "id": 1,
+  "result": {
+    "protocolVersion": "0.3.0",
+    "serverSeq": 0,
+    "snapshots": [ /* … */ ],
+    "capabilities": {
+      "chunking": {
+        "maxIncomingFrameBytes": 900000,
+        "maxIncomingMessageBytes": 16777216,
+        "maxIncomingGroups": 4,
+        "groupTimeoutMs": 30000
+      }
+    }
+  }
+}
+```
+
+Both sides advertised support, so segmenting is enabled in both directions. The effective limits are the receiver's for each direction: outbound from client to server uses the server's 16 MB / 900 KB; outbound from server to client uses the client's 32 MB / 900 KB.

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -7,8 +7,8 @@ The connection lifecycle defines how an AHP client and server establish, resume,
 The client initiates the connection with an `initialize` **request**. The client offers a list of protocol versions it can speak; the server picks one and responds with the negotiated version and initial state snapshots:
 
 ```
-1. Client → Server:  initialize(protocolVersions[], clientId, initialSubscriptions?, locale?)
-2. Server → Client:  { protocolVersion, serverSeq, snapshots[], defaultDirectory? }
+1. Client → Server:  initialize(protocolVersions[], clientId, initialSubscriptions?, locale?, capabilities?)
+2. Server → Client:  { protocolVersion, serverSeq, snapshots[], defaultDirectory?, capabilities? }
 ```
 
 ### Initialize (Client → Server)
@@ -22,10 +22,13 @@ The client initiates the connection with an `initialize` **request**. The client
   "method": "initialize",
   "params": {
     "channel": "ahp-root://",
-    "protocolVersions": ["0.2.0"],
+    "protocolVersions": ["0.3.0"],
     "clientId": "client-abc",
     "initialSubscriptions": ["ahp-root://"],
-    "locale": "en-US"
+    "locale": "en-US",
+    "capabilities": {
+      "chunking": { "maxIncomingFrameBytes": 900000, "maxIncomingMessageBytes": 33554432 }
+    }
   }
 }
 ```
@@ -36,6 +39,8 @@ The client initiates the connection with an `initialize` **request**. The client
 
 `locale` is an optional IETF BCP 47 language tag (e.g. `"en-US"`, `"ja"`) indicating the client's preferred language. The server SHOULD use this to localise user-facing strings such as confirmation option labels.
 
+`capabilities` is an optional [`ClientCapabilities`](/reference/common#clientcapabilities) object advertising features the client supports — currently the receive-side limits for [chunking](/specification/chunking). Omitting a capability means the client does not support it; the server MUST NOT use a capability the client did not advertise.
+
 ### Initialize Response (Server → Client)
 
 ```json
@@ -43,7 +48,7 @@ The client initiates the connection with an `initialize` **request**. The client
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "0.2.0",
+    "protocolVersion": "0.3.0",
     "serverSeq": 42,
     "defaultDirectory": "file:///home/testuser",
     "snapshots": [
@@ -52,7 +57,10 @@ The client initiates the connection with an `initialize` **request**. The client
         "state": { "agents": [...] },
         "fromSeq": 42
       }
-    ]
+    ],
+    "capabilities": {
+      "chunking": { "maxIncomingFrameBytes": 900000, "maxIncomingMessageBytes": 16777216 }
+    }
   }
 }
 ```
@@ -60,6 +68,8 @@ The client initiates the connection with an `initialize` **request**. The client
 `protocolVersion` is the version the server selected from the client's `protocolVersions` list. Both peers MUST use this version for the rest of the connection.
 
 If present, `defaultDirectory` provides a server-local starting location for remote filesystem browsing.
+
+`capabilities` is an optional [`ServerCapabilities`](/reference/common#servercapabilities) object mirroring the client's advertisement — the server publishes its receive-side limits so the client knows what it MAY send. As with the client's advertisement, omitting a capability means the server does not support it.
 
 If the server cannot accept the connection for any other reason, it MUST return a JSON-RPC error. See [Error Codes](/reference/error-codes) for defined codes.
 
@@ -84,10 +94,15 @@ If the transport connection drops, the client reconnects and sends a `reconnect`
     "channel": "ahp-root://",
     "clientId": "client-abc",
     "lastSeenServerSeq": 42,
-    "subscriptions": ["ahp-root://", "ahp-session:/<uuid>"]
+    "subscriptions": ["ahp-root://", "ahp-session:/<uuid>"],
+    "capabilities": {
+      "chunking": { "maxIncomingFrameBytes": 900000, "maxIncomingMessageBytes": 33554432 }
+    }
   }
 }
 ```
+
+`capabilities` is OPTIONAL on `reconnect`. The client SHOULD re-advertise its [`ClientCapabilities`](/reference/common#clientcapabilities) whenever the new transport's limits differ from the original connection's (e.g. when reconnecting through a relay with a stricter frame ceiling). If omitted, the server SHOULD assume the previously-negotiated capabilities still apply.
 
 The server MUST include all replayed data in the response before returning. If the server can replay from the requested sequence, it returns the missed action envelopes:
 

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -32,9 +32,10 @@ AHP uses [JSON-RPC 2.0](https://www.jsonrpc.org/specification) as its message fr
 Every push-style interaction in AHP is scoped to a **channel** — a URI-identified subscribable resource (the root catalogue, a session, a terminal, a changeset, …). The wire protocol surfaces this consistently:
 
 - **Every command's `params` carries a top-level `channel: URI`**, declared on the `BaseParams` interface that every command params type extends. Channel-scoped commands (`createSession`, `disposeSession`, `fetchTurns`, `completions`, …) pass the target URI; connection-level commands (`initialize`, `ping`, `listSessions`, the `resource*` commands, `authenticate`) narrow `channel` to the literal `'ahp-root://'`.
-- **Every notification's `params` carries a top-level `channel: URI`**, including the `action` envelope, `dispatchAction`, `unsubscribe`, and every protocol notification (`root/sessionAdded`, `auth/required`, …).
+- **Every application notification's `params` carries a top-level `channel: URI`**, including the `action` envelope, `dispatchAction`, `unsubscribe`, and every protocol notification (`root/sessionAdded`, `auth/required`, …).
+- **Control notifications** are exempt. The single registry that holds them — `ControlNotificationMap` — exists specifically for framing-layer messages such as [`ahp/messageSegment`](/specification/chunking) that belong to the wire layer rather than to any subscribable resource. These notifications MAY travel in either direction and are consumed by the receiver before normal channel routing.
 
-Implementations can therefore dispatch any incoming message by inspecting `(method, params.channel)` without per-method deserialisation. This invariant is verified at compile time in `types/version/message-checks.ts`. See [Channels & Subscriptions](/specification/subscriptions) for the URI scheme, the subscription mechanism, and the per-method table.
+Implementations can therefore dispatch any incoming application message by inspecting `(method, params.channel)` without per-method deserialisation; control notifications are dispatched by method alone. This invariant is verified at compile time in `types/version/message-checks.ts`. See [Channels & Subscriptions](/specification/subscriptions) for the URI scheme, the subscription mechanism, and the per-method table.
 
 ### Message Categories
 
@@ -44,6 +45,7 @@ Implementations can therefore dispatch any incoming message by inspecting `(meth
 | Client → Server (request) | Expects a response | `initialize`, `reconnect`, `subscribe`, `createSession`, `disposeSession`, `listSessions`, `fetchTurns`, `resourceRead`, `resourceWrite`, `resourceList`, `resourceCopy`, `resourceDelete`, `resourceMove` |
 | Server → Client (notification) | Pushed | `action`, `root/sessionAdded`, `root/sessionRemoved`, `root/sessionSummaryChanged`, `auth/required` |
 | Server → Client (response) | Correlated by `id` | Success result or JSON-RPC error |
+| Either direction (control) | Framing-layer; consumed before normal dispatch | `ahp/messageSegment` ([chunking](/specification/chunking)) |
 
 ### Requests
 
@@ -83,6 +85,7 @@ The specification is organised around the **channels** that AHP exposes — each
 - **[Lifecycle](/specification/lifecycle)** — Connection handshake, reconnection, and disconnection.
 - **[Channels & Subscriptions](/specification/subscriptions)** — The channel model, the universal `channel: URI` routing key, and the subscription mechanism shared by every channel type.
 - **[Authentication](/specification/authentication)** — RFC 9728 / RFC 6750 authentication flow.
+- **[Chunking](/specification/chunking)** — Capability-negotiated message segmenting for transports with frame-size ceilings.
 - **[Root Channel](/specification/root-channel)** — `ahp-root://` — agents, terminals catalogue, host config, session catalogue events.
 - **[Session Channel](/specification/session-channel)** — `ahp-session:/<uuid>` — per-session state, turns, tool calls, pending messages.
 - **[Terminal Channel](/specification/terminal-channel)** — per-terminal pty state, data flow, claims, command detection.

--- a/docs/specification/transport.md
+++ b/docs/specification/transport.md
@@ -23,7 +23,11 @@ When WebSocket is used:
 
 - The server acts as the WebSocket server.
 - Messages are sent as WebSocket **text** frames.
-- Each text frame contains exactly one complete JSON-RPC message.
+- Each text frame contains exactly one complete JSON-RPC message — with the single exception of the [chunking](/specification/chunking) primitive, which lets a logical message span multiple frames when the transport enforces a per-frame size ceiling. Reassembly is invisible to application code above the framing layer.
+
+## Frame size and chunking
+
+Some transports place a hard upper bound on the size of a single message — for example, [Azure Web PubSub](https://learn.microsoft.com/en-us/azure/azure-web-pubsub/) rejects any WebSocket frame larger than 1 MB. AHP provides an optional, capability-negotiated [chunking primitive](/specification/chunking) so a single logical JSON-RPC message can be split across multiple frames and reassembled before normal dispatch. Implementations operating behind a hard frame ceiling SHOULD advertise [`ChunkingCapability`](/reference/common#chunkingcapability) on both sides of the connection.
 
 ## Keep-Alive
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -13,7 +13,7 @@
           "type": "string"
         },
         "clientSeq": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": [
@@ -33,7 +33,7 @@
           "$ref": "#/$defs/StateAction"
         },
         "serverSeq": {
-          "type": "number"
+          "type": "integer"
         },
         "origin": {
           "$ref": "#/$defs/ActionOrigin"
@@ -77,7 +77,7 @@
           "$ref": "#/$defs/ActionType.RootActiveSessionsChanged"
         },
         "activeSessions": {
-          "type": "number",
+          "type": "integer",
           "description": "Current count of active sessions"
         }
       },
@@ -1183,11 +1183,11 @@
           "$ref": "#/$defs/ActionType.TerminalResized"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal height in rows"
         }
       },
@@ -1256,7 +1256,7 @@
           "$ref": "#/$defs/ActionType.TerminalExited"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code. `undefined` if the process was killed without an exit code."
         }
       },
@@ -1304,7 +1304,7 @@
           "description": "The command line text that was submitted"
         },
         "timestamp": {
-          "type": "number",
+          "type": "integer",
           "description": "Unix timestamp (ms) of when the command started executing, as measured\non the server."
         }
       },
@@ -1327,11 +1327,11 @@
           "description": "Matches the `commandId` from the corresponding `commandExecuted`"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Shell exit code. `undefined` if the shell did not report one."
         },
         "durationMs": {
-          "type": "number",
+          "type": "integer",
           "description": "Wall-clock duration of the command in milliseconds, as measured by the\nshell integration script on the server side."
         }
       },
@@ -1661,11 +1661,11 @@
       "description": "A zero-based position within a textual document.",
       "properties": {
         "line": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based line number."
         },
         "character": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based character offset within the line."
         }
       },
@@ -1714,7 +1714,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1780,11 +1780,11 @@
       "type": "object",
       "properties": {
         "inputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Input tokens consumed"
         },
         "outputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Output tokens generated"
         },
         "model": {
@@ -1792,7 +1792,7 @@
           "description": "Model used"
         },
         "cacheReadTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Tokens read from cache"
         },
         "_meta": {
@@ -1849,7 +1849,7 @@
           "description": "The current state of the resource"
         },
         "fromSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "The `serverSeq` at which this snapshot was taken. Subsequent actions will have `serverSeq > fromSeq`."
         }
       },
@@ -1871,7 +1871,7 @@
           "description": "Available agent backends and their models"
         },
         "activeSessions": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of active (non-disposed) sessions on the server"
         },
         "terminals": {
@@ -1950,7 +1950,7 @@
           "description": "Human-readable model name"
         },
         "maxContextWindow": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum context window size"
         },
         "supportsVision": {
@@ -2187,11 +2187,11 @@
           "description": "Human-readable description of what the session is currently doing"
         },
         "createdAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Creation timestamp"
         },
         "modifiedAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Last modification timestamp"
         },
         "project": {
@@ -2435,11 +2435,11 @@
           "description": "Format hint for text questions, such as `email`, `uri`, `date`, or `date-time`"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum string length"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum string length"
         },
         "defaultValue": {
@@ -2613,11 +2613,11 @@
           "description": "Whether the user may enter text in addition to selecting options"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum selected item count"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum selected item count"
         }
       },
@@ -3022,7 +3022,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -3075,7 +3075,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -3168,7 +3168,7 @@
           "description": "Whether this option represents an approval or denial"
         },
         "group": {
-          "type": "number",
+          "type": "integer",
           "description": "Logical group number for visual categorisation.\n\nClients SHOULD display options in the order they are defined and MAY\nuse differing group numbers to insert dividers between logical clusters\nof options."
         }
       },
@@ -3833,7 +3833,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -4037,7 +4037,7 @@
           "description": "Who currently holds this terminal"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, if the terminal process has exited"
         }
       },
@@ -4104,11 +4104,11 @@
           "description": "Current working directory of the terminal process"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal height in rows"
         },
         "content": {
@@ -4119,7 +4119,7 @@
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, set when the terminal process exits"
         },
         "claim": {
@@ -4180,7 +4180,7 @@
           "description": "Accumulated VT output. Appended to by `terminal/data` while `isComplete`\nis false. Shell integration escape sequences are stripped by the server."
         },
         "timestamp": {
-          "type": "number",
+          "type": "integer",
           "description": "Unix timestamp (ms) when execution started, as reported by the server."
         },
         "isComplete": {
@@ -4188,11 +4188,11 @@
           "description": "Whether the command has finished."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Shell exit code. Set at completion. `undefined` if unknown."
         },
         "durationMs": {
-          "type": "number",
+          "type": "integer",
           "description": "Wall-clock duration in milliseconds. Set at completion."
         }
       },
@@ -4222,15 +4222,15 @@
           "description": "Optional longer description."
         },
         "additions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line additions across the changeset, when known."
         },
         "deletions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line deletions across the changeset, when known."
         },
         "files": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of files in the changeset, when known."
         }
       },

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -7,7 +7,7 @@
   "$defs": {
     "BaseParams": {
       "type": "object",
-      "description": "Base shape every command's params extends.\n\n`channel` identifies the channel the command targets, mirroring the\n`channel` field on every protocol notification. For commands that operate\non a specific channel (a session, terminal, or changeset), `channel` is\nthat channel's URI. For commands that are connection-level rather than\nchannel-scoped (e.g. {@link InitializeParams | `initialize`},\n{@link PingParams | `ping`}, {@link ListSessionsParams | `listSessions`},\nthe `resource*` filesystem commands, and {@link AuthenticateParams |\n`authenticate`}), the params type narrows `channel` to the literal\nroot URI `'ahp-root://'`.\n\nThis invariant lets implementations route every incoming message —\nrequest, response, or notification — by inspecting `params.channel`\nwithout needing to know the per-method param shape.",
+      "description": "Base shape every command's params extends.\n\n`channel` identifies the channel the command targets, mirroring the\n`channel` field on every protocol notification. For commands that operate\non a specific channel (a session, terminal, or changeset), `channel` is\nthat channel's URI. For commands that are connection-level rather than\nchannel-scoped (e.g. {@link InitializeParams | `initialize`},\n{@link PingParams | `ping`}, {@link ListSessionsParams | `listSessions`},\nthe `resource*` filesystem commands, and {@link AuthenticateParams |\n`authenticate`}), the params type narrows `channel` to the literal\nroot URI `'ahp-root://'`.\n\nThis invariant lets implementations route every incoming message —\nrequest, response, or notification — by inspecting `params.channel`\nwithout needing to know the per-method param shape. The only AHP\nmessages exempt from the invariant are control notifications registered\nin `ControlNotificationMap` (e.g. `ahp/messageSegment`), which belong to\nthe framing layer rather than any subscribable resource.",
       "properties": {
         "channel": {
           "$ref": "#/$defs/URI",
@@ -17,6 +17,52 @@
       "required": [
         "channel"
       ]
+    },
+    "ChunkingCapability": {
+      "type": "object",
+      "description": "Receiver-side limits for the message-chunking primitive. A side that\nadvertises `chunking` permits the peer to send oversized JSON-RPC\nmessages as a sequence of `ahp/messageSegment` notifications.\n\nSee [Chunking](/specification/chunking) for the full sender and receiver\nbehaviour, validation rules, and reconnection interaction.",
+      "properties": {
+        "maxIncomingFrameBytes": {
+          "type": "number",
+          "description": "Maximum size, in UTF-8 bytes, of any single transport frame this side\nis willing to receive — for both unchunked JSON-RPC messages and\nindividual `ahp/messageSegment` notifications. Includes the JSON-RPC\nenvelope overhead. Senders MUST NOT emit a frame larger than this."
+        },
+        "maxIncomingMessageBytes": {
+          "type": "number",
+          "description": "Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message\nthis side is willing to receive. MUST be greater than or equal to\n`maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message\nwhose reassembled payload would exceed this value."
+        },
+        "maxIncomingGroups": {
+          "type": "number",
+          "description": "Maximum number of concurrently in-flight reassembly groups this side\nwill hold open. MUST be at least 1. If omitted, the sender SHOULD use\nan implementation-defined default."
+        },
+        "groupTimeoutMs": {
+          "type": "number",
+          "description": "Maximum time, in milliseconds, this side will hold an incomplete\nreassembly group before discarding it as abandoned. If omitted, the\nsender SHOULD use an implementation-defined default."
+        }
+      },
+      "required": [
+        "maxIncomingFrameBytes",
+        "maxIncomingMessageBytes"
+      ]
+    },
+    "ClientCapabilities": {
+      "type": "object",
+      "description": "Capabilities advertised by the client during `initialize` (or\n`reconnect`). Each field is independently optional; omitting a field\nmeans the client does not support that feature.",
+      "properties": {
+        "chunking": {
+          "$ref": "#/$defs/ChunkingCapability",
+          "description": "Chunking limits the server may apply when sending to this client."
+        }
+      }
+    },
+    "ServerCapabilities": {
+      "type": "object",
+      "description": "Capabilities advertised by the server in the `initialize` result. Each\nfield is independently optional; omitting a field means the server does\nnot support that feature.",
+      "properties": {
+        "chunking": {
+          "$ref": "#/$defs/ChunkingCapability",
+          "description": "Chunking limits the client may apply when sending to this server."
+        }
+      }
     },
     "InitializeParams": {
       "type": "object",
@@ -49,6 +95,10 @@
         "locale": {
           "type": "string",
           "description": "IETF BCP 47 language tag indicating the client's preferred locale\n(e.g. `\"en-US\"`, `\"ja\"`). The server SHOULD use this to localise\nuser-facing strings such as confirmation option labels."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "Client-side feature capabilities and the per-direction limits that\ngovern them. The client advertises what it is willing to *receive*; the\nserver's outbound behaviour respects these limits. Omitting a field\n(or the entire object) means the client does not support that feature."
         }
       },
       "required": [
@@ -86,6 +136,10 @@
             "type": "string"
           },
           "description": "Characters that, when typed in a {@link UserMessage} input, SHOULD cause\nthe client to issue a `completions` request with\n{@link CompletionItemKind.UserMessage}. Typically includes characters like\n`'@'` or `'/'`."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ServerCapabilities",
+          "description": "Server-side feature capabilities and the per-direction limits that\ngovern them. The server advertises what it is willing to *receive*;\nthe client's outbound behaviour respects these limits. Omitting a\nfield (or the entire object) means the server does not support that\nfeature."
         }
       },
       "required": [
@@ -133,6 +187,10 @@
             "$ref": "#/$defs/URI"
           },
           "description": "URIs the client was subscribed to"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "Client-side feature capabilities for the new transport connection.\n`reconnect` runs over a fresh transport whose limits the server has no\nother way to learn, so the client SHOULD re-advertise its capabilities\nhere whenever its limits have changed. If omitted, the server SHOULD\nassume the previously-negotiated capabilities still apply."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -23,19 +23,23 @@
       "description": "Receiver-side limits for the message-chunking primitive. A side that\nadvertises `chunking` permits the peer to send oversized JSON-RPC\nmessages as a sequence of `ahp/messageSegment` notifications.\n\nSee [Chunking](/specification/chunking) for the full sender and receiver\nbehaviour, validation rules, and reconnection interaction.",
       "properties": {
         "maxIncomingFrameBytes": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum size, in UTF-8 bytes, of any single transport frame this side\nis willing to receive — for both unchunked JSON-RPC messages and\nindividual `ahp/messageSegment` notifications. Includes the JSON-RPC\nenvelope overhead. Senders MUST NOT emit a frame larger than this."
         },
         "maxIncomingMessageBytes": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message\nthis side is willing to receive. MUST be greater than or equal to\n`maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message\nwhose reassembled payload would exceed this value."
         },
         "maxIncomingGroups": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum number of concurrently in-flight reassembly groups this side\nwill hold open. MUST be at least 1. If omitted, the sender SHOULD use\nan implementation-defined default."
         },
         "groupTimeoutMs": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum time, in milliseconds, this side will hold an incomplete\nreassembly group before discarding it as abandoned. If omitted, the\nsender SHOULD use an implementation-defined default."
         }
       },
@@ -116,7 +120,7 @@
           "description": "Protocol version selected by the server. MUST be one of the entries in\n`InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`)."
         },
         "serverSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "Current server sequence number"
         },
         "snapshots": {
@@ -178,7 +182,7 @@
           "description": "Client identifier from the original connection"
         },
         "lastSeenServerSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "Last `serverSeq` the client received"
         },
         "subscriptions": {
@@ -295,7 +299,7 @@
           "description": "Channel URI this action targets"
         },
         "clientSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "Client sequence number"
         },
         "action": {
@@ -854,7 +858,7 @@
           "description": "Turn ID to fetch before (exclusive). Omit to fetch from the most recent turn."
         },
         "limit": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum number of turns to return. Server MAY impose its own upper bound."
         }
       },
@@ -900,7 +904,7 @@
           "description": "The complete text of the input being completed (e.g. the full user\nmessage text typed so far)."
         },
         "offset": {
-          "type": "number",
+          "type": "integer",
           "description": "The character offset within `text` at which the completion is requested,\nmeasured in UTF-16 code units. MUST satisfy `0 <= offset <= text.length`."
         }
       },
@@ -920,11 +924,11 @@
           "description": "The text inserted into the input when this item is accepted."
         },
         "rangeStart": {
-          "type": "number",
+          "type": "integer",
           "description": "If defined, the start of the range in the input's `text` that is replaced\nby `insertText`. The range is the half-open interval\n`[rangeStart, rangeEnd)` of character offsets, measured in UTF-16 code\nunits.\n\nWhen omitted, the client SHOULD insert `insertText` at the cursor.\n\nNote: this range refers to positions in the *current* input. The\nattachment's own `rangeStart`/`rangeEnd` (when present) refer to\npositions in the final {@link UserMessage.text} after the item is\naccepted."
         },
         "rangeEnd": {
-          "type": "number",
+          "type": "integer",
           "description": "The end of the range in the input's `text` that is replaced by\n`insertText`. See {@link rangeStart}."
         },
         "attachment": {
@@ -974,11 +978,11 @@
           "description": "Initial working directory URI"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Initial terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Initial terminal height in rows"
         }
       },
@@ -1274,11 +1278,11 @@
       "description": "A zero-based position within a textual document.",
       "properties": {
         "line": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based line number."
         },
         "character": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based character offset within the line."
         }
       },
@@ -1327,7 +1331,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1393,11 +1397,11 @@
       "type": "object",
       "properties": {
         "inputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Input tokens consumed"
         },
         "outputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Output tokens generated"
         },
         "model": {
@@ -1405,7 +1409,7 @@
           "description": "Model used"
         },
         "cacheReadTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Tokens read from cache"
         },
         "_meta": {
@@ -1462,7 +1466,7 @@
           "description": "The current state of the resource"
         },
         "fromSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "The `serverSeq` at which this snapshot was taken. Subsequent actions will have `serverSeq > fromSeq`."
         }
       },
@@ -1484,7 +1488,7 @@
           "description": "Available agent backends and their models"
         },
         "activeSessions": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of active (non-disposed) sessions on the server"
         },
         "terminals": {
@@ -1563,7 +1567,7 @@
           "description": "Human-readable model name"
         },
         "maxContextWindow": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum context window size"
         },
         "supportsVision": {
@@ -1800,11 +1804,11 @@
           "description": "Human-readable description of what the session is currently doing"
         },
         "createdAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Creation timestamp"
         },
         "modifiedAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Last modification timestamp"
         },
         "project": {
@@ -2048,11 +2052,11 @@
           "description": "Format hint for text questions, such as `email`, `uri`, `date`, or `date-time`"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum string length"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum string length"
         },
         "defaultValue": {
@@ -2226,11 +2230,11 @@
           "description": "Whether the user may enter text in addition to selecting options"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum selected item count"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum selected item count"
         }
       },
@@ -2635,7 +2639,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -2688,7 +2692,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -2781,7 +2785,7 @@
           "description": "Whether this option represents an approval or denial"
         },
         "group": {
-          "type": "number",
+          "type": "integer",
           "description": "Logical group number for visual categorisation.\n\nClients SHOULD display options in the order they are defined and MAY\nuse differing group numbers to insert dividers between logical clusters\nof options."
         }
       },
@@ -3446,7 +3450,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -3650,7 +3654,7 @@
           "description": "Who currently holds this terminal"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, if the terminal process has exited"
         }
       },
@@ -3717,11 +3721,11 @@
           "description": "Current working directory of the terminal process"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal height in rows"
         },
         "content": {
@@ -3732,7 +3736,7 @@
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, set when the terminal process exits"
         },
         "claim": {
@@ -3793,7 +3797,7 @@
           "description": "Accumulated VT output. Appended to by `terminal/data` while `isComplete`\nis false. Shell integration escape sequences are stripped by the server."
         },
         "timestamp": {
-          "type": "number",
+          "type": "integer",
           "description": "Unix timestamp (ms) when execution started, as reported by the server."
         },
         "isComplete": {
@@ -3801,11 +3805,11 @@
           "description": "Whether the command has finished."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Shell exit code. Set at completion. `undefined` if unknown."
         },
         "durationMs": {
-          "type": "number",
+          "type": "integer",
           "description": "Wall-clock duration in milliseconds. Set at completion."
         }
       },
@@ -3835,15 +3839,15 @@
           "description": "Optional longer description."
         },
         "additions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line additions across the changeset, when known."
         },
         "deletions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line deletions across the changeset, when known."
         },
         "files": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of files in the changeset, when known."
         }
       },
@@ -3953,7 +3957,7 @@
           "type": "string"
         },
         "clientSeq": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": [
@@ -3973,7 +3977,7 @@
           "$ref": "#/$defs/StateAction"
         },
         "serverSeq": {
-          "type": "number"
+          "type": "integer"
         },
         "origin": {
           "$ref": "#/$defs/ActionOrigin"
@@ -4017,7 +4021,7 @@
           "$ref": "#/$defs/ActionType.RootActiveSessionsChanged"
         },
         "activeSessions": {
-          "type": "number",
+          "type": "integer",
           "description": "Current count of active sessions"
         }
       },
@@ -5123,11 +5127,11 @@
           "$ref": "#/$defs/ActionType.TerminalResized"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal height in rows"
         }
       },
@@ -5196,7 +5200,7 @@
           "$ref": "#/$defs/ActionType.TerminalExited"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code. `undefined` if the process was killed without an exit code."
         }
       },
@@ -5244,7 +5248,7 @@
           "description": "The command line text that was submitted"
         },
         "timestamp": {
-          "type": "number",
+          "type": "integer",
           "description": "Unix timestamp (ms) of when the command started executing, as measured\non the server."
         }
       },
@@ -5267,11 +5271,11 @@
           "description": "Matches the `commandId` from the corresponding `commandExecuted`"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Shell exit code. `undefined` if the shell did not report one."
         },
         "durationMs": {
-          "type": "number",
+          "type": "integer",
           "description": "Wall-clock duration of the command in milliseconds, as measured by the\nshell integration script on the server side."
         }
       },

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2989,7 +2989,7 @@
     },
     "BaseParams": {
       "type": "object",
-      "description": "Base shape every command's params extends.\n\n`channel` identifies the channel the command targets, mirroring the\n`channel` field on every protocol notification. For commands that operate\non a specific channel (a session, terminal, or changeset), `channel` is\nthat channel's URI. For commands that are connection-level rather than\nchannel-scoped (e.g. {@link InitializeParams | `initialize`},\n{@link PingParams | `ping`}, {@link ListSessionsParams | `listSessions`},\nthe `resource*` filesystem commands, and {@link AuthenticateParams |\n`authenticate`}), the params type narrows `channel` to the literal\nroot URI `'ahp-root://'`.\n\nThis invariant lets implementations route every incoming message —\nrequest, response, or notification — by inspecting `params.channel`\nwithout needing to know the per-method param shape.",
+      "description": "Base shape every command's params extends.\n\n`channel` identifies the channel the command targets, mirroring the\n`channel` field on every protocol notification. For commands that operate\non a specific channel (a session, terminal, or changeset), `channel` is\nthat channel's URI. For commands that are connection-level rather than\nchannel-scoped (e.g. {@link InitializeParams | `initialize`},\n{@link PingParams | `ping`}, {@link ListSessionsParams | `listSessions`},\nthe `resource*` filesystem commands, and {@link AuthenticateParams |\n`authenticate`}), the params type narrows `channel` to the literal\nroot URI `'ahp-root://'`.\n\nThis invariant lets implementations route every incoming message —\nrequest, response, or notification — by inspecting `params.channel`\nwithout needing to know the per-method param shape. The only AHP\nmessages exempt from the invariant are control notifications registered\nin `ControlNotificationMap` (e.g. `ahp/messageSegment`), which belong to\nthe framing layer rather than any subscribable resource.",
       "properties": {
         "channel": {
           "$ref": "#/$defs/URI",
@@ -2999,6 +2999,52 @@
       "required": [
         "channel"
       ]
+    },
+    "ChunkingCapability": {
+      "type": "object",
+      "description": "Receiver-side limits for the message-chunking primitive. A side that\nadvertises `chunking` permits the peer to send oversized JSON-RPC\nmessages as a sequence of `ahp/messageSegment` notifications.\n\nSee [Chunking](/specification/chunking) for the full sender and receiver\nbehaviour, validation rules, and reconnection interaction.",
+      "properties": {
+        "maxIncomingFrameBytes": {
+          "type": "number",
+          "description": "Maximum size, in UTF-8 bytes, of any single transport frame this side\nis willing to receive — for both unchunked JSON-RPC messages and\nindividual `ahp/messageSegment` notifications. Includes the JSON-RPC\nenvelope overhead. Senders MUST NOT emit a frame larger than this."
+        },
+        "maxIncomingMessageBytes": {
+          "type": "number",
+          "description": "Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message\nthis side is willing to receive. MUST be greater than or equal to\n`maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message\nwhose reassembled payload would exceed this value."
+        },
+        "maxIncomingGroups": {
+          "type": "number",
+          "description": "Maximum number of concurrently in-flight reassembly groups this side\nwill hold open. MUST be at least 1. If omitted, the sender SHOULD use\nan implementation-defined default."
+        },
+        "groupTimeoutMs": {
+          "type": "number",
+          "description": "Maximum time, in milliseconds, this side will hold an incomplete\nreassembly group before discarding it as abandoned. If omitted, the\nsender SHOULD use an implementation-defined default."
+        }
+      },
+      "required": [
+        "maxIncomingFrameBytes",
+        "maxIncomingMessageBytes"
+      ]
+    },
+    "ClientCapabilities": {
+      "type": "object",
+      "description": "Capabilities advertised by the client during `initialize` (or\n`reconnect`). Each field is independently optional; omitting a field\nmeans the client does not support that feature.",
+      "properties": {
+        "chunking": {
+          "$ref": "#/$defs/ChunkingCapability",
+          "description": "Chunking limits the server may apply when sending to this client."
+        }
+      }
+    },
+    "ServerCapabilities": {
+      "type": "object",
+      "description": "Capabilities advertised by the server in the `initialize` result. Each\nfield is independently optional; omitting a field means the server does\nnot support that feature.",
+      "properties": {
+        "chunking": {
+          "$ref": "#/$defs/ChunkingCapability",
+          "description": "Chunking limits the client may apply when sending to this server."
+        }
+      }
     },
     "InitializeParams": {
       "type": "object",
@@ -3031,6 +3077,10 @@
         "locale": {
           "type": "string",
           "description": "IETF BCP 47 language tag indicating the client's preferred locale\n(e.g. `\"en-US\"`, `\"ja\"`). The server SHOULD use this to localise\nuser-facing strings such as confirmation option labels."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "Client-side feature capabilities and the per-direction limits that\ngovern them. The client advertises what it is willing to *receive*; the\nserver's outbound behaviour respects these limits. Omitting a field\n(or the entire object) means the client does not support that feature."
         }
       },
       "required": [
@@ -3068,6 +3118,10 @@
             "type": "string"
           },
           "description": "Characters that, when typed in a {@link UserMessage} input, SHOULD cause\nthe client to issue a `completions` request with\n{@link CompletionItemKind.UserMessage}. Typically includes characters like\n`'@'` or `'/'`."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ServerCapabilities",
+          "description": "Server-side feature capabilities and the per-direction limits that\ngovern them. The server advertises what it is willing to *receive*;\nthe client's outbound behaviour respects these limits. Omitting a\nfield (or the entire object) means the server does not support that\nfeature."
         }
       },
       "required": [
@@ -3115,6 +3169,10 @@
             "$ref": "#/$defs/URI"
           },
           "description": "URIs the client was subscribed to"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "Client-side feature capabilities for the new transport connection.\n`reconnect` runs over a fresh transport whose limits the server has no\nother way to learn, so the client SHOULD re-advertise its capabilities\nhere whenever its limits have changed. If omitted, the server SHOULD\nassume the previously-negotiated capabilities still apply."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -7,7 +7,7 @@
   "$defs": {
     "JsonRpcErrorCode": {
       "description": "Standard JSON-RPC 2.0 error codes.",
-      "type": "number",
+      "type": "integer",
       "enum": [
         -32700,
         -32600,
@@ -18,7 +18,7 @@
     },
     "AhpErrorCode": {
       "description": "AHP application-specific error codes.",
-      "type": "number",
+      "type": "integer",
       "enum": [
         -32001,
         -32002,
@@ -29,7 +29,8 @@
         -32007,
         -32008,
         -32009,
-        -32010
+        -32010,
+        -32011
       ]
     },
     "AuthRequiredErrorData": {
@@ -316,11 +317,11 @@
       "description": "A zero-based position within a textual document.",
       "properties": {
         "line": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based line number."
         },
         "character": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based character offset within the line."
         }
       },
@@ -369,7 +370,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -435,11 +436,11 @@
       "type": "object",
       "properties": {
         "inputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Input tokens consumed"
         },
         "outputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Output tokens generated"
         },
         "model": {
@@ -447,7 +448,7 @@
           "description": "Model used"
         },
         "cacheReadTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Tokens read from cache"
         },
         "_meta": {
@@ -504,7 +505,7 @@
           "description": "The current state of the resource"
         },
         "fromSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "The `serverSeq` at which this snapshot was taken. Subsequent actions will have `serverSeq > fromSeq`."
         }
       },
@@ -526,7 +527,7 @@
           "description": "Available agent backends and their models"
         },
         "activeSessions": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of active (non-disposed) sessions on the server"
         },
         "terminals": {
@@ -605,7 +606,7 @@
           "description": "Human-readable model name"
         },
         "maxContextWindow": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum context window size"
         },
         "supportsVision": {
@@ -842,11 +843,11 @@
           "description": "Human-readable description of what the session is currently doing"
         },
         "createdAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Creation timestamp"
         },
         "modifiedAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Last modification timestamp"
         },
         "project": {
@@ -1090,11 +1091,11 @@
           "description": "Format hint for text questions, such as `email`, `uri`, `date`, or `date-time`"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum string length"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum string length"
         },
         "defaultValue": {
@@ -1268,11 +1269,11 @@
           "description": "Whether the user may enter text in addition to selecting options"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum selected item count"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum selected item count"
         }
       },
@@ -1677,7 +1678,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1730,7 +1731,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1823,7 +1824,7 @@
           "description": "Whether this option represents an approval or denial"
         },
         "group": {
-          "type": "number",
+          "type": "integer",
           "description": "Logical group number for visual categorisation.\n\nClients SHOULD display options in the order they are defined and MAY\nuse differing group numbers to insert dividers between logical clusters\nof options."
         }
       },
@@ -2488,7 +2489,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -2692,7 +2693,7 @@
           "description": "Who currently holds this terminal"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, if the terminal process has exited"
         }
       },
@@ -2759,11 +2760,11 @@
           "description": "Current working directory of the terminal process"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal height in rows"
         },
         "content": {
@@ -2774,7 +2775,7 @@
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, set when the terminal process exits"
         },
         "claim": {
@@ -2835,7 +2836,7 @@
           "description": "Accumulated VT output. Appended to by `terminal/data` while `isComplete`\nis false. Shell integration escape sequences are stripped by the server."
         },
         "timestamp": {
-          "type": "number",
+          "type": "integer",
           "description": "Unix timestamp (ms) when execution started, as reported by the server."
         },
         "isComplete": {
@@ -2843,11 +2844,11 @@
           "description": "Whether the command has finished."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Shell exit code. Set at completion. `undefined` if unknown."
         },
         "durationMs": {
-          "type": "number",
+          "type": "integer",
           "description": "Wall-clock duration in milliseconds. Set at completion."
         }
       },
@@ -2877,15 +2878,15 @@
           "description": "Optional longer description."
         },
         "additions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line additions across the changeset, when known."
         },
         "deletions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line deletions across the changeset, when known."
         },
         "files": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of files in the changeset, when known."
         }
       },
@@ -3005,19 +3006,23 @@
       "description": "Receiver-side limits for the message-chunking primitive. A side that\nadvertises `chunking` permits the peer to send oversized JSON-RPC\nmessages as a sequence of `ahp/messageSegment` notifications.\n\nSee [Chunking](/specification/chunking) for the full sender and receiver\nbehaviour, validation rules, and reconnection interaction.",
       "properties": {
         "maxIncomingFrameBytes": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum size, in UTF-8 bytes, of any single transport frame this side\nis willing to receive — for both unchunked JSON-RPC messages and\nindividual `ahp/messageSegment` notifications. Includes the JSON-RPC\nenvelope overhead. Senders MUST NOT emit a frame larger than this."
         },
         "maxIncomingMessageBytes": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message\nthis side is willing to receive. MUST be greater than or equal to\n`maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message\nwhose reassembled payload would exceed this value."
         },
         "maxIncomingGroups": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum number of concurrently in-flight reassembly groups this side\nwill hold open. MUST be at least 1. If omitted, the sender SHOULD use\nan implementation-defined default."
         },
         "groupTimeoutMs": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
           "description": "Maximum time, in milliseconds, this side will hold an incomplete\nreassembly group before discarding it as abandoned. If omitted, the\nsender SHOULD use an implementation-defined default."
         }
       },
@@ -3098,7 +3103,7 @@
           "description": "Protocol version selected by the server. MUST be one of the entries in\n`InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`)."
         },
         "serverSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "Current server sequence number"
         },
         "snapshots": {
@@ -3160,7 +3165,7 @@
           "description": "Client identifier from the original connection"
         },
         "lastSeenServerSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "Last `serverSeq` the client received"
         },
         "subscriptions": {
@@ -3277,7 +3282,7 @@
           "description": "Channel URI this action targets"
         },
         "clientSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "Client sequence number"
         },
         "action": {
@@ -3836,7 +3841,7 @@
           "description": "Turn ID to fetch before (exclusive). Omit to fetch from the most recent turn."
         },
         "limit": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum number of turns to return. Server MAY impose its own upper bound."
         }
       },
@@ -3882,7 +3887,7 @@
           "description": "The complete text of the input being completed (e.g. the full user\nmessage text typed so far)."
         },
         "offset": {
-          "type": "number",
+          "type": "integer",
           "description": "The character offset within `text` at which the completion is requested,\nmeasured in UTF-16 code units. MUST satisfy `0 <= offset <= text.length`."
         }
       },
@@ -3902,11 +3907,11 @@
           "description": "The text inserted into the input when this item is accepted."
         },
         "rangeStart": {
-          "type": "number",
+          "type": "integer",
           "description": "If defined, the start of the range in the input's `text` that is replaced\nby `insertText`. The range is the half-open interval\n`[rangeStart, rangeEnd)` of character offsets, measured in UTF-16 code\nunits.\n\nWhen omitted, the client SHOULD insert `insertText` at the cursor.\n\nNote: this range refers to positions in the *current* input. The\nattachment's own `rangeStart`/`rangeEnd` (when present) refer to\npositions in the final {@link UserMessage.text} after the item is\naccepted."
         },
         "rangeEnd": {
-          "type": "number",
+          "type": "integer",
           "description": "The end of the range in the input's `text` that is replaced by\n`insertText`. See {@link rangeStart}."
         },
         "attachment": {
@@ -3956,11 +3961,11 @@
           "description": "Initial working directory URI"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Initial terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Initial terminal height in rows"
         }
       },

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -27,6 +27,34 @@
         "resource"
       ]
     },
+    "MessageSegmentParams": {
+      "type": "object",
+      "description": "Carries one segment of a JSON-RPC message that the sender has split to\nstay below a transport frame ceiling. Reassembled by the receiver's\nframing layer before normal JSON-RPC dispatch.\n\n`ahp/messageSegment` is a **control** notification: it belongs to the\nframing layer, not to any subscribable resource, and is the only AHP\nnotification that does **not** carry a top-level `channel: URI`. It is\nregistered in {@link ControlNotificationMap} rather than the client- or\nserver-direction notification maps; it MAY be sent in either direction.\n\nChunking is opt-in per direction: a sender MUST NOT emit\n`ahp/messageSegment` unless the receiver has advertised\n{@link ChunkingCapability} during `initialize` (or `reconnect`). See\n[Chunking](/specification/chunking) for the full lifecycle, sender and\nreceiver behaviour, validation rules, and DoS limits.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Opaque sender-chosen identifier that scopes one in-flight reassembly.\n\nMUST be a non-empty string of at most 128 UTF-8 bytes. Receivers MUST\nNOT interpret the value. A `groupId` MUST be unique among the sender's\ncurrently in-flight reassemblies on a single connection; it MAY be\nreused once the receiver has either fully reassembled or discarded\nthat group. `groupId` and JSON-RPC `id` are independent namespaces."
+        },
+        "index": {
+          "type": "number",
+          "description": "0-based position of this segment within the group. MUST be a\nnon-negative integer strictly less than `total`. Receivers MUST reject\nduplicate or out-of-order indices as a protocol error."
+        },
+        "total": {
+          "type": "number",
+          "description": "Total number of segments in this group. MUST be at least 1 and less\nthan 65 536. MUST be identical across every segment of the group; a\nsubsequent segment with a different `total` is a protocol error."
+        },
+        "data": {
+          "type": "string",
+          "description": "Base64-encoded slice of the UTF-8 bytes of the original JSON-RPC\nmessage being reassembled. Uses the standard base64 alphabet\n([RFC 4648 §4](https://www.rfc-editor.org/rfc/rfc4648#section-4)) with\npadding. Concatenating the decoded bytes of segments `0..total-1` in\norder MUST produce a UTF-8 byte sequence that parses as exactly one\nJSON-RPC request, response, or notification — which MUST NOT itself\nbe an `ahp/messageSegment` (no recursion)."
+        }
+      },
+      "required": [
+        "groupId",
+        "index",
+        "total",
+        "data"
+      ]
+    },
     "SessionAddedParams": {
       "type": "object",
       "description": "Broadcast to all clients subscribed to the root channel when a new session\nis created.",
@@ -140,6 +168,9 @@
       "oneOf": [
         {
           "$ref": "#/$defs/AuthRequiredParams"
+        },
+        {
+          "$ref": "#/$defs/MessageSegmentParams"
         },
         {
           "$ref": "#/$defs/SessionAddedParams"

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -36,11 +36,14 @@
           "description": "Opaque sender-chosen identifier that scopes one in-flight reassembly.\n\nMUST be a non-empty string of at most 128 UTF-8 bytes. Receivers MUST\nNOT interpret the value. A `groupId` MUST be unique among the sender's\ncurrently in-flight reassemblies on a single connection; it MAY be\nreused once the receiver has either fully reassembled or discarded\nthat group. `groupId` and JSON-RPC `id` are independent namespaces."
         },
         "index": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 0,
           "description": "0-based position of this segment within the group. MUST be a\nnon-negative integer strictly less than `total`. Receivers MUST reject\nduplicate or out-of-order indices as a protocol error."
         },
         "total": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
           "description": "Total number of segments in this group. MUST be at least 1 and less\nthan 65 536. MUST be identical across every segment of the group; a\nsubsequent segment with a different `total` is a protocol error."
         },
         "data": {
@@ -127,11 +130,11 @@
               "description": "Human-readable description of what the session is currently doing"
             },
             "createdAt": {
-              "type": "number",
+              "type": "integer",
               "description": "Creation timestamp"
             },
             "modifiedAt": {
-              "type": "number",
+              "type": "integer",
               "description": "Last modification timestamp"
             },
             "project": {
@@ -405,11 +408,11 @@
       "description": "A zero-based position within a textual document.",
       "properties": {
         "line": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based line number."
         },
         "character": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based character offset within the line."
         }
       },
@@ -458,7 +461,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -524,11 +527,11 @@
       "type": "object",
       "properties": {
         "inputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Input tokens consumed"
         },
         "outputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Output tokens generated"
         },
         "model": {
@@ -536,7 +539,7 @@
           "description": "Model used"
         },
         "cacheReadTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Tokens read from cache"
         },
         "_meta": {
@@ -593,7 +596,7 @@
           "description": "The current state of the resource"
         },
         "fromSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "The `serverSeq` at which this snapshot was taken. Subsequent actions will have `serverSeq > fromSeq`."
         }
       },
@@ -615,7 +618,7 @@
           "description": "Available agent backends and their models"
         },
         "activeSessions": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of active (non-disposed) sessions on the server"
         },
         "terminals": {
@@ -694,7 +697,7 @@
           "description": "Human-readable model name"
         },
         "maxContextWindow": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum context window size"
         },
         "supportsVision": {
@@ -931,11 +934,11 @@
           "description": "Human-readable description of what the session is currently doing"
         },
         "createdAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Creation timestamp"
         },
         "modifiedAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Last modification timestamp"
         },
         "project": {
@@ -1179,11 +1182,11 @@
           "description": "Format hint for text questions, such as `email`, `uri`, `date`, or `date-time`"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum string length"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum string length"
         },
         "defaultValue": {
@@ -1357,11 +1360,11 @@
           "description": "Whether the user may enter text in addition to selecting options"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum selected item count"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum selected item count"
         }
       },
@@ -1766,7 +1769,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1819,7 +1822,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1912,7 +1915,7 @@
           "description": "Whether this option represents an approval or denial"
         },
         "group": {
-          "type": "number",
+          "type": "integer",
           "description": "Logical group number for visual categorisation.\n\nClients SHOULD display options in the order they are defined and MAY\nuse differing group numbers to insert dividers between logical clusters\nof options."
         }
       },
@@ -2577,7 +2580,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -2781,7 +2784,7 @@
           "description": "Who currently holds this terminal"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, if the terminal process has exited"
         }
       },
@@ -2848,11 +2851,11 @@
           "description": "Current working directory of the terminal process"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal height in rows"
         },
         "content": {
@@ -2863,7 +2866,7 @@
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, set when the terminal process exits"
         },
         "claim": {
@@ -2924,7 +2927,7 @@
           "description": "Accumulated VT output. Appended to by `terminal/data` while `isComplete`\nis false. Shell integration escape sequences are stripped by the server."
         },
         "timestamp": {
-          "type": "number",
+          "type": "integer",
           "description": "Unix timestamp (ms) when execution started, as reported by the server."
         },
         "isComplete": {
@@ -2932,11 +2935,11 @@
           "description": "Whether the command has finished."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Shell exit code. Set at completion. `undefined` if unknown."
         },
         "durationMs": {
-          "type": "number",
+          "type": "integer",
           "description": "Wall-clock duration in milliseconds. Set at completion."
         }
       },
@@ -2966,15 +2969,15 @@
           "description": "Optional longer description."
         },
         "additions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line additions across the changeset, when known."
         },
         "deletions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line deletions across the changeset, when known."
         },
         "files": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of files in the changeset, when known."
         }
       },

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -227,11 +227,11 @@
       "description": "A zero-based position within a textual document.",
       "properties": {
         "line": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based line number."
         },
         "character": {
-          "type": "number",
+          "type": "integer",
           "description": "Zero-based character offset within the line."
         }
       },
@@ -280,7 +280,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -346,11 +346,11 @@
       "type": "object",
       "properties": {
         "inputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Input tokens consumed"
         },
         "outputTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Output tokens generated"
         },
         "model": {
@@ -358,7 +358,7 @@
           "description": "Model used"
         },
         "cacheReadTokens": {
-          "type": "number",
+          "type": "integer",
           "description": "Tokens read from cache"
         },
         "_meta": {
@@ -415,7 +415,7 @@
           "description": "The current state of the resource"
         },
         "fromSeq": {
-          "type": "number",
+          "type": "integer",
           "description": "The `serverSeq` at which this snapshot was taken. Subsequent actions will have `serverSeq > fromSeq`."
         }
       },
@@ -437,7 +437,7 @@
           "description": "Available agent backends and their models"
         },
         "activeSessions": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of active (non-disposed) sessions on the server"
         },
         "terminals": {
@@ -516,7 +516,7 @@
           "description": "Human-readable model name"
         },
         "maxContextWindow": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum context window size"
         },
         "supportsVision": {
@@ -753,11 +753,11 @@
           "description": "Human-readable description of what the session is currently doing"
         },
         "createdAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Creation timestamp"
         },
         "modifiedAt": {
-          "type": "number",
+          "type": "integer",
           "description": "Last modification timestamp"
         },
         "project": {
@@ -1001,11 +1001,11 @@
           "description": "Format hint for text questions, such as `email`, `uri`, `date`, or `date-time`"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum string length"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum string length"
         },
         "defaultValue": {
@@ -1179,11 +1179,11 @@
           "description": "Whether the user may enter text in addition to selecting options"
         },
         "min": {
-          "type": "number",
+          "type": "integer",
           "description": "Minimum selected item count"
         },
         "max": {
-          "type": "number",
+          "type": "integer",
           "description": "Maximum selected item count"
         }
       },
@@ -1588,7 +1588,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1641,7 +1641,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -1734,7 +1734,7 @@
           "description": "Whether this option represents an approval or denial"
         },
         "group": {
-          "type": "number",
+          "type": "integer",
           "description": "Logical group number for visual categorisation.\n\nClients SHOULD display options in the order they are defined and MAY\nuse differing group numbers to insert dividers between logical clusters\nof options."
         }
       },
@@ -2399,7 +2399,7 @@
           "description": "Content URI"
         },
         "sizeHint": {
-          "type": "number",
+          "type": "integer",
           "description": "Approximate size in bytes"
         },
         "contentType": {
@@ -2603,7 +2603,7 @@
           "description": "Who currently holds this terminal"
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, if the terminal process has exited"
         }
       },
@@ -2670,11 +2670,11 @@
           "description": "Current working directory of the terminal process"
         },
         "cols": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal width in columns"
         },
         "rows": {
-          "type": "number",
+          "type": "integer",
           "description": "Terminal height in rows"
         },
         "content": {
@@ -2685,7 +2685,7 @@
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Process exit code, set when the terminal process exits"
         },
         "claim": {
@@ -2746,7 +2746,7 @@
           "description": "Accumulated VT output. Appended to by `terminal/data` while `isComplete`\nis false. Shell integration escape sequences are stripped by the server."
         },
         "timestamp": {
-          "type": "number",
+          "type": "integer",
           "description": "Unix timestamp (ms) when execution started, as reported by the server."
         },
         "isComplete": {
@@ -2754,11 +2754,11 @@
           "description": "Whether the command has finished."
         },
         "exitCode": {
-          "type": "number",
+          "type": "integer",
           "description": "Shell exit code. Set at completion. `undefined` if unknown."
         },
         "durationMs": {
-          "type": "number",
+          "type": "integer",
           "description": "Wall-clock duration in milliseconds. Set at completion."
         }
       },
@@ -2788,15 +2788,15 @@
           "description": "Optional longer description."
         },
         "additions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line additions across the changeset, when known."
         },
         "deletions": {
-          "type": "number",
+          "type": "integer",
           "description": "Aggregate line deletions across the changeset, when known."
         },
         "files": {
-          "type": "number",
+          "type": "integer",
           "description": "Number of files in the changeset, when known."
         }
       },

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -9,6 +9,7 @@ import {
   TypeAliasDeclaration,
   PropertySignature,
   Node,
+  SyntaxKind,
   Type,
   SourceFile,
 } from 'ts-morph';
@@ -35,6 +36,8 @@ interface JsonSchema {
   anyOf?: JsonSchema[];
   $ref?: string;
   $defs?: Record<string, JsonSchema>;
+  minimum?: number;
+  maximum?: number;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -55,6 +58,56 @@ function getPropertyType(prop: PropertySignature): string {
   const typeNode = prop.getTypeNode();
   if (typeNode) return typeNode.getText();
   return prop.getType().getText(prop);
+}
+
+/** Returns true if the property has a `@format float` JSDoc tag. */
+function hasFormatFloat(prop: PropertySignature): boolean {
+  for (const doc of prop.getJsDocs()) {
+    for (const tag of doc.getTags()) {
+      if (tag.getTagName() === 'format' && tag.getCommentText()?.trim() === 'float') {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Reads a numeric JSDoc tag like `@minimum 0` or `@maximum 65535`. Returns
+ * `undefined` if the tag is missing or its body is not a valid number.
+ */
+function getNumericTag(prop: PropertySignature, tagName: string): number | undefined {
+  for (const doc of prop.getJsDocs()) {
+    for (const tag of doc.getTags()) {
+      if (tag.getTagName() === tagName) {
+        const text = tag.getCommentText()?.trim();
+        if (text === undefined) return undefined;
+        const n = Number(text);
+        if (!Number.isFinite(n)) return undefined;
+        return n;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Applies JSDoc-driven constraints to a property's schema in place:
+ *
+ * - `number` becomes `integer` unless the property carries `@format float`.
+ *   This matches the project-wide convention documented in
+ *   `.github/instructions/general-instructions.instructions.md` and the
+ *   behaviour of the Swift / Rust generators.
+ * - `@minimum N` sets `minimum: N`; `@maximum N` sets `maximum: N`.
+ */
+function applyJsDocConstraints(schema: JsonSchema, prop: PropertySignature): void {
+  if (schema.type === 'number' && !hasFormatFloat(prop)) {
+    schema.type = 'integer';
+  }
+  const min = getNumericTag(prop, 'minimum');
+  if (min !== undefined) schema.minimum = min;
+  const max = getNumericTag(prop, 'maximum');
+  if (max !== undefined) schema.maximum = max;
 }
 
 function findInterface(project: Project, name: string): InterfaceDeclaration | undefined {
@@ -230,6 +283,7 @@ function interfaceToSchema(iface: InterfaceDeclaration, project: Project): JsonS
     const typeText = getPropertyType(prop);
     const desc = getPropertyDescription(prop);
     const propSchema = typeTextToSchema(typeText, project);
+    applyJsDocConstraints(propSchema, prop);
     if (desc) propSchema.description = desc;
     schema.properties![name] = propSchema;
     if (!prop.hasQuestionToken()) {
@@ -456,7 +510,48 @@ function generateNotificationsSchema(project: Project): JsonSchema {
   return schema;
 }
 
+/**
+ * Reads the numeric values from a `const`-asserted object literal like
+ * `AhpErrorCodes`. Used to keep the JSON Schema enum in sync with the
+ * source `as const` declaration so additions don't get silently dropped.
+ */
+function readNumericConstObject(project: Project, varName: string): number[] {
+  for (const sf of project.getSourceFiles()) {
+    const decl = sf.getVariableDeclaration(varName);
+    if (!decl) continue;
+    const init = decl.getInitializer();
+    if (!init) continue;
+    // The const is typically declared as `{ ... } as const`; unwrap.
+    let obj: Node = init;
+    if (Node.isAsExpression(init)) {
+      obj = init.getExpression();
+    }
+    if (!Node.isObjectLiteralExpression(obj)) continue;
+    const values: number[] = [];
+    for (const prop of obj.getProperties()) {
+      if (!Node.isPropertyAssignment(prop)) continue;
+      const valueNode = prop.getInitializer();
+      if (!valueNode) continue;
+      if (Node.isNumericLiteral(valueNode)) {
+        values.push(Number(valueNode.getText()));
+      } else if (Node.isPrefixUnaryExpression(valueNode)) {
+        const operand = valueNode.getOperand();
+        if (Node.isNumericLiteral(operand) && valueNode.getOperatorToken() === SyntaxKind.MinusToken) {
+          values.push(-Number(operand.getText()));
+        }
+      }
+    }
+    return values;
+  }
+  return [];
+}
+
 function generateErrorsSchema(project: Project): JsonSchema {
+  const ahpErrorCodes = readNumericConstObject(project, 'AhpErrorCodes');
+  if (ahpErrorCodes.length === 0) {
+    throw new Error('generate-json-schema: could not read AhpErrorCodes from types/common/errors.ts');
+  }
+
   const schema: JsonSchema = {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     $comment: 'Generated from types/errors.ts — do not edit',
@@ -466,13 +561,13 @@ function generateErrorsSchema(project: Project): JsonSchema {
     $defs: {
       JsonRpcErrorCode: {
         description: 'Standard JSON-RPC 2.0 error codes.',
-        type: 'number',
+        type: 'integer',
         enum: [-32700, -32600, -32601, -32602, -32603],
       },
       AhpErrorCode: {
         description: 'AHP application-specific error codes.',
-        type: 'number',
-        enum: [-32001, -32002, -32003, -32004, -32005, -32006, -32007, -32008, -32009, -32010],
+        type: 'integer',
+        enum: ahpErrorCodes,
       },
     },
   };

--- a/scripts/generate-markdown.ts
+++ b/scripts/generate-markdown.ts
@@ -1130,9 +1130,6 @@ function generateErrorCodesPage(project: Project): string {
     if (ta) lines.push(renderTypeAliasBlock(ta));
   }
 
-  // Version Introduction
-  lines.push('## Version Introduction\n');
-  lines.push('All error codes listed above were introduced in protocol version **1**.\n');
   return lines.join('\n');
 }
 
@@ -1245,8 +1242,6 @@ function generateMessagesPage(project: Project): string {
     lines.push('');
   }
 
-  lines.push('## Version Introduction\n');
-  lines.push('All messages listed above were introduced in protocol version **1**.\n');
   return lines.join('\n');
 }
 

--- a/scripts/generate-markdown.ts
+++ b/scripts/generate-markdown.ts
@@ -745,6 +745,30 @@ function emitNotificationsSection(project: Project, sourceFiles: SourceFile[]): 
   return lines.join('\n');
 }
 
+/**
+ * Emit a "Control Notifications" section: every exported `*Params` interface
+ * in the given source files whose method name appears in
+ * `ControlNotificationMap`. Control notifications belong to the framing
+ * layer and do not carry a `channel: URI`.
+ */
+function emitControlNotificationsSection(project: Project, sourceFiles: SourceFile[]): string {
+  const controlNotifMap = parseRegistryInterface(project, 'ControlNotificationMap', false);
+  const methodByParams = new Map<string, RegistryEntry>();
+  for (const entry of controlNotifMap) methodByParams.set(entry.paramsType, entry);
+
+  const lines: string[] = [];
+  for (const sf of sourceFiles) {
+    for (const stmt of sf.getStatements()) {
+      if (!Node.isInterfaceDeclaration(stmt) || !stmt.isExported()) continue;
+      const name = stmt.getName();
+      const entry = methodByParams.get(name);
+      if (!entry) continue;
+      lines.push(emitNotificationBlock(entry, stmt));
+    }
+  }
+  return lines.join('\n');
+}
+
 function emitNotificationBlock(entry: RegistryEntry, paramsIface: InterfaceDeclaration): string {
   const lines: string[] = [];
   const desc = getJsDocDescription(paramsIface);
@@ -850,17 +874,28 @@ function generateCommonPage(project: Project): string {
     lines.push(emitNotificationsSection(project, [notificationsSf]));
   }
 
+  // ─── Control Notifications ──────────────────────────────────────────────
+  if (notificationsSf) {
+    const controlNotifMap = parseRegistryInterface(project, 'ControlNotificationMap', false);
+    if (controlNotifMap.length > 0) {
+      lines.push('## Control Notifications\n');
+      lines.push('Control notifications belong to the framing layer rather than to any subscribable resource. They MAY be sent in either direction and are consumed by the receiver before normal JSON-RPC dispatch. Unlike application notifications, control notifications do **not** carry a top-level `channel: URI`.\n');
+      lines.push(schemaLink('notifications.schema.json'));
+      lines.push(emitControlNotificationsSection(project, [notificationsSf]));
+    }
+  }
+
   // ─── JSON-RPC Wire Types ────────────────────────────────────────────────
   if (messagesSf) {
     lines.push('## JSON-RPC Wire Types\n');
-    lines.push('Base JSON-RPC message shapes and the typed registries that drive the discriminated-union wrappers (`AhpRequest`, `AhpResponse`, `AhpClientNotification`, `AhpServerNotification`, `AhpNotification`, `ProtocolMessage`).\n');
+    lines.push('Base JSON-RPC message shapes and the typed registries that drive the discriminated-union wrappers (`AhpRequest`, `AhpResponse`, `AhpClientNotification`, `AhpServerNotification`, `AhpControlNotification`, `AhpNotification`, `ProtocolMessage`).\n');
     for (const name of ['JsonRpcRequest', 'JsonRpcSuccessResponse', 'JsonRpcErrorResponse', 'JsonRpcNotification', 'AhpErrorResponse']) {
       const iface = messagesSf.getInterface(name);
       if (iface) lines.push(renderInterfaceBlock(iface));
     }
     lines.push('### Registries\n');
     lines.push('The discriminated-union wrappers are parameterised over these registry interfaces. Each property is a JSON-RPC method name; each value is a `{ params; result? }` type literal.\n');
-    for (const name of ['CommandMap', 'ServerCommandMap', 'ClientNotificationMap', 'ServerNotificationMap']) {
+    for (const name of ['CommandMap', 'ServerCommandMap', 'ClientNotificationMap', 'ServerNotificationMap', 'ControlNotificationMap']) {
       const iface = messagesSf.getInterface(name);
       if (iface) lines.push(renderInterfaceCodeBlock(iface));
     }
@@ -869,7 +904,7 @@ function generateCommonPage(project: Project): string {
       'AhpRequest', 'AhpServerRequest',
       'AhpSuccessResponse', 'AhpResponse',
       'AhpServerSuccessResponse', 'AhpServerResponse',
-      'AhpClientNotification', 'AhpServerNotification', 'AhpNotification',
+      'AhpClientNotification', 'AhpServerNotification', 'AhpControlNotification', 'AhpNotification',
       'ProtocolMessage',
     ]) {
       const ta = messagesSf.getTypeAlias(name);
@@ -1124,6 +1159,7 @@ function generateMessagesPage(project: Project): string {
   const serverCommandMap = parseRegistryInterface(project, 'ServerCommandMap', true);
   const clientNotifMap = parseRegistryInterface(project, 'ClientNotificationMap', false);
   const serverNotifMap = parseRegistryInterface(project, 'ServerNotificationMap', false);
+  const controlNotifMap = parseRegistryInterface(project, 'ControlNotificationMap', false);
 
   const refLink = (entry: RegistryEntry): string => {
     const page = pageForMethod(project, entry.paramsType);
@@ -1197,6 +1233,17 @@ function generateMessagesPage(project: Project): string {
     lines.push(`| \`${entry.method}\` | ${escapeMarkdown(briefDescription(entry))} | ${ref} |`);
   }
   lines.push('');
+
+  if (controlNotifMap.length > 0) {
+    lines.push('## Control Notifications\n');
+    lines.push('Framing-layer notifications that MAY be sent in either direction. Consumed by the receiver before normal JSON-RPC dispatch. Control notifications do **not** carry a top-level `channel: URI`.\n');
+    lines.push('| Method | Description | Reference |');
+    lines.push('|---|---|---|');
+    for (const entry of controlNotifMap) {
+      lines.push(`| \`${entry.method}\` | ${escapeMarkdown(briefDescription(entry))} | ${refLink(entry)} |`);
+    }
+    lines.push('');
+  }
 
   lines.push('## Version Introduction\n');
   lines.push('All messages listed above were introduced in protocol version **1**.\n');

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -978,6 +978,9 @@ pub struct ActionEnvelope {
 const COMMAND_ENUMS = ['ReconnectResultType', 'ContentEncoding', 'CompletionItemKind'];
 
 const COMMAND_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: string }[] = [
+  { name: 'ChunkingCapability' },
+  { name: 'ClientCapabilities' },
+  { name: 'ServerCapabilities' },
   { name: 'InitializeParams' }, { name: 'InitializeResult' },
   { name: 'ReconnectParams' },
   { name: 'ReconnectReplayResult', omitDiscriminants: true },
@@ -1096,6 +1099,7 @@ const NOTIFICATION_STRUCTS = [
   'SessionRemovedParams',
   'SessionSummaryChangedParams',
   'AuthRequiredParams',
+  'MessageSegmentParams',
 ];
 
 function generateNotificationsFile(project: Project): string {

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -999,6 +999,7 @@ function generateActionsFile(project: Project): string {
 const COMMAND_ENUMS = ['ReconnectResultType', 'ContentEncoding', 'CompletionItemKind'];
 
 const COMMAND_STRUCTS = [
+  'ChunkingCapability', 'ClientCapabilities', 'ServerCapabilities',
   'InitializeParams', 'InitializeResult',
   'ReconnectParams', 'ReconnectReplayResult', 'ReconnectSnapshotResult',
   'SubscribeParams', 'SubscribeResult',
@@ -1147,6 +1148,7 @@ const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
 
 const NOTIFICATION_STRUCTS = [
   'SessionAddedParams', 'SessionRemovedParams', 'SessionSummaryChangedParams', 'AuthRequiredParams',
+  'MessageSegmentParams',
 ];
 
 function generateNotificationsFile(project: Project): string {

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -27,13 +27,84 @@ import type { ActionEnvelope, StateAction } from './actions.js';
  *
  * This invariant lets implementations route every incoming message —
  * request, response, or notification — by inspecting `params.channel`
- * without needing to know the per-method param shape.
+ * without needing to know the per-method param shape. The only AHP
+ * messages exempt from the invariant are control notifications registered
+ * in `ControlNotificationMap` (e.g. `ahp/messageSegment`), which belong to
+ * the framing layer rather than any subscribable resource.
  *
  * @category Commands
  */
 export interface BaseParams {
   /** Channel URI this command targets. */
   channel: URI;
+}
+
+// ─── Capabilities ────────────────────────────────────────────────────────────
+
+/**
+ * Receiver-side limits for the message-chunking primitive. A side that
+ * advertises `chunking` permits the peer to send oversized JSON-RPC
+ * messages as a sequence of `ahp/messageSegment` notifications.
+ *
+ * See [Chunking](/specification/chunking) for the full sender and receiver
+ * behaviour, validation rules, and reconnection interaction.
+ *
+ * @category Capabilities
+ * @version 0.3.0
+ */
+export interface ChunkingCapability {
+  /**
+   * Maximum size, in UTF-8 bytes, of any single transport frame this side
+   * is willing to receive — for both unchunked JSON-RPC messages and
+   * individual `ahp/messageSegment` notifications. Includes the JSON-RPC
+   * envelope overhead. Senders MUST NOT emit a frame larger than this.
+   */
+  maxIncomingFrameBytes: number;
+  /**
+   * Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message
+   * this side is willing to receive. MUST be greater than or equal to
+   * `maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message
+   * whose reassembled payload would exceed this value.
+   */
+  maxIncomingMessageBytes: number;
+  /**
+   * Maximum number of concurrently in-flight reassembly groups this side
+   * will hold open. MUST be at least 1. If omitted, the sender SHOULD use
+   * an implementation-defined default.
+   */
+  maxIncomingGroups?: number;
+  /**
+   * Maximum time, in milliseconds, this side will hold an incomplete
+   * reassembly group before discarding it as abandoned. If omitted, the
+   * sender SHOULD use an implementation-defined default.
+   */
+  groupTimeoutMs?: number;
+}
+
+/**
+ * Capabilities advertised by the client during `initialize` (or
+ * `reconnect`). Each field is independently optional; omitting a field
+ * means the client does not support that feature.
+ *
+ * @category Capabilities
+ * @version 0.3.0
+ */
+export interface ClientCapabilities {
+  /** Chunking limits the server may apply when sending to this client. */
+  chunking?: ChunkingCapability;
+}
+
+/**
+ * Capabilities advertised by the server in the `initialize` result. Each
+ * field is independently optional; omitting a field means the server does
+ * not support that feature.
+ *
+ * @category Capabilities
+ * @version 0.3.0
+ */
+export interface ServerCapabilities {
+  /** Chunking limits the client may apply when sending to this server. */
+  chunking?: ChunkingCapability;
 }
 
 // ─── initialize ──────────────────────────────────────────────────────────────
@@ -71,6 +142,15 @@ export interface InitializeParams extends BaseParams {
    * user-facing strings such as confirmation option labels.
    */
   locale?: string;
+  /**
+   * Client-side feature capabilities and the per-direction limits that
+   * govern them. The client advertises what it is willing to *receive*; the
+   * server's outbound behaviour respects these limits. Omitting a field
+   * (or the entire object) means the client does not support that feature.
+   *
+   * @version 0.3.0
+   */
+  capabilities?: ClientCapabilities;
 }
 
 /**
@@ -102,6 +182,16 @@ export interface InitializeResult {
    * `'@'` or `'/'`.
    */
   completionTriggerCharacters?: string[];
+  /**
+   * Server-side feature capabilities and the per-direction limits that
+   * govern them. The server advertises what it is willing to *receive*;
+   * the client's outbound behaviour respects these limits. Omitting a
+   * field (or the entire object) means the server does not support that
+   * feature.
+   *
+   * @version 0.3.0
+   */
+  capabilities?: ServerCapabilities;
 }
 
 // ─── ping ────────────────────────────────────────────────────────────────────
@@ -155,6 +245,16 @@ export interface ReconnectParams extends BaseParams {
   lastSeenServerSeq: number;
   /** URIs the client was subscribed to */
   subscriptions: URI[];
+  /**
+   * Client-side feature capabilities for the new transport connection.
+   * `reconnect` runs over a fresh transport whose limits the server has no
+   * other way to learn, so the client SHOULD re-advertise its capabilities
+   * here whenever its limits have changed. If omitted, the server SHOULD
+   * assume the previously-negotiated capabilities still apply.
+   *
+   * @version 0.3.0
+   */
+  capabilities?: ClientCapabilities;
 }
 
 /**

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -58,6 +58,8 @@ export interface ChunkingCapability {
    * is willing to receive — for both unchunked JSON-RPC messages and
    * individual `ahp/messageSegment` notifications. Includes the JSON-RPC
    * envelope overhead. Senders MUST NOT emit a frame larger than this.
+   *
+   * @minimum 1
    */
   maxIncomingFrameBytes: number;
   /**
@@ -65,18 +67,24 @@ export interface ChunkingCapability {
    * this side is willing to receive. MUST be greater than or equal to
    * `maxIncomingFrameBytes`. Senders MUST NOT initiate a chunked message
    * whose reassembled payload would exceed this value.
+   *
+   * @minimum 1
    */
   maxIncomingMessageBytes: number;
   /**
    * Maximum number of concurrently in-flight reassembly groups this side
    * will hold open. MUST be at least 1. If omitted, the sender SHOULD use
    * an implementation-defined default.
+   *
+   * @minimum 1
    */
   maxIncomingGroups?: number;
   /**
    * Maximum time, in milliseconds, this side will hold an incomplete
    * reassembly group before discarding it as abandoned. If omitted, the
    * sender SHOULD use an implementation-defined default.
+   *
+   * @minimum 1
    */
   groupTimeoutMs?: number;
 }

--- a/types/common/errors.ts
+++ b/types/common/errors.ts
@@ -84,6 +84,18 @@ export const AhpErrorCodes = {
    * overwriting (e.g. `resourceWrite` with `createOnly: true`).
    */
   AlreadyExists: -32010,
+  /**
+   * The sender cannot deliver a message because it would exceed the
+   * receiver's advertised frame ceiling and the receiver has not
+   * advertised chunking support (see
+   * {@link ChunkingCapability}). For requests, the sender returns this
+   * error to its local caller; for responses, the responder returns this
+   * error to the requester in place of the oversized result.
+   *
+   * @see {@link /specification/chunking | Chunking}
+   * @version 0.3.0
+   */
+  MessageTooLarge: -32011,
 } as const;
 
 /** Union type of all AHP application error codes. */

--- a/types/common/messages.ts
+++ b/types/common/messages.ts
@@ -65,7 +65,7 @@ import type {
   SessionRemovedParams,
   SessionSummaryChangedParams,
 } from '../channels-root/notifications.js';
-import type { AuthRequiredParams } from './notifications.js';
+import type { AuthRequiredParams, MessageSegmentParams } from './notifications.js';
 import type { AhpError } from './errors.js';
 
 // ─── JSON-RPC Base Types ─────────────────────────────────────────────────────
@@ -200,6 +200,29 @@ export interface ServerNotificationMap {
   'auth/required': { params: AuthRequiredParams };
 }
 
+/**
+ * Registry mapping each **control** notification method to its params type.
+ *
+ * Control notifications belong to the framing layer, not to any
+ * subscribable resource: they MAY be sent in either direction and are
+ * consumed by the receiver before normal JSON-RPC dispatch. Unlike entries
+ * in {@link ClientNotificationMap} and {@link ServerNotificationMap},
+ * entries here are **exempt** from the universal channel-URI invariant
+ * (their params MUST NOT carry a top-level `channel: URI`).
+ *
+ * Currently registered:
+ *
+ * - `ahp/messageSegment` — one segment of a JSON-RPC message that the
+ *   sender has split to stay below a transport frame ceiling. See
+ *   [Chunking](/specification/chunking).
+ *
+ * @category Notifications
+ * @version 0.3.0
+ */
+export interface ControlNotificationMap {
+  'ahp/messageSegment': { params: MessageSegmentParams };
+}
+
 // ─── Typed Requests ──────────────────────────────────────────────────────────
 
 /**
@@ -298,13 +321,27 @@ export type AhpServerNotification<M extends keyof ServerNotificationMap = keyof 
   } : never;
 
 /**
- * A fully typed JSON-RPC notification — either direction.
+ * A control notification — a framing-layer message that MAY be sent in
+ * either direction. Receivers consume control notifications before normal
+ * JSON-RPC dispatch. The only such notification today is
+ * `ahp/messageSegment`; see {@link ControlNotificationMap}.
+ */
+export type AhpControlNotification<M extends keyof ControlNotificationMap = keyof ControlNotificationMap> =
+  M extends unknown ? {
+    readonly jsonrpc: '2.0';
+    readonly method: M;
+    readonly params: ControlNotificationMap[M]['params'];
+  } : never;
+
+/**
+ * A fully typed JSON-RPC notification — either direction, including
+ * control notifications.
  *
  * The client → server `dispatchAction` method and the server → client
  * `action` method are distinct entries in the registries; their params have
  * unrelated shapes ({@link DispatchActionParams} vs {@link ActionEnvelope}).
  */
-export type AhpNotification = AhpClientNotification | AhpServerNotification;
+export type AhpNotification = AhpClientNotification | AhpServerNotification | AhpControlNotification;
 
 // ─── Protocol Message Union ──────────────────────────────────────────────────
 

--- a/types/common/notifications.ts
+++ b/types/common/notifications.ts
@@ -116,12 +116,17 @@ export interface MessageSegmentParams {
    * 0-based position of this segment within the group. MUST be a
    * non-negative integer strictly less than `total`. Receivers MUST reject
    * duplicate or out-of-order indices as a protocol error.
+   *
+   * @minimum 0
    */
   index: number;
   /**
    * Total number of segments in this group. MUST be at least 1 and less
    * than 65 536. MUST be identical across every segment of the group; a
    * subsequent segment with a different `total` is a protocol error.
+   *
+   * @minimum 1
+   * @maximum 65535
    */
   total: number;
   /**

--- a/types/common/notifications.ts
+++ b/types/common/notifications.ts
@@ -1,6 +1,7 @@
 /**
- * Common Notification Types — `auth/required`, currently the only connection-
- * level (non-channel-specific) protocol notification.
+ * Common Notification Types — `auth/required` (connection-level protocol
+ * notification) and `ahp/messageSegment` (control notification used by the
+ * framing layer for message chunking).
  *
  * @module common/notifications
  */
@@ -59,4 +60,78 @@ export interface AuthRequiredParams {
   resource: string;
   /** Why authentication is required */
   reason?: AuthRequiredReason;
+}
+
+// ─── ahp/messageSegment ──────────────────────────────────────────────────────
+
+/**
+ * Carries one segment of a JSON-RPC message that the sender has split to
+ * stay below a transport frame ceiling. Reassembled by the receiver's
+ * framing layer before normal JSON-RPC dispatch.
+ *
+ * `ahp/messageSegment` is a **control** notification: it belongs to the
+ * framing layer, not to any subscribable resource, and is the only AHP
+ * notification that does **not** carry a top-level `channel: URI`. It is
+ * registered in {@link ControlNotificationMap} rather than the client- or
+ * server-direction notification maps; it MAY be sent in either direction.
+ *
+ * Chunking is opt-in per direction: a sender MUST NOT emit
+ * `ahp/messageSegment` unless the receiver has advertised
+ * {@link ChunkingCapability} during `initialize` (or `reconnect`). See
+ * [Chunking](/specification/chunking) for the full lifecycle, sender and
+ * receiver behaviour, validation rules, and DoS limits.
+ *
+ * @category Protocol Notifications
+ * @method ahp/messageSegment
+ * @direction Either
+ * @messageType Notification
+ * @version 0.3.0
+ * @see {@link /specification/chunking | Chunking}
+ * @example
+ * ```json
+ * {
+ *   "jsonrpc": "2.0",
+ *   "method": "ahp/messageSegment",
+ *   "params": {
+ *     "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
+ *     "index": 0,
+ *     "total": 3,
+ *     "data": "eyJqc29ucnBjIjoiMi4wIiwibWV0aG9kIjoiYWN0aW9uIiwic..."
+ *   }
+ * }
+ * ```
+ */
+export interface MessageSegmentParams {
+  /**
+   * Opaque sender-chosen identifier that scopes one in-flight reassembly.
+   *
+   * MUST be a non-empty string of at most 128 UTF-8 bytes. Receivers MUST
+   * NOT interpret the value. A `groupId` MUST be unique among the sender's
+   * currently in-flight reassemblies on a single connection; it MAY be
+   * reused once the receiver has either fully reassembled or discarded
+   * that group. `groupId` and JSON-RPC `id` are independent namespaces.
+   */
+  groupId: string;
+  /**
+   * 0-based position of this segment within the group. MUST be a
+   * non-negative integer strictly less than `total`. Receivers MUST reject
+   * duplicate or out-of-order indices as a protocol error.
+   */
+  index: number;
+  /**
+   * Total number of segments in this group. MUST be at least 1 and less
+   * than 65 536. MUST be identical across every segment of the group; a
+   * subsequent segment with a different `total` is a protocol error.
+   */
+  total: number;
+  /**
+   * Base64-encoded slice of the UTF-8 bytes of the original JSON-RPC
+   * message being reassembled. Uses the standard base64 alphabet
+   * ([RFC 4648 §4](https://www.rfc-editor.org/rfc/rfc4648#section-4)) with
+   * padding. Concatenating the decoded bytes of segments `0..total-1` in
+   * order MUST produce a UTF-8 byte sequence that parses as exactly one
+   * JSON-RPC request, response, or notification — which MUST NOT itself
+   * be an `ahp/messageSegment` (no recursion).
+   */
+  data: string;
 }

--- a/types/messages.test.ts
+++ b/types/messages.test.ts
@@ -181,6 +181,15 @@ describe('_ExpectedServerNotifications matches ServerNotificationMap', () => {
   });
 });
 
+describe('_ExpectedControlNotifications matches ControlNotificationMap', () => {
+  const expected = parseExpectedUnion(messageChecksSrc, '_ExpectedControlNotifications');
+  const mapKeys = parseMapKeys(messagesSrc, 'ControlNotificationMap');
+
+  it('_ExpectedControlNotifications lists exactly the ControlNotificationMap keys', () => {
+    assert.deepStrictEqual(expected.sort(), mapKeys.sort());
+  });
+});
+
 describe('command params/result naming conventions', () => {
   for (const method of requests) {
     const pascal = method[0].toUpperCase() + method.slice(1);

--- a/types/version/message-checks.ts
+++ b/types/version/message-checks.ts
@@ -17,6 +17,7 @@ import type {
   ClientNotificationMap,
   ServerNotificationMap,
   ServerCommandMap,
+  ControlNotificationMap,
 } from '../messages.js';
 import type { BaseParams } from '../commands.js';
 import type { URI } from '../state.js';
@@ -44,6 +45,17 @@ type _AllParamsHaveChannel<M> = {
  */
 type _AllNotificationParamsHaveChannel<M> = {
   [K in keyof M]: M[K] extends { params: { channel: URI } } ? true : never;
+}[keyof M];
+
+/**
+ * Resolves to `true` if every entry in `M` has params that do **not**
+ * carry a top-level `channel: URI`. Used to enforce that control
+ * notifications (framing-layer messages such as `ahp/messageSegment`)
+ * stay out of the channel-routing namespace — they are dispatched by
+ * method alone, before normal channel routing kicks in.
+ */
+type _NoControlParamsHaveChannel<M> = {
+  [K in keyof M]: M[K] extends { params: { channel: unknown } } ? never : true;
 }[keyof M];
 
 // ─── Expected Method Names ───────────────────────────────────────────────────
@@ -90,6 +102,10 @@ type _ExpectedServerNotifications =
 type _ExpectedServerCommands =
   | 'resourceRequest';
 
+/** All control notification methods (framing layer, either direction). */
+type _ExpectedControlNotifications =
+  | 'ahp/messageSegment';
+
 // ─── Assertions ──────────────────────────────────────────────────────────────
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -100,6 +116,8 @@ type _CheckClientNotificationMapKeys = _Exact<keyof ClientNotificationMap, _Expe
 type _CheckServerNotificationMapKeys = _Exact<keyof ServerNotificationMap, _ExpectedServerNotifications>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckServerCommandMapKeys = _Exact<keyof ServerCommandMap, _ExpectedServerCommands>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckControlNotificationMapKeys = _Exact<keyof ControlNotificationMap, _ExpectedControlNotifications>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckClientNotificationsHaveChannel = _AllNotificationParamsHaveChannel<ClientNotificationMap> extends true ? true : never;
@@ -109,3 +127,9 @@ type _CheckServerNotificationsHaveChannel = _AllNotificationParamsHaveChannel<Se
 type _CheckCommandsHaveChannel = _AllParamsHaveChannel<CommandMap> extends true ? true : never;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckServerCommandsHaveChannel = _AllParamsHaveChannel<ServerCommandMap> extends true ? true : never;
+// Control notifications are *exempt* from the channel-URI invariant by
+// design — they belong to the framing layer rather than any subscribable
+// resource. This check enforces the inverse: no control notification's
+// params object carries a top-level `channel`.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _CheckControlNotificationsHaveNoChannel = _NoControlParamsHaveChannel<ControlNotificationMap> extends true ? true : never;

--- a/types/version/message-checks.ts
+++ b/types/version/message-checks.ts
@@ -27,35 +27,34 @@ import type { URI } from '../state.js';
 type _Exact<A, B> = [A] extends [B] ? [B] extends [A] ? true : never : never;
 
 /**
- * Resolves to `true` if every entry in `M` has params extending
- * {@link BaseParams} (i.e. carries a top-level `channel: URI`). Any
- * offending key is mapped to `never`, so the final union evaluates to
- * `never` and the assertion below fails to compile.
+ * Yields the union of keys `K in keyof M` whose `M[K]` does **not** extend
+ * `OK`. Resolves to `never` if every entry conforms.
+ *
+ * Used to build a positive invariant check: assert
+ * `[NonConformingKeys<M, OK>] extends [never]`. The `[T] extends [never]`
+ * wrapping prevents distribution over `never` (a bare `never` in a naked
+ * conditional otherwise distributes to `never`, which would mask the bug),
+ * and yielding `K` (not `never`) on failure prevents the older
+ * `true | never` collapse that allowed partial violations to slip past.
  */
-type _AllParamsHaveChannel<M> = {
-  [K in keyof M]: M[K] extends { params: BaseParams } ? true : never;
+type _NonConformingKeys<M, OK> = {
+  [K in keyof M]: M[K] extends OK ? never : K;
 }[keyof M];
 
 /**
- * Same as {@link _AllParamsHaveChannel} but for notification maps where
- * params are not required to extend `BaseParams` directly — only to have
- * a `channel: URI` field. Notifications keep using the structural check
- * so external producers (e.g. the `action` envelope) don't need to
- * import `BaseParams`.
+ * Yields the union of keys `K in keyof M` whose `M[K]['params']` carries a
+ * `channel` field — required *or* optional. Resolves to `never` if no
+ * entry has `channel`.
+ *
+ * The `'channel' extends keyof P` formulation is critical: a structural
+ * check like `{ params: { channel: unknown } }` only matches *required*
+ * `channel`, so an entry typed as `params: { channel?: URI }` would slip
+ * past. The `keyof` check correctly catches both forms.
  */
-type _AllNotificationParamsHaveChannel<M> = {
-  [K in keyof M]: M[K] extends { params: { channel: URI } } ? true : never;
-}[keyof M];
-
-/**
- * Resolves to `true` if every entry in `M` has params that do **not**
- * carry a top-level `channel: URI`. Used to enforce that control
- * notifications (framing-layer messages such as `ahp/messageSegment`)
- * stay out of the channel-routing namespace — they are dispatched by
- * method alone, before normal channel routing kicks in.
- */
-type _NoControlParamsHaveChannel<M> = {
-  [K in keyof M]: M[K] extends { params: { channel: unknown } } ? never : true;
+type _ParamsCarryingChannel<M> = {
+  [K in keyof M]: M[K] extends { params: infer P }
+    ? 'channel' extends keyof P ? K : never
+    : never;
 }[keyof M];
 
 // ─── Expected Method Names ───────────────────────────────────────────────────
@@ -107,6 +106,13 @@ type _ExpectedControlNotifications =
   | 'ahp/messageSegment';
 
 // ─── Assertions ──────────────────────────────────────────────────────────────
+//
+// Each assertion below resolves to `true` when the invariant holds and to
+// `never` when it doesn't. The `_CheckXxx` aliases serve no runtime
+// purpose — they exist so the assertion produces a compile error if it
+// fails. The `[T] extends [never]` wrapping is load-bearing: bare
+// `never extends never` distributes to `never`, which would silently
+// invert the result; the tuple-wrapping keeps the comparison literal.
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _CheckCommandMapKeys = _Exact<keyof CommandMap, _ExpectedCommands>;
@@ -120,16 +126,85 @@ type _CheckServerCommandMapKeys = _Exact<keyof ServerCommandMap, _ExpectedServer
 type _CheckControlNotificationMapKeys = _Exact<keyof ControlNotificationMap, _ExpectedControlNotifications>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _CheckClientNotificationsHaveChannel = _AllNotificationParamsHaveChannel<ClientNotificationMap> extends true ? true : never;
+type _CheckClientNotificationsHaveChannel =
+  [_NonConformingKeys<ClientNotificationMap, { params: { channel: URI } }>] extends [never] ? true : never;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _CheckServerNotificationsHaveChannel = _AllNotificationParamsHaveChannel<ServerNotificationMap> extends true ? true : never;
+type _CheckServerNotificationsHaveChannel =
+  [_NonConformingKeys<ServerNotificationMap, { params: { channel: URI } }>] extends [never] ? true : never;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _CheckCommandsHaveChannel = _AllParamsHaveChannel<CommandMap> extends true ? true : never;
+type _CheckCommandsHaveChannel =
+  [_NonConformingKeys<CommandMap, { params: BaseParams }>] extends [never] ? true : never;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _CheckServerCommandsHaveChannel = _AllParamsHaveChannel<ServerCommandMap> extends true ? true : never;
+type _CheckServerCommandsHaveChannel =
+  [_NonConformingKeys<ServerCommandMap, { params: BaseParams }>] extends [never] ? true : never;
 // Control notifications are *exempt* from the channel-URI invariant by
 // design — they belong to the framing layer rather than any subscribable
 // resource. This check enforces the inverse: no control notification's
-// params object carries a top-level `channel`.
+// params object carries a `channel` field, required or optional.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _CheckControlNotificationsHaveNoChannel = _NoControlParamsHaveChannel<ControlNotificationMap> extends true ? true : never;
+type _CheckControlNotificationsHaveNoChannel =
+  [_ParamsCarryingChannel<ControlNotificationMap>] extends [never] ? true : never;
+
+// ─── Self-tests ──────────────────────────────────────────────────────────────
+//
+// Synthetic maps with deliberate violations, used to verify that the
+// invariants above actually fire. Each block defines a known-bad map and
+// asserts via a string-sentinel literal type that the corresponding check
+// on that map yields a non-`never` result (i.e., the violation is caught).
+// If a future refactor silently re-broke an invariant, the bad map's
+// check would now yield `never`, the conditional would resolve to the
+// `'BUG: …'` branch, and the value-level assignment would fail to
+// typecheck — surfacing the regression at exactly this site.
+//
+// `@ts-expect-error` was tempting but does not work here: `never extends
+// true` is `true` (bottom-type semantics), so a broken invariant whose
+// result distributes to `never` would silently satisfy an
+// `_Expect<T extends true>` constraint and the directive would falsely
+// fire as "unused".
+
+namespace _SelfTest {
+  // A known-bad command map (missing `channel` outright).
+  interface _MissingChannel {
+    bad: { params: { notChannel: string } };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _missingChannelCatch:
+    [_NonConformingKeys<_MissingChannel, { params: BaseParams }>] extends [never]
+      ? 'BUG: command invariant did not fire on a fully-broken map'
+      : 'OK' = 'OK';
+
+  // A known-bad notification map where **one** entry conforms and another
+  // doesn't — the case the old `true | never = true` erasure silently
+  // accepted.
+  interface _PartiallyMissing {
+    good: { params: { channel: 'foo' } };
+    bad: { params: { notChannel: 'bar' } };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _partiallyMissingCatch:
+    [_NonConformingKeys<_PartiallyMissing, { params: { channel: URI } }>] extends [never]
+      ? 'BUG: notification invariant did not fire on a partial violation'
+      : 'OK' = 'OK';
+
+  // A known-bad control map carrying a required `channel`.
+  interface _RequiredChannelControl {
+    'control/withChannel': { params: { channel: URI; payload: string } };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _requiredChannelCatch:
+    [_ParamsCarryingChannel<_RequiredChannelControl>] extends [never]
+      ? 'BUG: control invariant did not catch required channel'
+      : 'OK' = 'OK';
+
+  // A known-bad control map carrying an **optional** `channel` — the case
+  // the structural `{ params: { channel: unknown } }` check missed because
+  // `{ channel?: URI }` does not extend `{ channel: unknown }`.
+  interface _OptionalChannelControl {
+    'control/optionalChannel': { params: { channel?: URI; payload: string } };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _optionalChannelCatch:
+    [_ParamsCarryingChannel<_OptionalChannelControl>] extends [never]
+      ? 'BUG: control invariant did not catch optional channel'
+      : 'OK' = 'OK';
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -6,7 +6,7 @@
 
 import type { StateAction } from '../actions.js';
 import { ActionType } from '../actions.js';
-import type { ServerNotificationMap } from '../messages.js';
+import type { ControlNotificationMap, ServerNotificationMap } from '../messages.js';
 
 // ─── Protocol Version Constants ──────────────────────────────────────────────
 
@@ -15,7 +15,7 @@ import type { ServerNotificationMap } from '../messages.js';
  *
  * Formatted as a [SemVer](https://semver.org) `MAJOR.MINOR.PATCH` string.
  */
-export const PROTOCOL_VERSION = '0.2.0';
+export const PROTOCOL_VERSION = '0.3.0';
 
 // ─── SemVer Comparison ───────────────────────────────────────────────────────
 
@@ -152,4 +152,30 @@ export const NOTIFICATION_INTRODUCED_IN: { readonly [K in ProtocolNotificationMe
  */
 export function isNotificationKnownToVersion(method: ProtocolNotificationMethod, clientVersion: string): boolean {
   return compareProtocolVersions(NOTIFICATION_INTRODUCED_IN[method], clientVersion) <= 0;
+}
+
+// ─── Exhaustive Control Notification Method → Version Map ──────────────────
+
+/**
+ * Maps every control notification method to the protocol version that
+ * introduced it. Adding a new control notification method to
+ * {@link ControlNotificationMap} without adding it here is a compile error.
+ *
+ * Control notifications belong to the framing layer (e.g. message
+ * chunking) rather than to any subscribable resource. They MAY be sent in
+ * either direction; receivers consume them before normal JSON-RPC
+ * dispatch.
+ *
+ * Versions are SemVer `MAJOR.MINOR.PATCH` strings (see `PROTOCOL_VERSION`).
+ */
+export const CONTROL_NOTIFICATION_INTRODUCED_IN: { readonly [K in keyof ControlNotificationMap]: string } = {
+  'ahp/messageSegment': '0.3.0',
+};
+
+/**
+ * Returns whether the given control notification method is known to the
+ * specified protocol version.
+ */
+export function isControlNotificationKnownToVersion(method: keyof ControlNotificationMap, clientVersion: string): boolean {
+  return compareProtocolVersions(CONTROL_NOTIFICATION_INTRODUCED_IN[method], clientVersion) <= 0;
 }


### PR DESCRIPTION
> **Tracks:** microsoft/agent-host-protocol#138

---

# RFC: Message Chunking

# Summary

Add a transport-agnostic **message-segmenting primitive** to AHP so a single logical JSON-RPC message can be split across multiple WebSocket (or other transport) frames and reassembled by the receiver before normal dispatch. Two new primitives:

1. A reserved control notification — `ahp/messageSegment` — that carries one segment of a larger message.
2. A `capabilities.chunking` object exchanged during `initialize` (and again on `reconnect` when the transport changes) so each side declares per-direction limits.

The wire-format payload is base64-encoded UTF-8 bytes of the original JSON-RPC message. The receiver concatenates the bytes of all segments in a group, decodes once, and dispatches the result as if it had arrived as a single message.

# Motivation

AHP today assumes any one JSON-RPC message can fit in a single transport frame. That assumption holds for direct WebSocket connections between a client and a daemon, where browsers and servers allow multi-megabyte frames in practice.

It breaks once a managed pub/sub transport with a hard frame cap sits in the path. Concretely, [Azure Web PubSub](https://learn.microsoft.com/en-us/azure/azure-web-pubsub/) — adopted as the relay substrate in [github/copilot-host#105](https://github.com/github/copilot-host/pull/105) — rejects any WebSocket frame larger than **1 MB** with a connection close. The reliable subprotocol has no service-side chunking.

The set of AHP messages that can plausibly exceed 1 MB on a long-running session:

| Message | When it gets large |
|---|---|
| `reconnect` result snapshot | A long session whose state has accumulated turns, tool calls, customizations, and changesets |
| `action` notification carrying `session/customizationsChanged` | Clients with rich customization blobs |
| `action` notification carrying `session/toolCallComplete` | Tools that return large blobs (file reads, large HTTP responses, `gh pr view --json` output) |
| `action` notification carrying `session/changesetsChanged` | Sessions that touched many files |
| `action` notification carrying `terminal/data` | `cat huge_file`, verbose build logs, large structured CLI output |
| `dispatchAction` params | A user paste of a large prompt |
| `resourceWrite` params | Writing a large file body through the host |

Direct WebSocket transports do not hit the 1 MB cap today, but a protocol-level primitive lets every transport with a frame ceiling — present or future — work uniformly. It also gives implementations a place to put per-transport tuning (smaller chunks for high-latency mobile links, larger chunks for LAN).

# Non-goals

- **Streaming text into state.** `session/delta` already streams partial text into the session reducer. This proposal does not change that. The word *segment* is chosen specifically to avoid confusion with the existing "chunk" of streaming text.
- **Exactly-once semantics for chunked requests across reconnect.** Idempotency is the caller's responsibility, as it is for unchunked requests today.
- **Resumable transfers across transport disconnect.** Reassembly state is dropped on disconnect; the server-side replay path handles missed actions naturally (see [§Reconnection](#reconnection)).
- **Binary frame transports.** This proposal targets JSON text frames. A future companion proposal can add a parallel binary form once we have a transport that needs it.
- **Compression.** Out of scope; compose with transport-level compression (e.g. WebSocket `permessage-deflate`) or a future application-level codec.

# Design overview

Segmenting layers **above** JSON-RPC. From the application's point of view, nothing changes — a notification is still a notification, a response is still a response. The framing layer underneath the dispatcher hides reassembly:

```mermaid
sequenceDiagram
    participant App as Application<br/>(reducer, handler)
    participant Frame as Segmenting layer
    participant Wire as Transport (1 frame ≤ N bytes)
    participant FrameR as Segmenting layer
    participant AppR as Application<br/>(reducer, handler)

    App->>Frame: dispatch ActionEnvelope (3 MB)
    Frame->>Frame: split into 4 base64 segments
    Frame->>Wire: ahp/messageSegment #0
    Frame->>Wire: ahp/messageSegment #1
    Frame->>Wire: ahp/messageSegment #2
    Frame->>Wire: ahp/messageSegment #3
    Wire-->>FrameR: ahp/messageSegment #0..#3
    FrameR->>FrameR: concat + base64-decode
    FrameR->>AppR: dispatch reassembled ActionEnvelope
```

A small in-flight reassembly table on the receiver holds partial groups keyed by `groupId`. Once a group is complete, the assembled bytes are parsed as a single JSON-RPC message and dispatched through the normal path.

# Wire format

## `ahp/messageSegment`

`ahp/messageSegment` is a JSON-RPC **notification**. It is **not** an application notification: it is a *control* notification consumed by the segmenting layer before normal JSON-RPC dispatch, and it does **not** carry a `channel: URI`.

```ts
interface MessageSegmentParams {
  /**
   * Opaque sender-chosen identifier that scopes one in-flight reassembly.
   *
   * MUST be a non-empty string of at most 128 UTF-8 bytes. Senders SHOULD
   * use a random 16-byte value encoded as hex or base64url; receivers MUST
   * NOT interpret the value.
   *
   * `groupId` and JSON-RPC `id` are independent namespaces. A `groupId`
   * MUST be unique among the sender's currently in-flight reassemblies on
   * a single connection; it MAY be reused once the receiver has either
   * fully reassembled or discarded that group.
   */
  readonly groupId: string;

  /**
   * 0-based position of this segment within the group. MUST be a
   * non-negative integer < total and < 2^31. MUST be strictly monotonically
   * increasing within a single `groupId`: receivers MUST reject duplicate
   * or out-of-order indices as a protocol error.
   */
  readonly index: number;

  /**
   * Total number of segments in this group. MUST be ≥ 1, MUST be < 2^16
   * (65,536), MUST be stable across every segment of the group. The first
   * segment establishes the total; subsequent segments with a different
   * `total` MUST be rejected as a protocol error.
   */
  readonly total: number;

  /**
   * Base64-encoded slice of the UTF-8 bytes of the original JSON-RPC
   * message being reassembled.
   *
   * `data` uses the standard base64 alphabet (RFC 4648 §4) with padding.
   * Concatenating the decoded bytes of segments 0..total-1 in order MUST
   * produce a UTF-8 byte sequence that parses as exactly one JSON-RPC
   * request, response, or notification.
   */
  readonly data: string;
}

interface MessageSegmentNotification {
  readonly jsonrpc: '2.0';
  readonly method: 'ahp/messageSegment';
  readonly params: MessageSegmentParams;
}
```

A new `ControlNotificationMap` registry sits alongside `ClientNotificationMap` and `ServerNotificationMap` for messages of this kind:

```ts
export interface ControlNotificationMap {
  'ahp/messageSegment': { params: MessageSegmentParams };
}
```

Control notifications travel in either direction. Receivers MUST handle them whether the peer is a client or a server.

## Base64 over raw text

`data` is base64 of the message's UTF-8 bytes — not the raw text. The rationale:

- **Byte-exact size accounting.** Senders sizing segments against a hard frame ceiling need to know the wire size before sending. Embedding raw JSON text inside another JSON string re-escapes every `"`, `\`, and control character, so the same logical content can land at very different wire sizes depending on its contents. Base64 has a fixed 4:3 expansion factor and no escaping.
- **No codepoint-boundary ambiguity.** Splitting a JSON string at a UTF-8 byte boundary that falls inside a multi-byte codepoint is a bug source. Base64 sidesteps it.
- **Forward-compatibility with non-UTF-8 future encodings.** If a future protocol version adopts CBOR or another binary message form, the same segmenting primitive applies unchanged.

The price is a flat ~33% data-overhead inflation. That is an acceptable cost for a primitive that exists specifically to fit under a hard wire ceiling.

# Capability negotiation

Segmenting is **opt-in per direction**. Each side advertises what it is willing to receive. The peer only segments outgoing messages if the receiver advertised support.

A new top-level `capabilities` field appears in both `InitializeParams` and `InitializeResult`:

```ts
export interface ClientCapabilities {
  readonly chunking?: ChunkingCapability;
}

export interface ServerCapabilities {
  readonly chunking?: ChunkingCapability;
}

export interface ChunkingCapability {
  /**
   * Maximum size, in UTF-8 bytes, of any single transport frame this side
   * is willing to receive — for both unchunked messages and individual
   * `ahp/messageSegment` notifications. Includes the JSON-RPC envelope
   * overhead.
   */
  readonly maxIncomingFrameBytes: number;

  /**
   * Maximum size, in UTF-8 bytes, of a fully reassembled JSON-RPC message
   * this side is willing to receive. MUST be ≥ `maxIncomingFrameBytes`.
   */
  readonly maxIncomingMessageBytes: number;

  /**
   * Maximum number of concurrent in-flight reassembly groups this side
   * will hold open. MUST be ≥ 1. Defaults to an implementation-defined
   * value if unset.
   */
  readonly maxIncomingGroups?: number;

  /**
   * Maximum time, in milliseconds, this side will hold an incomplete
   * group before discarding it as abandoned. Defaults to an
   * implementation-defined value if unset.
   */
  readonly groupTimeoutMs?: number;
}
```

```ts
// Additive in InitializeParams / InitializeResult / ReconnectParams.
export interface InitializeParams extends BaseParams {
  // ...existing fields...
  readonly capabilities?: ClientCapabilities;
}

export interface InitializeResult {
  // ...existing fields...
  readonly capabilities?: ServerCapabilities;
}

export interface ReconnectParams extends BaseParams {
  // ...existing fields...
  readonly capabilities?: ClientCapabilities;
}
```

Capabilities MUST also be exchanged in `ReconnectParams` because `reconnect` runs on a fresh transport whose limits the server has no other way to learn. `InitializeResult` is not re-issued; the server SHOULD assume its previously-negotiated capabilities still apply, but MAY downgrade by simply choosing not to segment. The client MAY include a fresh `capabilities` block on `reconnect` if its transport limits have changed.

## Capability matching

Once both sides have exchanged capabilities:

- If the **receiver** in a direction did not advertise `chunking`, the sender in that direction MUST NOT send `ahp/messageSegment`. It MUST send messages as-is; if any single message would exceed the transport's frame ceiling, the sender MUST fail the operation locally (or, for `action` notifications, MAY drop the connection with a defined error — see [§Reconnection](#reconnection)).
- If both sides advertised `chunking`, segmenting is enabled. The sender MUST respect the receiver's `maxIncomingFrameBytes` (for every frame it puts on the wire — segmented or not) and `maxIncomingMessageBytes` (for any message it segments).

# Sender behavior

For every outgoing JSON-RPC message *M*:

1. Serialize *M* to UTF-8 bytes — call the result `B`.
2. If `len(B)` plus the surrounding transport overhead is ≤ receiver's `maxIncomingFrameBytes`, send *M* as a single frame and stop.
3. Otherwise:
    1. If the receiver did not advertise `chunking`, fail the send (see [§Reconnection](#reconnection)).
    2. If `len(B) > maxIncomingMessageBytes`, fail the send.
    3. Mint a unique `groupId`.
    4. Compute the per-segment payload size `S` such that, after base64 encoding and inclusion in a `MessageSegmentNotification`, the resulting frame fits within `maxIncomingFrameBytes`. (Base64 expands by 4/3; allow for JSON envelope overhead.)
    5. Split `B` into `ceil(len(B) / S)` chunks, in order.
    6. Encode each chunk with base64 and send it as `ahp/messageSegment` with the correct `index`, `total`, and `groupId`.

The sender SHOULD send all segments of a group contiguously, but MAY interleave segments from different groups for fairness — see [Interleaving](#interleaving).

A sender MUST NOT segment an `ahp/messageSegment` (no recursion).

# Receiver behavior

The receiver maintains a small table:

```ts
type ReassemblyTable = Map<string, {
  total: number;
  nextIndex: number;
  bufferedBytes: number;
  segments: Uint8Array[];
  startedAt: number;
}>;
```

On every `ahp/messageSegment` notification:

1. Look up `groupId` in the table.
   - If absent and the table already holds `maxIncomingGroups` entries, reject as a protocol error.
   - If absent, validate `index === 0` and `total ≥ 1`; insert a new entry.
   - If present, validate `total` matches the previously-recorded total and `index === nextIndex`.
2. Decode `data` from base64. Reject if decoding fails or expansion exceeds the receiver's `maxIncomingFrameBytes`.
3. Append the decoded bytes to the group's buffer. If `bufferedBytes` exceeds `maxIncomingMessageBytes`, reject.
4. Increment `nextIndex`.
5. If `nextIndex === total`:
    1. Concatenate the segments into a single `Uint8Array`.
    2. Decode UTF-8 → JSON-RPC parse. Reject if either step fails.
    3. Reject if the reassembled message is itself an `ahp/messageSegment`.
    4. Dispatch the reassembled message through the normal handler path.
    5. Remove the entry from the table.

The receiver MUST run a periodic sweep that removes entries older than `groupTimeoutMs` (default implementation-defined, see [§Limits and DoS protections](#limits-and-dos-protections)). Sweep does not generate protocol errors; the sender will retry on reconnect.

On transport disconnect, the receiver MUST drop the entire reassembly table.

## Validation rules (errors)

`ahp/messageSegment` is a notification, so there is no JSON-RPC response path for errors. Any of the following conditions are **protocol errors** and the receiver MUST close the transport with a defined close reason (e.g. WebSocket close code `4400` with reason "invalid messageSegment"). The client SHOULD reconnect.

| Condition | Notes |
|---|---|
| `groupId` is missing, empty, or > 128 bytes | |
| `index` is not a non-negative integer | |
| `index >= total` | |
| `index !== nextIndex` for an existing group | Out-of-order delivery is impossible under a reliable, ordered transport; this is either a sender bug or interleaving with the same `groupId` |
| `total < 1` or `total >= 2^16` | |
| `total` changes mid-group | |
| `data` is missing or not a base64-encoded string | |
| Decoded segment exceeds the receiver's `maxIncomingFrameBytes` | |
| Accumulated bytes for the group exceed `maxIncomingMessageBytes` | |
| Active groups exceed `maxIncomingGroups` | |
| Reassembled bytes are not valid UTF-8 / not a valid JSON-RPC message | |
| Reassembled message is itself `ahp/messageSegment` | No recursion |
| `groupId` already in flight when a new `index === 0` segment arrives | |

## Interleaving

A sender MAY interleave segments from different `groupId`s — e.g., to keep a small, latency-sensitive `terminal/data` notification flowing while a multi-segment `session/customizationsChanged` is mid-transmission. Receivers MUST support up to `maxIncomingGroups` concurrent groups.

Senders SHOULD:

- Avoid starvation of small messages behind a bulk transfer.
- Bound the number of concurrent groups they originate at the receiver's `maxIncomingGroups`.
- Send segments of a single group in `index` order (the receiver requires this).

A simple sender that always sends groups contiguously is conformant.

# Channel-invariant exception

AHP's overview specifies:

> Every notification's `params` carries a top-level `channel: URI`.

This invariant lets receivers dispatch by `(method, params.channel)` without per-method deserialisation, and it is compile-time-checked in `types/version/message-checks.ts`.

`ahp/messageSegment` is a **control** notification — it belongs to the framing layer, not to any subscribable resource — so it does not carry a `channel`. Faking `channel: 'ahp-root://'` would imply incorrect routing semantics (root-channel handlers would receive segments) and would mislead future readers.

The proposal therefore introduces a third, narrow registry — `ControlNotificationMap` — that sits next to `ClientNotificationMap` and `ServerNotificationMap`. The compile-time invariant is updated to read: *every entry in `ClientNotificationMap` or `ServerNotificationMap` carries `channel`; entries in `ControlNotificationMap` do not.*

We expect `ControlNotificationMap` to stay tiny. Anything that is genuinely about a subscribable resource belongs in the existing two registries.

# Limits and DoS protections

Recommended default limits, intended as guidance not normative requirements:

| Limit | Default |
|---|---|
| `maxIncomingFrameBytes` | 900 KB on Web PubSub-relayed paths; 4 MB elsewhere |
| `maxIncomingMessageBytes` | 32 MB |
| `maxIncomingGroups` | 8 |
| `groupTimeoutMs` | 30 000 |
| `groupId` length | ≤ 128 UTF-8 bytes |
| `total` | < 2^16 (65 536) |

Implementations MUST enforce **some** finite value for each. A peer that omits `maxIncomingGroups` or `groupTimeoutMs` from its advertised capability is asking the other side to apply its own defaults; it is not asking for unbounded resources.

Specific attack vectors and mitigations:

- **`total: 2^31` slow-drip group.** Rejected by the `total < 2^16` validation rule.
- **Many half-finished groups.** Bounded by `maxIncomingGroups` plus `groupTimeoutMs` sweep.
- **Bytes that expand after JSON unescaping.** Base64 has no nested unescaping; rejected at decode time if the segment exceeds `maxIncomingFrameBytes`.
- **Huge `groupId` strings.** Rejected by the 128-byte cap.
- **Same `groupId` reused for two concurrent groups by a malicious peer.** Rejected by the "duplicate `groupId` in flight" rule.

# Reconnection

The interaction with the existing [reconnection flow](https://microsoft.github.io/agent-host-protocol/specification/lifecycle#reconnection) is the trickiest part of this design. Two cases:

## Server → client `action` envelopes

The server assigns `serverSeq` when it produces an `ActionEnvelope`. The client tracks `lastSeenServerSeq` and MUST update it **only after fully reassembling, parsing, and dispatching** the envelope — never on individual segment receipt.

If the transport drops mid-group:

1. The client's reassembly table is discarded.
2. The client reconnects with `lastSeenServerSeq` still pointing at the last *fully* processed envelope.
3. The server's existing replay path resends every action with `serverSeq > lastSeenServerSeq`, which includes the partially-delivered envelope. It will be segmented again on the new transport (possibly differently, since limits may have been re-negotiated).

No per-segment acknowledgement is required.

## Outstanding client → server (or server → client) requests

If a request is mid-segmentation when the transport drops, the request `id` is no longer meaningful on the new connection. The caller's promise (or equivalent) MUST be rejected with a transport-disconnect error. Whether the request is safe to retry is the **caller's** responsibility — chunking adds no exactly-once guarantee for non-idempotent operations. Callers SHOULD NOT blindly retry `createSession`, `resourceWrite`, or any other state-mutating request without an idempotency mechanism appropriate to that command. This matches the pre-existing semantics for non-segmented requests across reconnect.

## Fail-closed when the receiver did not advertise chunking

If a sender produces a message that would exceed the receiver's `maxIncomingFrameBytes` and the receiver did not advertise `chunking`:

- For **requests**, the sender MUST fail the local call with a defined error rather than send a frame the receiver would reject.
- For **responses**, the sender MUST return a JSON-RPC error of code `-32011` (`MessageTooLarge`, new code introduced by this proposal).
- For **notifications**, the sender MAY drop the notification and log; the receiver will fall back to the natural recovery mechanism for the affected channel (reconnect + state catch-up).

# Examples

## Example A — chunked `action` envelope

A 2.4 MB `session/toolCallComplete` action over a Web PubSub link with the receiver advertising `{ maxIncomingFrameBytes: 900 000, maxIncomingMessageBytes: 33 554 432, maxIncomingGroups: 8 }`:

```json
{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
  "params": {
    "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
    "index": 0, "total": 3,
    "data": "eyJqc29ucnBjIjoiMi4wIiwibWV0aG9kIjoiYWN0aW9uIiwicGFyYW1z..."
  }
}
{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
  "params": {
    "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
    "index": 1, "total": 3,
    "data": "OiB7ImNoYW5uZWwiOiJhaHAtc2Vzc2lvbjovYWJjLTEyMyIsImFjdGlvbi..."
  }
}
{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
  "params": {
    "groupId": "b9f1c6c2-3f4d-4f8e-9a2c-7d4c0e9a8e15",
    "index": 2, "total": 3,
    "data": "ifSwgInNlcnZlclNlcSI6NDIxLCAib3JpZ2luIjpudWxsfQ=="
  }
}
```

Concatenating the base64-decoded `data` payloads, in `index` order, produces the original UTF-8 bytes of:

```json
{ "jsonrpc": "2.0", "method": "action",
  "params": { "channel": "ahp-session:/abc-123", "action": { /* … large */ }, "serverSeq": 421, "origin": null }
}
```

which is then dispatched through the receiver's normal notification handler.

## Example B — chunked `reconnect` result

The server's `reconnect` response for a long-running session might carry a multi-megabyte `snapshot[]`. The framing layer segments the entire JSON-RPC response (including the `id` correlation field) the same way:

```json
{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
  "params": { "groupId": "g7", "index": 0, "total": 5, "data": "..." }
}
// ... segments 1..4 ...
{ "jsonrpc": "2.0", "method": "ahp/messageSegment",
  "params": { "groupId": "g7", "index": 4, "total": 5, "data": "..." }
}
```

After reassembly the client's JSON-RPC layer sees a normal:

```json
{ "jsonrpc": "2.0", "id": 17, "result": { "type": "snapshot", "snapshots": [ /* … */ ] } }
```

and correlates it with the in-flight `reconnect` request `id: 17`.

## Example C — capability advertisement

```json
// Client → Server
{
  "jsonrpc": "2.0", "id": 1, "method": "initialize",
  "params": {
    "channel": "ahp-root://",
    "protocolVersions": ["0.3.0", "0.2.0"],
    "clientId": "client-abc",
    "capabilities": {
      "chunking": {
        "maxIncomingFrameBytes": 900000,
        "maxIncomingMessageBytes": 33554432,
        "maxIncomingGroups": 8,
        "groupTimeoutMs": 30000
      }
    }
  }
}

// Server → Client
{
  "jsonrpc": "2.0", "id": 1,
  "result": {
    "protocolVersion": "0.3.0",
    "serverSeq": 0,
    "snapshots": [ /* … */ ],
    "capabilities": {
      "chunking": {
        "maxIncomingFrameBytes": 900000,
        "maxIncomingMessageBytes": 16777216,
        "maxIncomingGroups": 4,
        "groupTimeoutMs": 30000
      }
    }
  }
}
```

Both sides advertised support, so segmenting is enabled in both directions. The effective limits are the *receiver*'s for each direction: outbound from client to server uses the server's `16 MB / 900 KB`; outbound from server to client uses the client's `32 MB / 900 KB`.

# Alternatives considered

## A. Put `chunk` metadata on `ActionEnvelope` directly

The original sketch in [github/copilot-host#105](https://github.com/github/copilot-host/pull/105) suggested adding `chunk { index, total, groupId }` to `ActionEnvelope` itself. Rejected because it covers only the `action` notification — not `reconnect` results, `subscribe` results, `dispatchAction` params, `resourceWrite` params, or any other message that can grow large — and it leaks transport concerns into application action semantics.

## B. Layer segmenting below JSON-RPC, as a transport-binding concern

Cleaner separation of concerns, but it pushes the problem onto every transport binding. Each transport (WebSocket, TCP-with-framing, in-process) would need its own segmenting format, and JSON-RPC-aware middleware (proxies, logs, debuggers) could not see across the seam. A reserved control notification is portable.

## C. Raw UTF-8 substring instead of base64

Rejected — see [Base64 over raw text](#base64-over-raw-text). The hidden re-escaping inside the outer JSON envelope makes wire-size accounting unreliable, and codepoint-boundary splitting is a footgun.

## D. Per-segment ack with replay-from-segment

A reliable-delivery layer on top of the existing reliable transport. Rejected as redundant: AHP's transport requirements already guarantee ordered, reliable delivery within a single connection, and the existing reconnect-with-replay path handles transport drops cleanly. Per-segment acks would double message volume on the metered paths this proposal is trying to make tractable.

## E. Mandatory, no capability advertisement

Simpler, but a strict older implementation receiving an unsolicited `ahp/messageSegment` would silently ignore it (JSON-RPC notification semantics), causing silent message loss. Capability advertisement gates the sender so this never happens.

# Migration and versioning

This is an additive, capability-gated change. Older peers can interoperate with newer peers without modification, **provided** the older side never advertises `chunking` (which it cannot, because it has never heard of the capability).

The recommended rollout:

1. Bump the AHP protocol version to introduce `MessageSegmentParams`, the `ControlNotificationMap` registry, the `capabilities` field on `InitializeParams` / `InitializeResult` / `ReconnectParams`, and the `-32011 MessageTooLarge` error code.
2. New implementations advertise `chunking` only when speaking the new protocol version. Implementations speaking older protocol versions MUST NOT advertise or use `chunking`.
3. Sender-side fallback: when a peer does not advertise `chunking` but a sender produces an oversized message, the sender follows the [fail-closed rules](#fail-closed-when-the-receiver-did-not-advertise-chunking).

A version bump (rather than capability-only) is recommended because:

- It marks the introduction of a new control-notification registry — a structural change to the message taxonomy.
- It prevents accidental silent message loss to a non-capable peer that happens to ignore unknown `capabilities` fields.
- It lets implementations advertise the *full* extension surface (capabilities + control notification + error code + reconnect-time renegotiation) as one coherent feature.

# Open questions

1. **Should `maxIncomingFrameBytes` apply to *every* frame, or only to `ahp/messageSegment` frames?**
   Currently the proposal says every frame. This is the safer default — Web PubSub will close the connection regardless — but it means even small messages from a sender are bounded. Consider documenting it as "the smaller of the negotiated cap and the underlying transport's hard cap, whichever applies."

2. **Does `maxIncomingGroups` need separate inbound and outbound advertisements?**
   Today only the receive side advertises. A peer might want to declare it will only originate K groups concurrently to avoid the other side's table filling up, but that is implementation discipline rather than a wire concern.

3. **Should there be a `cancelGroup` control notification?**
   For abandoning a partially-sent group without waiting for the receiver's `groupTimeoutMs` sweep. Probably yes for very long timeouts; probably no for the default 30 s.

4. **Compression as a sibling control notification?**
   A future `ahp/messageCompressed` could carry one compressed message; combined with segmenting, this would reduce wire volume meaningfully. Out of scope for this proposal; flagged here so the control-notification registry is designed with room.

5. **Should `groupTimeoutMs` be enforceable by the *sender* too?**
   A misbehaving sender could open a group and never finish it. Receiver sweep handles this. Adding a sender-side obligation is largely advisory.

# Acknowledgements

The motivating real-world constraint and design conversations are documented in [github/copilot-host#105](https://github.com/github/copilot-host/pull/105). The pattern of a reserved JSON-RPC notification namespace for protocol-private control messages is well-established in [LSP's `$/`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#dollarRequests) convention; this proposal uses the AHP-native `ahp/` namespace for the same purpose.
