### PR TITLE
ci(kotlin): narrow ADO verify check to generated/ to avoid NOTICE.txt drift

### DIFF
--- a/clients/kotlin/pipeline.yml
+++ b/clients/kotlin/pipeline.yml
@@ -107,10 +107,16 @@ extends:
 
       - bash: |
           set -euo pipefail
-          if [ -n "$(git status --porcelain -- clients/kotlin)" ]; then
+          # Narrow path filter: only the generated/ subdir, not all of
+          # clients/kotlin. The ADO maven-package template drops files
+          # like NOTICE.txt into clients/kotlin during the publish step,
+          # which a broad check would mistake for stale generated source
+          # drift. Matches the GHA ci.yml pattern.
+          GENERATED_DIR=clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated
+          if [ -n "$(git status --porcelain -- $GENERATED_DIR)" ]; then
             echo "##vso[task.logissue type=error]Generated Kotlin sources are out of date. Run 'npm run generate:kotlin' and commit the result."
-            git status --porcelain -- clients/kotlin
-            git --no-pager diff -- clients/kotlin
+            git status --porcelain -- $GENERATED_DIR
+            git --no-pager diff -- $GENERATED_DIR
             exit 1
           fi
         displayName: ✅ Verify generated Kotlin is up to date


### PR DESCRIPTION
## Summary

Narrows the `Verify generated Kotlin is up to date` check in `clients/kotlin/pipeline.yml` from `clients/kotlin` (the whole client) down to `clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated` (the actual generator output).

## Why

The ESRP-backed `maven-package` template drops files like `NOTICE.txt` into `clients/kotlin` during the publish flow. The previous broad check would catch this as an untracked file and fail with:

```
##[error]Generated Kotlin sources are out of date. Run 'npm run generate:kotlin' and commit the result.
?? clients/kotlin/NOTICE.txt
```

…which is a misleading failure since the generated Kotlin sources were never stale.

## Notes

- Mirrors the same surgical narrowing applied to `clients/typescript/pipeline.yml` in #174.
- Still uses `git status --porcelain` (not `git diff`) so that new untracked generated files (e.g. a brand-new generator output) would be caught.
