### PR TITLE
ci(typescript): narrow ADO verify check to src/ to avoid lockfile drift

### DIFF
--- a/clients/typescript/pipeline.yml
+++ b/clients/typescript/pipeline.yml
@@ -99,10 +99,15 @@ extends:
 
           - bash: |
               set -euo pipefail
-              if [ -n "$(git status --porcelain -- clients/typescript)" ]; then
+              # Note: clients/typescript/src/types/ is gitignored — generated
+              # TS sources are produced fresh in CI and never committed. We
+              # check only clients/typescript/src (not the whole
+              # clients/typescript dir) so that lockfile mutations from the
+              # internal npm registry rewriting `resolved` URLs don't trip
+              # this check. Matches the GHA ci.yml pattern.
+              if ! git diff --quiet -- clients/typescript/src; then
                 echo "##vso[task.logissue type=error]Generated TypeScript sources are out of date. Run 'npm run generate:typescript' and commit the result."
-                git status --porcelain -- clients/typescript
-                git --no-pager diff -- clients/typescript
+                git --no-pager diff -- clients/typescript/src
                 exit 1
               fi
             displayName: ✅ Verify generated TypeScript is up to date


### PR DESCRIPTION
## Summary

Updates `clients/typescript/pipeline.yml` verify-generated-sources check to use a narrow path filter (`clients/typescript/src`) instead of the whole `clients/typescript` directory.

## Why

CI runs against Microsoft's internal Azure DevOps npm registry (`pkgs.dev.azure.com/monacotools/Monaco`), which causes `npm ci` to rewrite the `resolved` URLs in `package-lock.json` on every run. The previous broad `git status --porcelain -- clients/typescript` check would catch this lockfile drift and fail the build, even though no actual generated source had changed.

Example of the false-positive failure:

```
##[error]Generated TypeScript sources are out of date. Run 'npm run generate:typescript' and commit the result.
 M clients/typescript/package-lock.json
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/monacotools/Monaco/_packaging/vscode/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
```

## Notes

- `clients/typescript/src/types/` is `.gitignore`d — generated TS sources are produced fresh in CI and never committed. The verify check is effectively a safety net for hand-written `src/client/` and `src/ws/`.
- Matches the same fix already merged for the GHA `ci.yml` workflow in #171.
- ADO pipeline only triggers on `typescript/v*` tag pushes or manual runs, so no PR-level validation here for this change.
