### PR TITLE
kotlin: route serialization plugin to its own maven artifact

### DIFF
--- a/clients/kotlin/settings.gradle.kts
+++ b/clients/kotlin/settings.gradle.kts
@@ -12,9 +12,10 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             when (requested.id.id) {
-                "org.jetbrains.kotlin.jvm",
-                "org.jetbrains.kotlin.plugin.serialization" ->
+                "org.jetbrains.kotlin.jvm" ->
                     useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
+                "org.jetbrains.kotlin.plugin.serialization" ->
+                    useModule("org.jetbrains.kotlin:kotlin-serialization:${requested.version}")
                 "com.vanniktech.maven.publish" ->
                     useModule("com.vanniktech:gradle-maven-publish-plugin:${requested.version}")
             }


### PR DESCRIPTION
## Fixup for #176

PR #176's `resolutionStrategy.eachPlugin` block mapped **both** `org.jetbrains.kotlin.jvm` and `org.jetbrains.kotlin.plugin.serialization` to `org.jetbrains.kotlin:kotlin-gradle-plugin`. But the serialization plugin's descriptor isn't bundled in `kotlin-gradle-plugin` — it lives in a separate artifact: `org.jetbrains.kotlin:kotlin-serialization`.

GHA Kotlin CI started failing on main after #176 merged:

```
Caused by: org.gradle.api.plugins.UnknownPluginException:
Plugin with id 'org.jetbrains.kotlin.plugin.serialization' not found.
```

This PR splits the mapping so each plugin ID points at the correct Maven module.
