### PR TITLE
docs: add Go client to the root README clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Agent Host Protocol (AHP) defines how a portable, standalone sessions server
 - **Rust** — See [`clients/rust/`](clients/rust/) for the `ahp`, `ahp-types`, and `ahp-ws` crates. Released to crates.io via `rust/vX.Y.Z` tags ([`CHANGELOG`](clients/rust/CHANGELOG.md)).
 - **Kotlin** — Add `com.microsoft.agenthostprotocol:agent-host-protocol` from Maven Central to use from Android or any JVM project. See [`clients/kotlin/`](clients/kotlin/) for the source and [`CHANGELOG`](clients/kotlin/CHANGELOG.md). Released via `kotlin/vX.Y.Z` tags.
 - **TypeScript** — Install `@microsoft/agent-host-protocol` to use the wire types, reducers, `AhpClient`, and the `WebSocketTransport`. See [`clients/typescript/`](clients/typescript/) and [`CHANGELOG`](clients/typescript/CHANGELOG.md). Released via `typescript/vX.Y.Z` tags; the Azure DevOps publish pipeline at [`clients/typescript/pipeline.yml`](clients/typescript/pipeline.yml) picks up the tag, validates it, and publishes to npm.
+- **Go** — `go get github.com/microsoft/agent-host-protocol/clients/go` to use the `ahptypes` wire types, the `ahp` async client (client + pure reducers + pluggable `Transport`), and the `ahpws` WebSocket transport. See [`clients/go/`](clients/go/) and [`CHANGELOG`](clients/go/CHANGELOG.md). Released via `clients/go/vX.Y.Z` tags — the Go module proxy indexes the directory-prefixed tag directly from this repo, so there is no separate package registry.
 - **[AHPX](https://github.com/TylerLeonhardt/ahpx)** — A command-line and Node.js client for connecting to AHP servers, managing sessions, and sending prompts.
 - **[VS Code](https://github.com/microsoft/vscode)** — VS Code includes Agent Sessions client code for working with AHP hosts.
 
@@ -23,7 +24,7 @@ The Agent Host Protocol (AHP) defines how a portable, standalone sessions server
 
 - **[VS Code agent host](https://github.com/microsoft/vscode)** — The reference AHP server implementation. Start in [`src/vs/platform/agentHost/node/`](https://github.com/microsoft/vscode/tree/main/src/vs/platform/agentHost/node) when browsing the repository.
 
-For consumers that need to talk to two or more hosts at once, the Rust SDK ships a `MultiHostClient` abstraction in [`ahp::hosts`](https://docs.rs/ahp/latest/ahp/hosts/) and the Swift SDK ships `MultiHostClient` in `AgentHostProtocolClient`. Single-host consumers use the same API via `MultiHostClient::single` in Rust or `MultiHostClient.single(...)` in Swift. See [Connecting to Multiple Hosts](https://microsoft.github.io/agent-host-protocol/guide/clients-multi-host) for the design and surface.
+For consumers that need to talk to two or more hosts at once, the Rust SDK ships a `MultiHostClient` abstraction in [`ahp::hosts`](https://docs.rs/ahp/latest/ahp/hosts/), the Swift SDK ships `MultiHostClient` in `AgentHostProtocolClient`, and the Go SDK ships `MultiHostClient` in [`ahp/hosts`](clients/go/ahp/hosts/). Single-host consumers use the same API via `MultiHostClient::single` in Rust, `MultiHostClient.single(...)` in Swift, or `hosts.Single(...)` in Go. See [Connecting to Multiple Hosts](https://microsoft.github.io/agent-host-protocol/guide/clients-multi-host) for the design and surface.
 
 ## Versioning and releases
 


### PR DESCRIPTION
The Go client (`clients/go`) is on `main` with its own `README`, `CHANGELOG`, `AGENTS.md`, and a `publish-go.yml` workflow, but the root `README.md` "Clients" list — and the multi-host paragraph — were never updated to mention it. Every other first-party client (Swift, Rust, Kotlin, TypeScript) is listed; Go is the only one missing.

This PR adds:
- A **Go** bullet to the Clients list, matching the style of the others: `go get` line, the three packages (`ahptypes` / `ahp` / `ahpws`), a link to `clients/go/` + its CHANGELOG, and a note that releases happen via `clients/go/vX.Y.Z` tags through the Go module proxy (no separate registry).
- Go to the multi-host paragraph (the Go SDK ships `MultiHostClient` in `ahp/hosts`, with `hosts.Single(...)` for the single-host case).

Docs-only; no code or generated output changes, so no CHANGELOG entry per `AGENTS.md`.

> Note for maintainers: there is no `clients/go/v*` tag yet (current tags are `rust/*`, `spec/*`, `typescript/*`), so the first Go release tag still needs to be pushed to trigger `publish-go.yml`. This README entry documents the consumption path that is already wired up.