### PR TITLE
Add `_meta` to `UserMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 `NOTIFICATION_INTRODUCED_IN` maps in
 [`types/version/registry.ts`](types/version/registry.ts).
 
+### Added
+- `UserMessage._meta` optional `Record<string, unknown>` field for
+  provider-specific message metadata, mirroring the MCP `_meta` convention
+  already used on `MessageAttachmentBase`, `ToolDefinition`, `ToolCallBase`,
+  `UsageInfo`, and `SessionState`.
+
 ## [0.2.0] — Unreleased
 
 Spec version: `0.2.0`

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -14,6 +14,11 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ## [Unreleased]
 
+### Added
+- `UserMessage._meta` optional map field, generated as
+  `Map[string]json.RawMessage`, exposing the new spec-level provider
+  metadata channel on user messages.
+
 ## [0.1.0]
 
 Implements AHP `0.2.0`.

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -698,6 +698,12 @@ type UserMessage struct {
 	Text string `json:"text"`
 	// File/selection attachments
 	Attachments []MessageAttachment `json:"attachments,omitempty"`
+	// Additional provider-specific metadata for this message.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry context that does not fit any other
+	// field. Mirrors the MCP `_meta` convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // A choice in a select-style question.

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -20,6 +20,11 @@ Implements AHP `0.2.0`.
 `gradle.properties` currently pins `VERSION_NAME=0.2.0-SNAPSHOT`. Drop the
 `-SNAPSHOT` suffix and bump as appropriate before tagging the first release.
 
+### Added
+- `UserMessage.meta` optional `Map<String, JsonElement>?` field (serialized as
+  `_meta`), exposing the new spec-level provider metadata channel on user
+  messages.
+
 ## [0.2.0] — Unreleased
 
 Implements AHP `0.2.0`.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -1027,7 +1027,16 @@ data class UserMessage(
     /**
      * File/selection attachments
      */
-    val attachments: List<MessageAttachment>? = null
+    val attachments: List<MessageAttachment>? = null,
+    /**
+     * Additional provider-specific metadata for this message.
+     * 
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry context that does not fit any other
+     * field. Mirrors the MCP `_meta` convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -21,6 +21,10 @@ The in-tree source already supports protocol version `0.2.0` even though the
 last published crates are `0.1.0`. The next Rust release will bump the
 workspace version to align with the current spec.
 
+### Added
+- `UserMessage.meta` optional `JsonObject` field (serialized as `_meta`),
+  exposing the new spec-level provider metadata channel on user messages.
+
 ## [0.1.0] — 2026-01-01
 
 Implements AHP `0.1.0`.

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -898,6 +898,13 @@ pub struct UserMessage {
     /// File/selection attachments
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<MessageAttachment>>,
+    /// Additional provider-specific metadata for this message.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry context that does not fit any other
+    /// field. Mirrors the MCP `_meta` convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// A choice in a select-style question.

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -1226,6 +1226,7 @@ mod tests {
             user_message: UserMessage {
                 text: "hi".into(),
                 attachments: None,
+                meta: None,
             },
             queued_message_id: None,
         });
@@ -1245,6 +1246,7 @@ mod tests {
             user_message: UserMessage {
                 text: "hi".into(),
                 attachments: None,
+                meta: None,
             },
             response_parts: vec![ResponsePart::Markdown(MarkdownResponsePart {
                 id: "p1".into(),
@@ -1272,6 +1274,7 @@ mod tests {
             user_message: UserMessage {
                 text: "hi".into(),
                 attachments: None,
+                meta: None,
             },
             response_parts: Vec::new(),
             usage: None,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -901,13 +901,27 @@ public struct UserMessage: Codable, Sendable {
     public var text: String
     /// File/selection attachments
     public var attachments: [MessageAttachment]?
+    /// Additional provider-specific metadata for this message.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry context that does not fit any other
+    /// field. Mirrors the MCP `_meta` convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case attachments
+        case meta = "_meta"
+    }
 
     public init(
         text: String,
-        attachments: [MessageAttachment]? = nil
+        attachments: [MessageAttachment]? = nil,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.text = text
         self.attachments = attachments
+        self.meta = meta
     }
 }
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -22,6 +22,12 @@ Implements AHP `0.2.0`.
 [`VERSION`](VERSION) currently pins `0.2.0`; the first tag-driven Swift
 release will use the bare `v0.2.0` tag.
 
+### Added
+- `UserMessage.meta` optional `[String: AnyCodable]?` field (serialized as
+  `_meta`), exposing the new spec-level provider metadata channel on user
+  messages. The generated `init` gains a trailing `meta:` parameter that
+  defaults to `nil`.
+
 ## [0.2.0] — Unreleased
 
 Implements AHP `0.2.0`.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,6 +22,10 @@ hotfix escape hatch.
 
 Implements AHP `0.2.0`.
 
+### Added
+- `UserMessage._meta` optional `Record<string, unknown>` field, exposing the
+  new spec-level provider metadata channel on user messages.
+
 ## [0.2.0] — Unreleased
 
 Implements AHP `0.2.0`.

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -165,6 +165,7 @@ ActiveTurn {
 UserMessage {
   text: string
   attachments?: MessageAttachment[]
+  _meta?: Record<string, unknown>  // provider-specific metadata; see below
 }
 
 type MessageAttachment =
@@ -202,6 +203,8 @@ Attachments MAY be referenced inline by `text` via the optional `range` field, w
 Resource and embedded-resource attachments MAY also include `selection` to identify a selected range within the attached textual resource. This is distinct from `range`, which only describes where the attachment is referenced in the user message text. Selected text is not embedded inline; consumers can resolve the resource and read the selected range when needed. `selection` is only meaningful for textual resources; binary resources may still use resource or embedded-resource attachments, but they should not use this text selection field.
 
 Use `SimpleMessageAttachment` for opaque attachments whose model representation is supplied by the producer, `MessageEmbeddedResourceAttachment` for small inline base64 payloads (e.g. a pasted image), and `MessageResourceAttachment` to reference a resource by URI (the content is fetched via `resourceRead` when needed).
+
+`UserMessage._meta` carries additional provider-specific metadata for the message itself (independent of any attachment `_meta` blob). Clients MAY look for well-known keys here to provide enhanced UI, and agent hosts MAY use it to carry context that does not fit any other field. Mirrors the [MCP `_meta` convention](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta).
 
 Attachments produced by the [`completions`](#user-message-completions) command MAY include a `_meta` blob; clients MUST preserve every property of `_meta` when echoing the attachment back in the user message.
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2922,6 +2922,11 @@
             "$ref": "#/$defs/MessageAttachment"
           },
           "description": "File/selection attachments"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this message.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry context that does not fit any other\nfield. Mirrors the MCP `_meta` convention."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2464,6 +2464,11 @@
             "$ref": "#/$defs/MessageAttachment"
           },
           "description": "File/selection attachments"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this message.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry context that does not fit any other\nfield. Mirrors the MCP `_meta` convention."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -1556,6 +1556,11 @@
             "$ref": "#/$defs/MessageAttachment"
           },
           "description": "File/selection attachments"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this message.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry context that does not fit any other\nfield. Mirrors the MCP `_meta` convention."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1684,6 +1684,11 @@
             "$ref": "#/$defs/MessageAttachment"
           },
           "description": "File/selection attachments"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this message.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry context that does not fit any other\nfield. Mirrors the MCP `_meta` convention."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1467,6 +1467,11 @@
             "$ref": "#/$defs/MessageAttachment"
           },
           "description": "File/selection attachments"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this message.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry context that does not fit any other\nfield. Mirrors the MCP `_meta` convention."
         }
       },
       "required": [

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -614,6 +614,14 @@ export interface UserMessage {
   text: string;
   /** File/selection attachments */
   attachments?: MessageAttachment[];
+  /**
+   * Additional provider-specific metadata for this message.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry context that does not fit any other
+   * field. Mirrors the MCP `_meta` convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
Adds an optional `_meta?: Record<string, unknown>` field to `UserMessage` so user messages can carry provider-specific metadata, mirroring the MCP `_meta` convention already used on `MessageAttachmentBase`, `ToolDefinition`, `ToolCallBase`, `UsageInfo`, and `SessionState`.

### Changes

- **`types/channels-session/state.ts`**: add `UserMessage._meta` with JSDoc describing the MCP-aligned semantics.
- **Generated clients**: regenerated via `npm run generate`. `_meta` lands as the idiomatic optional map type in each client:
  - Go: `Meta map[string]json.RawMessage \`json:"_meta,omitempty"\``
  - Kotlin: `@SerialName("_meta") val meta: Map<String, JsonElement>? = null`
  - Rust: `#[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")] pub meta: Option<JsonObject>`
  - Swift: `public var meta: [String: AnyCodable]?` with `CodingKey` `meta = "_meta"` (and `init` gains a trailing `meta:` parameter defaulting to `nil`)
- **Schemas**: `schema/*.schema.json` regenerated; `UserMessage` picks up an optional `_meta` object.
- **Docs**: `docs/guide/state-model.md` shows `_meta` in the `UserMessage` snippet and adds a paragraph distinguishing it from the existing attachment-level `_meta` blob.
- **CHANGELOGs**: root spec changelog plus every client changelog (Go, Kotlin, Rust, Swift, TypeScript) gain an `Added` bullet under `## [Unreleased]` per the AGENTS.md "types/** ripples to every client" rule.

### Validation

- `npm run generate` — clean
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run verify:release-metadata` — passes
- `npm run verify:changelog` — passes
- `npx tsx --test types/*.test.ts types/version/*.test.ts` — **224/224 passing** (the `npm run test` wrapper otherwise trips the pre-existing c8/yargs incompatibility on Node 26 in this dev env, unrelated to this change)

### Compatibility

Purely additive. Existing producers and consumers that ignore `_meta` continue to round-trip messages unchanged, so no protocol version bump is required.

### Coordination with #155

#155 renames `UserMessage` → `Message` and adds a `MessageKind` discriminant. This PR was deliberately scoped to a single additive field on `UserMessage` so the new `_meta` field will carry forward cleanly into `Message._meta` when #155 lands (or rebases on top of this).

(Written by Copilot)