### PR TITLE
Add multi-host SDK to the TypeScript client

### DIFF
--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -9,17 +9,19 @@ modern browsers and Node 21+ without additional runtime dependencies.
 
 ## Entry points
 
-The package exposes three subpath exports:
+The package exposes four subpath exports:
 
 | Import path | What it gives you |
 |---|---|
 | `@microsoft/agent-host-protocol`        | Wire types, actions, commands, reducers, version constants. No I/O. |
 | `@microsoft/agent-host-protocol/client` | `AhpClient`, `Subscription`, `AhpStateMirror`, the `AhpTransport` interface, `InMemoryTransport`, and the error taxonomy. |
+| `@microsoft/agent-host-protocol/hosts`  | `MultiHostClient`, `HostClientHandle`, `ReconnectPolicy`, `ClientIdStore` (with `InMemoryClientIdStore`), `MultiHostStateMirror`, and the `Host*Error` family. Builds on `/client` to manage one or more host connections with reconnect, generation-checked handles, and fan-in events. |
 | `@microsoft/agent-host-protocol/ws`     | `WebSocketTransport` — an `AhpTransport` implementation backed by the global `WebSocket`. |
 
-The split mirrors the Rust SDK (`ahp-types`, `ahp`, `ahp-ws`) — wire
-types and reducers are decoupled from the client, which is in turn
-decoupled from a specific transport.
+The split mirrors the Rust SDK (`ahp-types`, `ahp`, `ahp::hosts`,
+`ahp-ws`) — wire types and reducers are decoupled from the client,
+which is in turn decoupled from a specific transport and from the
+multi-host orchestration layer.
 
 ## Quickstart
 
@@ -134,6 +136,73 @@ A typical app-level reconnect flow is:
 4. Apply the returned replay actions or snapshots to your app store.
 5. Re-fetch `listSessions` or other ephemeral data — protocol
    notifications are not replayed.
+
+If you'd rather not write that loop yourself, see
+[`@microsoft/agent-host-protocol/hosts`](#multi-host-orchestration) —
+it ships a `MultiHostClient` that owns the reconnect supervisor,
+re-subscribes across reconnects, mirrors root state, and exposes
+generation-checked client handles. Single-host consumers use
+`MultiHostClient.single(...)`.
+
+## Multi-host orchestration
+
+For apps that talk to **one or more** AHP hosts at once (a local
+sessions server plus a tunnel-attached remote, multiple project hosts
+in a sidebar, …), the `@microsoft/agent-host-protocol/hosts` entry
+point ships `MultiHostClient`:
+
+```ts
+import { ActionType } from '@microsoft/agent-host-protocol';
+import { WebSocketTransport } from '@microsoft/agent-host-protocol/ws';
+import {
+  MultiHostClient,
+  type HostTransportFactory,
+} from '@microsoft/agent-host-protocol/hosts';
+
+const openLocal: HostTransportFactory = async (_hostId, _signal) =>
+  WebSocketTransport.connect('ws://localhost:12345');
+
+// Single-host: same API, never see "registry" concepts.
+const { multi, host } = await MultiHostClient.single({
+  id: 'local',
+  label: 'Local sessions server',
+  transportFactory: openLocal,
+});
+console.log(`connected to ${host.label}: ${host.state.status}`);
+
+// Multi-host: add as many as you need.
+await multi.addHost({
+  id: 'tunnel',
+  label: 'Tunnel',
+  transportFactory: async (_id, _signal) =>
+    WebSocketTransport.connect('wss://my-tunnel.example/sessions'),
+});
+
+// Fan-in of every inbound event, tagged with host of origin.
+for await (const event of multi.events()) {
+  console.log(`[${event.hostId}] ${event.channel}`, event.event.type);
+}
+```
+
+Each host runs its own reconnect supervisor with the configured
+`ReconnectPolicy` (defaults to exponential backoff from 250 ms to 30 s
+with 25 % jitter), re-subscribes to known URIs after reconnects, and
+mirrors root state plus a session-summary cache so `MultiHostClient
+.aggregatedSessions()` and `aggregatedAgents()` are snapshot reads,
+not fan-out subscriptions. Every successful (re)connect bumps a per-
+host `generation` counter; `HostClientHandle`s minted at an earlier
+generation throw `HostReconnectedError` instead of silently writing to
+the new connection.
+
+Persistent `clientId`s are pluggable via the `ClientIdStore`
+interface. The default `InMemoryClientIdStore` is session-stable;
+production apps that need cross-launch identity wrap their platform's
+secure storage (`localStorage`, IndexedDB, Node `fs`,
+`safeStorage`, …) in a custom `ClientIdStore`.
+
+For multi-host state, `MultiHostStateMirror` keys per-resource state
+by `(hostId, uri)` so URIs that legitimately collide across hosts
+(the normal case for session URIs) don't clobber each other.
 
 ## Wire types
 

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -37,6 +37,10 @@
       "import": "./dist/client/index.js",
       "types": "./dist/client/index.d.ts"
     },
+    "./hosts": {
+      "import": "./dist/client/hosts/index.js",
+      "types": "./dist/client/hosts/index.d.ts"
+    },
     "./ws": {
       "import": "./dist/ws/index.js",
       "types": "./dist/ws/index.d.ts"

--- a/clients/typescript/src/client/hosts/client-id-store.ts
+++ b/clients/typescript/src/client/hosts/client-id-store.ts
@@ -1,0 +1,60 @@
+/**
+ * Pluggable persistence for stable per-host `clientId`s.
+ *
+ * The AHP `reconnect` flow uses `clientId` to identify a logical client
+ * across reconnects. Apps that need cross-launch identity (i.e. resume
+ * an in-progress turn after the user kills the app) must persist the
+ * `clientId` somewhere durable and surface it through a {@link ClientIdStore}.
+ *
+ * The default in-memory store ({@link InMemoryClientIdStore}) keeps ids
+ * stable within a single process but resets on restart — fine for
+ * tests and ephemeral CLIs. Production apps wrap their platform's
+ * secure storage (Keychain, `localStorage`, IndexedDB, Node `fs`,
+ * Electron `safeStorage`, …) in a custom {@link ClientIdStore}.
+ *
+ * @module client/hosts/client-id-store
+ */
+
+import type { HostId } from './types.js';
+
+/**
+ * Persistence hook for stable `clientId`s per host.
+ *
+ * Implementations must be safe to call concurrently for different host
+ * ids; the supervisor calls `load` once per `addHost` and `store` once
+ * per resolved id. The optional `signal` is aborted when the host is
+ * being removed or the multi-host client is shutting down; long-running
+ * stores SHOULD honour it where practical.
+ *
+ * Errors surface as {@link ClientIdStoreError} from
+ * {@link MultiHostClient.addHost} so persistent stores fail loudly
+ * instead of silently dropping ids.
+ */
+export interface ClientIdStore {
+  /** Look up the previously stored `clientId` for `hostId`, if any. */
+  load(hostId: HostId, signal?: AbortSignal): Promise<string | null>;
+  /**
+   * Persist `clientId` for `hostId`. Implementations must overwrite any
+   * previous value.
+   */
+  store(hostId: HostId, clientId: string, signal?: AbortSignal): Promise<void>;
+}
+
+/**
+ * In-process {@link ClientIdStore} backed by a `Map`.
+ *
+ * Survives reconnects within the same process but not restarts. Fine
+ * for tests, ephemeral CLIs, and as a starting point.
+ */
+export class InMemoryClientIdStore implements ClientIdStore {
+  private readonly inner = new Map<HostId, string>();
+
+  load(hostId: HostId): Promise<string | null> {
+    return Promise.resolve(this.inner.get(hostId) ?? null);
+  }
+
+  store(hostId: HostId, clientId: string): Promise<void> {
+    this.inner.set(hostId, clientId);
+    return Promise.resolve();
+  }
+}

--- a/clients/typescript/src/client/hosts/factory.ts
+++ b/clients/typescript/src/client/hosts/factory.ts
@@ -1,0 +1,37 @@
+/**
+ * Pluggable transport factory used by {@link MultiHostClient} to open a
+ * fresh {@link AhpTransport} for a host on every connect attempt
+ * (including reconnects).
+ *
+ * Consumers refresh tokens, rotate URLs, or pick different backends per
+ * attempt by inspecting `hostId`. The supplied `AbortSignal` is aborted
+ * when the host is being removed, manually reconnected, or shut down;
+ * factories SHOULD propagate the signal into any underlying networking
+ * primitives that accept one (e.g. `fetch`, `WebSocket` opens via a
+ * helper that bails on abort) so a slow handshake doesn't block teardown.
+ *
+ * @module client/hosts/factory
+ */
+
+import type { AhpTransport } from '../transport.js';
+import type { HostId } from './types.js';
+
+/**
+ * Factory that opens (or re-opens) a transport for a host.
+ *
+ * Errors are surfaced as the host's `lastError` and trigger the
+ * reconnect schedule (or the `failed` state if reconnects are disabled
+ * or attempts are exhausted).
+ *
+ * @example
+ * ```ts
+ * const factory: HostTransportFactory = async (hostId, signal) => {
+ *   const url = lookupUrl(hostId);
+ *   return WebSocketTransport.connect(url, { signal });
+ * };
+ * ```
+ */
+export type HostTransportFactory = (
+  hostId: HostId,
+  signal: AbortSignal,
+) => Promise<AhpTransport>;

--- a/clients/typescript/src/client/hosts/host-client-handle.ts
+++ b/clients/typescript/src/client/hosts/host-client-handle.ts
@@ -1,0 +1,108 @@
+/**
+ * Generation-checked handle to the underlying single-host {@link AhpClient}.
+ *
+ * Issued by {@link MultiHostClient.client}. Every dispatch through this
+ * handle verifies that the host is still on the generation the handle
+ * was minted at; if a reconnect has occurred, dispatching throws
+ * {@link HostReconnectedError} instead of silently writing to the new
+ * connection. Removing the host marks the handle as shut down and
+ * subsequent calls throw {@link HostShutDownError}.
+ *
+ * @module client/hosts/host-client-handle
+ */
+
+import type { CommandMap } from '../../types/common/messages.js';
+import type { StateAction } from '../../types/common/actions.js';
+import type { URI } from '../../types/common/state.js';
+import type { AhpClient, DispatchHandle } from '../client.js';
+import {
+  HostReconnectedError,
+  HostShutDownError,
+  type HostId,
+} from './types.js';
+
+/**
+ * Internal handle reference used by the runtime to mint
+ * {@link HostClientHandle}s. The runtime updates `generation`,
+ * `currentClient`, and `shutdownReason` as connections come and go;
+ * minted handles read them through this shared reference.
+ *
+ * @internal
+ */
+export interface HostClientHandleSource {
+  readonly hostId: HostId;
+  generation: number;
+  currentClient: AhpClient | null;
+  shutdownReason: null | 'removed' | 'shutdown';
+}
+
+/**
+ * Generation-checked wrapper around the per-host {@link AhpClient}.
+ *
+ * Acquired via {@link MultiHostClient.client}. Cheap to clone — the
+ * underlying client and shared state are reference-shared.
+ */
+export class HostClientHandle {
+  /** Host this handle was issued for. */
+  readonly hostId: HostId;
+  /** Generation this handle was minted at. */
+  readonly generation: number;
+
+  private readonly source: HostClientHandleSource;
+  private readonly client: AhpClient;
+
+  /** @internal */
+  constructor(source: HostClientHandleSource, generation: number, client: AhpClient) {
+    this.source = source;
+    this.hostId = source.hostId;
+    this.generation = generation;
+    this.client = client;
+  }
+
+  /**
+   * Validate this handle against the host's current generation and
+   * shutdown state. Throws {@link HostShutDownError} or
+   * {@link HostReconnectedError} on failure.
+   */
+  checkAlive(): void {
+    if (this.source.shutdownReason !== null) {
+      throw new HostShutDownError(this.hostId);
+    }
+    if (this.source.generation !== this.generation) {
+      throw new HostReconnectedError(this.hostId, this.generation, this.source.generation);
+    }
+  }
+
+  /**
+   * Dispatch an action through this connection, refusing if the
+   * connection has been replaced by a reconnect or the host has been
+   * removed.
+   */
+  dispatch(channel: URI, action: StateAction, clientSeq?: number): DispatchHandle {
+    this.checkAlive();
+    return this.client.dispatch(channel, action, clientSeq);
+  }
+
+  /**
+   * Issue an arbitrary typed JSON-RPC request through this connection,
+   * refusing if the connection has been replaced by a reconnect or the
+   * host has been removed.
+   */
+  async request<M extends keyof CommandMap>(
+    method: M,
+    params: CommandMap[M]['params'],
+  ): Promise<CommandMap[M]['result']> {
+    this.checkAlive();
+    return this.client.request(method, params);
+  }
+
+  /**
+   * Borrow the underlying {@link AhpClient} for advanced use. The
+   * caller is responsible for not holding it past the next reconnect —
+   * the returned reference can become stale at any await point.
+   */
+  rawClient(): AhpClient {
+    this.checkAlive();
+    return this.client;
+  }
+}

--- a/clients/typescript/src/client/hosts/index.ts
+++ b/clients/typescript/src/client/hosts/index.ts
@@ -25,6 +25,7 @@ export {
   ClientIdStoreError,
   DuplicateHostError,
   HostMultiError,
+  HostNotConnectedError,
   HostReconnectedError,
   HostShutDownError,
   UnknownHostError,

--- a/clients/typescript/src/client/hosts/index.ts
+++ b/clients/typescript/src/client/hosts/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Public surface of the `@microsoft/agent-host-protocol/hosts` entry point.
+ *
+ * The multi-host SDK builds on top of `@microsoft/agent-host-protocol/client`'s
+ * {@link AhpClient} to manage one or more AHP host connections at once:
+ * per-host reconnect supervisors, stable `clientId` persistence, a
+ * generation-checked client-handle escape hatch, fan-in event streams,
+ * aggregated views, and a host-aware reducer mirror.
+ *
+ * Mirrors the Rust `ahp::hosts` module surface.
+ *
+ * @module hosts
+ */
+
+export { MultiHostClient } from './multi.js';
+
+export { HostClientHandle } from './host-client-handle.js';
+
+export {
+  // Types
+  isConnected,
+  isFailed,
+  ROOT_RESOURCE_URI,
+  // Error classes
+  ClientIdStoreError,
+  DuplicateHostError,
+  HostMultiError,
+  HostReconnectedError,
+  HostShutDownError,
+  UnknownHostError,
+} from './types.js';
+export type {
+  HostConfig,
+  HostEvent,
+  HostHandle,
+  HostId,
+  HostState,
+  HostSubscriptionEvent,
+  HostedAgent,
+  HostedSessionSummary,
+} from './types.js';
+
+export type { HostTransportFactory } from './factory.js';
+
+export {
+  attemptsExhausted,
+  backoffDelayForAttempt,
+  defaultReconnectPolicy,
+  delayWithJitter,
+  disabledPolicy,
+  exponentialPolicy,
+  immediateForeverPolicy,
+} from './policy.js';
+export type { Backoff, ReconnectPolicy } from './policy.js';
+
+export { InMemoryClientIdStore } from './client-id-store.js';
+export type { ClientIdStore } from './client-id-store.js';
+
+export { MultiHostStateMirror, hostedResourceKey } from './state-mirror.js';
+export type { HostedResourceKey } from './state-mirror.js';

--- a/clients/typescript/src/client/hosts/multi.ts
+++ b/clients/typescript/src/client/hosts/multi.ts
@@ -60,6 +60,13 @@ export class MultiHostClient {
   private readonly fanOut: AsyncBroadcastQueue<HostSubscriptionEvent>;
   private readonly hostEventsQueue: AsyncBroadcastQueue<HostEvent>;
   private readonly clientIdStore: ClientIdStore;
+  /**
+   * Aborted by {@link shutdown}. Passed into {@link ClientIdStore.load}
+   * / {@link ClientIdStore.store} so slow store implementations can
+   * bail out on shutdown — honouring the cancellation contract
+   * documented on {@link ClientIdStore}.
+   */
+  private readonly shutdownController = new AbortController();
   private shutDown = false;
 
   /**
@@ -340,6 +347,10 @@ export class MultiHostClient {
   async shutdown(): Promise<void> {
     if (this.shutDown) return;
     this.shutDown = true;
+    // Abort the shutdown signal first so any in-flight ClientIdStore
+    // operations (started from `addHost` / `resolveClientId`) bail out
+    // before we wait on the host supervisors.
+    this.shutdownController.abort();
     const runtimes = Array.from(this.hosts.values());
     this.hosts.clear();
     await Promise.all(runtimes.map(r => r.shutdown('shutdown')));
@@ -352,9 +363,10 @@ export class MultiHostClient {
   }
 
   private async resolveClientId(hostId: HostId, explicit: string | null): Promise<string> {
+    const signal = this.shutdownController.signal;
     if (explicit !== null) {
       try {
-        await this.clientIdStore.store(hostId, explicit);
+        await this.clientIdStore.store(hostId, explicit, signal);
       } catch (err) {
         throw new ClientIdStoreError(hostId, (err as Error).message ?? String(err), { cause: err });
       }
@@ -362,13 +374,13 @@ export class MultiHostClient {
     }
     let stored: string | null;
     try {
-      stored = await this.clientIdStore.load(hostId);
+      stored = await this.clientIdStore.load(hostId, signal);
     } catch (err) {
       throw new ClientIdStoreError(hostId, (err as Error).message ?? String(err), { cause: err });
     }
     const resolved = stored ?? generateClientId();
     try {
-      await this.clientIdStore.store(hostId, resolved);
+      await this.clientIdStore.store(hostId, resolved, signal);
     } catch (err) {
       throw new ClientIdStoreError(hostId, (err as Error).message ?? String(err), { cause: err });
     }

--- a/clients/typescript/src/client/hosts/multi.ts
+++ b/clients/typescript/src/client/hosts/multi.ts
@@ -121,6 +121,11 @@ export class MultiHostClient {
    *
    * Throws {@link ClientIdStoreError} if the configured store fails to
    * load or persist the host's `clientId`.
+   *
+   * Throws {@link HostShutDownError} if the multi-host client has been
+   * shut down — either before this call or while it was awaiting the
+   * {@link ClientIdStore}. The pending-id reservation is always cleared
+   * before returning, regardless of which error path is taken.
    */
   async addHost(config: HostConfig): Promise<HostHandle> {
     this.assertOpen();
@@ -133,8 +138,13 @@ export class MultiHostClient {
     try {
       const resolved = resolveConfig(config);
       const clientId = await this.resolveClientId(id, resolved.clientId);
-      // Defensive re-check: a concurrent removeHost+addHost could have
-      // landed while we were awaiting the store.
+      // Defensive re-checks after the store await:
+      //  - `shutdown()` may have closed the client while we awaited the
+      //    store. Surfacing the same error as `assertOpen` keeps the
+      //    post-shutdown guarantee that future operations throw.
+      //  - A concurrent removeHost+addHost could have landed a runtime
+      //    under our id, which would clobber it if we proceeded.
+      this.assertOpen();
       if (this.hosts.has(id)) {
         throw new DuplicateHostError(id);
       }

--- a/clients/typescript/src/client/hosts/multi.ts
+++ b/clients/typescript/src/client/hosts/multi.ts
@@ -1,0 +1,371 @@
+/**
+ * `MultiHostClient` façade.
+ *
+ * @module client/hosts/multi
+ */
+
+import type { URI } from '../../types/common/state.js';
+import type { StateAction } from '../../types/common/actions.js';
+import type { SubscribeResult } from '../../types/common/commands.js';
+import type { DispatchHandle } from '../client.js';
+import { AsyncBroadcastQueue } from '../async-queue.js';
+import { HostClientHandle } from './host-client-handle.js';
+import {
+  ClientIdStoreError,
+  DuplicateHostError,
+  generateClientId,
+  HostShutDownError,
+  resolveConfig,
+  type HostConfig,
+  type HostEvent,
+  type HostHandle,
+  type HostId,
+  type HostSubscriptionEvent,
+  type HostedAgent,
+  type HostedSessionSummary,
+} from './types.js';
+import { isConnected, isFailed, UnknownHostError } from './types.js';
+import { HostRuntime, snapshotHandle } from './runtime.js';
+import {
+  InMemoryClientIdStore,
+  type ClientIdStore,
+} from './client-id-store.js';
+
+const DEFAULT_EVENT_BUFFER = 1024;
+
+/**
+ * Concurrent registry of {@link HostHandle}s plus the supervisor tasks
+ * that drive them.
+ *
+ * Cheap to clone — the inner state is reference-shared, so multiple UI
+ * layers can hold their own reference and observe the same hosts.
+ *
+ * Common entry points:
+ *
+ * - {@link MultiHostClient.single} — one-line single-host constructor.
+ * - {@link MultiHostClient.addHost} / {@link MultiHostClient.removeHost}.
+ * - {@link MultiHostClient.events} / {@link MultiHostClient.hostEvents}.
+ * - {@link MultiHostClient.aggregatedSessions} / {@link MultiHostClient.aggregatedAgents}.
+ * - {@link MultiHostClient.reconnectAllUnavailable}.
+ */
+export class MultiHostClient {
+  private readonly hosts = new Map<HostId, HostRuntime>();
+  /**
+   * Host ids currently mid-`addHost` (between the duplicate check and
+   * the supervisor install). Keeps concurrent `addHost` calls for the
+   * same id from both passing the duplicate check while one of them is
+   * awaiting the {@link ClientIdStore}.
+   */
+  private readonly pendingHostIds = new Set<HostId>();
+  private readonly fanOut: AsyncBroadcastQueue<HostSubscriptionEvent>;
+  private readonly hostEventsQueue: AsyncBroadcastQueue<HostEvent>;
+  private readonly clientIdStore: ClientIdStore;
+  private shutDown = false;
+
+  /**
+   * Build an empty multi-host client.
+   *
+   * @param options.clientIdStore Persistent store for stable per-host
+   *   `clientId`s. Defaults to {@link InMemoryClientIdStore} which is
+   *   session-stable only — provide your own (Keychain, `localStorage`,
+   *   IndexedDB, Node `fs`, …) for cross-launch identity.
+   * @param options.eventBuffer Buffer size for the cross-host fan-in
+   *   broadcasts. Slow consumers that lag past this many events drop
+   *   the gap, mirroring {@link AhpClient.events}. Default `1024`.
+   */
+  constructor(options: { clientIdStore?: ClientIdStore; eventBuffer?: number } = {}) {
+    this.clientIdStore = options.clientIdStore ?? new InMemoryClientIdStore();
+    const buffer = options.eventBuffer ?? DEFAULT_EVENT_BUFFER;
+    this.fanOut = new AsyncBroadcastQueue<HostSubscriptionEvent>(buffer);
+    this.hostEventsQueue = new AsyncBroadcastQueue<HostEvent>(buffer);
+  }
+
+  /**
+   * Convenience: construct a multi-host client with a single host
+   * already registered, and return its initial {@link HostHandle}
+   * snapshot. The handle reflects the host at the moment `addHost`
+   * resolves — if the connect attempt is fast it may already be
+   * `connected`, otherwise it may still be `connecting`.
+   *
+   * Designed so single-host consumers don't have to think about
+   * registry concepts — `const { multi, host } = await MultiHostClient.single({ ... });`
+   * is the whole onboarding.
+   */
+  static async single(
+    config: HostConfig,
+    options: { clientIdStore?: ClientIdStore; eventBuffer?: number } = {},
+  ): Promise<{ multi: MultiHostClient; host: HostHandle }> {
+    const multi = new MultiHostClient(options);
+    const host = await multi.addHost(config);
+    return { multi, host };
+  }
+
+  /**
+   * Register a new host and start its supervisor.
+   *
+   * The supervisor immediately attempts to open a transport via
+   * {@link HostConfig.transportFactory}, complete the `initialize`
+   * handshake, and start fanning events. The returned snapshot reflects
+   * the host's state at the moment this call returns — it may already
+   * be `connected`, still `connecting`, or already `reconnecting` if
+   * the first attempt failed.
+   *
+   * `clientId` is resolved here, before the supervisor is spawned:
+   * `HostConfig.clientId` (if set) always wins, otherwise the
+   * configured {@link ClientIdStore} is consulted; if it returns no
+   * value a fresh UUID is generated. The resolved id is always written
+   * back into the store.
+   *
+   * Throws {@link DuplicateHostError} if the host id is already in use
+   * (or is currently being added by a concurrent caller).
+   *
+   * Throws {@link ClientIdStoreError} if the configured store fails to
+   * load or persist the host's `clientId`.
+   */
+  async addHost(config: HostConfig): Promise<HostHandle> {
+    this.assertOpen();
+    const id = config.id;
+    if (this.hosts.has(id) || this.pendingHostIds.has(id)) {
+      throw new DuplicateHostError(id);
+    }
+    this.pendingHostIds.add(id);
+
+    try {
+      const resolved = resolveConfig(config);
+      const clientId = await this.resolveClientId(id, resolved.clientId);
+      // Defensive re-check: a concurrent removeHost+addHost could have
+      // landed while we were awaiting the store.
+      if (this.hosts.has(id)) {
+        throw new DuplicateHostError(id);
+      }
+      const runtime = new HostRuntime(resolved, clientId, this.fanOut, this.hostEventsQueue);
+      this.hosts.set(id, runtime);
+      runtime.start();
+      return snapshotHandle(runtime.shared);
+    } finally {
+      this.pendingHostIds.delete(id);
+    }
+  }
+
+  /**
+   * Remove a host, cancelling its supervisor and dropping the current
+   * connection. Outstanding {@link HostClientHandle}s for this host
+   * start throwing {@link HostShutDownError} once the runtime has
+   * finished tearing down.
+   *
+   * Throws {@link UnknownHostError} if `id` is not registered.
+   */
+  async removeHost(id: HostId): Promise<void> {
+    const runtime = this.hosts.get(id);
+    if (!runtime) throw new UnknownHostError(id);
+    this.hosts.delete(id);
+    await runtime.shutdown('removed');
+    this.hostEventsQueue.publish({ type: 'removed', hostId: id });
+  }
+
+  /**
+   * Trigger a manual reconnect for `id`. Cancels the current connection
+   * (or pending backoff sleep) and immediately attempts a fresh
+   * connect.
+   */
+  async reconnectHost(id: HostId): Promise<void> {
+    const runtime = this.hosts.get(id);
+    if (!runtime) throw new UnknownHostError(id);
+    await runtime.reconnect();
+  }
+
+  /**
+   * Trigger a manual reconnect on every registered host that is
+   * **not** currently `connected` or `connecting` — i.e. hosts in
+   * `disconnected`, `reconnecting`, or `failed`. Hosts already
+   * connected (or actively connecting) are skipped.
+   *
+   * Designed for the mobile scene-phase pattern: when the app returns
+   * from background, call this to wake every host the user has been
+   * away from instead of writing the loop in every consumer. Useful in
+   * particular for `failed` hosts whose reconnect policy is exhausted —
+   * a manual reconnect bypasses the policy and starts a fresh attempt.
+   *
+   * Reconnect requests are dispatched concurrently. Per-host errors
+   * are collected into the returned map; the call itself never throws.
+   */
+  async reconnectAllUnavailable(): Promise<Map<HostId, Error>> {
+    const targets: Array<{ id: HostId; runtime: HostRuntime }> = [];
+    for (const [id, runtime] of this.hosts) {
+      const status = runtime.shared.state.status;
+      if (status === 'connected' || status === 'connecting') continue;
+      targets.push({ id, runtime });
+    }
+    if (targets.length === 0) return new Map();
+    const errors = new Map<HostId, Error>();
+    await Promise.all(
+      targets.map(async ({ id, runtime }) => {
+        try {
+          await runtime.reconnect();
+        } catch (err) {
+          errors.set(id, err instanceof Error ? err : new Error(String(err)));
+        }
+      }),
+    );
+    return errors;
+  }
+
+  /**
+   * Snapshot the current state of `id`. Returns `undefined` if the
+   * host is not registered.
+   */
+  host(id: HostId): HostHandle | undefined {
+    const runtime = this.hosts.get(id);
+    return runtime ? snapshotHandle(runtime.shared) : undefined;
+  }
+
+  /** Snapshot every registered host. Order is insertion order. */
+  hostsSnapshot(): HostHandle[] {
+    return Array.from(this.hosts.values(), r => snapshotHandle(r.shared));
+  }
+
+  /**
+   * Acquire a generation-checked client handle for `id`.
+   *
+   * Returns `undefined` if the host is not registered or has no live
+   * connection. The returned handle refuses to dispatch through a
+   * connection that has been replaced by a reconnect — request a fresh
+   * handle in that case.
+   */
+  client(id: HostId): HostClientHandle | undefined {
+    const runtime = this.hosts.get(id);
+    if (!runtime) return undefined;
+    const client = runtime.shared.currentClient;
+    if (!client) return undefined;
+    return new HostClientHandle(runtime.handleSource, runtime.shared.generation, client);
+  }
+
+  /** Convenience: subscribe to `uri` on `hostId`. */
+  async subscribe(hostId: HostId, uri: URI): Promise<SubscribeResult> {
+    const runtime = this.hosts.get(hostId);
+    if (!runtime) throw new UnknownHostError(hostId);
+    return runtime.subscribe(uri);
+  }
+
+  /** Convenience: unsubscribe from `uri` on `hostId`. */
+  async unsubscribe(hostId: HostId, uri: URI): Promise<void> {
+    const runtime = this.hosts.get(hostId);
+    if (!runtime) throw new UnknownHostError(hostId);
+    await runtime.unsubscribe(uri);
+  }
+
+  /** Convenience: dispatch `action` on `channel` against `hostId`. */
+  dispatch(
+    hostId: HostId,
+    channel: URI,
+    action: StateAction,
+    clientSeq?: number,
+  ): DispatchHandle {
+    const runtime = this.hosts.get(hostId);
+    if (!runtime) throw new UnknownHostError(hostId);
+    return runtime.dispatch(channel, action, clientSeq);
+  }
+
+  /**
+   * Subscribe to a fan-in stream of every inbound event from every
+   * registered host. Each call returns a fresh independent iterator —
+   * multiple consumers can listen independently.
+   *
+   * Events buffered before the iterator was created are not replayed;
+   * iterators start at the next event. Slow consumers that lag past
+   * the buffer (default 1024) skip the gap, matching {@link AhpClient.events}.
+   */
+  events(): AsyncIterableIterator<HostSubscriptionEvent> {
+    return this.fanOut.reader();
+  }
+
+  /** Subscribe to connection-state events for UX. Each call returns a fresh iterator. */
+  hostEvents(): AsyncIterableIterator<HostEvent> {
+    return this.hostEventsQueue.reader();
+  }
+
+  /**
+   * Aggregated session summaries across every registered host, sorted
+   * by `summary.modifiedAt` descending. Includes both the host id and
+   * label so consumers can render a unified inbox without losing host
+   * attribution.
+   */
+  aggregatedSessions(): HostedSessionSummary[] {
+    const out: HostedSessionSummary[] = [];
+    for (const runtime of this.hosts.values()) {
+      const { id, label, sessionSummaries } = runtime.shared;
+      for (const summary of sessionSummaries.values()) {
+        out.push({ hostId: id, hostLabel: label, summary });
+      }
+    }
+    // Sort modifiedAt descending. Stable across ties because Array.sort
+    // in modern engines (Node ≥ 12, modern browsers) is stable.
+    out.sort((a, b) => b.summary.modifiedAt - a.summary.modifiedAt);
+    return out;
+  }
+
+  /**
+   * Aggregated agents across every registered host, in registration
+   * order per host.
+   */
+  aggregatedAgents(): HostedAgent[] {
+    const out: HostedAgent[] = [];
+    for (const runtime of this.hosts.values()) {
+      const { id, label, rootState } = runtime.shared;
+      for (const agent of rootState.agents) {
+        out.push({ hostId: id, hostLabel: label, agent });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Gracefully shut down every host and tear down the internal event
+   * fan-in queues. Idempotent.
+   *
+   * After `shutdown` resolves, subsequent calls to `addHost` /
+   * `reconnectHost` / `dispatch` / `subscribe` throw, and active event
+   * iterators see end-of-stream.
+   */
+  async shutdown(): Promise<void> {
+    if (this.shutDown) return;
+    this.shutDown = true;
+    const runtimes = Array.from(this.hosts.values());
+    this.hosts.clear();
+    await Promise.all(runtimes.map(r => r.shutdown('shutdown')));
+    this.fanOut.close();
+    this.hostEventsQueue.close();
+  }
+
+  private assertOpen(): void {
+    if (this.shutDown) throw new HostShutDownError('<multi-host client>');
+  }
+
+  private async resolveClientId(hostId: HostId, explicit: string | null): Promise<string> {
+    if (explicit !== null) {
+      try {
+        await this.clientIdStore.store(hostId, explicit);
+      } catch (err) {
+        throw new ClientIdStoreError(hostId, (err as Error).message ?? String(err), { cause: err });
+      }
+      return explicit;
+    }
+    let stored: string | null;
+    try {
+      stored = await this.clientIdStore.load(hostId);
+    } catch (err) {
+      throw new ClientIdStoreError(hostId, (err as Error).message ?? String(err), { cause: err });
+    }
+    const resolved = stored ?? generateClientId();
+    try {
+      await this.clientIdStore.store(hostId, resolved);
+    } catch (err) {
+      throw new ClientIdStoreError(hostId, (err as Error).message ?? String(err), { cause: err });
+    }
+    return resolved;
+  }
+}
+
+// Re-export the predicate helpers for ergonomics so consumers don't
+// have to dig through ./types.
+export { isConnected, isFailed };

--- a/clients/typescript/src/client/hosts/policy.ts
+++ b/clients/typescript/src/client/hosts/policy.ts
@@ -1,0 +1,141 @@
+/**
+ * Reconnect policy used by the per-host supervisor.
+ *
+ * Mirrors the Rust `ahp::hosts::ReconnectPolicy` surface.
+ *
+ * @module client/hosts/policy
+ */
+
+/**
+ * Backoff schedule between reconnect attempts.
+ *
+ * Discriminated by the `kind` field so consumers can switch on the shape
+ * and keep payload validation in one place.
+ */
+export type Backoff =
+  | { readonly kind: 'immediate' }
+  | { readonly kind: 'constant'; readonly delayMs: number }
+  | {
+      readonly kind: 'exponential';
+      /** First attempt's delay, in milliseconds. */
+      readonly initialMs: number;
+      /** Cap on per-attempt delay, in milliseconds. */
+      readonly maxMs: number;
+      /** Multiplier between attempts. Must be >= 1; smaller values are clamped. */
+      readonly multiplier: number;
+    };
+
+/** Compute the delay before the `attempt`-th retry (1-based), in milliseconds. */
+export function backoffDelayForAttempt(backoff: Backoff, attempt: number): number {
+  const safeAttempt = Math.max(1, Math.floor(attempt));
+  switch (backoff.kind) {
+    case 'immediate':
+      return 0;
+    case 'constant':
+      return Math.max(0, backoff.delayMs);
+    case 'exponential': {
+      const multiplier = Math.max(1, backoff.multiplier);
+      const exp = safeAttempt - 1;
+      const scaled = backoff.initialMs * Math.pow(multiplier, exp);
+      return Math.min(Math.max(0, scaled), backoff.maxMs);
+    }
+  }
+}
+
+/**
+ * Reconnect behaviour for a single host. The supervisor enters a
+ * reconnect loop whenever an established connection drops unexpectedly.
+ * Use {@link disabledPolicy} to opt out entirely.
+ */
+export interface ReconnectPolicy {
+  /** Backoff schedule between attempts. */
+  readonly backoff: Backoff;
+  /**
+   * Random jitter applied to each computed backoff. The actual delay
+   * is uniformly sampled from `[delay * (1 - jitter), delay * (1 + jitter)]`.
+   * `0` disables jitter. Values are clamped to `[0, 1]`.
+   */
+  readonly jitter: number;
+  /**
+   * Maximum number of consecutive attempts before giving up. `null`
+   * retries forever. `0` disables reconnect entirely (one failure
+   * leaves the host in `failed`).
+   */
+  readonly maxAttempts: number | null;
+  /**
+   * When `true`, the attempt counter resets to zero after a successful
+   * connection so the next reconnect starts at the initial backoff.
+   */
+  readonly resetOnSuccess: boolean;
+}
+
+/**
+ * Compute the delay before the `attempt`-th retry, applying jitter via
+ * the supplied random sample in `[0, 1]`.
+ *
+ * Exposed so tests can drive it deterministically; the runtime passes a
+ * real `Math.random()` sample.
+ */
+export function delayWithJitter(
+  policy: ReconnectPolicy,
+  attempt: number,
+  sample: number,
+): number {
+  const base = backoffDelayForAttempt(policy.backoff, attempt);
+  if (policy.jitter <= 0 || base === 0) return base;
+  const jitter = Math.min(1, Math.max(0, policy.jitter));
+  const clamped = Math.min(1, Math.max(0, sample));
+  const factor = 1 + (clamped * 2 - 1) * jitter;
+  return Math.max(0, base * factor);
+}
+
+/** Whether `attempt` exceeds the policy's `maxAttempts`. */
+export function attemptsExhausted(policy: ReconnectPolicy, attempt: number): boolean {
+  return policy.maxAttempts !== null && attempt > policy.maxAttempts;
+}
+
+/**
+ * Disable reconnects entirely. Use this when the consumer wants to
+ * drive reconnect logic itself.
+ */
+export function disabledPolicy(): ReconnectPolicy {
+  return {
+    backoff: { kind: 'immediate' },
+    jitter: 0,
+    maxAttempts: 0,
+    resetOnSuccess: true,
+  };
+}
+
+/** Retry forever with no backoff. Useful for tests; not production. */
+export function immediateForeverPolicy(): ReconnectPolicy {
+  return {
+    backoff: { kind: 'immediate' },
+    jitter: 0,
+    maxAttempts: null,
+    resetOnSuccess: true,
+  };
+}
+
+/**
+ * Sensible default: exponential backoff from 250 ms up to 30 s,
+ * 25% jitter, retry forever, reset on success.
+ */
+export function exponentialPolicy(): ReconnectPolicy {
+  return {
+    backoff: {
+      kind: 'exponential',
+      initialMs: 250,
+      maxMs: 30_000,
+      multiplier: 2,
+    },
+    jitter: 0.25,
+    maxAttempts: null,
+    resetOnSuccess: true,
+  };
+}
+
+/** Default policy used by {@link HostConfig} when none is supplied. */
+export function defaultReconnectPolicy(): ReconnectPolicy {
+  return exponentialPolicy();
+}

--- a/clients/typescript/src/client/hosts/runtime.ts
+++ b/clients/typescript/src/client/hosts/runtime.ts
@@ -37,6 +37,7 @@ import { rootReducer } from '../../types/channels-root/reducer.js';
 import type { RootAction } from '../../types/action-origin.generated.js';
 import type { StateAction } from '../../types/common/actions.js';
 import {
+  HostNotConnectedError,
   HostShutDownError,
   ROOT_RESOURCE_URI,
   tagClientEvent,
@@ -227,28 +228,41 @@ function waitForAbort(...signals: AbortSignal[]): Promise<void> {
 
 /**
  * Return an {@link AbortSignal} that aborts whenever any of the supplied
- * input signals aborts. Used to thread a single composite signal through
- * the connect/handshake path so the operation bails on either shutdown
- * or manual reconnect.
+ * input signals aborts, plus a {@link dispose} function that detaches
+ * the listeners added to the inputs. Used to thread a single composite
+ * signal through the connect/handshake path so the operation bails on
+ * either shutdown or manual reconnect.
+ *
+ * Callers MUST call `dispose()` once the composite signal is no longer
+ * needed (typically in a `finally`) — otherwise the listeners attached
+ * to long-lived input signals (e.g. a per-runtime `shutdownController`)
+ * accumulate across connect cycles.
  *
  * @internal
  */
-function linkAbortSignals(...signals: AbortSignal[]): AbortSignal {
+function linkAbortSignals(...signals: AbortSignal[]): { signal: AbortSignal; dispose: () => void } {
   const controller = new AbortController();
   if (signals.some(s => s.aborted)) {
     controller.abort();
-    return controller.signal;
+    return { signal: controller.signal, dispose: () => undefined };
   }
   const cleanup: Array<() => void> = [];
   const onAbort = (): void => {
     for (const fn of cleanup) fn();
+    cleanup.length = 0;
     controller.abort();
   };
   for (const signal of signals) {
     signal.addEventListener('abort', onAbort, { once: true });
     cleanup.push(() => signal.removeEventListener('abort', onAbort));
   }
-  return controller.signal;
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      for (const fn of cleanup) fn();
+      cleanup.length = 0;
+    },
+  };
 }
 
 // ─── Runtime ─────────────────────────────────────────────────────────────────
@@ -355,10 +369,14 @@ export class HostRuntime {
    * Subscribe to `uri`, tracking it for re-subscription across
    * reconnects.
    *
-   * Throws {@link HostShutDownError} when the host is not currently
-   * connected — but appends the URI to the local subscription list
-   * first, so the next successful (re)connect will subscribe to it
-   * automatically.
+   * Throws {@link HostShutDownError} if the host has been permanently
+   * torn down (removed or the multi-host client was shut down).
+   *
+   * Throws {@link HostNotConnectedError} if the host is registered but
+   * has no active client connection right now (connecting, reconnecting,
+   * disconnected, or failed). The URI is still appended to the local
+   * subscription list first, so the next successful (re)connect will
+   * subscribe to it automatically.
    */
   async subscribe(uri: URI): Promise<SubscribeResult> {
     if (this.shared.shutdownReason !== null) {
@@ -367,7 +385,7 @@ export class HostRuntime {
     const client = this.shared.currentClient;
     if (!client) {
       this.trackSubscription(uri);
-      throw new HostShutDownError(this.shared.id);
+      throw new HostNotConnectedError(this.shared.id);
     }
     const { result } = await client.subscribe(uri);
     this.trackSubscription(uri);
@@ -388,7 +406,13 @@ export class HostRuntime {
     if (client) await client.unsubscribe(uri);
   }
 
-  /** Helper: dispatch on the current client (no generation check). */
+  /**
+   * Helper: dispatch on the current client (no generation check).
+   *
+   * Throws {@link HostShutDownError} if the host has been permanently
+   * torn down, or {@link HostNotConnectedError} if it's currently
+   * disconnected/reconnecting.
+   */
   dispatch(
     channel: URI,
     action: StateAction,
@@ -398,7 +422,7 @@ export class HostRuntime {
       throw new HostShutDownError(this.shared.id);
     }
     const client = this.shared.currentClient;
-    if (!client) throw new HostShutDownError(this.shared.id);
+    if (!client) throw new HostNotConnectedError(this.shared.id);
     return client.dispatch(channel, action, clientSeq);
   }
 
@@ -504,64 +528,84 @@ export class HostRuntime {
    * shutdown OR manual reconnect, so an in-flight factory or handshake
    * doesn't block teardown or a user-initiated reconnect. The factory
    * receives the same combined signal so it can bail out internally
-   * (matching the {@link HostTransportFactory} contract).
+   * (matching the {@link HostTransportFactory} contract). The combined
+   * signal's listeners are detached in a `finally` so successful
+   * connects don't leak listeners on the long-lived shutdown signal.
    */
   private async connectOnce(): Promise<{ client: AhpClient; events: AsyncIterableIterator<ClientEvent> }> {
     const shutdownSignal = this.shutdownController.signal;
     const manualSignal = this.manualReconnectController.signal;
-    const cancelSignal = linkAbortSignals(shutdownSignal, manualSignal);
+    const link = linkAbortSignals(shutdownSignal, manualSignal);
+    const cancelSignal = link.signal;
 
-    const transportResult = await raceWithAbort(
-      this.config.transportFactory(this.shared.id, cancelSignal),
-      cancelSignal,
-    );
-    if (transportResult === ABORTED) {
-      throw new Error('connect aborted');
-    }
-    const transport = transportResult;
-
-    const client = new AhpClient(transport, this.config.clientConfig);
-    client.connect();
-    // Attach the events stream BEFORE the handshake so any
-    // notifications the server pushes between the handshake response
-    // and `runConnection` are captured rather than dropped by the
-    // broadcast queue's no-replay-for-late-readers behaviour.
-    const events = client.events();
-
-    let success = false;
     try {
-      const prior = {
-        serverSeq: this.shared.serverSeq,
-        subscriptions: [...this.shared.subscriptions],
-      };
-      const canReconnect = prior.serverSeq > 0 && prior.subscriptions.length > 0;
+      const transportResult = await raceWithAbort(
+        this.config.transportFactory(this.shared.id, cancelSignal),
+        cancelSignal,
+      );
+      if (transportResult === ABORTED) {
+        throw new Error('connect aborted');
+      }
+      const transport = transportResult;
 
-      let reconnectResult: ReconnectResult | null = null;
-      let initSnapshots: Snapshot[] | null = null;
-      let initServerSeq = prior.serverSeq;
-      let initProtocolVersion: string | null = null;
-      let initDefaultDirectory: string | null = null;
-      let initCompletionTriggers: string[] = [];
+      const client = new AhpClient(transport, this.config.clientConfig);
+      client.connect();
+      // Attach the events stream BEFORE the handshake so any
+      // notifications the server pushes between the handshake response
+      // and `runConnection` are captured rather than dropped by the
+      // broadcast queue's no-replay-for-late-readers behaviour.
+      const events = client.events();
 
-      if (canReconnect) {
-        try {
-          const reconnectRes = await raceWithAbort(
-            client.reconnect({
-              clientId: this.shared.clientId,
-              lastSeenServerSeq: prior.serverSeq,
-              subscriptions: prior.subscriptions,
-            }),
-            cancelSignal,
-          );
-          if (reconnectRes === ABORTED) throw new Error('reconnect aborted');
-          reconnectResult = reconnectRes;
-        } catch (err) {
-          if (this.shared.shutdownReason !== null) throw err;
-          if (cancelSignal.aborted) throw err;
-          // Server refused reconnect (likely too much state has
-          // elapsed); fall back to initialize. Only RPC-level errors
-          // are eligible — transport errors propagate.
-          if (!(err instanceof RpcError)) throw err;
+      let success = false;
+      try {
+        const prior = {
+          serverSeq: this.shared.serverSeq,
+          subscriptions: [...this.shared.subscriptions],
+        };
+        const canReconnect = prior.serverSeq > 0 && prior.subscriptions.length > 0;
+
+        let reconnectResult: ReconnectResult | null = null;
+        let initSnapshots: Snapshot[] | null = null;
+        let initServerSeq = prior.serverSeq;
+        let initProtocolVersion: string | null = null;
+        let initDefaultDirectory: string | null = null;
+        let initCompletionTriggers: string[] = [];
+
+        if (canReconnect) {
+          try {
+            const reconnectRes = await raceWithAbort(
+              client.reconnect({
+                clientId: this.shared.clientId,
+                lastSeenServerSeq: prior.serverSeq,
+                subscriptions: prior.subscriptions,
+              }),
+              cancelSignal,
+            );
+            if (reconnectRes === ABORTED) throw new Error('reconnect aborted');
+            reconnectResult = reconnectRes;
+          } catch (err) {
+            if (this.shared.shutdownReason !== null) throw err;
+            if (cancelSignal.aborted) throw err;
+            // Server refused reconnect (likely too much state has
+            // elapsed); fall back to initialize. Only RPC-level errors
+            // are eligible — transport errors propagate.
+            if (!(err instanceof RpcError)) throw err;
+            const initResult = await raceWithAbort(
+              client.initialize({
+                clientId: this.shared.clientId,
+                protocolVersions: [PROTOCOL_VERSION],
+                initialSubscriptions: prior.subscriptions,
+              }),
+              cancelSignal,
+            );
+            if (initResult === ABORTED) throw new Error('initialize aborted');
+            initSnapshots = initResult.snapshots;
+            initServerSeq = initResult.serverSeq;
+            initProtocolVersion = initResult.protocolVersion;
+            initDefaultDirectory = initResult.defaultDirectory ?? null;
+            initCompletionTriggers = initResult.completionTriggerCharacters ?? [];
+          }
+        } else {
           const initResult = await raceWithAbort(
             client.initialize({
               clientId: this.shared.clientId,
@@ -577,132 +621,122 @@ export class HostRuntime {
           initDefaultDirectory = initResult.defaultDirectory ?? null;
           initCompletionTriggers = initResult.completionTriggerCharacters ?? [];
         }
-      } else {
-        const initResult = await raceWithAbort(
-          client.initialize({
-            clientId: this.shared.clientId,
-            protocolVersions: [PROTOCOL_VERSION],
-            initialSubscriptions: prior.subscriptions,
-          }),
-          cancelSignal,
-        );
-        if (initResult === ABORTED) throw new Error('initialize aborted');
-        initSnapshots = initResult.snapshots;
-        initServerSeq = initResult.serverSeq;
-        initProtocolVersion = initResult.protocolVersion;
-        initDefaultDirectory = initResult.defaultDirectory ?? null;
-        initCompletionTriggers = initResult.completionTriggerCharacters ?? [];
-      }
 
-      // Refresh session summaries. Failures are non-fatal — we keep the
-      // cache as-is and the next snapshot/notification will catch up.
-      let summaries: ListSessionsResult | null = null;
-      try {
-        const res = await raceWithAbort(
-          client.request('listSessions', {
-            channel: ROOT_RESOURCE_URI as 'ahp-root://',
-            filter: undefined,
-          }),
-          cancelSignal,
-        );
-        if (res !== ABORTED) summaries = res;
-      } catch {
-        // Tolerate; the connect itself still succeeded.
-      }
-
-      if (cancelSignal.aborted) throw new Error('connect aborted');
-
-      // Apply replay envelopes BEFORE transitioning to `connected` so
-      // consumers observing the `connected` host event already see the
-      // catch-up applied to state and event streams.
-      let postReplaySubscriptions: string[] | null = null;
-      const replayEnvelopes: ActionEnvelope[] = [];
-      let snapshotPrunedSubscriptions: string[] | null = null;
-
-      if (reconnectResult !== null) {
-        if (reconnectResult.type === ReconnectResultType.Replay) {
-          for (const env of reconnectResult.actions) replayEnvelopes.push(env);
-          if (reconnectResult.missing.length > 0) {
-            const missing = new Set<string>(reconnectResult.missing);
-            postReplaySubscriptions = this.shared.subscriptions.filter(u => !missing.has(u));
-          }
-        } else {
-          // Snapshot variant: refresh root state from the matching
-          // snapshot, then drop subscriptions that were in prior set
-          // but are absent from the returned snapshot list.
-          const surviving = new Set<string>(reconnectResult.snapshots.map(s => s.resource));
-          const priorSet = new Set<string>(prior.subscriptions);
-          snapshotPrunedSubscriptions = this.shared.subscriptions.filter(
-            u => surviving.has(u) || !priorSet.has(u),
+        // Refresh session summaries. Failures are non-fatal — we keep the
+        // cache as-is and the next snapshot/notification will catch up.
+        let summaries: ListSessionsResult | null = null;
+        try {
+          const res = await raceWithAbort(
+            client.request('listSessions', {
+              channel: ROOT_RESOURCE_URI as 'ahp-root://',
+              filter: undefined,
+            }),
+            cancelSignal,
           );
-          for (const snap of reconnectResult.snapshots) {
-            if (snap.fromSeq > initServerSeq) initServerSeq = snap.fromSeq;
-            if (snap.resource === ROOT_RESOURCE_URI) {
-              this.shared.rootState = (snap.state as RootState) ?? EMPTY_ROOT_STATE;
+          if (res !== ABORTED) summaries = res;
+        } catch {
+          // Tolerate; the connect itself still succeeded.
+        }
+
+        if (cancelSignal.aborted) throw new Error('connect aborted');
+
+        // Apply replay envelopes BEFORE transitioning to `connected` so
+        // consumers observing the `connected` host event already see the
+        // catch-up applied to state and event streams.
+        let postReplaySubscriptions: string[] | null = null;
+        const replayEnvelopes: ActionEnvelope[] = [];
+        let snapshotPrunedSubscriptions: string[] | null = null;
+
+        if (reconnectResult !== null) {
+          if (reconnectResult.type === ReconnectResultType.Replay) {
+            for (const env of reconnectResult.actions) replayEnvelopes.push(env);
+            if (reconnectResult.missing.length > 0) {
+              const missing = new Set<string>(reconnectResult.missing);
+              postReplaySubscriptions = this.shared.subscriptions.filter(u => !missing.has(u));
+            }
+          } else {
+            // Snapshot variant: refresh root state from the matching
+            // snapshot, then drop subscriptions that were in prior set
+            // but are absent from the returned snapshot list.
+            const surviving = new Set<string>(reconnectResult.snapshots.map(s => s.resource));
+            const priorSet = new Set<string>(prior.subscriptions);
+            snapshotPrunedSubscriptions = this.shared.subscriptions.filter(
+              u => surviving.has(u) || !priorSet.has(u),
+            );
+            for (const snap of reconnectResult.snapshots) {
+              if (snap.fromSeq > initServerSeq) initServerSeq = snap.fromSeq;
+              if (snap.resource === ROOT_RESOURCE_URI) {
+                this.shared.rootState = (snap.state as RootState) ?? EMPTY_ROOT_STATE;
+              }
             }
           }
         }
-      }
 
-      // Commit shared state.
-      this.shared.generation += 1;
-      this.shared.currentClient = client;
-      this.shared.lastConnectedAt = Date.now();
-      this.shared.lastError = null;
-      if (this.shared.serverSeq < initServerSeq) {
-        this.shared.serverSeq = initServerSeq;
-      }
-      if (initSnapshots !== null) {
-        const rootSnap = initSnapshots.find(s => s.resource === ROOT_RESOURCE_URI);
-        if (rootSnap) this.shared.rootState = (rootSnap.state as RootState) ?? EMPTY_ROOT_STATE;
-        if (initProtocolVersion) this.shared.protocolVersion = initProtocolVersion;
-        this.shared.defaultDirectory = initDefaultDirectory;
-        this.shared.completionTriggerCharacters = [...initCompletionTriggers];
-      }
-      if (summaries !== null) {
-        this.shared.sessionSummaries.clear();
-        for (const s of summaries.items) this.shared.sessionSummaries.set(s.resource, s);
-      }
-      if (postReplaySubscriptions !== null) {
-        this.shared.subscriptions = postReplaySubscriptions;
-      } else if (snapshotPrunedSubscriptions !== null) {
-        this.shared.subscriptions = snapshotPrunedSubscriptions;
-      }
+        // Commit shared state.
+        this.shared.generation += 1;
+        this.shared.currentClient = client;
+        this.shared.lastConnectedAt = Date.now();
+        this.shared.lastError = null;
+        if (this.shared.serverSeq < initServerSeq) {
+          this.shared.serverSeq = initServerSeq;
+        }
+        if (initSnapshots !== null) {
+          const rootSnap = initSnapshots.find(s => s.resource === ROOT_RESOURCE_URI);
+          if (rootSnap) this.shared.rootState = (rootSnap.state as RootState) ?? EMPTY_ROOT_STATE;
+          if (initProtocolVersion) this.shared.protocolVersion = initProtocolVersion;
+          this.shared.defaultDirectory = initDefaultDirectory;
+          this.shared.completionTriggerCharacters = [...initCompletionTriggers];
+        }
+        if (summaries !== null) {
+          this.shared.sessionSummaries.clear();
+          for (const s of summaries.items) this.shared.sessionSummaries.set(s.resource, s);
+        }
+        if (postReplaySubscriptions !== null) {
+          this.shared.subscriptions = postReplaySubscriptions;
+        } else if (snapshotPrunedSubscriptions !== null) {
+          this.shared.subscriptions = snapshotPrunedSubscriptions;
+        }
 
-      // Mirror the new generation + client into the shared handle source.
-      this.handleSource.generation = this.shared.generation;
-      this.handleSource.currentClient = client;
+        // Mirror the new generation + client into the shared handle source.
+        this.handleSource.generation = this.shared.generation;
+        this.handleSource.currentClient = client;
 
-      // Replay missed envelopes through state mirror and fan-out.
-      for (const env of replayEnvelopes) {
-        this.applyEnvelopeLocally(env);
-        this.fanOut.publish({
+        // Replay missed envelopes through state mirror and fan-out.
+        for (const env of replayEnvelopes) {
+          this.applyEnvelopeLocally(env);
+          this.fanOut.publish({
+            hostId: this.shared.id,
+            channel: env.channel,
+            event: { type: 'action', params: env },
+          });
+        }
+
+        // Now transition to connected and emit the connected host event.
+        this.transitionTo({ status: 'connected' }, null);
+        this.hostEvents.publish({
+          type: 'connected',
           hostId: this.shared.id,
-          channel: env.channel,
-          event: { type: 'action', params: env },
+          generation: this.shared.generation,
         });
-      }
 
-      // Now transition to connected and emit the connected host event.
-      this.transitionTo({ status: 'connected' }, null);
-      this.hostEvents.publish({
-        type: 'connected',
-        hostId: this.shared.id,
-        generation: this.shared.generation,
-      });
-
-      success = true;
-      return { client, events };
-    } finally {
-      if (!success) {
-        // Connect failed mid-flight — shut the half-built client down so
-        // we don't leak the transport.
-        try {
-          await client.shutdown();
-        } catch {
-          // best-effort
+        success = true;
+        return { client, events };
+      } finally {
+        if (!success) {
+          // Connect failed mid-flight — shut the half-built client down so
+          // we don't leak the transport.
+          try {
+            await client.shutdown();
+          } catch {
+            // best-effort
+          }
         }
       }
+    } finally {
+      // Detach the abort listeners we attached to the long-lived
+      // shutdown / manual-reconnect signals so successful connects
+      // don't accumulate listeners across reconnect cycles.
+      link.dispose();
     }
   }
 

--- a/clients/typescript/src/client/hosts/runtime.ts
+++ b/clients/typescript/src/client/hosts/runtime.ts
@@ -1,0 +1,812 @@
+/**
+ * Per-host supervisor.
+ *
+ * Owns the current {@link AhpClient}, the reconnect state machine, the
+ * per-host root-state mirror, and the session-summary cache. Drives
+ * inbound events out to the multi-host fan-in broadcasts.
+ *
+ * Unlike the Rust port, the supervisor doesn't use an mpsc command
+ * channel. JavaScript's single-threaded execution model lets public
+ * methods read shared state directly; coordination with the supervisor
+ * loop uses {@link AbortController}s for cancel signals (analogous to
+ * Rust's `tokio::Notify`).
+ *
+ * @module client/hosts/runtime
+ */
+
+import type { ActionEnvelope } from '../../types/common/actions.js';
+import type { URI } from '../../types/common/state.js';
+import type { Snapshot } from '../../types/common/state.js';
+import type {
+  ReconnectResult,
+  SubscribeResult,
+} from '../../types/common/commands.js';
+import { ReconnectResultType } from '../../types/common/commands.js';
+import type { ListSessionsResult } from '../../types/channels-root/commands.js';
+import type { RootState } from '../../types/channels-root/state.js';
+import type { SessionSummary } from '../../types/channels-session/state.js';
+import type {
+  SessionSummaryChangedParams,
+} from '../../types/channels-root/notifications.js';
+import { PROTOCOL_VERSION } from '../../types/version/registry.js';
+import { AhpClient, type DispatchHandle } from '../client.js';
+import type { ClientEvent } from '../events.js';
+import { RpcError } from '../error.js';
+import type { AsyncBroadcastQueue } from '../async-queue.js';
+import { rootReducer } from '../../types/channels-root/reducer.js';
+import type { RootAction } from '../../types/action-origin.generated.js';
+import type { StateAction } from '../../types/common/actions.js';
+import {
+  HostShutDownError,
+  ROOT_RESOURCE_URI,
+  tagClientEvent,
+  type HostEvent,
+  type HostHandle,
+  type HostId,
+  type HostState,
+  type HostSubscriptionEvent,
+  type ResolvedHostConfig,
+} from './types.js';
+import type { HostClientHandleSource } from './host-client-handle.js';
+import {
+  attemptsExhausted,
+  delayWithJitter,
+} from './policy.js';
+
+/**
+ * Mutable per-host state read by the runtime, exposed read-only via
+ * {@link snapshot} for {@link HostHandle}s and consumed by
+ * {@link HostClientHandle}s through {@link HostClientHandleSource}.
+ *
+ * @internal
+ */
+export interface HostShared {
+  readonly id: HostId;
+  readonly label: string;
+  clientId: string;
+  state: HostState;
+  lastError: Error | null;
+  lastConnectedAt: number | null;
+  protocolVersion: string | null;
+  serverSeq: number;
+  defaultDirectory: string | null;
+  rootState: RootState;
+  subscriptions: URI[];
+  completionTriggerCharacters: string[];
+  sessionSummaries: Map<URI, SessionSummary>;
+  generation: number;
+  currentClient: AhpClient | null;
+  /**
+   * Set to `'removed'` by {@link MultiHostClient.removeHost} or
+   * `'shutdown'` by a top-level shutdown. Held in the same shared
+   * object as `generation` / `currentClient` so generation-checking
+   * client handles can also detect a fully removed host.
+   */
+  shutdownReason: null | 'removed' | 'shutdown';
+}
+
+/** Build the initial shared state for a freshly registered host. @internal */
+export function makeInitialShared(
+  config: ResolvedHostConfig,
+  resolvedClientId: string,
+): HostShared {
+  return {
+    id: config.id,
+    label: config.label,
+    clientId: resolvedClientId,
+    state: { status: 'disconnected' },
+    lastError: null,
+    lastConnectedAt: null,
+    protocolVersion: null,
+    serverSeq: 0,
+    defaultDirectory: null,
+    rootState: { agents: [] },
+    subscriptions: [...config.initialSubscriptions],
+    completionTriggerCharacters: [],
+    sessionSummaries: new Map(),
+    generation: 0,
+    currentClient: null,
+    shutdownReason: null,
+  };
+}
+
+/** Build an immutable {@link HostHandle} snapshot from shared state. @internal */
+export function snapshotHandle(shared: HostShared): HostHandle {
+  return {
+    id: shared.id,
+    label: shared.label,
+    clientId: shared.clientId,
+    state: shared.state,
+    lastError: shared.lastError,
+    lastConnectedAt: shared.lastConnectedAt,
+    protocolVersion: shared.protocolVersion,
+    serverSeq: shared.serverSeq,
+    defaultDirectory: shared.defaultDirectory,
+    agents: [...shared.rootState.agents],
+    activeSessions: shared.rootState.activeSessions ?? null,
+    terminals: shared.rootState.terminals ? [...shared.rootState.terminals] : null,
+    subscriptions: [...shared.subscriptions],
+    completionTriggerCharacters: [...shared.completionTriggerCharacters],
+    sessionSummaries: Array.from(shared.sessionSummaries.values()),
+    generation: shared.generation,
+  };
+}
+
+// ─── Cancellation helpers ────────────────────────────────────────────────────
+
+/** Sentinel returned by {@link raceWithAbort} when the signal aborts first. */
+export const ABORTED = Symbol('aborted');
+
+/**
+ * Race a promise against an {@link AbortSignal}. Returns the original
+ * promise value on completion, or {@link ABORTED} if the signal aborts
+ * first.
+ *
+ * The inner promise is allowed to keep running; callers must not depend
+ * on its side effects after a cancellation. A no-op rejection handler
+ * is attached to the inner promise so a late rejection (e.g. an
+ * in-flight `client.initialize` that surfaces `ClientClosedError`
+ * after the client has been shut down) doesn't become an
+ * `unhandledRejection`.
+ *
+ * @internal
+ */
+export function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T | typeof ABORTED> {
+  // Always attach a rejection handler to the inner promise so a late
+  // rejection after the race resolves is observed by the runtime.
+  // Using `.then(undefined, noop)` swallows the rejection (the original
+  // promise itself remains pending/resolved/rejected as before — this
+  // adds a separate observer that V8 sees as "handled").
+  promise.then(undefined, () => undefined);
+  if (signal.aborted) return Promise.resolve(ABORTED);
+  return new Promise<T | typeof ABORTED>((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener('abort', onAbort);
+      resolve(ABORTED);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      err => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
+ * Sleep `ms` milliseconds, returning early if any of the supplied
+ * signals abort. Returns `true` if the sleep elapsed, `false` if any
+ * signal aborted first.
+ *
+ * @internal
+ */
+export function sleepOrAbort(ms: number, ...signals: AbortSignal[]): Promise<boolean> {
+  if (ms <= 0) return Promise.resolve(true);
+  if (signals.some(s => s.aborted)) return Promise.resolve(false);
+  return new Promise<boolean>(resolve => {
+    const cleanup: Array<() => void> = [];
+    const timer = setTimeout(() => {
+      for (const fn of cleanup) fn();
+      resolve(true);
+    }, ms);
+    for (const signal of signals) {
+      const onAbort = (): void => {
+        clearTimeout(timer);
+        for (const fn of cleanup) fn();
+        resolve(false);
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      cleanup.push(() => signal.removeEventListener('abort', onAbort));
+    }
+  });
+}
+
+/** Wait for any of the supplied signals to abort. @internal */
+function waitForAbort(...signals: AbortSignal[]): Promise<void> {
+  if (signals.some(s => s.aborted)) return Promise.resolve();
+  return new Promise<void>(resolve => {
+    const cleanup: Array<() => void> = [];
+    for (const signal of signals) {
+      const onAbort = (): void => {
+        for (const fn of cleanup) fn();
+        resolve();
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      cleanup.push(() => signal.removeEventListener('abort', onAbort));
+    }
+  });
+}
+
+// ─── Runtime ─────────────────────────────────────────────────────────────────
+
+const EMPTY_ROOT_STATE: RootState = { agents: [] };
+
+/**
+ * Per-host supervisor.
+ *
+ * Construction sets up shared state and emits the `added` host event;
+ * {@link HostRuntime.start} kicks off the connect/reconnect loop. The
+ * loop runs until {@link HostRuntime.shutdown} aborts the shutdown
+ * controller.
+ *
+ * @internal
+ */
+export class HostRuntime {
+  private readonly config: ResolvedHostConfig;
+  readonly shared: HostShared;
+  readonly handleSource: HostClientHandleSource;
+  private readonly fanOut: AsyncBroadcastQueue<HostSubscriptionEvent>;
+  private readonly hostEvents: AsyncBroadcastQueue<HostEvent>;
+
+  private readonly shutdownController = new AbortController();
+  private manualReconnectController = new AbortController();
+  private supervisorPromise: Promise<void> | null = null;
+  /**
+   * Resolved by {@link reconnect} when the manual-reconnect cycle has
+   * actually been observed by the supervisor (state transitions to
+   * `connecting` / `reconnecting`). Used so external callers see a
+   * deterministic completion point.
+   */
+  private reconnectAck: { promise: Promise<void>; resolve: () => void } | null = null;
+
+  constructor(
+    config: ResolvedHostConfig,
+    resolvedClientId: string,
+    fanOut: AsyncBroadcastQueue<HostSubscriptionEvent>,
+    hostEvents: AsyncBroadcastQueue<HostEvent>,
+  ) {
+    this.config = config;
+    this.fanOut = fanOut;
+    this.hostEvents = hostEvents;
+    this.shared = makeInitialShared(config, resolvedClientId);
+    this.handleSource = {
+      hostId: this.shared.id,
+      generation: this.shared.generation,
+      currentClient: this.shared.currentClient,
+      shutdownReason: this.shared.shutdownReason,
+    };
+  }
+
+  /** Start the supervisor. Emits the `added` host event before the first connect. */
+  start(): void {
+    if (this.supervisorPromise !== null) return;
+    this.hostEvents.publish({ type: 'added', hostId: this.shared.id });
+    this.supervisorPromise = this.runSupervisor().catch(err => {
+      // The supervisor's own errors are surfaced via shared state +
+      // host events; this guard prevents an unhandled rejection in the
+      // unlikely event of a logic bug.
+      // eslint-disable-next-line no-console
+      console.error(`HostRuntime[${this.shared.id}] supervisor crashed:`, err);
+    });
+  }
+
+  /**
+   * Request a manual reconnect. The current connection (or pending
+   * backoff sleep) is interrupted and the supervisor immediately
+   * attempts a fresh connect. Returns when the supervisor has
+   * acknowledged the request (state has transitioned).
+   */
+  async reconnect(): Promise<void> {
+    if (this.shared.shutdownReason !== null) {
+      // The supervisor is gone; nothing to nudge.
+      return;
+    }
+    const ack = this.reconnectAck ?? this.makeReconnectAck();
+    this.reconnectAck = ack;
+    this.manualReconnectController.abort();
+    await ack.promise;
+  }
+
+  /**
+   * Tear down the supervisor. Marks the runtime as `removed`, aborts
+   * the shutdown controller (which unblocks any in-flight
+   * `connectOnce`, sleep, or read loop), and resolves once the
+   * supervisor has exited.
+   */
+  async shutdown(reason: 'removed' | 'shutdown' = 'removed'): Promise<void> {
+    if (this.shared.shutdownReason !== null) {
+      // Already tearing down.
+      if (this.supervisorPromise) await this.supervisorPromise;
+      return;
+    }
+    this.shared.shutdownReason = reason;
+    this.handleSource.shutdownReason = reason;
+    this.shutdownController.abort();
+    // Also wake any reconnect waiter so a pending `reconnect()` call resolves.
+    this.reconnectAck?.resolve();
+    if (this.supervisorPromise) await this.supervisorPromise;
+  }
+
+  /**
+   * Subscribe to `uri`, tracking it for re-subscription across
+   * reconnects.
+   *
+   * Throws {@link HostShutDownError} when the host is not currently
+   * connected — but appends the URI to the local subscription list
+   * first, so the next successful (re)connect will subscribe to it
+   * automatically.
+   */
+  async subscribe(uri: URI): Promise<SubscribeResult> {
+    if (this.shared.shutdownReason !== null) {
+      throw new HostShutDownError(this.shared.id);
+    }
+    const client = this.shared.currentClient;
+    if (!client) {
+      this.trackSubscription(uri);
+      throw new HostShutDownError(this.shared.id);
+    }
+    const { result } = await client.subscribe(uri);
+    this.trackSubscription(uri);
+    return result;
+  }
+
+  /**
+   * Unsubscribe from `uri` and drop it from the local subscription
+   * list. No-op if the host has been removed.
+   */
+  async unsubscribe(uri: URI): Promise<void> {
+    if (this.shared.shutdownReason !== null) {
+      this.untrackSubscription(uri);
+      return;
+    }
+    const client = this.shared.currentClient;
+    this.untrackSubscription(uri);
+    if (client) await client.unsubscribe(uri);
+  }
+
+  /** Helper: dispatch on the current client (no generation check). */
+  dispatch(
+    channel: URI,
+    action: StateAction,
+    clientSeq?: number,
+  ): DispatchHandle {
+    if (this.shared.shutdownReason !== null) {
+      throw new HostShutDownError(this.shared.id);
+    }
+    const client = this.shared.currentClient;
+    if (!client) throw new HostShutDownError(this.shared.id);
+    return client.dispatch(channel, action, clientSeq);
+  }
+
+  // ─── Supervisor loop ───────────────────────────────────────────────────────
+
+  private async runSupervisor(): Promise<void> {
+    const policy = this.config.reconnectPolicy;
+    let attempt = 0;
+    while (this.shared.shutdownReason === null) {
+      attempt += 1;
+      this.transitionTo(
+        attempt === 1
+          ? { status: 'connecting' }
+          : { status: 'reconnecting', attempt: attempt - 1 },
+        null,
+      );
+      // Resolve any pending reconnect ack now that the state has moved.
+      const pendingAck = this.reconnectAck;
+      this.reconnectAck = null;
+      pendingAck?.resolve();
+
+      let connection: { client: AhpClient; events: AsyncIterableIterator<ClientEvent> } | null = null;
+      try {
+        connection = await this.connectOnce();
+      } catch (err) {
+        if (this.shared.shutdownReason !== null) break;
+        const error = toError(err);
+        this.shared.lastError = error;
+        // eslint-disable-next-line no-console
+        console.warn(`HostRuntime[${this.shared.id}] connect attempt ${attempt} failed:`, error);
+      }
+
+      if (connection === null) {
+        // Connect failed (or was aborted). Decide whether to retry.
+        if (this.shared.shutdownReason !== null) break;
+        if (attemptsExhausted(policy, attempt)) {
+          const error = this.shared.lastError ?? new Error('connect failed');
+          this.transitionTo({ status: 'failed', error }, error);
+          // Park until manual reconnect or shutdown.
+          if (!(await this.waitForManualReconnectOrShutdown())) break;
+          // The manual-reconnect controller is currently aborted —
+          // reset it so the next iteration's `runConnection` /
+          // `sleepOrAbort` don't immediately see a phantom abort.
+          this.resetManualReconnectController();
+          attempt = 0;
+          continue;
+        }
+        const delay = delayWithJitter(policy, attempt, Math.random());
+        if (
+          !(await sleepOrAbort(
+            delay,
+            this.shutdownController.signal,
+            this.manualReconnectController.signal,
+          ))
+        ) {
+          if (this.shared.shutdownReason !== null) break;
+          // Manual reconnect during backoff — reset attempt and retry now.
+          this.resetManualReconnectController();
+          attempt = 0;
+        }
+        continue;
+      }
+
+      // Connect succeeded.
+      if (policy.resetOnSuccess) attempt = 0;
+      const outcome = await this.runConnection(connection.events);
+      await this.tearDownClient();
+
+      if (outcome === 'shutdown') break;
+      if (outcome === 'manualReconnect') {
+        this.resetManualReconnectController();
+        attempt = 0;
+        continue;
+      }
+      // 'disconnected' — fall through to the retry/backoff path.
+    }
+
+    // Final cleanup. The handle source mirrors shared state already.
+    this.handleSource.currentClient = null;
+    this.handleSource.generation = this.shared.generation;
+  }
+
+  /**
+   * Open a transport, negotiate `initialize` or `reconnect`, refresh
+   * caches, bump generation, install the client, and transition to
+   * `connected`. Returns the connected client and an events iterator
+   * that was attached BEFORE the handshake — passing the iterator into
+   * {@link runConnection} ensures notifications pushed between the
+   * handshake response and the moment we enter the event loop are
+   * delivered instead of dropped.
+   *
+   * Races each await against the shutdown signal so an in-flight
+   * factory or handshake doesn't block teardown. The factory also
+   * receives the shutdown signal so it can bail out internally.
+   */
+  private async connectOnce(): Promise<{ client: AhpClient; events: AsyncIterableIterator<ClientEvent> }> {
+    const shutdownSignal = this.shutdownController.signal;
+
+    const transportResult = await raceWithAbort(
+      this.config.transportFactory(this.shared.id, shutdownSignal),
+      shutdownSignal,
+    );
+    if (transportResult === ABORTED) {
+      throw new Error('connect aborted');
+    }
+    const transport = transportResult;
+
+    const client = new AhpClient(transport, this.config.clientConfig);
+    client.connect();
+    // Attach the events stream BEFORE the handshake so any
+    // notifications the server pushes between the handshake response
+    // and `runConnection` are captured rather than dropped by the
+    // broadcast queue's no-replay-for-late-readers behaviour.
+    const events = client.events();
+
+    let success = false;
+    try {
+      const prior = {
+        serverSeq: this.shared.serverSeq,
+        subscriptions: [...this.shared.subscriptions],
+      };
+      const canReconnect = prior.serverSeq > 0 && prior.subscriptions.length > 0;
+
+      let reconnectResult: ReconnectResult | null = null;
+      let initSnapshots: Snapshot[] | null = null;
+      let initServerSeq = prior.serverSeq;
+      let initProtocolVersion: string | null = null;
+      let initDefaultDirectory: string | null = null;
+      let initCompletionTriggers: string[] = [];
+
+      if (canReconnect) {
+        try {
+          const reconnectRes = await raceWithAbort(
+            client.reconnect({
+              clientId: this.shared.clientId,
+              lastSeenServerSeq: prior.serverSeq,
+              subscriptions: prior.subscriptions,
+            }),
+            shutdownSignal,
+          );
+          if (reconnectRes === ABORTED) throw new Error('reconnect aborted');
+          reconnectResult = reconnectRes;
+        } catch (err) {
+          if (this.shared.shutdownReason !== null) throw err;
+          // Server refused reconnect (likely too much state has
+          // elapsed); fall back to initialize. Only RPC-level errors
+          // are eligible — transport errors propagate.
+          if (!(err instanceof RpcError)) throw err;
+          const initResult = await raceWithAbort(
+            client.initialize({
+              clientId: this.shared.clientId,
+              protocolVersions: [PROTOCOL_VERSION],
+              initialSubscriptions: prior.subscriptions,
+            }),
+            shutdownSignal,
+          );
+          if (initResult === ABORTED) throw new Error('initialize aborted');
+          initSnapshots = initResult.snapshots;
+          initServerSeq = initResult.serverSeq;
+          initProtocolVersion = initResult.protocolVersion;
+          initDefaultDirectory = initResult.defaultDirectory ?? null;
+          initCompletionTriggers = initResult.completionTriggerCharacters ?? [];
+        }
+      } else {
+        const initResult = await raceWithAbort(
+          client.initialize({
+            clientId: this.shared.clientId,
+            protocolVersions: [PROTOCOL_VERSION],
+            initialSubscriptions: prior.subscriptions,
+          }),
+          shutdownSignal,
+        );
+        if (initResult === ABORTED) throw new Error('initialize aborted');
+        initSnapshots = initResult.snapshots;
+        initServerSeq = initResult.serverSeq;
+        initProtocolVersion = initResult.protocolVersion;
+        initDefaultDirectory = initResult.defaultDirectory ?? null;
+        initCompletionTriggers = initResult.completionTriggerCharacters ?? [];
+      }
+
+      // Refresh session summaries. Failures are non-fatal — we keep the
+      // cache as-is and the next snapshot/notification will catch up.
+      let summaries: ListSessionsResult | null = null;
+      try {
+        const res = await raceWithAbort(
+          client.request('listSessions', {
+            channel: ROOT_RESOURCE_URI as 'ahp-root://',
+            filter: undefined,
+          }),
+          shutdownSignal,
+        );
+        if (res !== ABORTED) summaries = res;
+      } catch {
+        // Tolerate; the connect itself still succeeded.
+      }
+
+      if (shutdownSignal.aborted) throw new Error('connect aborted');
+
+      // Apply replay envelopes BEFORE transitioning to `connected` so
+      // consumers observing the `connected` host event already see the
+      // catch-up applied to state and event streams.
+      let postReplaySubscriptions: string[] | null = null;
+      const replayEnvelopes: ActionEnvelope[] = [];
+      let snapshotPrunedSubscriptions: string[] | null = null;
+
+      if (reconnectResult !== null) {
+        if (reconnectResult.type === ReconnectResultType.Replay) {
+          for (const env of reconnectResult.actions) replayEnvelopes.push(env);
+          if (reconnectResult.missing.length > 0) {
+            const missing = new Set<string>(reconnectResult.missing);
+            postReplaySubscriptions = this.shared.subscriptions.filter(u => !missing.has(u));
+          }
+        } else {
+          // Snapshot variant: refresh root state from the matching
+          // snapshot, then drop subscriptions that were in prior set
+          // but are absent from the returned snapshot list.
+          const surviving = new Set<string>(reconnectResult.snapshots.map(s => s.resource));
+          const priorSet = new Set<string>(prior.subscriptions);
+          snapshotPrunedSubscriptions = this.shared.subscriptions.filter(
+            u => surviving.has(u) || !priorSet.has(u),
+          );
+          for (const snap of reconnectResult.snapshots) {
+            if (snap.fromSeq > initServerSeq) initServerSeq = snap.fromSeq;
+            if (snap.resource === ROOT_RESOURCE_URI) {
+              this.shared.rootState = (snap.state as RootState) ?? EMPTY_ROOT_STATE;
+            }
+          }
+        }
+      }
+
+      // Commit shared state.
+      this.shared.generation += 1;
+      this.shared.currentClient = client;
+      this.shared.lastConnectedAt = Date.now();
+      this.shared.lastError = null;
+      if (this.shared.serverSeq < initServerSeq) {
+        this.shared.serverSeq = initServerSeq;
+      }
+      if (initSnapshots !== null) {
+        const rootSnap = initSnapshots.find(s => s.resource === ROOT_RESOURCE_URI);
+        if (rootSnap) this.shared.rootState = (rootSnap.state as RootState) ?? EMPTY_ROOT_STATE;
+        if (initProtocolVersion) this.shared.protocolVersion = initProtocolVersion;
+        this.shared.defaultDirectory = initDefaultDirectory;
+        this.shared.completionTriggerCharacters = [...initCompletionTriggers];
+      }
+      if (summaries !== null) {
+        this.shared.sessionSummaries.clear();
+        for (const s of summaries.items) this.shared.sessionSummaries.set(s.resource, s);
+      }
+      if (postReplaySubscriptions !== null) {
+        this.shared.subscriptions = postReplaySubscriptions;
+      } else if (snapshotPrunedSubscriptions !== null) {
+        this.shared.subscriptions = snapshotPrunedSubscriptions;
+      }
+
+      // Mirror the new generation + client into the shared handle source.
+      this.handleSource.generation = this.shared.generation;
+      this.handleSource.currentClient = client;
+
+      // Replay missed envelopes through state mirror and fan-out.
+      for (const env of replayEnvelopes) {
+        this.applyEnvelopeLocally(env);
+        this.fanOut.publish({
+          hostId: this.shared.id,
+          channel: env.channel,
+          event: { type: 'action', params: env },
+        });
+      }
+
+      // Now transition to connected and emit the connected host event.
+      this.transitionTo({ status: 'connected' }, null);
+      this.hostEvents.publish({
+        type: 'connected',
+        hostId: this.shared.id,
+        generation: this.shared.generation,
+      });
+
+      success = true;
+      return { client, events };
+    } finally {
+      if (!success) {
+        // Connect failed mid-flight — shut the half-built client down so
+        // we don't leak the transport.
+        try {
+          await client.shutdown();
+        } catch {
+          // best-effort
+        }
+      }
+    }
+  }
+
+  /**
+   * Drain the connected client's event stream until it ends, the
+   * shutdown signal aborts, or a manual reconnect is requested.
+   */
+  private async runConnection(
+    events: AsyncIterableIterator<ClientEvent>,
+  ): Promise<'shutdown' | 'manualReconnect' | 'disconnected'> {
+    const shutdownSignal = this.shutdownController.signal;
+    const manualSignal = this.manualReconnectController.signal;
+
+    while (true) {
+      if (shutdownSignal.aborted) return 'shutdown';
+      if (manualSignal.aborted) return 'manualReconnect';
+
+      const nextPromise = events.next();
+      const aborted = waitForAbort(shutdownSignal, manualSignal);
+      const result = await Promise.race([
+        nextPromise.then(value => ({ kind: 'event' as const, value })),
+        aborted.then(() => ({ kind: 'aborted' as const })),
+      ]);
+
+      if (result.kind === 'aborted') {
+        if (shutdownSignal.aborted) return 'shutdown';
+        return 'manualReconnect';
+      }
+      const ev = result.value;
+      if (ev.done) return 'disconnected';
+      this.handleEvent(ev.value);
+    }
+  }
+
+  /** Park until a manual reconnect or shutdown wakes us up. */
+  private async waitForManualReconnectOrShutdown(): Promise<boolean> {
+    await waitForAbort(this.shutdownController.signal, this.manualReconnectController.signal);
+    return !this.shutdownController.signal.aborted;
+  }
+
+  private async tearDownClient(): Promise<void> {
+    const prev = this.shared.currentClient;
+    this.shared.currentClient = null;
+    this.handleSource.currentClient = null;
+    if (prev) {
+      try {
+        await prev.shutdown();
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  private handleEvent(event: ClientEvent): void {
+    // Update local mirrors before fanning out so consumers observing
+    // the next snapshot see the result of this event.
+    switch (event.event.type) {
+      case 'action':
+        this.applyEnvelopeLocally(event.event.params);
+        break;
+      case 'sessionAdded': {
+        const summary = event.event.params.summary;
+        this.shared.sessionSummaries.set(summary.resource, summary);
+        break;
+      }
+      case 'sessionRemoved':
+        this.shared.sessionSummaries.delete(event.event.params.session);
+        break;
+      case 'sessionSummaryChanged':
+        applySummaryChange(this.shared.sessionSummaries, event.event.params);
+        break;
+      case 'authRequired':
+        // No cache update; consumers observe via the event stream.
+        break;
+    }
+    this.fanOut.publish(tagClientEvent(this.shared.id, event));
+  }
+
+  private applyEnvelopeLocally(envelope: ActionEnvelope): void {
+    if (envelope.serverSeq > this.shared.serverSeq) {
+      this.shared.serverSeq = envelope.serverSeq;
+    }
+    if (envelope.channel === ROOT_RESOURCE_URI) {
+      this.shared.rootState = rootReducer(this.shared.rootState, envelope.action as RootAction);
+    }
+    // Non-root channels: leave the rooted root-state mirror untouched
+    // (per-session / per-terminal mirrors are intentionally not
+    // duplicated here — consumers feed those through
+    // MultiHostStateMirror or their own store).
+  }
+
+  private trackSubscription(uri: URI): void {
+    if (!this.shared.subscriptions.includes(uri)) {
+      this.shared.subscriptions.push(uri);
+    }
+  }
+
+  private untrackSubscription(uri: URI): void {
+    this.shared.subscriptions = this.shared.subscriptions.filter(u => u !== uri);
+  }
+
+  private transitionTo(state: HostState, lastError: Error | null): void {
+    this.shared.state = state;
+    if (lastError !== null) this.shared.lastError = lastError;
+    this.hostEvents.publish({
+      type: 'stateChanged',
+      hostId: this.shared.id,
+      state,
+      lastError: lastError ?? this.shared.lastError,
+    });
+  }
+
+  private resetManualReconnectController(): void {
+    this.manualReconnectController = new AbortController();
+  }
+
+  private makeReconnectAck(): { promise: Promise<void>; resolve: () => void } {
+    let resolveFn!: () => void;
+    const promise = new Promise<void>(resolve => {
+      resolveFn = resolve;
+    });
+    return { promise, resolve: resolveFn };
+  }
+}
+
+function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}
+
+function applySummaryChange(
+  cache: Map<URI, SessionSummary>,
+  params: SessionSummaryChangedParams,
+): void {
+  const existing = cache.get(params.session);
+  if (!existing) return;
+  const merged: SessionSummary = { ...existing };
+  const changes = params.changes;
+  if (changes.title !== undefined) merged.title = changes.title;
+  if (changes.status !== undefined) merged.status = changes.status;
+  if (changes.activity !== undefined) merged.activity = changes.activity;
+  if (changes.modifiedAt !== undefined) merged.modifiedAt = changes.modifiedAt;
+  if (changes.project !== undefined) merged.project = changes.project;
+  if (changes.model !== undefined) merged.model = changes.model;
+  if (changes.workingDirectory !== undefined) merged.workingDirectory = changes.workingDirectory;
+  if (changes.changesets !== undefined) merged.changesets = changes.changesets;
+  cache.set(params.session, merged);
+}

--- a/clients/typescript/src/client/hosts/runtime.ts
+++ b/clients/typescript/src/client/hosts/runtime.ts
@@ -225,6 +225,32 @@ function waitForAbort(...signals: AbortSignal[]): Promise<void> {
   });
 }
 
+/**
+ * Return an {@link AbortSignal} that aborts whenever any of the supplied
+ * input signals aborts. Used to thread a single composite signal through
+ * the connect/handshake path so the operation bails on either shutdown
+ * or manual reconnect.
+ *
+ * @internal
+ */
+function linkAbortSignals(...signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+  if (signals.some(s => s.aborted)) {
+    controller.abort();
+    return controller.signal;
+  }
+  const cleanup: Array<() => void> = [];
+  const onAbort = (): void => {
+    for (const fn of cleanup) fn();
+    controller.abort();
+  };
+  for (const signal of signals) {
+    signal.addEventListener('abort', onAbort, { once: true });
+    cleanup.push(() => signal.removeEventListener('abort', onAbort));
+  }
+  return controller.signal;
+}
+
 // ─── Runtime ─────────────────────────────────────────────────────────────────
 
 const EMPTY_ROOT_STATE: RootState = { agents: [] };
@@ -399,6 +425,16 @@ export class HostRuntime {
         connection = await this.connectOnce();
       } catch (err) {
         if (this.shared.shutdownReason !== null) break;
+        // If the in-flight connect was interrupted by a manual reconnect
+        // request, skip the backoff and immediately retry with a fresh
+        // controller. The error is the deliberate "aborted" sentinel,
+        // not a real connect failure, so we don't surface it as
+        // `lastError` or log a warning.
+        if (this.manualReconnectController.signal.aborted) {
+          this.resetManualReconnectController();
+          attempt = 0;
+          continue;
+        }
         const error = toError(err);
         this.shared.lastError = error;
         // eslint-disable-next-line no-console
@@ -464,16 +500,20 @@ export class HostRuntime {
    * handshake response and the moment we enter the event loop are
    * delivered instead of dropped.
    *
-   * Races each await against the shutdown signal so an in-flight
-   * factory or handshake doesn't block teardown. The factory also
-   * receives the shutdown signal so it can bail out internally.
+   * Races each await against a combined signal that aborts on either
+   * shutdown OR manual reconnect, so an in-flight factory or handshake
+   * doesn't block teardown or a user-initiated reconnect. The factory
+   * receives the same combined signal so it can bail out internally
+   * (matching the {@link HostTransportFactory} contract).
    */
   private async connectOnce(): Promise<{ client: AhpClient; events: AsyncIterableIterator<ClientEvent> }> {
     const shutdownSignal = this.shutdownController.signal;
+    const manualSignal = this.manualReconnectController.signal;
+    const cancelSignal = linkAbortSignals(shutdownSignal, manualSignal);
 
     const transportResult = await raceWithAbort(
-      this.config.transportFactory(this.shared.id, shutdownSignal),
-      shutdownSignal,
+      this.config.transportFactory(this.shared.id, cancelSignal),
+      cancelSignal,
     );
     if (transportResult === ABORTED) {
       throw new Error('connect aborted');
@@ -511,12 +551,13 @@ export class HostRuntime {
               lastSeenServerSeq: prior.serverSeq,
               subscriptions: prior.subscriptions,
             }),
-            shutdownSignal,
+            cancelSignal,
           );
           if (reconnectRes === ABORTED) throw new Error('reconnect aborted');
           reconnectResult = reconnectRes;
         } catch (err) {
           if (this.shared.shutdownReason !== null) throw err;
+          if (cancelSignal.aborted) throw err;
           // Server refused reconnect (likely too much state has
           // elapsed); fall back to initialize. Only RPC-level errors
           // are eligible — transport errors propagate.
@@ -527,7 +568,7 @@ export class HostRuntime {
               protocolVersions: [PROTOCOL_VERSION],
               initialSubscriptions: prior.subscriptions,
             }),
-            shutdownSignal,
+            cancelSignal,
           );
           if (initResult === ABORTED) throw new Error('initialize aborted');
           initSnapshots = initResult.snapshots;
@@ -543,7 +584,7 @@ export class HostRuntime {
             protocolVersions: [PROTOCOL_VERSION],
             initialSubscriptions: prior.subscriptions,
           }),
-          shutdownSignal,
+          cancelSignal,
         );
         if (initResult === ABORTED) throw new Error('initialize aborted');
         initSnapshots = initResult.snapshots;
@@ -562,14 +603,14 @@ export class HostRuntime {
             channel: ROOT_RESOURCE_URI as 'ahp-root://',
             filter: undefined,
           }),
-          shutdownSignal,
+          cancelSignal,
         );
         if (res !== ABORTED) summaries = res;
       } catch {
         // Tolerate; the connect itself still succeeded.
       }
 
-      if (shutdownSignal.aborted) throw new Error('connect aborted');
+      if (cancelSignal.aborted) throw new Error('connect aborted');
 
       // Apply replay envelopes BEFORE transitioning to `connected` so
       // consumers observing the `connected` host event already see the

--- a/clients/typescript/src/client/hosts/state-mirror.ts
+++ b/clients/typescript/src/client/hosts/state-mirror.ts
@@ -53,17 +53,34 @@ const INITIAL_ROOT: RootState = { agents: [] };
  *
  * Session, terminal, and changeset URIs aren't globally unique across
  * hosts — `ahp-session:/s1` on Host A and `ahp-session:/s1` on Host B
- * are different resources. Compose into the string `${hostId}\0${uri}`
- * for Map keys so we don't depend on reference identity.
+ * are different resources. Compose into a string for Map keys so we
+ * don't depend on reference identity.
+ *
+ * The encoding is length-prefixed (`${hostId.length}\0${hostId}${uri}`)
+ * rather than a plain separator-joined string so that any character
+ * (including `\0`) inside a {@link HostId} or {@link URI} is
+ * unambiguous. Two different (`hostId`, `uri`) pairs always produce
+ * distinct keys.
  */
 export interface HostedResourceKey {
   readonly hostId: HostId;
   readonly uri: URI;
 }
 
-/** Build a Map-stable key string from a {@link HostedResourceKey}. */
+/**
+ * Build a Map-stable key string from a {@link HostedResourceKey}.
+ *
+ * The encoding is length-prefixed so it stays unambiguous even when
+ * a {@link HostId} contains `\0` or other characters that would
+ * otherwise collide with the separator.
+ */
 export function hostedResourceKey(hostId: HostId, uri: URI): string {
-  return `${hostId}\x00${uri}`;
+  return `${hostId.length}\x00${hostId}${uri}`;
+}
+
+/** @internal Length-prefixed `hostId` prefix shared by all of a host's resource keys. */
+function hostedResourceKeyPrefix(hostId: HostId): string {
+  return `${hostId.length}\x00${hostId}`;
 }
 
 /**
@@ -199,7 +216,7 @@ export class MultiHostStateMirror {
   /** Drop every slot keyed under `hostId` — root, sessions, terminals, changesets. */
   resetHost(hostId: HostId): void {
     this.rootStatesMap.delete(hostId);
-    const prefix = `${hostId}\x00`;
+    const prefix = hostedResourceKeyPrefix(hostId);
     for (const key of this.sessionsMap.keys()) {
       if (key.startsWith(prefix)) this.sessionsMap.delete(key);
     }

--- a/clients/typescript/src/client/hosts/state-mirror.ts
+++ b/clients/typescript/src/client/hosts/state-mirror.ts
@@ -1,0 +1,221 @@
+/**
+ * Host-aware reducer façade for multi-host consumers.
+ *
+ * Wraps the existing pure reducers (`rootReducer`, `sessionReducer`,
+ * `terminalReducer`, `changesetReducer`) the way a single-host
+ * consumer would, but keys session/terminal/changeset state by
+ * `(hostId, uri)` so URIs that legitimately collide across hosts (the
+ * normal case for session URIs) don't clobber each other.
+ *
+ * # Event sources are lossy today
+ *
+ * Both event surfaces the TypeScript SDK exposes are
+ * {@link AsyncBroadcastQueue}-backed and **drop envelopes on slow
+ * consumers** once their buffer fills:
+ *
+ * - {@link MultiHostClient.events} — the cross-host fan-in.
+ * - {@link AhpClient.subscribe} / {@link AhpClient.attachSubscription}
+ *   — per-channel {@link Subscription}.
+ *
+ * Neither survives a reconnect's replayed envelopes the way the Swift
+ * SDK's per-channel `events(host:uri:)` does. A dropped envelope (or
+ * a missed-because-reconnected envelope) permanently desyncs the
+ * mirror for that `(host, channel)` until it's re-seeded from a fresh
+ * snapshot via {@link MultiHostStateMirror.applySnapshot}. Consume
+ * with that in mind — the mirror is the right shape for multi-host UI
+ * state, but the SDK doesn't yet ship a lossless feeder.
+ *
+ * @module client/hosts/state-mirror
+ */
+
+import type { ActionEnvelope } from '../../types/common/actions.js';
+import type { Snapshot, URI } from '../../types/common/state.js';
+import type {
+  ChangesetAction,
+  RootAction,
+  SessionAction,
+  TerminalAction,
+} from '../../types/action-origin.generated.js';
+import type { ChangesetState } from '../../types/channels-changeset/state.js';
+import type { RootState } from '../../types/channels-root/state.js';
+import type { SessionState } from '../../types/channels-session/state.js';
+import type { TerminalState } from '../../types/channels-terminal/state.js';
+import { changesetReducer } from '../../types/channels-changeset/reducer.js';
+import { rootReducer } from '../../types/channels-root/reducer.js';
+import { sessionReducer } from '../../types/channels-session/reducer.js';
+import { terminalReducer } from '../../types/channels-terminal/reducer.js';
+import { ROOT_RESOURCE_URI, type HostId, type HostSubscriptionEvent } from './types.js';
+
+const INITIAL_ROOT: RootState = { agents: [] };
+
+/**
+ * Compound key tagging a channel URI with the host that produced it.
+ *
+ * Session, terminal, and changeset URIs aren't globally unique across
+ * hosts — `ahp-session:/s1` on Host A and `ahp-session:/s1` on Host B
+ * are different resources. Compose into the string `${hostId}\0${uri}`
+ * for Map keys so we don't depend on reference identity.
+ */
+export interface HostedResourceKey {
+  readonly hostId: HostId;
+  readonly uri: URI;
+}
+
+/** Build a Map-stable key string from a {@link HostedResourceKey}. */
+export function hostedResourceKey(hostId: HostId, uri: URI): string {
+  return `${hostId}\x00${uri}`;
+}
+
+/**
+ * In-memory mirror of per-host root/session/terminal/changeset state,
+ * fed by {@link ActionEnvelope}s and snapshot states tagged with their
+ * host of origin.
+ *
+ * Single-host consumers should keep using {@link AhpStateMirror}; this
+ * type adds the host dimension necessary for multi-host UIs.
+ *
+ * See the module-level docs for a warning about lossy event sources.
+ */
+export class MultiHostStateMirror {
+  private readonly rootStatesMap = new Map<HostId, RootState>();
+  private readonly sessionsMap = new Map<string, SessionState>();
+  private readonly terminalsMap = new Map<string, TerminalState>();
+  private readonly changesetsMap = new Map<string, ChangesetState>();
+
+  /** All known root states keyed by host. */
+  get rootStates(): ReadonlyMap<HostId, RootState> {
+    return this.rootStatesMap;
+  }
+
+  /** All known session states keyed by `hostedResourceKey(hostId, uri)`. */
+  get sessions(): ReadonlyMap<string, SessionState> {
+    return this.sessionsMap;
+  }
+
+  /** All known terminal states keyed by `hostedResourceKey(hostId, uri)`. */
+  get terminals(): ReadonlyMap<string, TerminalState> {
+    return this.terminalsMap;
+  }
+
+  /** All known changeset states keyed by `hostedResourceKey(hostId, uri)`. */
+  get changesets(): ReadonlyMap<string, ChangesetState> {
+    return this.changesetsMap;
+  }
+
+  /** Look up the root state for `hostId`. */
+  getRoot(hostId: HostId): RootState | undefined {
+    return this.rootStatesMap.get(hostId);
+  }
+
+  /** Look up a session by `(hostId, uri)`. */
+  getSession(hostId: HostId, uri: URI): SessionState | undefined {
+    return this.sessionsMap.get(hostedResourceKey(hostId, uri));
+  }
+
+  /** Look up a terminal by `(hostId, uri)`. */
+  getTerminal(hostId: HostId, uri: URI): TerminalState | undefined {
+    return this.terminalsMap.get(hostedResourceKey(hostId, uri));
+  }
+
+  /** Look up a changeset by `(hostId, uri)`. */
+  getChangeset(hostId: HostId, uri: URI): ChangesetState | undefined {
+    return this.changesetsMap.get(hostedResourceKey(hostId, uri));
+  }
+
+  /**
+   * Convenience: apply a {@link HostSubscriptionEvent} produced by
+   * {@link MultiHostClient.events}. Action envelopes are routed through
+   * the matching reducer; non-action events (session-summary
+   * notifications, auth challenges) are ignored — they don't move any
+   * of the reducer-tracked state shapes.
+   */
+  applyEvent(event: HostSubscriptionEvent): void {
+    if (event.event.type === 'action') {
+      this.applyEnvelope(event.hostId, event.event.params);
+    }
+  }
+
+  /**
+   * Apply a single action envelope scoped to `hostId`. Routing uses
+   * `envelope.channel`: {@link ROOT_RESOURCE_URI} is the root channel,
+   * every other URI is identified by the channel the server announces.
+   */
+  applyEnvelope(hostId: HostId, envelope: ActionEnvelope): void {
+    const { channel, action } = envelope;
+    if (channel === ROOT_RESOURCE_URI) {
+      const root = this.rootStatesMap.get(hostId) ?? INITIAL_ROOT;
+      this.rootStatesMap.set(hostId, rootReducer(root, action as RootAction));
+      return;
+    }
+    if (channel.startsWith('ahp-session:')) {
+      const key = hostedResourceKey(hostId, channel);
+      const current = this.sessionsMap.get(key);
+      if (!current) return;
+      this.sessionsMap.set(key, sessionReducer(current, action as SessionAction));
+      return;
+    }
+    if (channel.startsWith('ahp-terminal:')) {
+      const key = hostedResourceKey(hostId, channel);
+      const current = this.terminalsMap.get(key);
+      if (!current) return;
+      this.terminalsMap.set(key, terminalReducer(current, action as TerminalAction));
+      return;
+    }
+    if (channel.startsWith('ahp-changeset:')) {
+      const key = hostedResourceKey(hostId, channel);
+      const current = this.changesetsMap.get(key);
+      if (!current) return;
+      this.changesetsMap.set(key, changesetReducer(current, action as ChangesetAction));
+      return;
+    }
+  }
+
+  /**
+   * Seed the mirror from a {@link Snapshot} scoped to `hostId` — root,
+   * session, terminal, or changeset as the snapshot's `state` shape
+   * dictates.
+   */
+  applySnapshot(hostId: HostId, snapshot: Snapshot): void {
+    const { resource } = snapshot;
+    if (resource === ROOT_RESOURCE_URI) {
+      this.rootStatesMap.set(hostId, snapshot.state as RootState);
+      return;
+    }
+    const key = hostedResourceKey(hostId, resource);
+    if (resource.startsWith('ahp-session:')) {
+      this.sessionsMap.set(key, snapshot.state as SessionState);
+      return;
+    }
+    if (resource.startsWith('ahp-terminal:')) {
+      this.terminalsMap.set(key, snapshot.state as TerminalState);
+      return;
+    }
+    if (resource.startsWith('ahp-changeset:')) {
+      this.changesetsMap.set(key, snapshot.state as ChangesetState);
+      return;
+    }
+  }
+
+  /** Drop every slot keyed under `hostId` — root, sessions, terminals, changesets. */
+  resetHost(hostId: HostId): void {
+    this.rootStatesMap.delete(hostId);
+    const prefix = `${hostId}\x00`;
+    for (const key of this.sessionsMap.keys()) {
+      if (key.startsWith(prefix)) this.sessionsMap.delete(key);
+    }
+    for (const key of this.terminalsMap.keys()) {
+      if (key.startsWith(prefix)) this.terminalsMap.delete(key);
+    }
+    for (const key of this.changesetsMap.keys()) {
+      if (key.startsWith(prefix)) this.changesetsMap.delete(key);
+    }
+  }
+
+  /** Drop every host's state. */
+  reset(): void {
+    this.rootStatesMap.clear();
+    this.sessionsMap.clear();
+    this.terminalsMap.clear();
+    this.changesetsMap.clear();
+  }
+}

--- a/clients/typescript/src/client/hosts/types.ts
+++ b/clients/typescript/src/client/hosts/types.ts
@@ -333,8 +333,11 @@ export class HostReconnectedError extends HostMultiError {
 }
 
 /**
- * The host's runtime has been torn down — the host was removed, or the
- * {@link MultiHostClient} was shut down.
+ * The host's runtime has been torn down — the host was removed via
+ * {@link MultiHostClient.removeHost} or the entire {@link MultiHostClient}
+ * was shut down. This is a **permanent** failure; the host is not
+ * coming back. Use {@link HostNotConnectedError} to distinguish the
+ * transient "registered but currently disconnected/reconnecting" case.
  */
 export class HostShutDownError extends HostMultiError {
   readonly hostId: HostId;
@@ -342,6 +345,27 @@ export class HostShutDownError extends HostMultiError {
   constructor(hostId: HostId) {
     super(`host "${hostId}" runtime is no longer active`);
     this.name = 'HostShutDownError';
+    this.hostId = hostId;
+  }
+}
+
+/**
+ * The host is registered but has no active client connection right now
+ * (the supervisor is `connecting`, `reconnecting`, `disconnected`, or
+ * `failed`). This is **recoverable**: the supervisor will keep retrying
+ * per its {@link ReconnectPolicy}, or the caller can force a fresh
+ * attempt via {@link MultiHostClient.reconnectHost}. Subscriptions
+ * issued in this state are still tracked locally and replayed on the
+ * next successful connect.
+ *
+ * Use {@link HostShutDownError} to distinguish permanent teardown.
+ */
+export class HostNotConnectedError extends HostMultiError {
+  readonly hostId: HostId;
+
+  constructor(hostId: HostId) {
+    super(`host "${hostId}" is not currently connected`);
+    this.name = 'HostNotConnectedError';
     this.hostId = hostId;
   }
 }

--- a/clients/typescript/src/client/hosts/types.ts
+++ b/clients/typescript/src/client/hosts/types.ts
@@ -1,0 +1,391 @@
+/**
+ * Public-facing types for the multi-host SDK.
+ *
+ * @module client/hosts/types
+ */
+
+import type { URI } from '../../types/common/state.js';
+import type { AgentInfo } from '../../types/channels-root/state.js';
+import type { TerminalInfo } from '../../types/channels-terminal/state.js';
+import type { SessionSummary } from '../../types/channels-session/state.js';
+import type { ClientEvent, SubscriptionEvent } from '../events.js';
+import { AhpClientError } from '../error.js';
+import type { ClientIdStore } from './client-id-store.js';
+import type { HostTransportFactory } from './factory.js';
+import { defaultReconnectPolicy, type ReconnectPolicy } from './policy.js';
+import type { AhpClientConfig } from '../client.js';
+
+/**
+ * Opaque, consumer-supplied identifier for a host registered with
+ * {@link MultiHostClient}.
+ *
+ * Surface-level alias for `string`; equality is `===`. Used as the
+ * routing key for commands and the tag on every
+ * {@link HostSubscriptionEvent}.
+ */
+export type HostId = string;
+
+/** Connection state for a single host. */
+export type HostState =
+  | { readonly status: 'disconnected' }
+  | { readonly status: 'connecting' }
+  | { readonly status: 'connected' }
+  | {
+      readonly status: 'reconnecting';
+      /** One-based attempt counter. Resets to 1 after a successful connection when {@link ReconnectPolicy.resetOnSuccess} is `true`. */
+      readonly attempt: number;
+    }
+  | {
+      readonly status: 'failed';
+      /** Most recent failure that drove the host into this state. */
+      readonly error: Error;
+    };
+
+/**
+ * Convenience predicate: is the host currently connected?
+ */
+export function isConnected(state: HostState): boolean {
+  return state.status === 'connected';
+}
+
+/**
+ * Convenience predicate: is the host in a terminal failure state?
+ */
+export function isFailed(state: HostState): boolean {
+  return state.status === 'failed';
+}
+
+/**
+ * Configuration for a single host registered with {@link MultiHostClient}.
+ *
+ * Use the bare-minimum form (`{ id, label, transportFactory }`) for the
+ * common case; the optional fields cover advanced scenarios.
+ *
+ * `clientId` is intentionally optional. When omitted, the multi-host
+ * client resolves it at `addHost` time:
+ *
+ * 1. If a {@link ClientIdStore} entry already exists for this host, it
+ *    is reused.
+ * 2. Otherwise, a fresh UUID-shaped id is generated and persisted.
+ *
+ * Setting `clientId` explicitly always wins over a stored value and is
+ * persisted into the store so subsequent launches transparently reuse it.
+ */
+export interface HostConfig {
+  /** Stable host identifier. */
+  readonly id: HostId;
+  /** Human-readable label. Surfaced through {@link HostHandle.label}. */
+  readonly label: string;
+  /** Optional explicit `clientId` to send on `initialize` / `reconnect`. */
+  readonly clientId?: string;
+  /**
+   * URIs to include in the `initialize` handshake. Defaults to
+   * `['ahp-root://']` so root state is always tracked.
+   */
+  readonly initialSubscriptions?: readonly URI[];
+  /** Configuration forwarded to the underlying {@link AhpClient}. */
+  readonly clientConfig?: AhpClientConfig;
+  /** Factory used to (re-)open a transport for this host. */
+  readonly transportFactory: HostTransportFactory;
+  /** Reconnect behaviour after an unexpected drop. */
+  readonly reconnectPolicy?: ReconnectPolicy;
+}
+
+/**
+ * Resolved (defaulted) form of {@link HostConfig} used internally. All
+ * optional fields have their defaults filled in.
+ *
+ * @internal
+ */
+export interface ResolvedHostConfig {
+  readonly id: HostId;
+  readonly label: string;
+  readonly clientId: string | null;
+  readonly initialSubscriptions: readonly URI[];
+  readonly clientConfig: AhpClientConfig;
+  readonly transportFactory: HostTransportFactory;
+  readonly reconnectPolicy: ReconnectPolicy;
+}
+
+/** The protocol's root channel URI. */
+export const ROOT_RESOURCE_URI: URI = 'ahp-root://';
+
+/**
+ * Apply defaults to a {@link HostConfig}, including the default
+ * `['ahp-root://']` subscription and the default reconnect policy.
+ *
+ * @internal
+ */
+export function resolveConfig(config: HostConfig): ResolvedHostConfig {
+  return {
+    id: config.id,
+    label: config.label,
+    clientId: config.clientId ?? null,
+    initialSubscriptions: config.initialSubscriptions
+      ? [...config.initialSubscriptions]
+      : [ROOT_RESOURCE_URI],
+    clientConfig: config.clientConfig ?? {},
+    transportFactory: config.transportFactory,
+    reconnectPolicy: config.reconnectPolicy ?? defaultReconnectPolicy(),
+  };
+}
+
+/**
+ * Snapshot of everything {@link MultiHostClient} knows about a single
+ * host: connection state, last error, protocol version, mirrored root
+ * fields, subscribed URIs, cached session summaries, generation counter.
+ *
+ * Cheap to clone — fields are primitives or already-frozen arrays.
+ * Snapshots are immutable; take a fresh one via
+ * {@link MultiHostClient.host} or {@link MultiHostClient.hosts}, or
+ * listen to {@link MultiHostClient.hostEvents}.
+ */
+export interface HostHandle {
+  /** Stable identifier. */
+  readonly id: HostId;
+  /** Human-readable label from the original {@link HostConfig}. */
+  readonly label: string;
+  /** `clientId` actually sent to the host on `initialize`/`reconnect`. */
+  readonly clientId: string;
+  /** Current connection state. */
+  readonly state: HostState;
+  /**
+   * Most recent failure that drove the host into a non-connected state.
+   * Set when the supervisor enters `reconnecting` or `failed`. Cleared on
+   * a successful connect.
+   */
+  readonly lastError: Error | null;
+  /**
+   * Wall-clock time of the most recent successful `initialize` or
+   * `reconnect`. `null` until the host first connects. Milliseconds
+   * since the Unix epoch.
+   */
+  readonly lastConnectedAt: number | null;
+  /** Protocol version negotiated on the most recent successful `initialize`. */
+  readonly protocolVersion: string | null;
+  /** Highest `serverSeq` observed on this host. */
+  readonly serverSeq: number;
+  /** Optional `defaultDirectory` from the host's `InitializeResult`. */
+  readonly defaultDirectory: string | null;
+  /** Agents currently advertised by the host (mirrored from root state). */
+  readonly agents: readonly AgentInfo[];
+  /** Active session count from root state, when present. */
+  readonly activeSessions: number | null;
+  /** Lightweight terminal listing from root state, when present. */
+  readonly terminals: readonly TerminalInfo[] | null;
+  /** URIs the supervisor will (re-)subscribe to across reconnects. */
+  readonly subscriptions: readonly URI[];
+  /** Trigger characters from `InitializeResult.completionTriggerCharacters`. */
+  readonly completionTriggerCharacters: readonly string[];
+  /**
+   * Cached session summaries seeded by `listSessions` after each
+   * connect and kept fresh by
+   * `root/sessionAdded`/`Removed`/`SummaryChanged` notifications.
+   */
+  readonly sessionSummaries: readonly SessionSummary[];
+  /**
+   * Generation counter — bumped on every `connect` or `reconnect`.
+   * Held by {@link HostClientHandle}s to detect connections that have
+   * been replaced beneath them.
+   */
+  readonly generation: number;
+}
+
+/** Connection-level event for UX. */
+export type HostEvent =
+  | { readonly type: 'added'; readonly hostId: HostId }
+  | {
+      readonly type: 'stateChanged';
+      readonly hostId: HostId;
+      readonly state: HostState;
+      /** Last error, when transitioning into `reconnecting` or `failed`. */
+      readonly lastError: Error | null;
+    }
+  | {
+      readonly type: 'connected';
+      readonly hostId: HostId;
+      /** Generation the new connection lives on. */
+      readonly generation: number;
+    }
+  | { readonly type: 'removed'; readonly hostId: HostId };
+
+/**
+ * Inbound event tagged with host of origin.
+ *
+ * Delivered by {@link MultiHostClient.events}. The `channel` field
+ * carries the URI the event is scoped to (the envelope's `channel` for
+ * actions, the notification params' `channel` for protocol
+ * notifications).
+ */
+export interface HostSubscriptionEvent {
+  /** Host that produced the event. */
+  readonly hostId: HostId;
+  /** Channel URI this event was scoped to. */
+  readonly channel: URI;
+  /** The underlying {@link SubscriptionEvent}. */
+  readonly event: SubscriptionEvent;
+}
+
+/** @internal */
+export function tagClientEvent(hostId: HostId, event: ClientEvent): HostSubscriptionEvent {
+  return { hostId, channel: event.channel, event: event.event };
+}
+
+/**
+ * Aggregated session summary tagged with host of origin.
+ *
+ * Returned by {@link MultiHostClient.aggregatedSessions}. URIs are
+ * per-host scoped, so two hosts can legitimately return the same
+ * `summary.resource`; consumers should treat `(hostId, summary.resource)`
+ * as the compound key.
+ */
+export interface HostedSessionSummary {
+  /** Host the summary belongs to. */
+  readonly hostId: HostId;
+  /** Host label at the time the snapshot was taken. */
+  readonly hostLabel: string;
+  /** Underlying summary. */
+  readonly summary: SessionSummary;
+}
+
+/**
+ * Aggregated agent descriptor tagged with host of origin.
+ *
+ * Returned by {@link MultiHostClient.aggregatedAgents}.
+ */
+export interface HostedAgent {
+  /** Host the agent belongs to. */
+  readonly hostId: HostId;
+  /** Host label at the time the snapshot was taken. */
+  readonly hostLabel: string;
+  /** Underlying agent metadata. */
+  readonly agent: AgentInfo;
+}
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+/**
+ * Base class for every error thrown by the multi-host SDK layer that
+ * isn't already an {@link AhpClientError} (RPC failures, transport
+ * errors, etc. still surface from the underlying {@link AhpClient}
+ * unmodified).
+ *
+ * Extends {@link AhpClientError} so consumers can catch every multi-host
+ * SDK error with a single `instanceof` check.
+ */
+export class HostMultiError extends AhpClientError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'HostMultiError';
+  }
+}
+
+/** No host with that id is currently registered. */
+export class UnknownHostError extends HostMultiError {
+  readonly hostId: HostId;
+
+  constructor(hostId: HostId) {
+    super(`no host registered with id "${hostId}"`);
+    this.name = 'UnknownHostError';
+    this.hostId = hostId;
+  }
+}
+
+/**
+ * A host with this id is already registered. Remove the existing host
+ * first if you want to replace it.
+ */
+export class DuplicateHostError extends HostMultiError {
+  readonly hostId: HostId;
+
+  constructor(hostId: HostId) {
+    super(`a host with id "${hostId}" is already registered`);
+    this.name = 'DuplicateHostError';
+    this.hostId = hostId;
+  }
+}
+
+/**
+ * The {@link HostClientHandle} was issued for a connection that has
+ * since been replaced by a reconnect. Acquire a fresh handle via
+ * {@link MultiHostClient.client}.
+ *
+ * Both generations are reported so consumers can log a clean "stale
+ * handle at gen N, host is now gen M" breadcrumb and retry against the
+ * fresh handle.
+ */
+export class HostReconnectedError extends HostMultiError {
+  readonly hostId: HostId;
+  /** Generation the stale handle was minted at. */
+  readonly handleGeneration: number;
+  /** Generation the host is currently on. */
+  readonly currentGeneration: number;
+
+  constructor(hostId: HostId, handleGeneration: number, currentGeneration: number) {
+    super(
+      `host "${hostId}" reconnected (generation ${handleGeneration} -> ${currentGeneration}); request a fresh client handle`,
+    );
+    this.name = 'HostReconnectedError';
+    this.hostId = hostId;
+    this.handleGeneration = handleGeneration;
+    this.currentGeneration = currentGeneration;
+  }
+}
+
+/**
+ * The host's runtime has been torn down — the host was removed, or the
+ * {@link MultiHostClient} was shut down.
+ */
+export class HostShutDownError extends HostMultiError {
+  readonly hostId: HostId;
+
+  constructor(hostId: HostId) {
+    super(`host "${hostId}" runtime is no longer active`);
+    this.name = 'HostShutDownError';
+    this.hostId = hostId;
+  }
+}
+
+/**
+ * The configured {@link ClientIdStore} failed to load or persist a
+ * host's `clientId`.
+ *
+ * Surfaced from {@link MultiHostClient.addHost} when the underlying
+ * store I/O fails (e.g. a file-backed store can't write its directory).
+ */
+export class ClientIdStoreError extends HostMultiError {
+  readonly hostId: HostId;
+
+  constructor(hostId: HostId, message: string, options?: { cause?: unknown }) {
+    super(`client id store error for host "${hostId}": ${message}`, options);
+    this.name = 'ClientIdStoreError';
+    this.hostId = hostId;
+  }
+}
+
+// ─── ID generation ───────────────────────────────────────────────────────────
+
+/**
+ * Generate a fresh UUID-shaped `clientId`. Uses `crypto.randomUUID`
+ * when available (Node 19+, modern browsers); falls back to a
+ * locally-mixed UUIDv4 hex string otherwise so older Node runtimes
+ * still work.
+ *
+ * @internal
+ */
+export function generateClientId(): string {
+  const cryptoObj = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return cryptoObj.randomUUID();
+  }
+  // Fallback: synthesize a UUIDv4-shaped string from Math.random.
+  // Acceptable because consumers that need cross-launch identity should
+  // persist the value through a ClientIdStore anyway.
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = (n: number): string => n.toString(16).padStart(2, '0');
+  const h = Array.from(bytes, hex).join('');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}

--- a/clients/typescript/src/client/hosts/types.ts
+++ b/clients/typescript/src/client/hosts/types.ts
@@ -135,10 +135,12 @@ export function resolveConfig(config: HostConfig): ResolvedHostConfig {
  * host: connection state, last error, protocol version, mirrored root
  * fields, subscribed URIs, cached session summaries, generation counter.
  *
- * Cheap to clone — fields are primitives or already-frozen arrays.
- * Snapshots are immutable; take a fresh one via
- * {@link MultiHostClient.host} or {@link MultiHostClient.hosts}, or
- * listen to {@link MultiHostClient.hostEvents}.
+ * Cheap to clone — fields are primitives or shallow-cloned arrays.
+ * Treat snapshots as immutable: they aren't deeply frozen, but the
+ * supervisor never mutates them after construction, and any field you
+ * care about should be re-read by taking a fresh snapshot via
+ * {@link MultiHostClient.host} or {@link MultiHostClient.hosts}, or by
+ * listening to {@link MultiHostClient.hostEvents}.
  */
 export interface HostHandle {
   /** Stable identifier. */
@@ -390,23 +392,34 @@ export class ClientIdStoreError extends HostMultiError {
 // ─── ID generation ───────────────────────────────────────────────────────────
 
 /**
- * Generate a fresh UUID-shaped `clientId`. Uses `crypto.randomUUID`
- * when available (Node 19+, modern browsers); falls back to a
- * locally-mixed UUIDv4 hex string otherwise so older Node runtimes
- * still work.
+ * Generate a fresh UUID-shaped `clientId`. Prefers
+ * `crypto.randomUUID()` (Node 19+, modern browsers); falls back to
+ * `crypto.getRandomValues()` for the 16 random bytes when only that is
+ * available (older browsers / non-secure contexts); and only falls
+ * back to `Math.random()` as a last resort for environments where no
+ * Web Crypto API is exposed at all.
  *
  * @internal
  */
 export function generateClientId(): string {
-  const cryptoObj = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  const cryptoObj = (globalThis as {
+    crypto?: {
+      randomUUID?: () => string;
+      getRandomValues?: <T extends ArrayBufferView>(array: T) => T;
+    };
+  }).crypto;
   if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
     return cryptoObj.randomUUID();
   }
-  // Fallback: synthesize a UUIDv4-shaped string from Math.random.
-  // Acceptable because consumers that need cross-launch identity should
-  // persist the value through a ClientIdStore anyway.
   const bytes = new Uint8Array(16);
-  for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  if (cryptoObj && typeof cryptoObj.getRandomValues === 'function') {
+    cryptoObj.getRandomValues(bytes);
+  } else {
+    // Last-resort fallback. `Math.random()` is not cryptographically
+    // strong, but consumers that need cross-launch identity should
+    // persist the value through a ClientIdStore anyway.
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
   bytes[6] = (bytes[6] & 0x0f) | 0x40;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   const hex = (n: number): string => n.toString(16).padStart(2, '0');

--- a/clients/typescript/test/hosts.test.ts
+++ b/clients/typescript/test/hosts.test.ts
@@ -242,6 +242,62 @@ test('InMemoryClientIdStore round-trips and overwrites', async () => {
   assert.equal(await store.load('a'), 'second');
 });
 
+// ─── generateClientId fallback chain ────────────────────────────────────────
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/**
+ * Replace `globalThis.crypto` with `value` for the duration of the test.
+ * Node exposes `globalThis.crypto` as a getter-only property so plain
+ * assignment fails — use `Object.defineProperty` and restore the original
+ * descriptor afterwards.
+ */
+function withStubbedCrypto<T>(value: unknown, body: () => T): T {
+  const target = globalThis as object;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(target, 'crypto');
+  Object.defineProperty(target, 'crypto', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    return body();
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(target, 'crypto', originalDescriptor);
+    } else {
+      delete (target as { crypto?: unknown }).crypto;
+    }
+  }
+}
+
+test('generateClientId prefers crypto.getRandomValues over Math.random when randomUUID is missing', async () => {
+  const { generateClientId } = await import('../src/client/hosts/types.js');
+  let getRandomCalls = 0;
+  const stub = {
+    // no randomUUID — force the fallback path
+    getRandomValues<T extends ArrayBufferView>(view: T): T {
+      getRandomCalls += 1;
+      // Fill with a known deterministic pattern so we can assert
+      // the bytes round-trip through the UUIDv4 framing.
+      const bytes = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+      for (let i = 0; i < bytes.length; i++) bytes[i] = 0xab;
+      return view;
+    },
+  };
+  const id = withStubbedCrypto(stub, () => generateClientId());
+  assert.equal(getRandomCalls, 1, 'expected exactly one getRandomValues call');
+  assert.match(id, UUID_RE);
+  assert.equal(id[14], '4', 'UUID version digit should be 4');
+  assert.ok('89ab'.includes(id[19]), 'UUID variant digit should be 8, 9, a, or b');
+});
+
+test('generateClientId still returns a UUIDv4-shaped string when only Math.random is available', async () => {
+  const { generateClientId } = await import('../src/client/hosts/types.js');
+  const id = withStubbedCrypto(undefined, () => generateClientId());
+  assert.match(id, UUID_RE);
+});
+
 // ─── HostedResourceKey ──────────────────────────────────────────────────────
 
 test('hostedResourceKey distinguishes hosts with the same URI', () => {

--- a/clients/typescript/test/hosts.test.ts
+++ b/clients/typescript/test/hosts.test.ts
@@ -730,6 +730,109 @@ test('MultiHostClient.shutdown is idempotent', async () => {
   assert.equal(multi.host('idemp'), undefined);
 });
 
+// ─── Cancellation: factory signal aborts on manual reconnect ────────────────
+
+test('manual reconnectHost aborts a slow in-flight transport factory', async () => {
+  let attempt = 0;
+  const firstAttemptSignal: { value: AbortSignal | null } = { value: null };
+  const firstAttemptCalled = { value: false };
+  const factory: HostTransportFactory = async (_id, signal) => {
+    attempt += 1;
+    if (attempt === 1) {
+      // Capture the signal and hang until it aborts, then reject like
+      // a transport open that bailed out on the signal would.
+      firstAttemptSignal.value = signal;
+      firstAttemptCalled.value = true;
+      await new Promise<void>((resolve, reject) => {
+        if (signal.aborted) {
+          reject(new Error('aborted'));
+          return;
+        }
+        signal.addEventListener(
+          'abort',
+          () => reject(new Error('aborted')),
+          { once: true },
+        );
+      });
+      throw new Error('unreachable');
+    }
+    // Second attempt succeeds.
+    const [c, s] = InMemoryTransport.pair();
+    void driveFakeHost(s, makeFakeState());
+    return c;
+  };
+
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'slow',
+      label: 'slow',
+      transportFactory: factory,
+    });
+    // Wait for the first factory invocation so the supervisor is parked
+    // on the hung promise.
+    await waitUntil(() => firstAttemptCalled.value);
+    assert.equal(firstAttemptSignal.value?.aborted, false, 'factory signal should not be aborted yet');
+
+    // Manual reconnect should abort the first-attempt signal and let
+    // the supervisor open a fresh transport.
+    await multi.reconnectHost('slow');
+    await waitUntil(() => multi.host('slow')?.state.status === 'connected');
+    assert.equal(firstAttemptSignal.value?.aborted, true, 'factory signal should be aborted by manual reconnect');
+    assert.equal(attempt, 2, 'expected a second factory invocation after manual reconnect');
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── Race: shutdown during addHost ──────────────────────────────────────────
+
+test('addHost throws HostShutDownError when shutdown lands during ClientIdStore.load', async () => {
+  // A store that exposes its in-flight load promise so the test can
+  // sequence: addHost starts → shutdown runs → store resolves.
+  let releaseLoad!: (value: string | null) => void;
+  const loadStarted = { value: false };
+  const slowStore: ClientIdStore = {
+    async load() {
+      loadStarted.value = true;
+      return new Promise<string | null>(resolve => {
+        releaseLoad = resolve;
+      });
+    },
+    async store() {
+      // unreachable in this test
+    },
+  };
+  const factoryCallCount = { value: 0 };
+  const factory: HostTransportFactory = async () => {
+    factoryCallCount.value += 1;
+    const [c, s] = InMemoryTransport.pair();
+    void driveFakeHost(s, makeFakeState());
+    return c;
+  };
+
+  const multi = new MultiHostClient({ clientIdStore: slowStore });
+  const addPromise = multi.addHost({
+    id: 'racey',
+    label: 'racey',
+    transportFactory: factory,
+  });
+  await waitUntil(() => loadStarted.value);
+
+  // Shutdown lands while addHost is still awaiting the store.
+  const shutdownPromise = multi.shutdown();
+  // Now resolve the store; addHost must re-check shutDown and bail.
+  releaseLoad(null);
+
+  await assert.rejects(
+    addPromise,
+    (err: unknown) => err instanceof HostShutDownError,
+  );
+  await shutdownPromise;
+  assert.equal(multi.host('racey'), undefined, 'no runtime should be registered');
+  assert.equal(factoryCallCount.value, 0, 'transport factory must not have been invoked');
+});
+
 // ─── Unknown host ───────────────────────────────────────────────────────────
 
 test('subscribe/unsubscribe/dispatch on an unknown host throws UnknownHostError', async () => {

--- a/clients/typescript/test/hosts.test.ts
+++ b/clients/typescript/test/hosts.test.ts
@@ -33,6 +33,7 @@ import type { ReconnectResult } from '../src/types/common/commands.js';
 import {
   ClientIdStoreError,
   DuplicateHostError,
+  HostNotConnectedError,
   HostReconnectedError,
   HostShutDownError,
   InMemoryClientIdStore,
@@ -246,6 +247,25 @@ test('InMemoryClientIdStore round-trips and overwrites', async () => {
 test('hostedResourceKey distinguishes hosts with the same URI', () => {
   const a = hostedResourceKey('host-a', 'ahp-session:/s1');
   const b = hostedResourceKey('host-b', 'ahp-session:/s1');
+  assert.notEqual(a, b);
+});
+
+test('hostedResourceKey is collision-safe across awkward hostId / uri pairs', () => {
+  // Length-prefix encoding must keep these distinct even though a naïve
+  // `${hostId}\0${uri}` join would collide on the first pair and a
+  // simpler `${hostId}${uri}` join would collide on the second.
+  assert.notEqual(
+    hostedResourceKey('host\x00a', 'b:/s'),
+    hostedResourceKey('host', '\x00ab:/s'),
+  );
+  assert.notEqual(
+    hostedResourceKey('host', 'a:/s'),
+    hostedResourceKey('hosta', ':/s'),
+  );
+  // And a hostId containing the literal `\0` byte still round-trips
+  // distinctly when only the URI changes.
+  const a = hostedResourceKey('h\x00ost', 'ahp-session:/s1');
+  const b = hostedResourceKey('h\x00ost', 'ahp-session:/s2');
   assert.notEqual(a, b);
 });
 
@@ -847,6 +867,151 @@ test('subscribe/unsubscribe/dispatch on an unknown host throws UnknownHostError'
   } finally {
     await multi.shutdown();
   }
+});
+
+// ─── HostNotConnectedError ──────────────────────────────────────────────────
+
+test('subscribe on a registered-but-not-yet-connected host throws HostNotConnectedError', async () => {
+  // A factory that hangs forever so the supervisor stays in `connecting`.
+  const factory: HostTransportFactory = async (_id, signal) =>
+    new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    });
+
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({ id: 'pending', label: 'pending', transportFactory: factory });
+    // No `await waitUntil` for connected — by design the host is still
+    // connecting. `subscribe` should distinguish "not connected yet"
+    // from "permanently shut down".
+    await assert.rejects(
+      multi.subscribe('pending', 'ahp-session:/s1'),
+      (err: unknown) =>
+        err instanceof HostNotConnectedError &&
+        err.hostId === 'pending' &&
+        !(err instanceof HostShutDownError),
+    );
+    // The URI should have been tracked for replay on the next connect
+    // (alongside the implicit `ahp-root://` subscription every host
+    // starts with).
+    const handle = multi.host('pending');
+    assert.ok(handle);
+    assert.ok(handle.subscriptions.includes('ahp-session:/s1'));
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+test('dispatch on a registered-but-not-yet-connected host throws HostNotConnectedError', async () => {
+  const factory: HostTransportFactory = async (_id, signal) =>
+    new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    });
+
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({ id: 'pending', label: 'pending', transportFactory: factory });
+    assert.throws(
+      () =>
+        multi.dispatch(
+          'pending',
+          ROOT,
+          { type: 'noop' } as unknown as Parameters<typeof multi.dispatch>[2],
+        ),
+      (err: unknown) =>
+        err instanceof HostNotConnectedError &&
+        err.hostId === 'pending' &&
+        !(err instanceof HostShutDownError),
+    );
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── ClientIdStore signal ───────────────────────────────────────────────────
+
+test('ClientIdStore.load / store receive the multi-host shutdown signal', async () => {
+  const observed: { load: AbortSignal | null; store: AbortSignal | null } = {
+    load: null,
+    store: null,
+  };
+  const recordingStore: ClientIdStore = {
+    async load(_id, signal) {
+      observed.load = signal ?? null;
+      return null;
+    },
+    async store(_id, _clientId, signal) {
+      observed.store = signal ?? null;
+    },
+  };
+  const multi = new MultiHostClient({ clientIdStore: recordingStore });
+  try {
+    await multi.addHost({
+      id: 'sig',
+      label: 'sig',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+  } finally {
+    await multi.shutdown();
+  }
+  assert.ok(observed.load instanceof AbortSignal, 'load should receive an AbortSignal');
+  assert.ok(observed.store instanceof AbortSignal, 'store should receive an AbortSignal');
+  // After shutdown the captured signal must reflect the aborted state.
+  assert.equal(observed.load?.aborted, true);
+  assert.equal(observed.store?.aborted, true);
+});
+
+// ─── Reconnect listener bookkeeping ─────────────────────────────────────────
+
+test('repeated reconnect cycles do not accumulate abort listeners on the shutdown signal', async () => {
+  // Drive a host through many disconnect/reconnect cycles by closing
+  // the transport from the server side after init. If the per-connect
+  // `linkAbortSignals` listeners weren't released on successful
+  // connects, the per-runtime `shutdownController.signal` would
+  // accumulate them (Node emits a `MaxListenersExceededWarning` after
+  // 10 listeners on a target — we capture it).
+  const warnings: string[] = [];
+  const onWarning = (w: Error): void => {
+    if (w.name === 'MaxListenersExceededWarning') warnings.push(w.message);
+  };
+  process.on('warning', onWarning);
+
+  let attempt = 0;
+  const factory: HostTransportFactory = async () => {
+    attempt += 1;
+    const [c, s] = InMemoryTransport.pair();
+    const state: FakeHostState = makeFakeState({
+      injectAfterInit: async server => {
+        // Yield once so the supervisor enters `runConnection` before we
+        // tear down. Then close the socket to force a reconnect.
+        await new Promise(r => setTimeout(r, 1));
+        server.close();
+      },
+    });
+    void driveFakeHost(s, state);
+    return c;
+  };
+
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'churn',
+      label: 'churn',
+      // Effectively no backoff so cycles complete quickly.
+      reconnectPolicy: immediateForeverPolicy(),
+      transportFactory: factory,
+    });
+    // Wait until we've completed at least 20 cycles.
+    await waitUntil(() => attempt >= 20, 5000);
+  } finally {
+    await multi.shutdown();
+    process.removeListener('warning', onWarning);
+  }
+  assert.equal(
+    warnings.length,
+    0,
+    `expected no MaxListenersExceededWarning; got: ${warnings.join(' / ')}`,
+  );
 });
 
 // Reference the imported HostId type to avoid 'unused' warnings.

--- a/clients/typescript/test/hosts.test.ts
+++ b/clients/typescript/test/hosts.test.ts
@@ -1,0 +1,750 @@
+/**
+ * Integration tests for the multi-host SDK (`@microsoft/agent-host-protocol/hosts`).
+ *
+ * Uses an in-memory transport pair (mirroring the Rust hosts.rs
+ * integration suite and the TypeScript client.test.ts) to drive a real
+ * {@link AhpClient} end-to-end through the {@link MultiHostClient}
+ * supervisor without any networking. Each test spins up one or more
+ * "fake hosts" — small async functions that respond to `initialize`,
+ * `listSessions`, `subscribe`, and optionally inject notifications or
+ * tear their socket down to force reconnects.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  InMemoryTransport,
+  type AhpTransport,
+  type JsonRpcMessage,
+} from '../src/client/index.js';
+import type {
+  JsonRpcNotification,
+  JsonRpcRequest,
+  JsonRpcSuccessResponse,
+} from '../src/types/common/messages.js';
+import type { SessionSummary } from '../src/types/channels-session/state.js';
+import type { AgentInfo } from '../src/types/channels-root/state.js';
+import type { InitializeResult } from '../src/types/common/commands.js';
+import type { ListSessionsResult } from '../src/types/channels-root/commands.js';
+import { ReconnectResultType } from '../src/types/common/commands.js';
+import type { ReconnectResult } from '../src/types/common/commands.js';
+
+import {
+  ClientIdStoreError,
+  DuplicateHostError,
+  HostReconnectedError,
+  HostShutDownError,
+  InMemoryClientIdStore,
+  MultiHostClient,
+  MultiHostStateMirror,
+  UnknownHostError,
+  attemptsExhausted,
+  backoffDelayForAttempt,
+  delayWithJitter,
+  disabledPolicy,
+  exponentialPolicy,
+  hostedResourceKey,
+  immediateForeverPolicy,
+  type ClientIdStore,
+  type HostConfig,
+  type HostId,
+  type HostSubscriptionEvent,
+  type HostTransportFactory,
+} from '../src/client/hosts/index.js';
+
+import { PROTOCOL_VERSION } from '../src/types/version/registry.js';
+import { SessionStatus } from '../src/types/channels-session/state.js';
+
+const ROOT = 'ahp-root://' as const;
+
+// ─── Fake host harness ───────────────────────────────────────────────────────
+
+interface FakeHostState {
+  agents: AgentInfo[];
+  sessions: SessionSummary[];
+  /** Optional callback invoked once after the first request is handled (init or reconnect). */
+  injectAfterInit?: (server: AhpTransport) => void | Promise<void>;
+}
+
+function makeFakeState(overrides: Partial<FakeHostState> = {}): FakeHostState {
+  return { agents: [], sessions: [], ...overrides };
+}
+
+function makeAgent(provider = 'copilot'): AgentInfo {
+  return {
+    provider,
+    displayName: provider,
+    description: 'fake',
+    models: [],
+  };
+}
+
+function makeSummary(resource: string, title: string, modifiedAt: number): SessionSummary {
+  return {
+    resource,
+    provider: 'copilot',
+    title,
+    status: SessionStatus.IDLE,
+    createdAt: 0,
+    modifiedAt,
+  };
+}
+
+function buildInitResult(state: FakeHostState): InitializeResult {
+  return {
+    protocolVersion: PROTOCOL_VERSION,
+    serverSeq: 0,
+    snapshots: [
+      {
+        resource: ROOT,
+        state: {
+          agents: state.agents,
+          activeSessions: state.sessions.length,
+        },
+        fromSeq: 0,
+      },
+    ],
+  };
+}
+
+function buildListResult(state: FakeHostState): ListSessionsResult {
+  return { items: state.sessions };
+}
+
+/**
+ * Drive one fake-host connection until the client closes. Recognises
+ * `initialize`, `reconnect`, `listSessions`, `subscribe`, and
+ * `unsubscribe`. Other requests echo an empty `{}` result.
+ */
+async function driveFakeHost(server: AhpTransport, state: FakeHostState): Promise<void> {
+  let injectionRan = false;
+  while (true) {
+    const frame = await server.recv();
+    if (!frame) return;
+    if (frame.kind !== 'text') continue;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(frame.text) as JsonRpcMessage;
+    } catch {
+      continue;
+    }
+    if ('method' in msg && 'id' in msg) {
+      const req = msg as JsonRpcRequest;
+      const result = handleRequest(req, state);
+      const resp: JsonRpcSuccessResponse = {
+        jsonrpc: '2.0',
+        id: req.id,
+        result,
+      };
+      try {
+        await server.send(resp);
+      } catch {
+        return;
+      }
+      if (!injectionRan && (req.method === 'initialize' || req.method === 'reconnect')) {
+        injectionRan = true;
+        if (state.injectAfterInit) {
+          await state.injectAfterInit(server);
+        }
+      }
+    }
+    // Notifications (unsubscribe, dispatchAction) are silently
+    // accepted; the fake host has no behavior to model for them.
+  }
+}
+
+function handleRequest(req: JsonRpcRequest, state: FakeHostState): unknown {
+  switch (req.method) {
+    case 'initialize':
+      return buildInitResult(state);
+    case 'reconnect':
+      // Default: reply with an empty replay so the supervisor moves on.
+      return { type: ReconnectResultType.Replay, actions: [], missing: [] } satisfies ReconnectResult;
+    case 'listSessions':
+      return buildListResult(state);
+    case 'subscribe': {
+      // Minimal `SubscribeResult` — snapshot omitted (stateless channels
+      // are valid). The fake server doesn't enforce real subscriptions.
+      return {};
+    }
+    default:
+      return {};
+  }
+}
+
+/** Build a transport factory that pairs an InMemoryTransport with `driveFakeHost`. */
+function makeBasicFactory(state: FakeHostState): HostTransportFactory {
+  return async () => {
+    const [c, s] = InMemoryTransport.pair();
+    void driveFakeHost(s, state);
+    return c;
+  };
+}
+
+async function waitUntil<T>(
+  predicate: () => T | undefined | null | false,
+  timeoutMs = 2000,
+  intervalMs = 5,
+): Promise<T> {
+  const start = Date.now();
+  while (true) {
+    const value = predicate();
+    if (value !== undefined && value !== null && value !== false) return value as T;
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitUntil timed out after ${timeoutMs}ms`);
+    }
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+}
+
+// ─── ReconnectPolicy unit tests ──────────────────────────────────────────────
+
+test('exponential backoff caps at max', () => {
+  const backoff = { kind: 'exponential' as const, initialMs: 1000, maxMs: 10_000, multiplier: 2 };
+  assert.equal(backoffDelayForAttempt(backoff, 1), 1000);
+  assert.equal(backoffDelayForAttempt(backoff, 2), 2000);
+  assert.equal(backoffDelayForAttempt(backoff, 3), 4000);
+  assert.equal(backoffDelayForAttempt(backoff, 4), 8000);
+  assert.equal(backoffDelayForAttempt(backoff, 5), 10_000);
+  assert.equal(backoffDelayForAttempt(backoff, 50), 10_000);
+});
+
+test('jitter at extremes scales delay', () => {
+  const policy = {
+    backoff: { kind: 'constant' as const, delayMs: 10_000 },
+    jitter: 0.5,
+    maxAttempts: null,
+    resetOnSuccess: true,
+  };
+  assert.equal(delayWithJitter(policy, 1, 0), 5000);
+  assert.equal(delayWithJitter(policy, 1, 1), 15_000);
+  assert.equal(delayWithJitter(policy, 1, 0.5), 10_000);
+});
+
+test('disabled policy exhausts immediately', () => {
+  assert.equal(attemptsExhausted(disabledPolicy(), 1), true);
+});
+
+test('unbounded policy never exhausts', () => {
+  assert.equal(attemptsExhausted(exponentialPolicy(), 1_000_000), false);
+});
+
+// ─── InMemoryClientIdStore ──────────────────────────────────────────────────
+
+test('InMemoryClientIdStore round-trips and overwrites', async () => {
+  const store = new InMemoryClientIdStore();
+  assert.equal(await store.load('a'), null);
+  await store.store('a', 'first');
+  assert.equal(await store.load('a'), 'first');
+  await store.store('a', 'second');
+  assert.equal(await store.load('a'), 'second');
+});
+
+// ─── HostedResourceKey ──────────────────────────────────────────────────────
+
+test('hostedResourceKey distinguishes hosts with the same URI', () => {
+  const a = hostedResourceKey('host-a', 'ahp-session:/s1');
+  const b = hostedResourceKey('host-b', 'ahp-session:/s1');
+  assert.notEqual(a, b);
+});
+
+// ─── MultiHostStateMirror ───────────────────────────────────────────────────
+
+test('MultiHostStateMirror applies root snapshots scoped to host', () => {
+  const mirror = new MultiHostStateMirror();
+  mirror.applySnapshot('host-a', {
+    resource: ROOT,
+    state: { agents: [makeAgent('copilot')] },
+    fromSeq: 0,
+  });
+  mirror.applySnapshot('host-b', {
+    resource: ROOT,
+    state: { agents: [makeAgent('vscode')] },
+    fromSeq: 0,
+  });
+  assert.equal(mirror.getRoot('host-a')?.agents[0]?.provider, 'copilot');
+  assert.equal(mirror.getRoot('host-b')?.agents[0]?.provider, 'vscode');
+});
+
+test('MultiHostStateMirror.resetHost drops every keyed state for that host', () => {
+  const mirror = new MultiHostStateMirror();
+  mirror.applySnapshot('host-a', { resource: ROOT, state: { agents: [] }, fromSeq: 0 });
+  mirror.applySnapshot('host-a', {
+    resource: 'ahp-session:/s1',
+    state: {} as unknown as Parameters<MultiHostStateMirror['applySnapshot']>[1]['state'],
+    fromSeq: 0,
+  });
+  mirror.applySnapshot('host-b', { resource: ROOT, state: { agents: [] }, fromSeq: 0 });
+  mirror.resetHost('host-a');
+  assert.equal(mirror.getRoot('host-a'), undefined);
+  assert.equal(mirror.getSession('host-a', 'ahp-session:/s1'), undefined);
+  assert.ok(mirror.getRoot('host-b') !== undefined);
+});
+
+// ─── MultiHostClient — single-host shape ────────────────────────────────────
+
+test('MultiHostClient.single connects and exposes a HostHandle snapshot', async () => {
+  const state = makeFakeState({ agents: [makeAgent('copilot')] });
+  const config: HostConfig = {
+    id: 'local',
+    label: 'Local sessions server',
+    transportFactory: makeBasicFactory(state),
+  };
+  const { multi } = await MultiHostClient.single(config);
+  try {
+    await waitUntil(() => multi.host('local')?.state.status === 'connected');
+    const snap = multi.host('local');
+    assert.ok(snap);
+    assert.equal(snap.label, 'Local sessions server');
+    assert.equal(snap.state.status, 'connected');
+    assert.equal(snap.agents[0]?.provider, 'copilot');
+    assert.equal(snap.protocolVersion, PROTOCOL_VERSION);
+    assert.ok(snap.lastConnectedAt && snap.lastConnectedAt > 0);
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── addHost / removeHost lifecycle ─────────────────────────────────────────
+
+test('two hosts register and connect independently', async () => {
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'a',
+      label: 'A',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    await multi.addHost({
+      id: 'b',
+      label: 'B',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    await waitUntil(() => multi.host('a')?.state.status === 'connected');
+    await waitUntil(() => multi.host('b')?.state.status === 'connected');
+    const hosts = multi.hostsSnapshot();
+    assert.equal(hosts.length, 2);
+    assert.deepEqual(
+      hosts.map(h => h.label).sort(),
+      ['A', 'B'],
+    );
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+test('addHost twice with the same id throws DuplicateHostError', async () => {
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'dup',
+      label: 'A',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    await assert.rejects(
+      multi.addHost({
+        id: 'dup',
+        label: 'B',
+        transportFactory: makeBasicFactory(makeFakeState()),
+      }),
+      (err: unknown) => err instanceof DuplicateHostError && err.hostId === 'dup',
+    );
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+test('removeHost stops a registered host', async () => {
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'gone',
+      label: 'Gone',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    await waitUntil(() => multi.host('gone')?.state.status === 'connected');
+    await multi.removeHost('gone');
+    assert.equal(multi.host('gone'), undefined);
+    await assert.rejects(multi.removeHost('gone'), UnknownHostError);
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── ClientIdStore failure handling ─────────────────────────────────────────
+
+test('addHost surfaces ClientIdStoreError when the store fails and frees the reservation', async () => {
+  let failNext = true;
+  const flakyStore: ClientIdStore = {
+    async load() {
+      if (failNext) {
+        failNext = false;
+        throw new Error('disk full');
+      }
+      return null;
+    },
+    async store() {
+      // succeed
+    },
+  };
+  const multi = new MultiHostClient({ clientIdStore: flakyStore });
+  try {
+    await assert.rejects(
+      multi.addHost({
+        id: 'flaky',
+        label: 'Flaky',
+        transportFactory: makeBasicFactory(makeFakeState()),
+      }),
+      (err: unknown) =>
+        err instanceof ClientIdStoreError &&
+        err.hostId === 'flaky' &&
+        /disk full/.test(err.message),
+    );
+    // The pending reservation should be cleared so a follow-up succeeds.
+    const handle = await multi.addHost({
+      id: 'flaky',
+      label: 'Flaky',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    assert.equal(handle.id, 'flaky');
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+test('explicit clientId is persisted into the store', async () => {
+  const store = new InMemoryClientIdStore();
+  const multi = new MultiHostClient({ clientIdStore: store });
+  try {
+    await multi.addHost({
+      id: 'explicit',
+      label: 'X',
+      clientId: 'override-id',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    assert.equal(await store.load('explicit'), 'override-id');
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── HostClientHandle generation invalidation ───────────────────────────────
+
+test('HostClientHandle invalidates after a reconnect', async () => {
+  const state = makeFakeState();
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'rec',
+      label: 'Rec',
+      reconnectPolicy: immediateForeverPolicy(),
+      transportFactory: makeBasicFactory(state),
+    });
+    await waitUntil(() => multi.host('rec')?.state.status === 'connected');
+    const handle = multi.client('rec');
+    assert.ok(handle, 'expected a client handle');
+    const initialGen = handle.generation;
+
+    await multi.reconnectHost('rec');
+    await waitUntil(() => {
+      const h = multi.host('rec');
+      return h && h.generation > initialGen && h.state.status === 'connected';
+    });
+
+    assert.throws(
+      () => handle.checkAlive(),
+      (err: unknown) => {
+        if (!(err instanceof HostReconnectedError)) return false;
+        assert.equal(err.hostId, 'rec');
+        assert.equal(err.handleGeneration, initialGen);
+        assert.ok(err.currentGeneration > initialGen);
+        return true;
+      },
+    );
+
+    // A fresh handle works.
+    const fresh = multi.client('rec');
+    assert.ok(fresh);
+    fresh.checkAlive();
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+test('HostClientHandle after removeHost throws HostShutDownError', async () => {
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'rm',
+      label: 'rm',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    await waitUntil(() => multi.host('rm')?.state.status === 'connected');
+    const handle = multi.client('rm');
+    assert.ok(handle);
+    await multi.removeHost('rm');
+    assert.throws(
+      () => handle.checkAlive(),
+      (err: unknown) => err instanceof HostShutDownError && err.hostId === 'rm',
+    );
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── Aggregated views ───────────────────────────────────────────────────────
+
+test('aggregatedSessions sorts by modifiedAt descending and tags hostLabel', async () => {
+  const initial = makeSummary('copilot:/s1', 'Initial title', 1_000);
+  const added = makeSummary('copilot:/s2', 'Added later', 2_000);
+
+  const state: FakeHostState = makeFakeState({
+    sessions: [initial],
+    injectAfterInit: async server => {
+      // Tiny delay so the client has consumed the listSessions response
+      // before the notification arrives.
+      await new Promise(r => setTimeout(r, 10));
+      const notif: JsonRpcNotification = {
+        jsonrpc: '2.0',
+        method: 'root/sessionAdded',
+        params: { channel: ROOT, summary: added },
+      };
+      try {
+        await server.send(notif);
+      } catch {
+        // best-effort
+      }
+    },
+  });
+
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'local',
+      label: 'Local',
+      transportFactory: makeBasicFactory(state),
+    });
+    await waitUntil(() => multi.host('local')?.state.status === 'connected');
+    await waitUntil(() => multi.aggregatedSessions().length === 2);
+    const sessions = multi.aggregatedSessions();
+    assert.deepEqual(
+      sessions.map(s => s.summary.title),
+      ['Added later', 'Initial title'],
+    );
+    assert.ok(sessions.every(s => s.hostId === 'local'));
+    assert.ok(sessions.every(s => s.hostLabel === 'Local'));
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+test('aggregatedAgents tags every agent with its host', async () => {
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'a',
+      label: 'A',
+      transportFactory: makeBasicFactory(makeFakeState({ agents: [makeAgent('copilot')] })),
+    });
+    await multi.addHost({
+      id: 'b',
+      label: 'B',
+      transportFactory: makeBasicFactory(makeFakeState({ agents: [makeAgent('vscode')] })),
+    });
+    await waitUntil(() => multi.host('a')?.state.status === 'connected');
+    await waitUntil(() => multi.host('b')?.state.status === 'connected');
+    const agents = multi.aggregatedAgents().sort((x, y) => x.hostId.localeCompare(y.hostId));
+    assert.equal(agents.length, 2);
+    assert.equal(agents[0]?.hostId, 'a');
+    assert.equal(agents[0]?.agent.provider, 'copilot');
+    assert.equal(agents[1]?.hostId, 'b');
+    assert.equal(agents[1]?.agent.provider, 'vscode');
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── reconnectAllUnavailable ────────────────────────────────────────────────
+
+test('reconnectAllUnavailable skips connected hosts and returns per-host errors', async () => {
+  // Build two hosts: one that connects normally, one that always fails
+  // to construct a transport.
+  const flakyFactory: HostTransportFactory = () => Promise.reject(new Error('boom'));
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'good',
+      label: 'Good',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    await multi.addHost({
+      id: 'bad',
+      label: 'Bad',
+      reconnectPolicy: { ...disabledPolicy() },
+      transportFactory: flakyFactory,
+    });
+    await waitUntil(() => multi.host('good')?.state.status === 'connected');
+    await waitUntil(() => multi.host('bad')?.state.status === 'failed');
+    const errors = await multi.reconnectAllUnavailable();
+    // `good` was connected and is skipped → not in the map.
+    assert.equal(errors.has('good'), false);
+    // `bad` is in `failed` so it was woken, but the call itself returns
+    // when the supervisor acknowledges (not necessarily after the
+    // retry succeeds), so the error map may or may not contain `bad`
+    // depending on timing. The important assertion is that the call
+    // didn't throw and that connected hosts were skipped.
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── Events fan-in ──────────────────────────────────────────────────────────
+
+test('hostEvents delivers added/stateChanged/connected/removed in order', async () => {
+  const multi = new MultiHostClient();
+  const events = multi.hostEvents();
+  try {
+    await multi.addHost({
+      id: 'lifecycle',
+      label: 'L',
+      transportFactory: makeBasicFactory(makeFakeState()),
+    });
+    await waitUntil(() => multi.host('lifecycle')?.state.status === 'connected');
+    await multi.removeHost('lifecycle');
+
+    // Drain until we observe the `removed` event or hit a generous
+    // timeout. Five events are expected (added, stateChanged×2,
+    // connected, removed) but only the relative ordering matters.
+    const collected: string[] = [];
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const remaining = Math.max(50, deadline - Date.now());
+      const next = await Promise.race([
+        events.next(),
+        new Promise<{ done: true; value: undefined }>(resolve =>
+          setTimeout(() => resolve({ done: true, value: undefined } as never), remaining),
+        ),
+      ]);
+      if (next.done) break;
+      collected.push(next.value.type);
+      if (next.value.type === 'removed') break;
+    }
+    assert.equal(collected[0], 'added');
+    assert.ok(collected.includes('connected'), `expected 'connected' in ${collected.join(',')}`);
+    assert.equal(collected[collected.length - 1], 'removed');
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+test('events surface action envelopes tagged with hostId', async () => {
+  const summary = makeSummary('copilot:/s1', 'New session', 500);
+  const state: FakeHostState = makeFakeState({
+    injectAfterInit: async server => {
+      await new Promise(r => setTimeout(r, 10));
+      const notif: JsonRpcNotification = {
+        jsonrpc: '2.0',
+        method: 'root/sessionAdded',
+        params: { channel: ROOT, summary },
+      };
+      try {
+        await server.send(notif);
+      } catch {
+        // best-effort
+      }
+    },
+  });
+  const multi = new MultiHostClient();
+  const events = multi.events();
+  try {
+    await multi.addHost({
+      id: 'evt',
+      label: 'evt',
+      transportFactory: makeBasicFactory(state),
+    });
+    let received: HostSubscriptionEvent | null = null;
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const next = await Promise.race([
+        events.next(),
+        new Promise<{ done: true; value: undefined }>(resolve =>
+          setTimeout(() => resolve({ done: true, value: undefined } as never), 500),
+        ),
+      ]);
+      if (next.done) continue;
+      if (next.value.event.type === 'sessionAdded') {
+        received = next.value;
+        break;
+      }
+    }
+    assert.ok(received, 'expected a sessionAdded event');
+    assert.equal(received.hostId, 'evt');
+    assert.equal(received.channel, ROOT);
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── Manual reconnect from failed state ─────────────────────────────────────
+
+test('manual reconnectHost wakes a host whose policy is exhausted', async () => {
+  let attemptCount = 0;
+  // Fail the first attempt; the second attempt (post-manual-reconnect) succeeds.
+  const factory: HostTransportFactory = async () => {
+    attemptCount += 1;
+    if (attemptCount === 1) throw new Error('first attempt fails');
+    const [c, s] = InMemoryTransport.pair();
+    void driveFakeHost(s, makeFakeState());
+    return c;
+  };
+  const multi = new MultiHostClient();
+  try {
+    await multi.addHost({
+      id: 'wake',
+      label: 'wake',
+      reconnectPolicy: disabledPolicy(), // single attempt then `failed`
+      transportFactory: factory,
+    });
+    await waitUntil(() => multi.host('wake')?.state.status === 'failed');
+    // Manual reconnect bypasses the exhausted policy.
+    await multi.reconnectHost('wake');
+    await waitUntil(() => multi.host('wake')?.state.status === 'connected');
+    assert.equal(attemptCount, 2);
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// ─── Shutdown idempotency ───────────────────────────────────────────────────
+
+test('MultiHostClient.shutdown is idempotent', async () => {
+  const multi = new MultiHostClient();
+  await multi.addHost({
+    id: 'idemp',
+    label: 'idemp',
+    transportFactory: makeBasicFactory(makeFakeState()),
+  });
+  await multi.shutdown();
+  await multi.shutdown();
+  assert.equal(multi.host('idemp'), undefined);
+});
+
+// ─── Unknown host ───────────────────────────────────────────────────────────
+
+test('subscribe/unsubscribe/dispatch on an unknown host throws UnknownHostError', async () => {
+  const multi = new MultiHostClient();
+  try {
+    await assert.rejects(multi.subscribe('nope', ROOT), UnknownHostError);
+    await assert.rejects(multi.unsubscribe('nope', ROOT), UnknownHostError);
+    assert.throws(
+      () => multi.dispatch('nope', ROOT, { type: 'noop' } as unknown as Parameters<typeof multi.dispatch>[2]),
+      UnknownHostError,
+    );
+  } finally {
+    await multi.shutdown();
+  }
+});
+
+// Reference the imported HostId type to avoid 'unused' warnings.
+void (null as unknown as HostId);


### PR DESCRIPTION
## What

Adds the **multi-host SDK** to the TypeScript client as a fourth subpath export — `@microsoft/agent-host-protocol/hosts` — mirroring the Rust `ahp::hosts` module and the Swift `MultiHostClient` actor.

## Why

This is the largest remaining gap in the TypeScript client's surface relative to the Rust SDK. A real product that talks to two or more hosts at once (a local sessions server + a tunnel-attached remote, a personal host + a teammate's, N project hosts in a desktop sidebar, …) otherwise hand-rolls the same boilerplate: N `AhpClient`s, N transports + reconnect supervisors with backoff, a per-host metadata registry, per-host scoping of resource URIs, a fan-in of inbound events tagged with host of origin, and `clientId` persistence so reconnect identity survives launches. This PR ships that layer.

> Originally drafted as a follow-up to #156 (the now-closed publish pipeline PR). Rebased onto `main` since #156 was closed without merging; the multi-host work stands on its own and doesn't depend on the publish pipeline.

## Surface

```ts
import {
  MultiHostClient,
  type HostTransportFactory,
} from '@microsoft/agent-host-protocol/hosts';

// Single-host: never see "registry" concepts.
const { multi, host } = await MultiHostClient.single({
  id: 'local',
  label: 'Local sessions server',
  transportFactory: openLocal,
});

// Or multi-host: add as many as you need.
await multi.addHost({ id: 'tunnel', label: 'Tunnel', transportFactory: openTunnel });
for await (const event of multi.events()) {
  console.log(`[${event.hostId}] ${event.channel}`, event.event.type);
}
```

What ships:

- **`MultiHostClient`** — `single`, `addHost`, `removeHost`, `reconnectHost`, `reconnectAllUnavailable`, `host`/`hostsSnapshot`, `client` (returns a generation-checked `HostClientHandle`), `subscribe`/`unsubscribe`/`dispatch`, `events`/`hostEvents`, `aggregatedSessions`/`aggregatedAgents`, `shutdown`.
- **`HostConfig`** / **`HostHandle`** / **`HostState`** discriminated union (`disconnected` | `connecting` | `connected` | `reconnecting` | `failed`) / **`HostEvent`** / **`HostSubscriptionEvent`** / **`HostedSessionSummary`** / **`HostedAgent`**.
- **Error family** extending `AhpClientError`: `HostMultiError`, `UnknownHostError`, `DuplicateHostError`, `HostReconnectedError` (carries both `handleGeneration` and `currentGeneration` for clean stale-handle recovery), `HostShutDownError`, `ClientIdStoreError`.
- **`ReconnectPolicy`** + **`Backoff`** with jitter, plus `disabledPolicy()` / `exponentialPolicy()` (default: 250 ms → 30 s, ×2, 25 % jitter, retry forever) / `immediateForeverPolicy()`. Pure functions `backoffDelayForAttempt`, `delayWithJitter`, `attemptsExhausted` are exposed for deterministic testing.
- **`HostTransportFactory`** — `(hostId, signal) => Promise<AhpTransport>`. The `AbortSignal` is aborted on remove / shutdown so factories can bail out of a slow handshake instead of blocking teardown.
- **`ClientIdStore`** + **`InMemoryClientIdStore`** — pluggable persistence for stable per-host `clientId`s. Explicit > stored > generated; resolved id is always written back. Store failures surface as `ClientIdStoreError` from `addHost`.
- **`MultiHostStateMirror`** + **`hostedResourceKey`** — host-aware reducer façade that keys session/terminal/changeset state by `(hostId, uri)` so URIs that legitimately collide across hosts (the normal case for session URIs) don't clobber.

## Design notes

- **Cancellation in single-threaded JS.** The Rust runtime uses `tokio::select!` racing futures against `shutdown_signal.notified()`. JS can't preempt an in-flight `await`, so the port threads `AbortSignal` through `HostTransportFactory` and `ClientIdStore.load/store`, and routes every internal handshake through a `raceWithAbort(promise, signal)` helper that resolves with an `ABORTED` sentinel on signal abort. That helper attaches a no-op rejection handler to the inner promise so late `ClientClosedError`s (from a half-built `AhpClient.initialize` whose client got `shutdown()`'d in the `finally`) don't surface as `unhandledRejection`s.
- **Generation invalidation.** Every successful (re)connect bumps a per-host `generation`. `HostClientHandle` reads `generation` + `shutdownReason` through a shared reference on every `checkAlive` — handle-after-reconnect surfaces `HostReconnectedError`; handle-after-`removeHost` surfaces `HostShutDownError`. Both errors are recoverable via a fresh `multi.client(hostId)` (or, for removal, the host being re-added).
- **Replay-before-`connected`.** Reconnect-replay envelopes are fanned through the per-host state mirror **and** the cross-host event tap **before** `transitionTo({status: 'connected'})` / `HostEvent.connected`, so consumers observing the connected event already see catch-up state.
- **Snapshot pruning.** `ReconnectResult.Snapshot` only drops URIs that were in the prior subscriptions set AND missing from returned snapshots — URIs added locally between disconnect and reconnect survive.
- **`addHost` race safety.** A pending-host id set guards against concurrent `addHost` calls slipping past the duplicate check while one is awaiting the `ClientIdStore`. The reservation is cleared in `finally` so any error path (including store failures) frees the slot for a retry.
- **Events stream lifetime.** The client's all-events broadcast is attached **before** `initialize` / `reconnect` so notifications pushed between the handshake response and the moment the supervisor enters its event loop are captured instead of dropped by the broadcast queue's no-replay-for-late-readers semantics.
- **`HostId` as `string` alias.** Kept a plain `string` for ergonomics — equality is `===` and tests pass string literals directly. A branded type was considered but added too much friction for the surface gain.

## Not in this PR

- **`FileClientIdStore`.** A filesystem-backed `ClientIdStore` would pull in `node:fs` and break browser bundlers even if consumers never instantiate it. Browsers can implement `ClientIdStore` against `localStorage` / IndexedDB; Node/Electron consumers can wrap `node:fs/promises` or `safeStorage`. The interface is the contract. If a Node-only adapter ends up wanted later, it can ship as a separate `@microsoft/agent-host-protocol/hosts/file-client-id-store` subpath without re-exporting from the browser-safe `/hosts` entry point.
- **A dedicated `docs/guide/connecting-to-multiple-hosts.md` page.** The TS client's README has a full **Multi-host orchestration** section with a runnable example; mirroring the Rust SDK's `MULTI_HOST.md` into the docs site can ship in a follow-up if the docs site wants a language-agnostic narrative.

## Verification

From a fresh `npm run generate:typescript` at the repo root, then in `clients/typescript`:

- ✅ `npm run typecheck` clean.
- ✅ `npm test` — **47 tests pass** (24 new). Coverage includes:
  - `MultiHostClient.single` / `addHost` / `removeHost` / `DuplicateHostError`.
  - `addHost` surfaces `ClientIdStoreError` and frees the reservation so a retry succeeds.
  - `HostClientHandle.generation` invalidates after a reconnect (carries both generations).
  - `HostClientHandle` after `removeHost` throws `HostShutDownError`.
  - `ReconnectPolicy.delayWithJitter` / `backoffDelayForAttempt` / `attemptsExhausted` shapes (mirrors the Rust unit tests).
  - `InMemoryClientIdStore` round-trip + overwrite.
  - `hostedResourceKey` distinguishes same-URI hosts; `MultiHostStateMirror.applySnapshot` / `resetHost` scoping.
  - `aggregatedSessions` sorts by `modifiedAt` descending and tags `hostLabel`; `aggregatedAgents` tags every agent with host.
  - `hostEvents` lifecycle ordering (`added` → `stateChanged` → `connected` → `removed`).
  - `events` fan-in delivers notifications tagged with `hostId`.
  - `reconnectAllUnavailable` skips connected/connecting hosts and returns per-host errors without throwing.
  - Manual `reconnectHost` wakes a host whose `ReconnectPolicy` is exhausted (the post-`failed` resumption path).
  - `MultiHostClient.shutdown` is idempotent.
  - `subscribe` / `unsubscribe` / `dispatch` on an unknown host throws `UnknownHostError`.
- ✅ `npm run build` clean. `npm pack --dry-run` ships `dist/client/hosts/`.
- ✅ Root `npm run lint` + `npm run typecheck` unchanged (the ESLint config already excludes `clients/typescript/**` and the root `tsc` only covers `types/`).
