### PR TITLE
Fix SessionReady reducer clobbering activity status mid-turn

### DIFF
--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -432,8 +432,9 @@ pub fn apply_action_to_root(state: &mut RootState, action: &StateAction) -> Redu
 pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -> ReduceOutcome {
     match action {
         StateAction::SessionReady(_) => {
+            // Lifecycle-only transition. Must not touch `summary.status`: see
+            // the equivalent TypeScript reducer for the rationale.
             state.lifecycle = SessionLifecycle::Ready;
-            state.summary.status = summary_status(state, None);
             ReduceOutcome::Applied
         }
         StateAction::SessionCreationFailed(a) => {

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -71,9 +71,10 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
     // ── Lifecycle ──────────────────────────────────────────────────────────
 
     case .sessionReady:
+        // Lifecycle-only transition. Must not touch `summary.status`: see
+        // the equivalent TypeScript reducer for the rationale.
         var next = state
         next.lifecycle = .ready
-        next.summary.status = .idle
         return next
 
     case .sessionCreationFailed(let a):

--- a/types/channels-session/reducer.ts
+++ b/types/channels-session/reducer.ts
@@ -265,11 +265,15 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
     // ── Lifecycle ──────────────────────────────────────────────────────────
 
     case ActionType.SessionReady:
-      return {
-        ...state,
-        lifecycle: SessionLifecycle.Ready,
-        summary: { ...state.summary, status: SessionStatus.Idle },
-      };
+      // `SessionReady` is purely a lifecycle transition (Creating ->
+      // Ready). It must not touch `summary.status`: for provisional
+      // sessions the first turn can start before materialization
+      // completes, so an `activeTurn` may already be set when this
+      // action is dispatched (e.g. from a materialize-session handler).
+      // Other reducers keep `summary.status` in sync with the activity
+      // state via `summaryStatus`/`refreshSummaryStatus`, so leaving it
+      // alone here is correct.
+      return { ...state, lifecycle: SessionLifecycle.Ready };
 
     case ActionType.SessionCreationFailed:
       return {

--- a/types/test-cases/reducers/147-session-ready-preserves-inprogress-status.json
+++ b/types/test-cases/reducers/147-session-ready-preserves-inprogress-status.json
@@ -1,0 +1,49 @@
+{
+  "description": "session/ready preserves in-progress status when activeTurn is already set (provisional session whose first turn started before materialization)",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 8,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "creating",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/ready"
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 8,
+      "createdAt": 1000,
+      "modifiedAt": 1000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "userMessage": {
+        "text": "Hello"
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`SessionReady` is a lifecycle transition (`Creating` → `Ready`) but the reducer was also hardcoding `summary.status = SessionStatus.Idle`. For **provisional sessions**, the first turn can start before materialization completes, so by the time `SessionReady` is dispatched from the materialize-session handler, an `activeTurn` may already exist and the status may already be `InProgress`. `SessionReady` would then briefly clobber that to `Idle`, and the next tool-call lifecycle action (which calls `refreshSummaryStatus`) would flip it back to `InProgress` — producing a spinner-flicker for clients that bind directly to `summary.status`.

Observed sequence from a VS Code repro of [microsoft/vscode#316543](https://github.com/microsoft/vscode/issues/316543) with diagnostic logs:

```
21:07:36.560  handler  _handleTurn starting               (dispatches SessionTurnStarted)
21:07:36.898  list     sessionAdded   protocolStatus=InProgress(0x8)
21:07:36.999  list     sessionSummaryChanged  protocolStatus=Idle(0x1)   ← bug (~100ms later)
21:07:39.838  list     sessionSummaryChanged  protocolStatus=InProgress(0x8)  ← refreshSummaryStatus flips back
21:07:47.256  handler  _handleTurn onTurnEnded
21:07:47.356  list     sessionSummaryChanged  protocolStatus=Idle(0x1)   ← legitimate end-of-turn
```

## Fix

Every other reducer that touches activity-related data already keeps `summary.status` in sync via `summaryStatus`/`refreshSummaryStatus`. `SessionReady` therefore doesn't need to recompute the status — it just shouldn't touch it at all. For non-provisional sessions (where no turn is active when `SessionReady` runs) this is equivalent to the previous behavior, since the status will already be `Idle`.

## Test

Added fixture `147-session-ready-preserves-inprogress-status.json` that exercises the provisional-session ordering (`activeTurn` set + `status = InProgress` before `SessionReady`) and verifies the status is preserved. Verified the new fixture fails on `main` and passes with this change. Reducer coverage stays at 100% branches.

(Written by Copilot)