### PR TITLE
rust: enforce rustfmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
+
       - run: cargo clippy --workspace -- -D warnings
 
       - run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,18 @@ jobs:
       - name: Generate TypeScript client sources
         run: npm run generate:typescript
 
+      # Verify the committed TypeScript generated sources are in sync with the
+      # TypeScript protocol definitions. Check only clients/typescript/src
+      # (the actual generated files), not lock files which naturally drift
+      # with npm ci.
+      - name: Verify generated TypeScript is up to date
+        run: |
+          if ! git diff --quiet -- clients/typescript/src; then
+            echo "::error::Generated TypeScript sources are out of date. Run 'npm run generate:typescript' and commit the result."
+            git --no-pager diff -- clients/typescript/src
+            exit 1
+          fi
+
       - name: Install TypeScript client dependencies
         working-directory: clients/typescript
         run: npm ci

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -676,7 +676,10 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
                 // Unknown variant — no id to match on.
                 return ReduceOutcome::NoOp;
             };
-            if let Some(idx) = list.iter().position(|c| customization_id(c) == Some(action_id)) {
+            if let Some(idx) = list
+                .iter()
+                .position(|c| customization_id(c) == Some(action_id))
+            {
                 list[idx] = a.customization.clone();
             } else {
                 list.push(a.customization.clone());
@@ -688,14 +691,20 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
                 return ReduceOutcome::NoOp;
             };
             // Try to remove a top-level container.
-            if let Some(idx) = list.iter().position(|c| customization_id(c) == Some(a.id.as_str())) {
+            if let Some(idx) = list
+                .iter()
+                .position(|c| customization_id(c) == Some(a.id.as_str()))
+            {
                 list.remove(idx);
                 return ReduceOutcome::Applied;
             }
             // Otherwise look for a child to remove.
             for container in list.iter_mut() {
                 if let Some(children) = container_children_mut(container) {
-                    if let Some(idx) = children.iter().position(|c| child_id_of(c) == Some(a.id.as_str())) {
+                    if let Some(idx) = children
+                        .iter()
+                        .position(|c| child_id_of(c) == Some(a.id.as_str()))
+                    {
                         children.remove(idx);
                         return ReduceOutcome::Applied;
                     }


### PR DESCRIPTION
## Summary
- add a rustfmt gate to the Rust job in  ()
- run rustfmt on  to fix the current formatting drift that broke publish-rust validation

## Why
The Rust publish workflow already checks formatting, but main CI did not. This allowed an unformatted Rust change to merge and only fail later at publish time. Adding the same gate to CI prevents this from reaching  again.

## Validation
- 
- 
- 
