### PR TITLE
Use PROTOCOL_VERSION instead of hard-coded string

### DIFF
--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -34,7 +34,7 @@ export const PROTOCOL_VERSION = '0.3.0';
  * `scripts/verify-release-metadata.ts`.
  */
 export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = Object.freeze([
-  '0.3.0',
+  PROTOCOL_VERSION,
 ]);
 
 // ─── SemVer Comparison ───────────────────────────────────────────────────────


### PR DESCRIPTION
Resolve: https://github.com/microsoft/agent-host-protocol/issues/180 
Coming from: https://github.com/microsoft/vscode/pull/318511 

My understanding is that we can't just simply edit/shouldn't registry.ts in vscode, but rather that should come from here.?