### PR TITLE
kotlin: drop resolutionStrategy.eachPlugin block

### DIFF
--- a/clients/kotlin/settings.gradle.kts
+++ b/clients/kotlin/settings.gradle.kts
@@ -3,23 +3,6 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-    // Redirect Gradle plugin marker requests to the actual Maven
-    // coordinates so plugin resolution works even when the build
-    // environment's Maven mirror (e.g. an internal Azure Artifacts feed
-    // used by ESRP-backed publish runs) doesn't have the tiny
-    // `<plugin-id>.gradle.plugin` redirect POMs synced. The real
-    // artifacts live in mavenCentral and are always mirrored.
-    resolutionStrategy {
-        eachPlugin {
-            when (requested.id.id) {
-                "org.jetbrains.kotlin.jvm",
-                "org.jetbrains.kotlin.plugin.serialization" ->
-                    useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
-                "com.vanniktech.maven.publish" ->
-                    useModule("com.vanniktech:gradle-maven-publish-plugin:${requested.version}")
-            }
-        }
-    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

Removes the `pluginManagement.resolutionStrategy.eachPlugin` block from `clients/kotlin/settings.gradle.kts`. Net −17 lines.

## Why it's no longer needed

PR #176 added the block on a wrong hypothesis (that the ESRP build env's Maven mirror was missing the tiny `<plugin-id>.gradle.plugin` marker POMs). The real cause was 1ES Network Isolation silently blocking the public Maven Central / Gradle Plugin Portal entirely. That root cause is now fixed in the `vscode-engineering` maven-package template via a new `customMavenRegistry` parameter + Gradle init script that routes resolution through the Monaco Azure Artifacts Maven feed (which mirrors Maven Central upstream, including plugin marker POMs).

## Validation

- GHA Kotlin CI ✅
- Manual ADO publish-pipeline dry-run (publish unticked) ✅

## Follow-ups

- Close #177 (the fixup PR that patched a bug in the eachPlugin mapping — now irrelevant since the whole block is gone)
- Delete stale branches `hotfix/kotlin-plugin-resolution`, `hotfix/kotlin-serialization-plugin`, `test/kotlin-pin-2.1.20`, and this one
- Bump `ref: connor4312/maven-pipeline` in `clients/kotlin/pipeline.yml` to the stable ref once the vscode-engineering template change lands
