### PR TITLE
clients/typescript: wire up npm publishing pipeline

### DIFF
--- a/clients/typescript/pipeline.yml
+++ b/clients/typescript/pipeline.yml
@@ -1,0 +1,73 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  branches:
+    include:
+      - main
+pr: none
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: microsoft/vscode-engineering
+      ref: main
+      endpoint: Monaco
+
+parameters:
+  - name: publishPackage
+    displayName: 🚀 Publish @microsoft/agent-host-protocol
+    type: boolean
+    default: false
+
+extends:
+  template: azure-pipelines/npm-package/pipeline.yml@templates
+  parameters:
+    npmPackages:
+      - name: agent-host-protocol
+        workingDirectory: clients/typescript
+        ghCreateTag: false
+        publishPackage: ${{ parameters.publishPackage }}
+
+        # Runs on the Package job — produces the artifact that gets published.
+        # Generated wire types and the compiled `dist/` are both required by
+        # the package's `files` field, so they must exist before `npm pack`.
+        buildSteps:
+          - script: npm ci
+            displayName: 📦 Install root dependencies
+
+          - script: npm run generate:typescript
+            displayName: 🛠 Generate TypeScript wire types
+
+          - script: npm ci
+            workingDirectory: clients/typescript
+            displayName: 📦 Install client dependencies
+
+          - script: npm run build
+            workingDirectory: clients/typescript
+            displayName: 🛠 Build client
+
+        testPlatforms:
+          - name: Linux
+            nodeVersions:
+              - 22.x
+
+        # Runs on each test platform job.
+        testSteps:
+          - script: npm ci
+            displayName: 📦 Install root dependencies
+
+          - script: npm run generate:typescript
+            displayName: 🛠 Generate TypeScript wire types
+
+          - script: npm ci
+            workingDirectory: clients/typescript
+            displayName: 📦 Install client dependencies
+
+          - script: npm run typecheck
+            workingDirectory: clients/typescript
+            displayName: ✅ Typecheck client
+
+          - script: npm test
+            workingDirectory: clients/typescript
+            displayName: 🧪 Test client


### PR DESCRIPTION
- The previous pipeline.yml was the unmodified vscode-engineering
  npm-package template stub (referenced 'test-cli' and had no real
  install/build/test sequence), so it could never publish the
  TypeScript client. Replace it with a working configuration.
- Wire types under clients/typescript/src/types/ are generated from
  the canonical types/*.ts sources and are intentionally gitignored,
  so CI must run the root-level generate:typescript script before any
  client step or both typecheck/build will fail.
- Both buildSteps (which produces the artifact npm pack consumes) and
  testSteps need the full chain (root install -> generate -> client
  install) since they run on separate jobs without shared state.
- The package's 'files' field ships dist/, which only exists after
  npm run build, so the build is part of buildSteps rather than left
  to a pack-time prepare hook.

Fixes no issue

(Commit message generated by Copilot)