### PR TITLE
docs: add Clients guide page with install snippets for each registry

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,6 +43,7 @@ export default withMermaid(defineConfig({
           text: 'More',
           items: [
             { text: 'AHP and ACP', link: '/guide/ahp-and-acp' },
+            { text: 'Clients', link: '/guide/clients' },
             { text: 'Implementations', link: '/guide/implementations' },
           ],
         },

--- a/docs/guide/clients.md
+++ b/docs/guide/clients.md
@@ -1,0 +1,180 @@
+# Clients
+
+This repository ships official client libraries for five languages.
+Every client's wire types are generated from the canonical TypeScript
+sources in [`types/`](https://github.com/microsoft/agent-host-protocol/tree/main/types),
+so the same protocol shape is presented idiomatically in each
+ecosystem. Each library is versioned and released independently — see
+[`RELEASING.md`](https://github.com/microsoft/agent-host-protocol/blob/main/RELEASING.md)
+for the per-language tag scheme.
+
+Pick the language you want to integrate against and install from the
+package registry it normally ships through.
+
+| Language       | Package                                                  | Registry        |
+| -------------- | -------------------------------------------------------- | --------------- |
+| [Rust](#rust)             | `ahp-types`, `ahp`, `ahp-ws`                  | crates.io       |
+| [TypeScript](#typescript) | `@microsoft/agent-host-protocol`              | npm             |
+| [Kotlin / JVM](#kotlin)   | `com.microsoft.agenthostprotocol:agent-host-protocol` | Maven Central |
+| [Swift](#swift)           | `AgentHostProtocol`, `AgentHostProtocolClient` | Swift Package Manager |
+| [Go](#go)                 | `github.com/microsoft/agent-host-protocol/clients/go` | Go module proxy |
+
+## Rust
+
+Three crates on [crates.io](https://crates.io), mirroring the split
+between wire types, transport-agnostic client, and a WebSocket
+adapter:
+
+- [`ahp-types`](https://crates.io/crates/ahp-types) — generated wire
+  types, no I/O.
+- [`ahp`](https://crates.io/crates/ahp) — async `Client` with pure
+  reducers, a pluggable `Transport` trait, and the multi-host
+  registry under `ahp::hosts`.
+- [`ahp-ws`](https://crates.io/crates/ahp-ws) — WebSocket transport
+  built on `tokio-tungstenite`.
+
+```bash
+cargo add ahp ahp-ws
+# add `ahp-types` directly only if you need the wire types without
+# the client runtime.
+```
+
+See the [Rust client README](https://github.com/microsoft/agent-host-protocol/tree/main/clients/rust)
+for the quick start, custom transports, and multi-host details.
+
+## TypeScript
+
+A single browser- and Node-friendly package on
+[npm](https://www.npmjs.com/package/@microsoft/agent-host-protocol)
+with four subpath entry points (wire types, client, multi-host
+orchestration, WebSocket transport):
+
+```bash
+npm install @microsoft/agent-host-protocol
+```
+
+```ts
+import { AhpClient } from '@microsoft/agent-host-protocol/client';
+import { WebSocketTransport } from '@microsoft/agent-host-protocol/ws';
+```
+
+See the [TypeScript client README](https://github.com/microsoft/agent-host-protocol/tree/main/clients/typescript)
+for the full subpath table and a complete quick start.
+
+## Kotlin
+
+Pure Kotlin/JVM artifact on
+[Maven Central](https://central.sonatype.com/artifact/com.microsoft.agenthostprotocol/agent-host-protocol).
+Targets Java 8 bytecode, so it can be consumed unchanged from
+Android, server-side JVM services, and KMP/JVM targets.
+
+### Gradle (Kotlin DSL)
+
+```kotlin
+dependencies {
+    implementation("com.microsoft.agenthostprotocol:agent-host-protocol:0.2.0")
+}
+```
+
+### Gradle (Groovy DSL)
+
+```groovy
+dependencies {
+    implementation 'com.microsoft.agenthostprotocol:agent-host-protocol:0.2.0'
+}
+```
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.microsoft.agenthostprotocol</groupId>
+    <artifactId>agent-host-protocol</artifactId>
+    <version>0.2.0</version>
+</dependency>
+```
+
+The library transitively depends on `org.jetbrains.kotlinx:kotlinx-serialization-json`.
+See the [Kotlin client README](https://github.com/microsoft/agent-host-protocol/tree/main/clients/kotlin)
+for usage, the `Ahp.json` serializer instance, and what is/isn't
+included in the box (no transport yet — bring your own OkHttp/Ktor).
+
+## Swift
+
+Distributed via Swift Package Manager. The `Package.swift` manifest
+lives at the repository root because SwiftPM only resolves manifests
+at the root of a remote git repo; the Swift sources themselves live
+under `clients/swift/AgentHostProtocol/`.
+
+### Package.swift dependency
+
+```swift
+.package(url: "https://github.com/microsoft/agent-host-protocol.git", from: "0.1.0")
+```
+
+### Target dependencies
+
+```swift
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "AgentHostProtocol", package: "agent-host-protocol"),
+        .product(name: "AgentHostProtocolClient", package: "agent-host-protocol"),
+    ]
+)
+```
+
+- `AgentHostProtocol` — generated wire types, commands, notifications,
+  actions, and pure reducers.
+- `AgentHostProtocolClient` — single-host `AHPClient`, `MultiHostClient`,
+  state mirrors, and the `URLSessionWebSocketTransport` /
+  `NWConnectionWebSocketTransport` transports.
+
+See the [Swift client README](https://github.com/microsoft/agent-host-protocol/tree/main/clients/swift/AgentHostProtocol)
+for the minimal single-host and multi-host examples, transport
+choices, and reconnect layering guidance.
+
+## Go
+
+Single Go module resolved through the public Go module proxy. Three
+packages mirror the Rust three-crate split:
+
+- `ahptypes` — wire protocol types only.
+- `ahp` — async `Client` over a pluggable `Transport`, pure reducers,
+  and the multi-host runtime under `ahp/hosts`.
+- `ahpws` — WebSocket transport built on
+  [`github.com/coder/websocket`](https://github.com/coder/websocket).
+
+```bash
+go get github.com/microsoft/agent-host-protocol/clients/go@latest
+```
+
+```go
+import (
+    "github.com/microsoft/agent-host-protocol/clients/go/ahp"
+    "github.com/microsoft/agent-host-protocol/clients/go/ahptypes"
+    "github.com/microsoft/agent-host-protocol/clients/go/ahpws"
+)
+```
+
+See the [Go client README](https://github.com/microsoft/agent-host-protocol/tree/main/clients/go)
+for the WebSocket quick start.
+
+## Picking a protocol version
+
+Every client exposes two protocol-version constants:
+
+- `PROTOCOL_VERSION` — the SemVer string for the version that
+  client's current release implements.
+- `SUPPORTED_PROTOCOL_VERSIONS` — every version the client is
+  willing to negotiate, most-preferred-first. Pass it (or a
+  derived list/array) as `protocolVersions` on `InitializeParams`
+  during the handshake.
+
+Client package versions track the spec version, but they are not
+required to match exactly — a client released after a patch-only
+client fix may sit at a higher patch than the matching spec
+release. The two version constants above always reflect the
+protocol versions that build of the client can speak. See
+[Versioning](/specification/versioning) for the full negotiation
+model.

--- a/docs/guide/clients.md
+++ b/docs/guide/clients.md
@@ -49,6 +49,8 @@ A single browser- and Node-friendly package on
 with four subpath entry points (wire types, client, multi-host
 orchestration, WebSocket transport):
 
+[![npm](https://img.shields.io/npm/v/@microsoft/agent-host-protocol.svg)](https://www.npmjs.com/package/@microsoft/agent-host-protocol)
+
 ```bash
 npm install @microsoft/agent-host-protocol
 ```
@@ -67,6 +69,8 @@ Pure Kotlin/JVM artifact on
 [Maven Central](https://central.sonatype.com/artifact/com.microsoft.agenthostprotocol/agent-host-protocol).
 Targets Java 8 bytecode, so it can be consumed unchanged from
 Android, server-side JVM services, and KMP/JVM targets.
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.agenthostprotocol/agent-host-protocol)](https://central.sonatype.com/artifact/com.microsoft.agenthostprotocol/agent-host-protocol)
 
 ### Gradle (Kotlin DSL)
 

--- a/docs/guide/implementations.md
+++ b/docs/guide/implementations.md
@@ -4,9 +4,15 @@ These projects implement or consume the Agent Host Protocol.
 
 ## Clients
 
-- **Swift** — Add `https://github.com/microsoft/agent-host-protocol` as a Swift Package Manager dependency to use the `AgentHostProtocol` library. See [the Swift client](https://github.com/microsoft/agent-host-protocol/tree/main/clients/swift) for an example iOS client. The `Package.swift` manifest lives at the repository root because SwiftPM only resolves manifests at the root of a remote git repo; the actual Swift sources live under `clients/swift/AgentHostProtocol/`.
-- **Rust** — See [the Rust client crates](https://github.com/microsoft/agent-host-protocol/tree/main/clients/rust) for the `ahp`, `ahp-types`, and `ahp-ws` crates.
-- **TypeScript** — `npm install @microsoft/agent-host-protocol` for the wire types, reducers, `AhpClient`, and `WebSocketTransport`. See [the TypeScript client](https://github.com/microsoft/agent-host-protocol/tree/main/clients/typescript). Browser-friendly; works in any environment that exposes the global `WebSocket`.
+The five clients shipped from this repository are released to the
+package registry idiomatic for each ecosystem. See [Clients](/guide/clients)
+for install snippets and per-language entry points.
+
+- **Rust** — three crates on crates.io (`ahp-types`, `ahp`, `ahp-ws`). See [the Rust client crates](https://github.com/microsoft/agent-host-protocol/tree/main/clients/rust).
+- **TypeScript** — `npm install @microsoft/agent-host-protocol` for wire types, reducers, `AhpClient`, `MultiHostClient`, and `WebSocketTransport`. See [the TypeScript client](https://github.com/microsoft/agent-host-protocol/tree/main/clients/typescript). Browser-friendly; works in any environment that exposes the global `WebSocket`.
+- **Kotlin / JVM** — `com.microsoft.agenthostprotocol:agent-host-protocol` on Maven Central. Pure Kotlin/JVM (Java 8 bytecode) so it works unchanged on Android, server-side JVM, and KMP/JVM targets. See [the Kotlin client](https://github.com/microsoft/agent-host-protocol/tree/main/clients/kotlin).
+- **Swift** — add `https://github.com/microsoft/agent-host-protocol` as a Swift Package Manager dependency for the `AgentHostProtocol` and `AgentHostProtocolClient` libraries. See [the Swift client](https://github.com/microsoft/agent-host-protocol/tree/main/clients/swift) for an example iOS client. The `Package.swift` manifest lives at the repository root because SwiftPM only resolves manifests at the root of a remote git repo; the actual Swift sources live under `clients/swift/AgentHostProtocol/`.
+- **Go** — `go get github.com/microsoft/agent-host-protocol/clients/go@latest` for the `ahptypes`, `ahp`, and `ahpws` packages, mirroring the Rust three-crate split. See [the Go client](https://github.com/microsoft/agent-host-protocol/tree/main/clients/go).
 - **[AHPX](https://github.com/TylerLeonhardt/ahpx)** — A command-line and Node.js client for connecting to AHP servers, managing sessions, and sending prompts.
 - **[VS Code](https://github.com/microsoft/vscode)** — VS Code includes Agent Sessions client code for working with AHP hosts.
 


### PR DESCRIPTION
## What

Adds a new `docs/guide/clients.md` page to the GitHub Pages site that
lists every official client shipped from this repo and how to install
each one from its respective package registry:

| Language       | Package                                                  | Registry        |
| -------------- | -------------------------------------------------------- | --------------- |
| Rust           | `ahp-types`, `ahp`, `ahp-ws`                             | crates.io       |
| TypeScript     | `@microsoft/agent-host-protocol`                         | npm             |
| Kotlin / JVM   | `com.microsoft.agenthostprotocol:agent-host-protocol`    | Maven Central   |
| Swift          | `AgentHostProtocol`, `AgentHostProtocolClient`           | Swift Package Manager |
| Go             | `github.com/microsoft/agent-host-protocol/clients/go`    | Go module proxy |

Each section shows the registry-native install snippet (with Gradle
Kotlin DSL / Gradle Groovy DSL / Maven variants for Kotlin), links
back to the per-client README for deeper usage, and the page closes
with a short note on `PROTOCOL_VERSION` / `SUPPORTED_PROTOCOL_VERSIONS`
and how client package versions relate to spec versions.

Also:

- Surfaces the new page in the VitePress sidebar under the guide
  **More** section (`docs/.vitepress/config.mts`).
- Refreshes `docs/guide/implementations.md` to add the Go and Kotlin
  entries (previously only Swift, Rust, and TypeScript were listed)
  and points the section header at the new Clients page for install
  details.

## Why

The two new generated clients (Go and Kotlin) were not yet documented
on the GitHub Pages site, and Rust/TypeScript/Swift only had bare
links to the per-client folders without registry-level install
snippets. This adds a single canonical "how do I install this from my
language's package manager?" page.

## Notes

- Per `AGENTS.md`, docs-only changes do not need CHANGELOG entries, so
  none were added.
- `vitepress build docs` finds the same 54 pre-existing `/reference/*`
  dead links before and after these changes — none are introduced by
  this PR.