### PR TITLE
Fix dead VitePress link to resourceWrite command

### DIFF
--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -1945,7 +1945,7 @@ pub struct ClientPluginCustomization {
 /// Presence in the customization list signals that the host may discover
 /// customizations from this directory. When `writable` is `true`, clients
 /// MAY persist new customizations into the directory using
-/// [`resourceWrite`](/reference/commands#resourcewrite); the host will
+/// [`resourceWrite`](/reference/common#resourcewrite); the host will
 /// then surface the resulting child via the customization actions.
 ///
 /// The directory may not yet exist on disk.

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -166,7 +166,7 @@ For removals:
 
 ## Saving New Customizations
 
-When a client wants to persist a new customization (e.g. write a new skill file), it targets a `DirectoryCustomization` with `writable: true` and uses [`resourceWrite`](/reference/commands#resourcewrite) to write into it. The host watches the directory and surfaces the resulting child by re-dispatching `session/customizationUpdated` for the directory (which carries the updated `children` array).
+When a client wants to persist a new customization (e.g. write a new skill file), it targets a `DirectoryCustomization` with `writable: true` and uses [`resourceWrite`](/reference/common#resourcewrite) to write into it. The host watches the directory and surfaces the resulting child by re-dispatching `session/customizationUpdated` for the directory (which carries the updated `children` array).
 
 The protocol does not define a dedicated save action — directories plus `resourceWrite` are enough.
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -4263,7 +4263,7 @@
     },
     "DirectoryCustomization": {
       "type": "object",
-      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/commands#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
+      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/common#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
       "properties": {
         "id": {
           "type": "string",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -3805,7 +3805,7 @@
     },
     "DirectoryCustomization": {
       "type": "object",
-      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/commands#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
+      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/common#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
       "properties": {
         "id": {
           "type": "string",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2897,7 +2897,7 @@
     },
     "DirectoryCustomization": {
       "type": "object",
-      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/commands#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
+      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/common#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
       "properties": {
         "id": {
           "type": "string",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -3025,7 +3025,7 @@
     },
     "DirectoryCustomization": {
       "type": "object",
-      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/commands#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
+      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/common#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
       "properties": {
         "id": {
           "type": "string",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -2808,7 +2808,7 @@
     },
     "DirectoryCustomization": {
       "type": "object",
-      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/commands#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
+      "description": "A directory the host watches for this session.\n\nPresence in the customization list signals that the host may discover\ncustomizations from this directory. When `writable` is `true`, clients\nMAY persist new customizations into the directory using\n[`resourceWrite`](/reference/common#resourcewrite); the host will\nthen surface the resulting child via the customization actions.\n\nThe directory may not yet exist on disk.",
       "properties": {
         "id": {
           "type": "string",

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -1473,7 +1473,7 @@ export interface ClientPluginCustomization extends PluginCustomization {
  * Presence in the customization list signals that the host may discover
  * customizations from this directory. When `writable` is `true`, clients
  * MAY persist new customizations into the directory using
- * [`resourceWrite`](/reference/commands#resourcewrite); the host will
+ * [`resourceWrite`](/reference/common#resourcewrite); the host will
  * then surface the resulting child via the customization actions.
  *
  * The directory may not yet exist on disk.


### PR DESCRIPTION
## Why

The **Deploy Documentation** workflow has been failing on every merge into `main` since #152. The build fails with:

```
[vitepress] 2 dead link(s) found.
```

Both links point to `/reference/commands#resourcewrite`, but there is no `commands` page in the generated reference. The pages are per-channel (`common`, `root`, `session`, `terminal`, `changeset`, `otlp`) plus `messages` and `error-codes`. The `resourceWrite` command is defined on the `common` channel (`docs/reference/common.md#resourcewrite`), which is what `docs/reference/messages.md` already links to.

## What

- Updated the JSDoc on `DirectoryCustomization` in `types/channels-session/state.ts` to use `/reference/common#resourcewrite`. This is the source of truth for the link that ends up in the generated `docs/reference/session.md`.
- Updated the same link in the hand-written `docs/guide/customizations.md`.
- Ran `npm run generate` to refresh the derived schema and Rust outputs that embed the JSDoc as descriptions.

## Verification

`npm run docs:build` now completes successfully:

```
✓ building client + server bundles...
✓ rendering pages...
build complete in 6.61s.
```

`npm run typecheck` passes.