### PR TITLE
kotlin: redirect plugin marker resolution to maven artifacts

### DIFF
--- a/clients/kotlin/settings.gradle.kts
+++ b/clients/kotlin/settings.gradle.kts
@@ -3,6 +3,23 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
+    // Redirect Gradle plugin marker requests to the actual Maven
+    // coordinates so plugin resolution works even when the build
+    // environment's Maven mirror (e.g. an internal Azure Artifacts feed
+    // used by ESRP-backed publish runs) doesn't have the tiny
+    // `<plugin-id>.gradle.plugin` redirect POMs synced. The real
+    // artifacts live in mavenCentral and are always mirrored.
+    resolutionStrategy {
+        eachPlugin {
+            when (requested.id.id) {
+                "org.jetbrains.kotlin.jvm",
+                "org.jetbrains.kotlin.plugin.serialization" ->
+                    useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
+                "com.vanniktech.maven.publish" ->
+                    useModule("com.vanniktech:gradle-maven-publish-plugin:${requested.version}")
+            }
+        }
+    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

Adds a `pluginManagement.resolutionStrategy.eachPlugin` block to `clients/kotlin/settings.gradle.kts` that maps Kotlin and Vanniktech plugin IDs directly to their real Maven coordinates, bypassing the Gradle Plugin Portal's `<plugin-id>.gradle.plugin` marker artifacts.

## Why

The ESRP-backed ADO publish pipeline fails Gradle plugin resolution during the "Run Gradle check" step:

```
Plugin [id: 'org.jetbrains.kotlin.jvm', version: '2.3.21'] was not found in any of the following sources:
- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Included Builds (No included builds contain this plugin)
- Plugin Repositories (could not resolve plugin artifact 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.3.21')
```

Microsoft's internal Maven mirror (Azure Artifacts feed) mirrors the real Kotlin plugin artifact (`org.jetbrains.kotlin:kotlin-gradle-plugin`) but doesn't sync the tiny `<plugin-id>.gradle.plugin` redirect POMs that Gradle Plugin Portal uses internally. Gradle resolution falls over because the marker artifact is missing.

The `eachPlugin` resolution strategy tells Gradle: "when you see this plugin ID, skip the marker dance and pull this Maven module directly." That module IS mirrored, so resolution succeeds.

## Notes

- GHA CI still works unchanged — public plugin portal serves both marker and real artifact, so the resolution strategy is a no-op there.
- Confirmed Kotlin 2.3.21 exists on both [plugins.gradle.org](https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/2.3.21/) and [Maven Central](https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.21/), so this is mirror sync coverage, not a missing upstream artifact.
