### PR TITLE
Add forward-compat Unknown variants to Kotlin discriminated unions

### DIFF
--- a/clients/kotlin/AGENTS.md
+++ b/clients/kotlin/AGENTS.md
@@ -151,6 +151,8 @@ public object ChangesetReducer : Reducer<ChangesetState, StateAction>
 
 Each reducer dispatches on the [`StateAction`] sealed interface and handles the action variants that belong to its channel. Actions belonging to other channels (or unknown `StateActionUnknown` variants returned by the wire-types decoder when the server sends a newer action type than this version of the client knows about) fall through to an `else -> state` no-op — this matches the forward-compatibility semantics of the canonical TypeScript and Swift reducers.
 
+State-channel unions decoded inside actions follow the same principle: when the server emits a discriminator this client doesn't recognise (e.g. a future `ResponsePart` kind, `ToolCallState`, `Customization` type, etc.) the decoder lifts the raw JSON into an `XUnknown` variant rather than throwing. The reducer treats those variants conservatively — `customizationId` returns `null` so an unknown container can't false-match a real id, `SessionCustomizationUpdated` short-circuits to NoOp when the payload is Unknown, and cancellation collapses unknown tool calls to empty cancelled state. These behaviours mirror the Rust reducer exactly.
+
 ### Hand-port from TypeScript
 
 Each reducer is a direct hand-port of the corresponding file in `types/channels-*/reducer.ts`. Notable mechanical translations:
@@ -167,8 +169,8 @@ Each reducer is a direct hand-port of the corresponding file in `types/channels-
 The Kotlin port preserves Swift parity caveats already documented in PR #115:
 
 1. **`T | null` vs `T?`** — both collapse to nullable Kotlin fields. With `explicitNulls = false`, both encode as absent.
-2. **Discriminator validation** — no runtime check that, e.g., a `MarkdownResponsePart`'s `kind` matches `MARKDOWN`. Mirrors Swift.
-3. **`StateActionUnknown`** — only the wire `type` string is preserved; the rest of an unknown action's payload is dropped. The reducer treats it as a no-op, which is the documented behavior.
+2. **Discriminator validation** — no runtime check that, e.g., a `MarkdownResponsePart`'s `kind` matches `MARKDOWN`. Mirrors Swift. For forward-compat unions, an *unrecognised* discriminator decodes to the `XUnknown(val raw: JsonObject)` variant (mirrors Rust's `Unknown(serde_json::Value)`) and round-trips its raw payload on re-encode.
+3. **`StateActionUnknown`** — only the wire `type` string is preserved; the rest of an unknown action's payload is dropped. The reducer treats it as a no-op. The newer state-channel `XUnknown` variants (`ResponsePartUnknown`, `ToolCallStateUnknown`, `CustomizationUnknown`, etc.) are not lossy — they capture the full raw JSON object.
 
 ### Injectable timestamp
 
@@ -186,11 +188,7 @@ Tests override this with a constant to produce deterministic output, then restor
 
 The fixture path is wired into the test JVM via the `ahp.reducerFixturesDir` system property in `build.gradle.kts`, so the test works under `./gradlew test`, IDE runs that delegate to Gradle (the IntelliJ default), or CI without depending on the current working directory. When neither Gradle nor a delegating runner sets the property, the test falls back to walking upward from `user.dir` looking for `types/test-cases/reducers/`, so direct IDE JUnit runs from inside the repo still work.
 
-A small `SKIPPED_FIXTURES` set carries any fixtures intentionally skipped because they exercise wire-type decoding behaviour this package doesn't yet support (e.g. unknown `ResponsePart` discriminators). The `coverageReport().decodable-fixture-budget` assertion bounds the skip set size so regressions surface in CI. As of the initial port, exactly one fixture is skipped:
-
-| Fixture | Why skipped |
-| --- | --- |
-| `103-delta-skips-parts-without-id.json` | Initial state contains a `ResponsePart` with `kind: "unknownFuturePart"`. The generated `ResponsePartSerializer` throws on unknown discriminators (no `ResponsePartUnknown` variant analogous to `StateActionUnknown`). Fixing this is a generator-side wire-types change outside the reducer-port scope. |
+A small `SKIPPED_FIXTURES` set carries any fixtures intentionally skipped because they exercise wire-type decoding behaviour this package doesn't yet support. The `coverageReport().decodable-fixture-budget` assertion bounds the skip set size so regressions surface in CI. The full reducer fixture corpus is currently covered (`SKIPPED_FIXTURES` is empty and `MAX_SKIPPED_FIXTURES = 0`). Forward-compat coverage for unknown discriminators on state-channel unions (`ResponsePart`, `ToolCallState`, `Customization`, …) is exercised by `103-delta-skips-parts-without-id.json` and the dedicated round-trip tests in `DiscriminatedUnionTest`.
 
 ### `ReducersTest`
 

--- a/clients/kotlin/AGENTS.md
+++ b/clients/kotlin/AGENTS.md
@@ -151,7 +151,7 @@ public object ChangesetReducer : Reducer<ChangesetState, StateAction>
 
 Each reducer dispatches on the [`StateAction`] sealed interface and handles the action variants that belong to its channel. Actions belonging to other channels (or unknown `StateActionUnknown` variants returned by the wire-types decoder when the server sends a newer action type than this version of the client knows about) fall through to an `else -> state` no-op — this matches the forward-compatibility semantics of the canonical TypeScript and Swift reducers.
 
-State-channel unions decoded inside actions follow the same principle: when the server emits a discriminator this client doesn't recognise (e.g. a future `ResponsePart` kind, `ToolCallState`, `Customization` type, etc.) the decoder lifts the raw JSON into an `XUnknown` variant rather than throwing. The reducer treats those variants conservatively — `customizationId` returns `null` so an unknown container can't false-match a real id, `SessionCustomizationUpdated` short-circuits to NoOp when the payload is Unknown, and cancellation collapses unknown tool calls to empty cancelled state. These behaviours mirror the Rust reducer exactly.
+State-channel unions decoded inside actions follow the same principle: when the server emits a discriminator this client doesn't recognise (e.g. a future `ResponsePart` kind, `ToolCallState`, `Customization` type, etc.) the decoder lifts the raw JSON into an `XUnknown` variant rather than throwing. `StateActionUnknown` uses the same shape for unknown action types. Reducers treat these variants conservatively — `customizationId` returns `null` so an unknown container can't false-match a real id, `SessionCustomizationUpdated` short-circuits to NoOp when the payload is Unknown, and cancellation collapses unknown tool calls to empty cancelled state. These behaviours mirror the Rust reducer exactly.
 
 ### Hand-port from TypeScript
 
@@ -170,7 +170,7 @@ The Kotlin port preserves Swift parity caveats already documented in PR #115:
 
 1. **`T | null` vs `T?`** — both collapse to nullable Kotlin fields. With `explicitNulls = false`, both encode as absent.
 2. **Discriminator validation** — no runtime check that, e.g., a `MarkdownResponsePart`'s `kind` matches `MARKDOWN`. Mirrors Swift. For forward-compat unions, an *unrecognised* discriminator decodes to the `XUnknown(val raw: JsonObject)` variant (mirrors Rust's `Unknown(serde_json::Value)`) and round-trips its raw payload on re-encode.
-3. **`StateActionUnknown`** — only the wire `type` string is preserved; the rest of an unknown action's payload is dropped. The reducer treats it as a no-op. The newer state-channel `XUnknown` variants (`ResponsePartUnknown`, `ToolCallStateUnknown`, `CustomizationUnknown`, etc.) are not lossy — they capture the full raw JSON object.
+3. **`StateActionUnknown`** — captures the full raw JSON object of an unknown action (same shape as the state-channel `XUnknown` variants). The reducer treats it as a no-op. Re-encoding round-trips the original payload back to the wire.
 
 ### Injectable timestamp
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -19,10 +19,12 @@ import com.microsoft.agenthostprotocol.generated.ChildCustomizationMcpServer
 import com.microsoft.agenthostprotocol.generated.ChildCustomizationPrompt
 import com.microsoft.agenthostprotocol.generated.ChildCustomizationRule
 import com.microsoft.agenthostprotocol.generated.ChildCustomizationSkill
+import com.microsoft.agenthostprotocol.generated.ChildCustomizationUnknown
 import com.microsoft.agenthostprotocol.generated.ConfirmationOption
 import com.microsoft.agenthostprotocol.generated.Customization
 import com.microsoft.agenthostprotocol.generated.CustomizationDirectory
 import com.microsoft.agenthostprotocol.generated.CustomizationPlugin
+import com.microsoft.agenthostprotocol.generated.CustomizationUnknown
 import com.microsoft.agenthostprotocol.generated.ErrorInfo
 import com.microsoft.agenthostprotocol.generated.MarkdownResponsePart
 import com.microsoft.agenthostprotocol.generated.PendingMessage
@@ -122,6 +124,7 @@ import com.microsoft.agenthostprotocol.generated.ToolCallStatePendingConfirmatio
 import com.microsoft.agenthostprotocol.generated.ToolCallStatePendingResultConfirmation
 import com.microsoft.agenthostprotocol.generated.ToolCallStateRunning
 import com.microsoft.agenthostprotocol.generated.ToolCallStateStreaming
+import com.microsoft.agenthostprotocol.generated.ToolCallStateUnknown
 import com.microsoft.agenthostprotocol.generated.ToolCallStatus
 import com.microsoft.agenthostprotocol.generated.ToolCallStreamingState
 import com.microsoft.agenthostprotocol.generated.Turn
@@ -260,6 +263,11 @@ private fun toolCallBase(tc: ToolCallState): ToolCallBase = when (tc) {
     is ToolCallStateCancelled -> tc.value.let {
         ToolCallBase(it.toolCallId, it.toolName, it.displayName, it.toolClientId, it.meta)
     }
+    // Forward-compat: unknown lifecycle variants have no extractable base; mirror
+    // Rust's `ToolCallState::Unknown(_) => (String::new(), ...)`. Combined with
+    // `toolCallIdOf` returning `""`, this guarantees an unknown tool call never
+    // matches a real `toolCallId` in delta/lookup paths.
+    is ToolCallStateUnknown -> ToolCallBase("", "", "", null, null)
 }
 
 /** Resolves a selected confirmation option by ID from a pending-confirmation state. */
@@ -270,33 +278,42 @@ private fun resolveSelectedOption(options: List<ConfirmationOption>?, id: String
 
 private fun toolCallIdOf(tc: ToolCallState): String = toolCallBase(tc).toolCallId
 
-private fun customizationId(c: Customization): String = when (c) {
+private fun customizationId(c: Customization): String? = when (c) {
     is CustomizationPlugin -> c.value.id
     is CustomizationDirectory -> c.value.id
+    // Unknown variants carry an opaque `raw` JSON object — no id to expose.
+    // Returning `null` mirrors Rust's `Customization::Unknown(_) => None`, so
+    // an unknown container can never collide with a real id during lookups.
+    is CustomizationUnknown -> null
 }
 
 private fun customizationChildren(c: Customization): List<ChildCustomization>? = when (c) {
     is CustomizationPlugin -> c.value.children
     is CustomizationDirectory -> c.value.children
+    is CustomizationUnknown -> null
 }
 
 private fun withCustomizationChildren(c: Customization, children: List<ChildCustomization>): Customization = when (c) {
     is CustomizationPlugin -> CustomizationPlugin(c.value.copy(children = children))
     is CustomizationDirectory -> CustomizationDirectory(c.value.copy(children = children))
+    // Pass-through: we can't structurally edit a payload we don't understand.
+    is CustomizationUnknown -> c
 }
 
 private fun withCustomizationEnabled(c: Customization, enabled: Boolean): Customization = when (c) {
     is CustomizationPlugin -> CustomizationPlugin(c.value.copy(enabled = enabled))
     is CustomizationDirectory -> CustomizationDirectory(c.value.copy(enabled = enabled))
+    is CustomizationUnknown -> c
 }
 
-private fun childCustomizationId(c: ChildCustomization): String = when (c) {
+private fun childCustomizationId(c: ChildCustomization): String? = when (c) {
     is ChildCustomizationAgent -> c.value.id
     is ChildCustomizationSkill -> c.value.id
     is ChildCustomizationPrompt -> c.value.id
     is ChildCustomizationRule -> c.value.id
     is ChildCustomizationHook -> c.value.id
     is ChildCustomizationMcpServer -> c.value.id
+    is ChildCustomizationUnknown -> null
 }
 
 /**
@@ -397,6 +414,10 @@ private fun endTurn(
             is ToolCallStateRunning -> tc.value.invocationMessage
             is ToolCallStatePendingResultConfirmation -> tc.value.invocationMessage
             is ToolCallStateCompleted, is ToolCallStateCancelled -> error("filtered above")
+            // Mirrors Rust's catch-all (`_ => Default::default()`). An unknown tool
+            // call cancelled at turn end becomes a Cancelled state with empty
+            // invocation message — destructive, but matches Rust parity exactly.
+            is ToolCallStateUnknown -> com.microsoft.agenthostprotocol.generated.StringOrMarkdown.Plain("")
         }
         val toolInput: String? = when (tc) {
             is ToolCallStateStreaming -> null
@@ -404,6 +425,7 @@ private fun endTurn(
             is ToolCallStateRunning -> tc.value.toolInput
             is ToolCallStatePendingResultConfirmation -> tc.value.toolInput
             is ToolCallStateCompleted, is ToolCallStateCancelled -> error("filtered above")
+            is ToolCallStateUnknown -> null
         }
         ResponsePartToolCall(
             part.value.copy(
@@ -950,14 +972,21 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
 
     is StateActionSessionCustomizationUpdated -> {
         val a = action.value
-        val list = state.customizations ?: emptyList()
-        val idx = list.indexOfFirst { customizationId(it) == customizationId(a.customization) }
-        if (idx < 0) {
-            state.copy(customizations = list + a.customization)
+        // Match Rust: an unknown customization has no id, so we can't locate or
+        // insert it sensibly — NoOp the update entirely.
+        val targetId = customizationId(a.customization)
+        if (targetId == null) {
+            state
         } else {
-            val updated = list.toMutableList()
-            updated[idx] = a.customization
-            state.copy(customizations = updated)
+            val list = state.customizations ?: emptyList()
+            val idx = list.indexOfFirst { customizationId(it) == targetId }
+            if (idx < 0) {
+                state.copy(customizations = list + a.customization)
+            } else {
+                val updated = list.toMutableList()
+                updated[idx] = a.customization
+                state.copy(customizations = updated)
+            }
         }
     }
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -976,9 +976,11 @@ data class TerminalCommandFinishedAction(
 /**
  * Discriminated union of all state actions.
  *
- * Unknown wire types decode to [StateActionUnknown] and reducers should treat
- * them as no-ops; this is critical for forward compatibility across protocol
- * versions.
+ * Unknown wire types decode to [StateActionUnknown], which captures the full
+ * raw JSON object (mirrors the state-channel `XUnknown` variants and Rust's
+ * `Unknown(serde_json::Value)`). Reducers should treat unknown actions as
+ * no-ops; the captured payload is re-emitted unchanged on encode so unknown
+ * actions can round-trip across protocol versions.
  */
 @Serializable(with = StateActionSerializer::class)
 sealed interface StateAction
@@ -1043,7 +1045,7 @@ sealed interface StateAction
 @JvmInline value class StateActionTerminalCommandDetectionAvailable(val value: TerminalCommandDetectionAvailableAction) : StateAction
 @JvmInline value class StateActionTerminalCommandExecuted(val value: TerminalCommandExecutedAction) : StateAction
 @JvmInline value class StateActionTerminalCommandFinished(val value: TerminalCommandFinishedAction) : StateAction
-@JvmInline value class StateActionUnknown(val type: String) : StateAction
+@JvmInline value class StateActionUnknown(val raw: JsonObject) : StateAction
 
 internal object StateActionSerializer : KSerializer<StateAction> {
     override val descriptor: SerialDescriptor =
@@ -1118,7 +1120,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             "terminal/commandDetectionAvailable" -> StateActionTerminalCommandDetectionAvailable(input.json.decodeFromJsonElement(TerminalCommandDetectionAvailableAction.serializer(), element))
             "terminal/commandExecuted" -> StateActionTerminalCommandExecuted(input.json.decodeFromJsonElement(TerminalCommandExecutedAction.serializer(), element))
             "terminal/commandFinished" -> StateActionTerminalCommandFinished(input.json.decodeFromJsonElement(TerminalCommandFinishedAction.serializer(), element))
-            else -> StateActionUnknown(type)
+            else -> StateActionUnknown(obj)
         }
     }
 
@@ -1186,9 +1188,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             is StateActionTerminalCommandDetectionAvailable -> output.json.encodeToJsonElement(TerminalCommandDetectionAvailableAction.serializer(), value.value)
             is StateActionTerminalCommandExecuted -> output.json.encodeToJsonElement(TerminalCommandExecutedAction.serializer(), value.value)
             is StateActionTerminalCommandFinished -> output.json.encodeToJsonElement(TerminalCommandFinishedAction.serializer(), value.value)
-            is StateActionUnknown -> buildJsonObject {
-                put("type", JsonPrimitive(value.type))
-            }
+            is StateActionUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -1058,7 +1058,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for StateAction")
         val type = (obj["type"] as? JsonPrimitive)?.contentOrNull
-            ?: error("Missing \"type\" discriminator on StateAction")
+            ?: return StateActionUnknown(obj)
         return when (type) {
             "root/agentsChanged" -> StateActionRootAgentsChanged(input.json.decodeFromJsonElement(RootAgentsChangedAction.serializer(), element))
             "root/activeSessionsChanged" -> StateActionRootActiveSessionsChanged(input.json.decodeFromJsonElement(RootActiveSessionsChangedAction.serializer(), element))

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -3016,7 +3016,8 @@ value class ResponsePartSystemNotification(val value: SystemNotificationResponse
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class ResponsePartUnknown(val raw: JsonObject) : ResponsePart
@@ -3078,7 +3079,8 @@ value class ToolCallStateCancelled(val value: ToolCallCancelledState) : ToolCall
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class ToolCallStateUnknown(val raw: JsonObject) : ToolCallState
@@ -3134,7 +3136,8 @@ value class TerminalClaimSession(val value: TerminalSessionClaim) : TerminalClai
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class TerminalClaimUnknown(val raw: JsonObject) : TerminalClaim
@@ -3182,7 +3185,8 @@ value class TerminalContentPartCommand(val value: TerminalCommandPart) : Termina
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class TerminalContentPartUnknown(val raw: JsonObject) : TerminalContentPart
@@ -3236,7 +3240,8 @@ value class SessionInputQuestionMultiSelect(val value: SessionInputMultiSelectQu
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class SessionInputQuestionUnknown(val raw: JsonObject) : SessionInputQuestion
@@ -3297,7 +3302,8 @@ value class SessionInputAnswerValueSelectedMany(val value: SessionInputSelectedM
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class SessionInputAnswerValueUnknown(val raw: JsonObject) : SessionInputAnswerValue
@@ -3351,7 +3357,8 @@ value class SessionInputAnswerSkipped(val value: SessionInputSkipped) : SessionI
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class SessionInputAnswerUnknown(val raw: JsonObject) : SessionInputAnswer
@@ -3402,7 +3409,8 @@ value class MessageAttachmentResource(val value: MessageResourceAttachment) : Me
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class MessageAttachmentUnknown(val raw: JsonObject) : MessageAttachment
@@ -3452,7 +3460,8 @@ value class CustomizationDirectory(val value: DirectoryCustomization) : Customiz
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class CustomizationUnknown(val raw: JsonObject) : Customization
@@ -3508,7 +3517,8 @@ value class ChildCustomizationMcpServer(val value: McpServerCustomization) : Chi
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class ChildCustomizationUnknown(val raw: JsonObject) : ChildCustomization
@@ -3568,7 +3578,8 @@ value class CustomizationLoadStateError(val value: CustomizationErrorState) : Cu
  *
  * Older clients may receive newer wire variants they don't recognise; capturing
  * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers treat instances of this variant as no-ops.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
  */
 @JvmInline
 value class CustomizationLoadStateUnknown(val raw: JsonObject) : CustomizationLoadState

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -3011,6 +3011,15 @@ value class ResponsePartToolCall(val value: ToolCallResponsePart) : ResponsePart
 value class ResponsePartReasoning(val value: ReasoningResponsePart) : ResponsePart
 @JvmInline
 value class ResponsePartSystemNotification(val value: SystemNotificationResponsePart) : ResponsePart
+/**
+ * Forward-compat catch-all for unknown ResponsePart discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class ResponsePartUnknown(val raw: JsonObject) : ResponsePart
 
 internal object ResponsePartSerializer : KSerializer<ResponsePart> {
     override val descriptor: SerialDescriptor =
@@ -3023,14 +3032,14 @@ internal object ResponsePartSerializer : KSerializer<ResponsePart> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for ResponsePart")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: error("Missing kind discriminator on ResponsePart")
+            ?: return ResponsePartUnknown(obj)
         return when (discriminant) {
             "markdown" -> ResponsePartMarkdown(input.json.decodeFromJsonElement(MarkdownResponsePart.serializer(), element))
             "contentRef" -> ResponsePartContentRef(input.json.decodeFromJsonElement(ResourceReponsePart.serializer(), element))
             "toolCall" -> ResponsePartToolCall(input.json.decodeFromJsonElement(ToolCallResponsePart.serializer(), element))
             "reasoning" -> ResponsePartReasoning(input.json.decodeFromJsonElement(ReasoningResponsePart.serializer(), element))
             "systemNotification" -> ResponsePartSystemNotification(input.json.decodeFromJsonElement(SystemNotificationResponsePart.serializer(), element))
-            else -> error("Unknown ResponsePart discriminator: $discriminant")
+            else -> ResponsePartUnknown(obj)
         }
     }
 
@@ -3043,6 +3052,7 @@ internal object ResponsePartSerializer : KSerializer<ResponsePart> {
             is ResponsePartToolCall -> output.json.encodeToJsonElement(ToolCallResponsePart.serializer(), value.value)
             is ResponsePartReasoning -> output.json.encodeToJsonElement(ReasoningResponsePart.serializer(), value.value)
             is ResponsePartSystemNotification -> output.json.encodeToJsonElement(SystemNotificationResponsePart.serializer(), value.value)
+            is ResponsePartUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3063,6 +3073,15 @@ value class ToolCallStatePendingResultConfirmation(val value: ToolCallPendingRes
 value class ToolCallStateCompleted(val value: ToolCallCompletedState) : ToolCallState
 @JvmInline
 value class ToolCallStateCancelled(val value: ToolCallCancelledState) : ToolCallState
+/**
+ * Forward-compat catch-all for unknown ToolCallState discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class ToolCallStateUnknown(val raw: JsonObject) : ToolCallState
 
 internal object ToolCallStateSerializer : KSerializer<ToolCallState> {
     override val descriptor: SerialDescriptor =
@@ -3075,7 +3094,7 @@ internal object ToolCallStateSerializer : KSerializer<ToolCallState> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for ToolCallState")
         val discriminant = (obj["status"] as? JsonPrimitive)?.content
-            ?: error("Missing status discriminator on ToolCallState")
+            ?: return ToolCallStateUnknown(obj)
         return when (discriminant) {
             "streaming" -> ToolCallStateStreaming(input.json.decodeFromJsonElement(ToolCallStreamingState.serializer(), element))
             "pending-confirmation" -> ToolCallStatePendingConfirmation(input.json.decodeFromJsonElement(ToolCallPendingConfirmationState.serializer(), element))
@@ -3083,7 +3102,7 @@ internal object ToolCallStateSerializer : KSerializer<ToolCallState> {
             "pending-result-confirmation" -> ToolCallStatePendingResultConfirmation(input.json.decodeFromJsonElement(ToolCallPendingResultConfirmationState.serializer(), element))
             "completed" -> ToolCallStateCompleted(input.json.decodeFromJsonElement(ToolCallCompletedState.serializer(), element))
             "cancelled" -> ToolCallStateCancelled(input.json.decodeFromJsonElement(ToolCallCancelledState.serializer(), element))
-            else -> error("Unknown ToolCallState discriminator: $discriminant")
+            else -> ToolCallStateUnknown(obj)
         }
     }
 
@@ -3097,6 +3116,7 @@ internal object ToolCallStateSerializer : KSerializer<ToolCallState> {
             is ToolCallStatePendingResultConfirmation -> output.json.encodeToJsonElement(ToolCallPendingResultConfirmationState.serializer(), value.value)
             is ToolCallStateCompleted -> output.json.encodeToJsonElement(ToolCallCompletedState.serializer(), value.value)
             is ToolCallStateCancelled -> output.json.encodeToJsonElement(ToolCallCancelledState.serializer(), value.value)
+            is ToolCallStateUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3109,6 +3129,15 @@ sealed interface TerminalClaim
 value class TerminalClaimClient(val value: TerminalClientClaim) : TerminalClaim
 @JvmInline
 value class TerminalClaimSession(val value: TerminalSessionClaim) : TerminalClaim
+/**
+ * Forward-compat catch-all for unknown TerminalClaim discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class TerminalClaimUnknown(val raw: JsonObject) : TerminalClaim
 
 internal object TerminalClaimSerializer : KSerializer<TerminalClaim> {
     override val descriptor: SerialDescriptor =
@@ -3121,11 +3150,11 @@ internal object TerminalClaimSerializer : KSerializer<TerminalClaim> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for TerminalClaim")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: error("Missing kind discriminator on TerminalClaim")
+            ?: return TerminalClaimUnknown(obj)
         return when (discriminant) {
             "client" -> TerminalClaimClient(input.json.decodeFromJsonElement(TerminalClientClaim.serializer(), element))
             "session" -> TerminalClaimSession(input.json.decodeFromJsonElement(TerminalSessionClaim.serializer(), element))
-            else -> error("Unknown TerminalClaim discriminator: $discriminant")
+            else -> TerminalClaimUnknown(obj)
         }
     }
 
@@ -3135,6 +3164,7 @@ internal object TerminalClaimSerializer : KSerializer<TerminalClaim> {
         val element: JsonElement = when (value) {
             is TerminalClaimClient -> output.json.encodeToJsonElement(TerminalClientClaim.serializer(), value.value)
             is TerminalClaimSession -> output.json.encodeToJsonElement(TerminalSessionClaim.serializer(), value.value)
+            is TerminalClaimUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3147,6 +3177,15 @@ sealed interface TerminalContentPart
 value class TerminalContentPartUnclassified(val value: TerminalUnclassifiedPart) : TerminalContentPart
 @JvmInline
 value class TerminalContentPartCommand(val value: TerminalCommandPart) : TerminalContentPart
+/**
+ * Forward-compat catch-all for unknown TerminalContentPart discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class TerminalContentPartUnknown(val raw: JsonObject) : TerminalContentPart
 
 internal object TerminalContentPartSerializer : KSerializer<TerminalContentPart> {
     override val descriptor: SerialDescriptor =
@@ -3159,11 +3198,11 @@ internal object TerminalContentPartSerializer : KSerializer<TerminalContentPart>
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for TerminalContentPart")
         val discriminant = (obj["type"] as? JsonPrimitive)?.content
-            ?: error("Missing type discriminator on TerminalContentPart")
+            ?: return TerminalContentPartUnknown(obj)
         return when (discriminant) {
             "unclassified" -> TerminalContentPartUnclassified(input.json.decodeFromJsonElement(TerminalUnclassifiedPart.serializer(), element))
             "command" -> TerminalContentPartCommand(input.json.decodeFromJsonElement(TerminalCommandPart.serializer(), element))
-            else -> error("Unknown TerminalContentPart discriminator: $discriminant")
+            else -> TerminalContentPartUnknown(obj)
         }
     }
 
@@ -3173,6 +3212,7 @@ internal object TerminalContentPartSerializer : KSerializer<TerminalContentPart>
         val element: JsonElement = when (value) {
             is TerminalContentPartUnclassified -> output.json.encodeToJsonElement(TerminalUnclassifiedPart.serializer(), value.value)
             is TerminalContentPartCommand -> output.json.encodeToJsonElement(TerminalCommandPart.serializer(), value.value)
+            is TerminalContentPartUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3191,6 +3231,15 @@ value class SessionInputQuestionBoolean(val value: SessionInputBooleanQuestion) 
 value class SessionInputQuestionSingleSelect(val value: SessionInputSingleSelectQuestion) : SessionInputQuestion
 @JvmInline
 value class SessionInputQuestionMultiSelect(val value: SessionInputMultiSelectQuestion) : SessionInputQuestion
+/**
+ * Forward-compat catch-all for unknown SessionInputQuestion discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class SessionInputQuestionUnknown(val raw: JsonObject) : SessionInputQuestion
 
 internal object SessionInputQuestionSerializer : KSerializer<SessionInputQuestion> {
     override val descriptor: SerialDescriptor =
@@ -3203,7 +3252,7 @@ internal object SessionInputQuestionSerializer : KSerializer<SessionInputQuestio
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for SessionInputQuestion")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: error("Missing kind discriminator on SessionInputQuestion")
+            ?: return SessionInputQuestionUnknown(obj)
         return when (discriminant) {
             "text" -> SessionInputQuestionText(input.json.decodeFromJsonElement(SessionInputTextQuestion.serializer(), element))
             "number" -> SessionInputQuestionNumber(input.json.decodeFromJsonElement(SessionInputNumberQuestion.serializer(), element))
@@ -3211,7 +3260,7 @@ internal object SessionInputQuestionSerializer : KSerializer<SessionInputQuestio
             "boolean" -> SessionInputQuestionBoolean(input.json.decodeFromJsonElement(SessionInputBooleanQuestion.serializer(), element))
             "single-select" -> SessionInputQuestionSingleSelect(input.json.decodeFromJsonElement(SessionInputSingleSelectQuestion.serializer(), element))
             "multi-select" -> SessionInputQuestionMultiSelect(input.json.decodeFromJsonElement(SessionInputMultiSelectQuestion.serializer(), element))
-            else -> error("Unknown SessionInputQuestion discriminator: $discriminant")
+            else -> SessionInputQuestionUnknown(obj)
         }
     }
 
@@ -3224,6 +3273,7 @@ internal object SessionInputQuestionSerializer : KSerializer<SessionInputQuestio
             is SessionInputQuestionBoolean -> output.json.encodeToJsonElement(SessionInputBooleanQuestion.serializer(), value.value)
             is SessionInputQuestionSingleSelect -> output.json.encodeToJsonElement(SessionInputSingleSelectQuestion.serializer(), value.value)
             is SessionInputQuestionMultiSelect -> output.json.encodeToJsonElement(SessionInputMultiSelectQuestion.serializer(), value.value)
+            is SessionInputQuestionUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3242,6 +3292,15 @@ value class SessionInputAnswerValueBoolean(val value: SessionInputBooleanAnswerV
 value class SessionInputAnswerValueSelected(val value: SessionInputSelectedAnswerValue) : SessionInputAnswerValue
 @JvmInline
 value class SessionInputAnswerValueSelectedMany(val value: SessionInputSelectedManyAnswerValue) : SessionInputAnswerValue
+/**
+ * Forward-compat catch-all for unknown SessionInputAnswerValue discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class SessionInputAnswerValueUnknown(val raw: JsonObject) : SessionInputAnswerValue
 
 internal object SessionInputAnswerValueSerializer : KSerializer<SessionInputAnswerValue> {
     override val descriptor: SerialDescriptor =
@@ -3254,14 +3313,14 @@ internal object SessionInputAnswerValueSerializer : KSerializer<SessionInputAnsw
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for SessionInputAnswerValue")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: error("Missing kind discriminator on SessionInputAnswerValue")
+            ?: return SessionInputAnswerValueUnknown(obj)
         return when (discriminant) {
             "text" -> SessionInputAnswerValueText(input.json.decodeFromJsonElement(SessionInputTextAnswerValue.serializer(), element))
             "number" -> SessionInputAnswerValueNumber(input.json.decodeFromJsonElement(SessionInputNumberAnswerValue.serializer(), element))
             "boolean" -> SessionInputAnswerValueBoolean(input.json.decodeFromJsonElement(SessionInputBooleanAnswerValue.serializer(), element))
             "selected" -> SessionInputAnswerValueSelected(input.json.decodeFromJsonElement(SessionInputSelectedAnswerValue.serializer(), element))
             "selected-many" -> SessionInputAnswerValueSelectedMany(input.json.decodeFromJsonElement(SessionInputSelectedManyAnswerValue.serializer(), element))
-            else -> error("Unknown SessionInputAnswerValue discriminator: $discriminant")
+            else -> SessionInputAnswerValueUnknown(obj)
         }
     }
 
@@ -3274,6 +3333,7 @@ internal object SessionInputAnswerValueSerializer : KSerializer<SessionInputAnsw
             is SessionInputAnswerValueBoolean -> output.json.encodeToJsonElement(SessionInputBooleanAnswerValue.serializer(), value.value)
             is SessionInputAnswerValueSelected -> output.json.encodeToJsonElement(SessionInputSelectedAnswerValue.serializer(), value.value)
             is SessionInputAnswerValueSelectedMany -> output.json.encodeToJsonElement(SessionInputSelectedManyAnswerValue.serializer(), value.value)
+            is SessionInputAnswerValueUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3286,6 +3346,15 @@ sealed interface SessionInputAnswer
 value class SessionInputAnswerDraft(val value: SessionInputAnswered) : SessionInputAnswer
 @JvmInline
 value class SessionInputAnswerSkipped(val value: SessionInputSkipped) : SessionInputAnswer
+/**
+ * Forward-compat catch-all for unknown SessionInputAnswer discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class SessionInputAnswerUnknown(val raw: JsonObject) : SessionInputAnswer
 
 internal object SessionInputAnswerSerializer : KSerializer<SessionInputAnswer> {
     override val descriptor: SerialDescriptor =
@@ -3298,12 +3367,12 @@ internal object SessionInputAnswerSerializer : KSerializer<SessionInputAnswer> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for SessionInputAnswer")
         val discriminant = (obj["state"] as? JsonPrimitive)?.content
-            ?: error("Missing state discriminator on SessionInputAnswer")
+            ?: return SessionInputAnswerUnknown(obj)
         return when (discriminant) {
             "draft" -> SessionInputAnswerDraft(input.json.decodeFromJsonElement(SessionInputAnswered.serializer(), element))
             "submitted" -> SessionInputAnswerDraft(input.json.decodeFromJsonElement(SessionInputAnswered.serializer(), element))
             "skipped" -> SessionInputAnswerSkipped(input.json.decodeFromJsonElement(SessionInputSkipped.serializer(), element))
-            else -> error("Unknown SessionInputAnswer discriminator: $discriminant")
+            else -> SessionInputAnswerUnknown(obj)
         }
     }
 
@@ -3313,6 +3382,7 @@ internal object SessionInputAnswerSerializer : KSerializer<SessionInputAnswer> {
         val element: JsonElement = when (value) {
             is SessionInputAnswerDraft -> output.json.encodeToJsonElement(SessionInputAnswered.serializer(), value.value)
             is SessionInputAnswerSkipped -> output.json.encodeToJsonElement(SessionInputSkipped.serializer(), value.value)
+            is SessionInputAnswerUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3327,6 +3397,15 @@ value class MessageAttachmentSimple(val value: SimpleMessageAttachment) : Messag
 value class MessageAttachmentEmbeddedResource(val value: MessageEmbeddedResourceAttachment) : MessageAttachment
 @JvmInline
 value class MessageAttachmentResource(val value: MessageResourceAttachment) : MessageAttachment
+/**
+ * Forward-compat catch-all for unknown MessageAttachment discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class MessageAttachmentUnknown(val raw: JsonObject) : MessageAttachment
 
 internal object MessageAttachmentSerializer : KSerializer<MessageAttachment> {
     override val descriptor: SerialDescriptor =
@@ -3339,12 +3418,12 @@ internal object MessageAttachmentSerializer : KSerializer<MessageAttachment> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for MessageAttachment")
         val discriminant = (obj["type"] as? JsonPrimitive)?.content
-            ?: error("Missing type discriminator on MessageAttachment")
+            ?: return MessageAttachmentUnknown(obj)
         return when (discriminant) {
             "simple" -> MessageAttachmentSimple(input.json.decodeFromJsonElement(SimpleMessageAttachment.serializer(), element))
             "embeddedResource" -> MessageAttachmentEmbeddedResource(input.json.decodeFromJsonElement(MessageEmbeddedResourceAttachment.serializer(), element))
             "resource" -> MessageAttachmentResource(input.json.decodeFromJsonElement(MessageResourceAttachment.serializer(), element))
-            else -> error("Unknown MessageAttachment discriminator: $discriminant")
+            else -> MessageAttachmentUnknown(obj)
         }
     }
 
@@ -3355,6 +3434,7 @@ internal object MessageAttachmentSerializer : KSerializer<MessageAttachment> {
             is MessageAttachmentSimple -> output.json.encodeToJsonElement(SimpleMessageAttachment.serializer(), value.value)
             is MessageAttachmentEmbeddedResource -> output.json.encodeToJsonElement(MessageEmbeddedResourceAttachment.serializer(), value.value)
             is MessageAttachmentResource -> output.json.encodeToJsonElement(MessageResourceAttachment.serializer(), value.value)
+            is MessageAttachmentUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3367,6 +3447,15 @@ sealed interface Customization
 value class CustomizationPlugin(val value: PluginCustomization) : Customization
 @JvmInline
 value class CustomizationDirectory(val value: DirectoryCustomization) : Customization
+/**
+ * Forward-compat catch-all for unknown Customization discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class CustomizationUnknown(val raw: JsonObject) : Customization
 
 internal object CustomizationSerializer : KSerializer<Customization> {
     override val descriptor: SerialDescriptor =
@@ -3379,11 +3468,11 @@ internal object CustomizationSerializer : KSerializer<Customization> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for Customization")
         val discriminant = (obj["type"] as? JsonPrimitive)?.content
-            ?: error("Missing type discriminator on Customization")
+            ?: return CustomizationUnknown(obj)
         return when (discriminant) {
             "plugin" -> CustomizationPlugin(input.json.decodeFromJsonElement(PluginCustomization.serializer(), element))
             "directory" -> CustomizationDirectory(input.json.decodeFromJsonElement(DirectoryCustomization.serializer(), element))
-            else -> error("Unknown Customization discriminator: $discriminant")
+            else -> CustomizationUnknown(obj)
         }
     }
 
@@ -3393,6 +3482,7 @@ internal object CustomizationSerializer : KSerializer<Customization> {
         val element: JsonElement = when (value) {
             is CustomizationPlugin -> output.json.encodeToJsonElement(PluginCustomization.serializer(), value.value)
             is CustomizationDirectory -> output.json.encodeToJsonElement(DirectoryCustomization.serializer(), value.value)
+            is CustomizationUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3413,6 +3503,15 @@ value class ChildCustomizationRule(val value: RuleCustomization) : ChildCustomiz
 value class ChildCustomizationHook(val value: HookCustomization) : ChildCustomization
 @JvmInline
 value class ChildCustomizationMcpServer(val value: McpServerCustomization) : ChildCustomization
+/**
+ * Forward-compat catch-all for unknown ChildCustomization discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class ChildCustomizationUnknown(val raw: JsonObject) : ChildCustomization
 
 internal object ChildCustomizationSerializer : KSerializer<ChildCustomization> {
     override val descriptor: SerialDescriptor =
@@ -3425,7 +3524,7 @@ internal object ChildCustomizationSerializer : KSerializer<ChildCustomization> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for ChildCustomization")
         val discriminant = (obj["type"] as? JsonPrimitive)?.content
-            ?: error("Missing type discriminator on ChildCustomization")
+            ?: return ChildCustomizationUnknown(obj)
         return when (discriminant) {
             "agent" -> ChildCustomizationAgent(input.json.decodeFromJsonElement(AgentCustomization.serializer(), element))
             "skill" -> ChildCustomizationSkill(input.json.decodeFromJsonElement(SkillCustomization.serializer(), element))
@@ -3433,7 +3532,7 @@ internal object ChildCustomizationSerializer : KSerializer<ChildCustomization> {
             "rule" -> ChildCustomizationRule(input.json.decodeFromJsonElement(RuleCustomization.serializer(), element))
             "hook" -> ChildCustomizationHook(input.json.decodeFromJsonElement(HookCustomization.serializer(), element))
             "mcpServer" -> ChildCustomizationMcpServer(input.json.decodeFromJsonElement(McpServerCustomization.serializer(), element))
-            else -> error("Unknown ChildCustomization discriminator: $discriminant")
+            else -> ChildCustomizationUnknown(obj)
         }
     }
 
@@ -3447,6 +3546,7 @@ internal object ChildCustomizationSerializer : KSerializer<ChildCustomization> {
             is ChildCustomizationRule -> output.json.encodeToJsonElement(RuleCustomization.serializer(), value.value)
             is ChildCustomizationHook -> output.json.encodeToJsonElement(HookCustomization.serializer(), value.value)
             is ChildCustomizationMcpServer -> output.json.encodeToJsonElement(McpServerCustomization.serializer(), value.value)
+            is ChildCustomizationUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3463,6 +3563,15 @@ value class CustomizationLoadStateLoaded(val value: CustomizationLoadedState) : 
 value class CustomizationLoadStateDegraded(val value: CustomizationDegradedState) : CustomizationLoadState
 @JvmInline
 value class CustomizationLoadStateError(val value: CustomizationErrorState) : CustomizationLoadState
+/**
+ * Forward-compat catch-all for unknown CustomizationLoadState discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers treat instances of this variant as no-ops.
+ */
+@JvmInline
+value class CustomizationLoadStateUnknown(val raw: JsonObject) : CustomizationLoadState
 
 internal object CustomizationLoadStateSerializer : KSerializer<CustomizationLoadState> {
     override val descriptor: SerialDescriptor =
@@ -3475,13 +3584,13 @@ internal object CustomizationLoadStateSerializer : KSerializer<CustomizationLoad
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for CustomizationLoadState")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: error("Missing kind discriminator on CustomizationLoadState")
+            ?: return CustomizationLoadStateUnknown(obj)
         return when (discriminant) {
             "loading" -> CustomizationLoadStateLoading(input.json.decodeFromJsonElement(CustomizationLoadingState.serializer(), element))
             "loaded" -> CustomizationLoadStateLoaded(input.json.decodeFromJsonElement(CustomizationLoadedState.serializer(), element))
             "degraded" -> CustomizationLoadStateDegraded(input.json.decodeFromJsonElement(CustomizationDegradedState.serializer(), element))
             "error" -> CustomizationLoadStateError(input.json.decodeFromJsonElement(CustomizationErrorState.serializer(), element))
-            else -> error("Unknown CustomizationLoadState discriminator: $discriminant")
+            else -> CustomizationLoadStateUnknown(obj)
         }
     }
 
@@ -3493,6 +3602,7 @@ internal object CustomizationLoadStateSerializer : KSerializer<CustomizationLoad
             is CustomizationLoadStateLoaded -> output.json.encodeToJsonElement(CustomizationLoadedState.serializer(), value.value)
             is CustomizationLoadStateDegraded -> output.json.encodeToJsonElement(CustomizationDegradedState.serializer(), value.value)
             is CustomizationLoadStateError -> output.json.encodeToJsonElement(CustomizationErrorState.serializer(), value.value)
+            is CustomizationLoadStateUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -3506,6 +3616,14 @@ sealed interface ToolResultContent {
     @JvmInline value class FileEdit(val value: ToolResultFileEditContent) : ToolResultContent
     @JvmInline value class Terminal(val value: ToolResultTerminalContent) : ToolResultContent
     @JvmInline value class Subagent(val value: ToolResultSubagentContent) : ToolResultContent
+
+    /**
+     * Forward-compat catch-all for unknown ToolResultContent types.
+     *
+     * Older clients may receive newer wire variants they don't recognise; capturing
+     * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+     */
+    @JvmInline value class Unknown(val raw: JsonObject) : ToolResultContent
 }
 
 internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
@@ -3519,7 +3637,7 @@ internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for ToolResultContent")
         val type = (obj["type"] as? JsonPrimitive)?.contentOrNull
-            ?: error("ToolResultContent missing type")
+            ?: return ToolResultContent.Unknown(obj)
         return when (type) {
             "text" -> ToolResultContent.Text(input.json.decodeFromJsonElement(ToolResultTextContent.serializer(), element))
             "embeddedResource" -> ToolResultContent.EmbeddedResource(input.json.decodeFromJsonElement(ToolResultEmbeddedResourceContent.serializer(), element))
@@ -3527,7 +3645,7 @@ internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
             "fileEdit" -> ToolResultContent.FileEdit(input.json.decodeFromJsonElement(ToolResultFileEditContent.serializer(), element))
             "terminal" -> ToolResultContent.Terminal(input.json.decodeFromJsonElement(ToolResultTerminalContent.serializer(), element))
             "subagent" -> ToolResultContent.Subagent(input.json.decodeFromJsonElement(ToolResultSubagentContent.serializer(), element))
-            else -> error("Unknown ToolResultContent type: $type")
+            else -> ToolResultContent.Unknown(obj)
         }
     }
 
@@ -3541,6 +3659,7 @@ internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
             is ToolResultContent.FileEdit -> output.json.encodeToJsonElement(ToolResultFileEditContent.serializer(), value.value)
             is ToolResultContent.Terminal -> output.json.encodeToJsonElement(ToolResultTerminalContent.serializer(), value.value)
             is ToolResultContent.Subagent -> output.json.encodeToJsonElement(ToolResultSubagentContent.serializer(), value.value)
+            is ToolResultContent.Unknown -> value.raw
         }
         output.encodeJsonElement(element)
     }

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/DiscriminatedUnionTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/DiscriminatedUnionTest.kt
@@ -4,17 +4,21 @@ import com.microsoft.agenthostprotocol.generated.ChangesetOperationRangeTarget
 import com.microsoft.agenthostprotocol.generated.ChangesetOperationResourceTarget
 import com.microsoft.agenthostprotocol.generated.ChangesetOperationTarget
 import com.microsoft.agenthostprotocol.generated.ChangesetOperationTargetRange
+import com.microsoft.agenthostprotocol.generated.Customization
+import com.microsoft.agenthostprotocol.generated.CustomizationUnknown
 import com.microsoft.agenthostprotocol.generated.MarkdownResponsePart
 import com.microsoft.agenthostprotocol.generated.ReasoningResponsePart
 import com.microsoft.agenthostprotocol.generated.ResponsePart
 import com.microsoft.agenthostprotocol.generated.ResponsePartKind
 import com.microsoft.agenthostprotocol.generated.ResponsePartMarkdown
 import com.microsoft.agenthostprotocol.generated.ResponsePartReasoning
+import com.microsoft.agenthostprotocol.generated.ResponsePartUnknown
 import com.microsoft.agenthostprotocol.generated.SessionInputNumberQuestion
 import com.microsoft.agenthostprotocol.generated.SessionInputQuestion
 import com.microsoft.agenthostprotocol.generated.SessionInputQuestionNumber
 import com.microsoft.agenthostprotocol.generated.SessionInputQuestionKind
 import com.microsoft.agenthostprotocol.generated.StringOrMarkdown
+import com.microsoft.agenthostprotocol.generated.ToolResultContent
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
@@ -176,5 +180,68 @@ class DiscriminatedUnionTest {
         )
         val obj = json.parseToJsonElement(encoded) as JsonObject
         assertEquals(JsonPrimitive("resource"), obj["kind"])
+    }
+
+    @Test
+    fun `ResponsePart unknown kind decodes to ResponsePartUnknown and round-trips`() {
+        // A newer server may emit response part kinds this client has not yet
+        // learned about. The decoder must capture the raw payload in a
+        // forward-compat Unknown variant instead of throwing.
+        val wire = """{"kind":"unknownFuturePart","id":"x1","payload":{"foo":42}}"""
+
+        val decoded = json.decodeFromString(ResponsePart.serializer(), wire)
+        val asUnknown = assertIs<ResponsePartUnknown>(decoded)
+        assertEquals(JsonPrimitive("unknownFuturePart"), asUnknown.raw["kind"])
+        assertEquals(JsonPrimitive("x1"), asUnknown.raw["id"])
+
+        // Re-encoding produces the same JSON tree (semantic round-trip — key
+        // order and whitespace aren't guaranteed but the parsed tree matches).
+        val reEncoded = json.encodeToString(ResponsePart.serializer(), decoded)
+        val reTree = json.parseToJsonElement(reEncoded).jsonObject
+        assertEquals(json.parseToJsonElement(wire).jsonObject, reTree)
+    }
+
+    @Test
+    fun `ToolResultContent unknown type decodes to Unknown and round-trips`() {
+        val wire = """{"type":"futureBlob","payload":{"bytes":"AAEC"}}"""
+
+        val decoded = json.decodeFromString(ToolResultContent.serializer(), wire)
+        val asUnknown = assertIs<ToolResultContent.Unknown>(decoded)
+        assertEquals(JsonPrimitive("futureBlob"), asUnknown.raw["type"])
+
+        val reEncoded = json.encodeToString(ToolResultContent.serializer(), decoded)
+        val reTree = json.parseToJsonElement(reEncoded).jsonObject
+        assertEquals(json.parseToJsonElement(wire).jsonObject, reTree)
+    }
+
+    @Test
+    fun `Customization unknown type decodes to CustomizationUnknown without throwing`() {
+        val wire = """{"type":"futurePlugin","id":"c1","enabled":true}"""
+
+        val decoded = json.decodeFromString(Customization.serializer(), wire)
+        val asUnknown = assertIs<CustomizationUnknown>(decoded)
+        assertEquals(JsonPrimitive("futurePlugin"), asUnknown.raw["type"])
+        assertEquals(JsonPrimitive("c1"), asUnknown.raw["id"])
+
+        val reEncoded = json.encodeToString(Customization.serializer(), decoded)
+        val reTree = json.parseToJsonElement(reEncoded).jsonObject
+        assertEquals(json.parseToJsonElement(wire).jsonObject, reTree)
+    }
+
+    @Test
+    fun `ResponsePart with missing kind decodes to ResponsePartUnknown`() {
+        // A payload missing its discriminator entirely is also routed to the
+        // Unknown variant for forward-compat unions. This matches Rust's
+        // `#[serde(untagged)]` Unknown arm — anything we can't dispatch on
+        // becomes Unknown rather than throwing.
+        val wire = """{"id":"x1","payload":{"foo":42}}"""
+
+        val decoded = json.decodeFromString(ResponsePart.serializer(), wire)
+        val asUnknown = assertIs<ResponsePartUnknown>(decoded)
+        assertEquals(JsonPrimitive("x1"), asUnknown.raw["id"])
+
+        val reEncoded = json.encodeToString(ResponsePart.serializer(), decoded)
+        val reTree = json.parseToJsonElement(reEncoded).jsonObject
+        assertEquals(json.parseToJsonElement(wire).jsonObject, reTree)
     }
 }

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/FixtureDrivenReducerTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/FixtureDrivenReducerTest.kt
@@ -302,26 +302,19 @@ class FixtureDrivenReducerTest {
         /**
          * Fixture descriptions intentionally skipped because they exercise
          * decoding behaviour the generated wire types in this package do
-         * not yet support (e.g. unknown `ResponsePart` discriminators
-         * surviving a round trip). Each entry is keyed by the fixture's
-         * top-level `description` field so re-numbering or splitting JSON
-         * files doesn't silently change what is skipped.
+         * not yet support. Each entry is keyed by the fixture's top-level
+         * `description` field so re-numbering or splitting JSON files
+         * doesn't silently change what is skipped. As of this writing the
+         * full reducer fixture corpus is covered (zero skipped).
          */
-        private val SKIPPED_FIXTURES: Set<String> = setOf(
-            // Initial state has a ResponsePart with `kind: "unknownFuturePart"`.
-            // ResponsePartSerializer in the generated wire types throws on
-            // unknown discriminators (no `ResponsePartUnknown` variant
-            // analogous to `StateActionUnknown`). Adding that variant is a
-            // wire-types change outside this reducer-port PR's scope.
-            "delta skips response parts without id field",
-        )
+        private val SKIPPED_FIXTURES: Set<String> = emptySet()
 
         /**
          * Upper bound on how many fixtures may be skipped. Raising this
          * requires a corresponding entry in [SKIPPED_FIXTURES]; lowering
          * it requires removing one.
          */
-        private const val MAX_SKIPPED_FIXTURES: Int = 1
+        private const val MAX_SKIPPED_FIXTURES: Int = 0
     }
 }
 

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/ReducersTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/ReducersTest.kt
@@ -8,12 +8,14 @@ import com.microsoft.agenthostprotocol.generated.ChangesetStatusChangedAction
 import com.microsoft.agenthostprotocol.generated.ActionType
 import com.microsoft.agenthostprotocol.generated.ChangesetClearedAction
 import com.microsoft.agenthostprotocol.generated.ChangesetFileSetAction
+import com.microsoft.agenthostprotocol.generated.CustomizationUnknown
 import com.microsoft.agenthostprotocol.generated.ErrorInfo
 import com.microsoft.agenthostprotocol.generated.FileEdit
 import com.microsoft.agenthostprotocol.generated.PendingMessage
 import com.microsoft.agenthostprotocol.generated.PendingMessageKind
 import com.microsoft.agenthostprotocol.generated.RootAgentsChangedAction
 import com.microsoft.agenthostprotocol.generated.RootState
+import com.microsoft.agenthostprotocol.generated.SessionCustomizationUpdatedAction
 import com.microsoft.agenthostprotocol.generated.SessionLifecycle
 import com.microsoft.agenthostprotocol.generated.SessionPendingMessageSetAction
 import com.microsoft.agenthostprotocol.generated.SessionQueuedMessagesReorderedAction
@@ -25,6 +27,7 @@ import com.microsoft.agenthostprotocol.generated.StateActionChangesetCleared
 import com.microsoft.agenthostprotocol.generated.StateActionChangesetFileSet
 import com.microsoft.agenthostprotocol.generated.StateActionChangesetStatusChanged
 import com.microsoft.agenthostprotocol.generated.StateActionRootAgentsChanged
+import com.microsoft.agenthostprotocol.generated.StateActionSessionCustomizationUpdated
 import com.microsoft.agenthostprotocol.generated.StateActionSessionPendingMessageSet
 import com.microsoft.agenthostprotocol.generated.StateActionSessionQueuedMessagesReordered
 import com.microsoft.agenthostprotocol.generated.StateActionSessionTitleChanged
@@ -38,6 +41,9 @@ import com.microsoft.agenthostprotocol.generated.TerminalDataAction
 import com.microsoft.agenthostprotocol.generated.TerminalInputAction
 import com.microsoft.agenthostprotocol.generated.TerminalState
 import com.microsoft.agenthostprotocol.generated.UserMessage
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -325,6 +331,26 @@ class ReducersTest {
         lifecycle = SessionLifecycle.READY,
         turns = emptyList(),
     )
+
+    @Test
+    fun `SessionCustomizationUpdated with CustomizationUnknown is a no-op`() {
+        // An unknown customization has no extractable id, so the reducer
+        // cannot upsert it sensibly. Match Rust: NoOp the action entirely,
+        // leaving the existing customization list untouched.
+        val baseline = newSession()
+        val raw: JsonObject = buildJsonObject {
+            put("type", JsonPrimitive("futurePluginVariant"))
+            put("payload", buildJsonObject { put("foo", JsonPrimitive(1)) })
+        }
+        val action = StateActionSessionCustomizationUpdated(
+            SessionCustomizationUpdatedAction(
+                type = ActionType.SESSION_CUSTOMIZATION_UPDATED,
+                customization = CustomizationUnknown(raw),
+            ),
+        )
+        val after = sessionReducer(baseline, action)
+        assertSame(baseline, after)
+    }
 
     private companion object {
         private const val MOCK_NOW: Long = 9999L

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/StateActionTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/StateActionTest.kt
@@ -66,6 +66,24 @@ class StateActionTest {
     }
 
     @Test
+    fun `action without type discriminator decodes to StateActionUnknown without throwing`() {
+        // Symmetric with the state-channel `XUnknown` variants: a payload
+        // that's missing its `type` discriminator entirely is also routed
+        // to Unknown rather than throwing. The reducer's `else -> state`
+        // arm can then no-op it. The captured raw payload still
+        // round-trips so the channel stays alive across protocol drift.
+        val malformedWire = """{"payload":{"foo":42}}"""
+        val decoded = json.decodeFromString(StateAction.serializer(), malformedWire)
+        val unknown = assertIs<StateActionUnknown>(decoded)
+        assertNull(unknown.raw["type"])
+        assertEquals(JsonPrimitive(42), unknown.raw["payload"]?.jsonObject?.get("foo"))
+
+        val reEncoded = json.encodeToString(StateAction.serializer(), decoded)
+        val reTree = json.parseToJsonElement(reEncoded).jsonObject
+        assertEquals(json.parseToJsonElement(malformedWire).jsonObject, reTree)
+    }
+
+    @Test
     fun `ActionEnvelope wraps a StateAction with serverSeq`() {
         // Channel-scoped envelope: every server-pushed action now carries
         // the channel URI it belongs to. Per-session actions like

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/StateActionTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/StateActionTest.kt
@@ -50,11 +50,19 @@ class StateActionTest {
     fun `unknown action type decodes to StateActionUnknown without throwing`() {
         // A future server may emit an action whose `type` is unknown to
         // this client. The reducer must be able to no-op it; that requires
-        // the deserializer to never throw on unknown types.
-        val futureWire = """{"type":"session/futureUnknownAction","payload":{}}"""
+        // the deserializer to never throw on unknown types. The raw JSON
+        // object is captured so the action round-trips back across the
+        // wire with its full payload intact.
+        val futureWire = """{"type":"session/futureUnknownAction","payload":{"foo":42}}"""
         val decoded = json.decodeFromString(StateAction.serializer(), futureWire)
         val unknown = assertIs<StateActionUnknown>(decoded)
-        assertEquals("session/futureUnknownAction", unknown.type)
+        assertEquals(JsonPrimitive("session/futureUnknownAction"), unknown.raw["type"])
+        assertEquals(JsonPrimitive(42), unknown.raw["payload"]?.jsonObject?.get("foo"))
+
+        // Re-encoded JSON tree matches the original (semantic round-trip).
+        val reEncoded = json.encodeToString(StateAction.serializer(), decoded)
+        val reTree = json.parseToJsonElement(reEncoded).jsonObject
+        assertEquals(json.parseToJsonElement(futureWire).jsonObject, reTree)
     }
 
     @Test

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1123,9 +1123,11 @@ function generateActionsFile(project: Project): string {
   lines.push('/**');
   lines.push(' * Discriminated union of all state actions.');
   lines.push(' *');
-  lines.push(' * Unknown wire types decode to [StateActionUnknown] and reducers should treat');
-  lines.push(' * them as no-ops; this is critical for forward compatibility across protocol');
-  lines.push(' * versions.');
+  lines.push(' * Unknown wire types decode to [StateActionUnknown], which captures the full');
+  lines.push(' * raw JSON object (mirrors the state-channel `XUnknown` variants and Rust\'s');
+  lines.push(' * `Unknown(serde_json::Value)`). Reducers should treat unknown actions as');
+  lines.push(' * no-ops; the captured payload is re-emitted unchanged on encode so unknown');
+  lines.push(' * actions can round-trip across protocol versions.');
   lines.push(' */');
   lines.push('@Serializable(with = StateActionSerializer::class)');
   lines.push('sealed interface StateAction');
@@ -1134,7 +1136,7 @@ function generateActionsFile(project: Project): string {
     const dataClass = v.tsInterface === '_merged_' ? 'SessionToolCallConfirmedAction' : v.tsInterface;
     lines.push(`@JvmInline value class StateAction${v.caseName}(val value: ${dataClass}) : StateAction`);
   }
-  lines.push('@JvmInline value class StateActionUnknown(val type: String) : StateAction');
+  lines.push('@JvmInline value class StateActionUnknown(val raw: JsonObject) : StateAction');
   lines.push('');
 
   lines.push('internal object StateActionSerializer : KSerializer<StateAction> {');
@@ -1154,7 +1156,7 @@ function generateActionsFile(project: Project): string {
     const dataClass = v.tsInterface === '_merged_' ? 'SessionToolCallConfirmedAction' : v.tsInterface;
     lines.push(`            ${JSON.stringify(v.type)} -> StateAction${v.caseName}(input.json.decodeFromJsonElement(${dataClass}.serializer(), element))`);
   }
-  lines.push('            else -> StateActionUnknown(type)');
+  lines.push('            else -> StateActionUnknown(obj)');
   lines.push('        }');
   lines.push('    }');
   lines.push('');
@@ -1166,9 +1168,7 @@ function generateActionsFile(project: Project): string {
     const dataClass = v.tsInterface === '_merged_' ? 'SessionToolCallConfirmedAction' : v.tsInterface;
     lines.push(`            is StateAction${v.caseName} -> output.json.encodeToJsonElement(${dataClass}.serializer(), value.value)`);
   }
-  lines.push('            is StateActionUnknown -> buildJsonObject {');
-  lines.push('                put("type", JsonPrimitive(value.type))');
-  lines.push('            }');
+  lines.push('            is StateActionUnknown -> value.raw');
   lines.push('        }');
   lines.push('        output.encodeJsonElement(element)');
   lines.push('    }');

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -435,6 +435,18 @@ interface UnionConfig {
   name: string;
   discriminantField: string;
   variants: UnionVariant[];
+  /**
+   * Forward-compat catch-all. When `true`, the generator emits an extra
+   * `${name}Unknown(val raw: JsonObject)` value class and routes any unknown
+   * discriminator into it (rather than throwing). The raw `JsonObject` is
+   * captured at decode time and re-emitted unchanged on serialize so unknown
+   * future variants round-trip through this client without losing fields.
+   *
+   * Mirrors the `unknown: true` flag on `scripts/generate-rust.ts`'s
+   * `UnionConfig`, which emits a parallel `Unknown(serde_json::Value)` variant
+   * on the same set of state-channel unions.
+   */
+  unknown?: boolean;
 }
 
 /**
@@ -466,6 +478,17 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
     lines.push(`@JvmInline`);
     lines.push(`value class ${config.name}${v.caseName}(val value: ${v.structName}) : ${config.name}`);
   }
+  if (config.unknown) {
+    lines.push('/**');
+    lines.push(` * Forward-compat catch-all for unknown ${config.name} discriminators.`);
+    lines.push(' *');
+    lines.push(' * Older clients may receive newer wire variants they don\'t recognise; capturing');
+    lines.push(' * the raw `JsonObject` lets such payloads round-trip through the client unchanged.');
+    lines.push(' * Reducers treat instances of this variant as no-ops.');
+    lines.push(' */');
+    lines.push(`@JvmInline`);
+    lines.push(`value class ${config.name}Unknown(val raw: JsonObject) : ${config.name}`);
+  }
   lines.push('');
 
   // Custom KSerializer
@@ -480,13 +503,21 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
   lines.push('        val obj = element as? JsonObject');
   lines.push(`            ?: error("Expected JsonObject for ${config.name}")`);
   lines.push(`        val discriminant = (obj[${JSON.stringify(config.discriminantField)}] as? JsonPrimitive)?.content`);
-  lines.push(`            ?: error("Missing ${config.discriminantField} discriminator on ${config.name}")`);
+  if (config.unknown) {
+    lines.push(`            ?: return ${config.name}Unknown(obj)`);
+  } else {
+    lines.push(`            ?: error("Missing ${config.discriminantField} discriminator on ${config.name}")`);
+  }
   lines.push('        return when (discriminant) {');
   for (const v of config.variants) {
     const variantClass = `${config.name}${(byStruct.get(v.structName) ?? v).caseName}`;
     lines.push(`            ${JSON.stringify(v.discriminantValue)} -> ${variantClass}(input.json.decodeFromJsonElement(${v.structName}.serializer(), element))`);
   }
-  lines.push(`            else -> error("Unknown ${config.name} discriminator: $discriminant")`);
+  if (config.unknown) {
+    lines.push(`            else -> ${config.name}Unknown(obj)`);
+  } else {
+    lines.push(`            else -> error("Unknown ${config.name} discriminator: $discriminant")`);
+  }
   lines.push('        }');
   lines.push('    }');
   lines.push('');
@@ -497,6 +528,9 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
   for (const v of byStruct.values()) {
     const variantClass = `${config.name}${v.caseName}`;
     lines.push(`            is ${variantClass} -> output.json.encodeToJsonElement(${v.structName}.serializer(), value.value)`);
+  }
+  if (config.unknown) {
+    lines.push(`            is ${config.name}Unknown -> value.raw`);
   }
   lines.push('        }');
   lines.push('        output.encodeJsonElement(element)');
@@ -646,6 +680,14 @@ sealed interface ToolResultContent {
     @JvmInline value class FileEdit(val value: ToolResultFileEditContent) : ToolResultContent
     @JvmInline value class Terminal(val value: ToolResultTerminalContent) : ToolResultContent
     @JvmInline value class Subagent(val value: ToolResultSubagentContent) : ToolResultContent
+
+    /**
+     * Forward-compat catch-all for unknown ToolResultContent types.
+     *
+     * Older clients may receive newer wire variants they don't recognise; capturing
+     * the raw \`JsonObject\` lets such payloads round-trip through the client unchanged.
+     */
+    @JvmInline value class Unknown(val raw: JsonObject) : ToolResultContent
 }
 
 internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
@@ -659,7 +701,7 @@ internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for ToolResultContent")
         val type = (obj["type"] as? JsonPrimitive)?.contentOrNull
-            ?: error("ToolResultContent missing type")
+            ?: return ToolResultContent.Unknown(obj)
         return when (type) {
             "text" -> ToolResultContent.Text(input.json.decodeFromJsonElement(ToolResultTextContent.serializer(), element))
             "embeddedResource" -> ToolResultContent.EmbeddedResource(input.json.decodeFromJsonElement(ToolResultEmbeddedResourceContent.serializer(), element))
@@ -667,7 +709,7 @@ internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
             "fileEdit" -> ToolResultContent.FileEdit(input.json.decodeFromJsonElement(ToolResultFileEditContent.serializer(), element))
             "terminal" -> ToolResultContent.Terminal(input.json.decodeFromJsonElement(ToolResultTerminalContent.serializer(), element))
             "subagent" -> ToolResultContent.Subagent(input.json.decodeFromJsonElement(ToolResultSubagentContent.serializer(), element))
-            else -> error("Unknown ToolResultContent type: $type")
+            else -> ToolResultContent.Unknown(obj)
         }
     }
 
@@ -681,6 +723,7 @@ internal object ToolResultContentSerializer : KSerializer<ToolResultContent> {
             is ToolResultContent.FileEdit -> output.json.encodeToJsonElement(ToolResultFileEditContent.serializer(), value.value)
             is ToolResultContent.Terminal -> output.json.encodeToJsonElement(ToolResultTerminalContent.serializer(), value.value)
             is ToolResultContent.Subagent -> output.json.encodeToJsonElement(ToolResultSubagentContent.serializer(), value.value)
+            is ToolResultContent.Unknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -748,6 +791,7 @@ const RESPONSE_PART_UNION: UnionConfig = {
     { caseName: 'Reasoning', structName: 'ReasoningResponsePart', discriminantValue: 'reasoning' },
     { caseName: 'SystemNotification', structName: 'SystemNotificationResponsePart', discriminantValue: 'systemNotification' },
   ],
+  unknown: true,
 };
 
 const TOOL_CALL_STATE_UNION: UnionConfig = {
@@ -761,6 +805,7 @@ const TOOL_CALL_STATE_UNION: UnionConfig = {
     { caseName: 'Completed', structName: 'ToolCallCompletedState', discriminantValue: 'completed' },
     { caseName: 'Cancelled', structName: 'ToolCallCancelledState', discriminantValue: 'cancelled' },
   ],
+  unknown: true,
 };
 
 const TERMINAL_CLAIM_UNION: UnionConfig = {
@@ -770,6 +815,7 @@ const TERMINAL_CLAIM_UNION: UnionConfig = {
     { caseName: 'Client', structName: 'TerminalClientClaim', discriminantValue: 'client' },
     { caseName: 'Session', structName: 'TerminalSessionClaim', discriminantValue: 'session' },
   ],
+  unknown: true,
 };
 
 const TERMINAL_CONTENT_PART_UNION: UnionConfig = {
@@ -779,6 +825,7 @@ const TERMINAL_CONTENT_PART_UNION: UnionConfig = {
     { caseName: 'Unclassified', structName: 'TerminalUnclassifiedPart', discriminantValue: 'unclassified' },
     { caseName: 'Command', structName: 'TerminalCommandPart', discriminantValue: 'command' },
   ],
+  unknown: true,
 };
 
 const SESSION_INPUT_QUESTION_UNION: UnionConfig = {
@@ -794,6 +841,7 @@ const SESSION_INPUT_QUESTION_UNION: UnionConfig = {
     { caseName: 'SingleSelect', structName: 'SessionInputSingleSelectQuestion', discriminantValue: 'single-select' },
     { caseName: 'MultiSelect', structName: 'SessionInputMultiSelectQuestion', discriminantValue: 'multi-select' },
   ],
+  unknown: true,
 };
 
 const SESSION_INPUT_ANSWER_VALUE_UNION: UnionConfig = {
@@ -806,6 +854,7 @@ const SESSION_INPUT_ANSWER_VALUE_UNION: UnionConfig = {
     { caseName: 'Selected', structName: 'SessionInputSelectedAnswerValue', discriminantValue: 'selected' },
     { caseName: 'SelectedMany', structName: 'SessionInputSelectedManyAnswerValue', discriminantValue: 'selected-many' },
   ],
+  unknown: true,
 };
 
 const SESSION_INPUT_ANSWER_UNION: UnionConfig = {
@@ -816,6 +865,7 @@ const SESSION_INPUT_ANSWER_UNION: UnionConfig = {
     { caseName: 'Submitted', structName: 'SessionInputAnswered', discriminantValue: 'submitted' },
     { caseName: 'Skipped', structName: 'SessionInputSkipped', discriminantValue: 'skipped' },
   ],
+  unknown: true,
 };
 
 const MESSAGE_ATTACHMENT_UNION: UnionConfig = {
@@ -826,6 +876,7 @@ const MESSAGE_ATTACHMENT_UNION: UnionConfig = {
     { caseName: 'EmbeddedResource', structName: 'MessageEmbeddedResourceAttachment', discriminantValue: 'embeddedResource' },
     { caseName: 'Resource', structName: 'MessageResourceAttachment', discriminantValue: 'resource' },
   ],
+  unknown: true,
 };
 
 const CUSTOMIZATION_UNION: UnionConfig = {
@@ -835,6 +886,7 @@ const CUSTOMIZATION_UNION: UnionConfig = {
     { caseName: 'Plugin', structName: 'PluginCustomization', discriminantValue: 'plugin' },
     { caseName: 'Directory', structName: 'DirectoryCustomization', discriminantValue: 'directory' },
   ],
+  unknown: true,
 };
 
 const CHILD_CUSTOMIZATION_UNION: UnionConfig = {
@@ -848,6 +900,7 @@ const CHILD_CUSTOMIZATION_UNION: UnionConfig = {
     { caseName: 'Hook', structName: 'HookCustomization', discriminantValue: 'hook' },
     { caseName: 'McpServer', structName: 'McpServerCustomization', discriminantValue: 'mcpServer' },
   ],
+  unknown: true,
 };
 
 const CUSTOMIZATION_LOAD_STATE_UNION: UnionConfig = {
@@ -859,6 +912,7 @@ const CUSTOMIZATION_LOAD_STATE_UNION: UnionConfig = {
     { caseName: 'Degraded', structName: 'CustomizationDegradedState', discriminantValue: 'degraded' },
     { caseName: 'Error', structName: 'CustomizationErrorState', discriminantValue: 'error' },
   ],
+  unknown: true,
 };
 
 function generateStateFile(project: Project): string {

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -479,12 +479,13 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
     lines.push(`value class ${config.name}${v.caseName}(val value: ${v.structName}) : ${config.name}`);
   }
   if (config.unknown) {
-    lines.push('/**');
+    lines.push(`/**`);
     lines.push(` * Forward-compat catch-all for unknown ${config.name} discriminators.`);
     lines.push(' *');
     lines.push(' * Older clients may receive newer wire variants they don\'t recognise; capturing');
     lines.push(' * the raw `JsonObject` lets such payloads round-trip through the client unchanged.');
-    lines.push(' * Reducers treat instances of this variant as no-ops.');
+    lines.push(' * Reducers handle this variant conservatively on a per-union basis (typically');
+    lines.push(' * as a no-op, but see `Reducers.kt` for the exact treatment).');
     lines.push(' */');
     lines.push(`@JvmInline`);
     lines.push(`value class ${config.name}Unknown(val raw: JsonObject) : ${config.name}`);
@@ -1150,7 +1151,7 @@ function generateActionsFile(project: Project): string {
   lines.push('        val obj = element as? JsonObject');
   lines.push('            ?: error("Expected JsonObject for StateAction")');
   lines.push('        val type = (obj["type"] as? JsonPrimitive)?.contentOrNull');
-  lines.push('            ?: error("Missing \\"type\\" discriminator on StateAction")');
+  lines.push('            ?: return StateActionUnknown(obj)');
   lines.push('        return when (type) {');
   for (const v of ACTION_VARIANTS) {
     const dataClass = v.tsInterface === '_merged_' ? 'SessionToolCallConfirmedAction' : v.tsInterface;


### PR DESCRIPTION
## What

Adds forward-compat `Unknown` variants to the Kotlin generator for the 11 generic state-channel discriminated unions plus the hand-rolled `ToolResultContent` union, and **upgrades `StateActionUnknown` to the same shape** so the action channel matches. Every unrecognised discriminator now decodes to `XUnknown(val raw: JsonObject)` instead of throwing, and re-encodes back to its original JSON tree on the wire. Mirrors the canonical `Unknown(serde_json::Value)` pattern that already ships in Rust.

Addresses the follow-up called out at the bottom of #149's "Out of scope" section:

> A separate small follow-up could add `ResponsePartUnknown` / `ToolCallStateUnknown` / etc. variants to the generator for full forward-compat parity with `StateActionUnknown`, which would unskip fixture 103 and harden Kotlin against newer servers introducing new response part shapes.

Was originally drafted as stacked on PR #149; that PR has now merged, so this targets `main` directly.

## Why

The wire-types layer is the boundary at which Kotlin clients first decide whether a newer server is "this is fine, just ignore the parts I don't recognise" vs "throw and tear down the connection." This PR extends the same forward-compat guarantee to every union a newer server is most likely to grow new variants of, on both the state-tree and action channels:

- **State-tree unions**: `ResponsePart` (most likely to gain new content kinds), `ToolCallState` (new lifecycle states), `Customization` / `ChildCustomization` / `CustomizationLoadState` (new container or child types), `TerminalClaim` / `TerminalContentPart`, `SessionInputQuestion` / `SessionInputAnswer*`, `MessageAttachment`, `ToolResultContent`.
- **Action channel**: `StateAction` already had a `StateActionUnknown` variant, but it only preserved the wire `type` string. This PR widens it to capture the full raw JSON object — same shape, same forward-compat fidelity, no lossy asymmetry.

The pattern is intentionally **not** applied to `ReconnectResult` or `ChangesetOperationTarget`: those are RPC reply shapes where an unrecognised discriminator indicates a server bug rather than protocol evolution. Rust treats them the same way.

## Generator change

`scripts/generate-kotlin.ts` gains an `unknown?: boolean` field on `UnionConfig`. When set:

- `generateDiscriminatedUnion()` emits `@JvmInline value class ${name}Unknown(val raw: JsonObject) : ${name}` alongside the existing per-variant wrappers.
- The deserializer routes **both** missing-discriminator and unrecognised-discriminator cases into `${name}Unknown(obj)` (instead of `error(...)`).
- The serializer adds `is ${name}Unknown -> value.raw` so the captured payload re-emits unchanged.
- The generated KDoc reads *"Reducers handle this variant conservatively on a per-union basis (typically as a no-op, but see `Reducers.kt` for the exact treatment)"* — accurate for the asymmetric reducer behaviour described below.

`unknown: true` is set on the same 11 unions Rust marks: `RESPONSE_PART`, `TOOL_CALL_STATE`, `TERMINAL_CLAIM`, `TERMINAL_CONTENT_PART`, `SESSION_INPUT_QUESTION`, `SESSION_INPUT_ANSWER_VALUE`, `SESSION_INPUT_ANSWER`, `MESSAGE_ATTACHMENT`, `CUSTOMIZATION`, `CHILD_CUSTOMIZATION`, `CUSTOMIZATION_LOAD_STATE`.

The hand-rolled `generateToolResultContentUnion()` is updated separately to keep its nested-class style: it now emits `ToolResultContent.Unknown(val raw: JsonObject)` rather than a top-level `ToolResultContentUnknown`.

The hand-rolled `StateAction` dispatch is also updated: `StateActionUnknown` now takes `val raw: JsonObject`, and **both the unknown-`type` *and* missing-`type` paths** route to `StateActionUnknown(obj)` (symmetric with the state-channel `XUnknown` variants). The serializer arm emits `value.raw` directly so unknown actions round-trip with their full payload.

## Reducer changes (`Reducers.kt`)

Adding a new variant to a sealed interface breaks every exhaustive `when` over it; each broken arm is filled in to mirror Rust's per-arm behaviour:

- `customizationId(c)` / `childCustomizationId(c)` change return type from `String` to `String?` — Unknown returns `null` (mirrors Rust's `Option<&str>`). This prevents two unknown customizations from false-matching each other on an empty-string id during lookups.
- `StateActionSessionCustomizationUpdated` short-circuits to a NoOp when the action customization has no id, mirroring Rust's `let Some(action_id) = ... else { return NoOp }`.
- `customizationChildren(c)` → `null` for Unknown; `withCustomizationChildren` / `withCustomizationEnabled` pass through unchanged.
- `toolCallBase(tc)` → `ToolCallBase("", "", "", null, null)` for Unknown, matching Rust's `(String::new(), …, None, None)`. Combined with empty-string id, this guarantees an unknown tool call never matches a real `toolCallId` in delta or lookup paths.
- Both `finalizeToolCallsForCancellation` whens inside `endTurn` gain Unknown arms (`StringOrMarkdown.Plain("")` / `null`) — this destructively converts an Unknown tool call to empty Cancelled state on turn end. Destructive but exactly matches Rust's `_ => Default::default()` and is required for fixture parity.

The `StateActionUnknown` shape change has zero reducer impact — every reducer uses `else -> state` and never inspects the payload.

## Tests

- `FixtureDrivenReducerTest`: fixture `103-delta-skips-parts-without-id.json` is **no longer skipped**. `SKIPPED_FIXTURES` is now `emptySet()` and `MAX_SKIPPED_FIXTURES = 0`; the `decodable-fixture-budget` assertion enforces zero skipped fixtures going forward.
- `DiscriminatedUnionTest`: 4 new round-trip tests covering
  - `ResponsePartUnknown` (unknown `kind`),
  - `ResponsePartUnknown` (missing `kind` — explicit coverage of the more permissive branch),
  - `ToolResultContent.Unknown`,
  - `CustomizationUnknown`.

  Each decodes an opaque payload, asserts the variant, then re-encodes and asserts the parsed JSON tree equals the original. The round-trip is **semantic** (parsed-tree equality), not byte-for-byte — key order and whitespace are not preserved.
- `StateActionTest`:
  - the existing `unknown action type decodes to StateActionUnknown without throwing` test now asserts `unknown.raw["type"]` and `unknown.raw["payload"]?.jsonObject?.get("foo")` and verifies the full round-trip;
  - new `action without type discriminator decodes to StateActionUnknown without throwing` regression test exercises the missing-`type` path symmetrically.
- `ReducersTest`: new `SessionCustomizationUpdated with CustomizationUnknown is a no-op` test exercises the reducer-level NoOp path with `assertSame(baseline, after)`.

## Test counts

| | Before this PR | After this PR |
| --- | --- | --- |
| `BitsetEnumTest` | 6 | 6 |
| `DiscriminatedUnionTest` | 8 | 12 |
| `GeneratedStructsTest` | 8 | 8 |
| `StateActionTest` | 6 | 7 |
| `ReducersTest` | 9 | 10 |
| `FixtureDrivenReducerTest` | 163 (1 skipped) | 164 (0 skipped, fixture 103 now passes) |
| **Total** | **200 (1 skipped)** | **207 (0 skipped)** |

## Docs

`clients/kotlin/AGENTS.md` is updated to describe the new Unknown variant pattern, document that `StateActionUnknown` shares the same `raw: JsonObject` shape (the previous "lossy" caveat is removed), document the reducer behaviour for the new state-tree variants, and remove the now-stale fixture-103 row.

## Local validation

```text
$ npm run generate:kotlin          # idempotent — no diff on re-run
$ npm run lint                     # pass
$ npm run typecheck                # pass
$ cd clients/kotlin && ./gradlew test --rerun
... 207 passed, 0 skipped
```

## Out of scope

- Adding Unknown to `ReconnectResult` / `ChangesetOperationTarget` — closed RPC reply shapes; Rust doesn't either.
- Forward-compat for unknown enum values — much larger generator change, separate concern.
- Same items #149 already deferred: Android example client, WebSocket transport, KMP build target.
