### PR TITLE
session: add ChangesSummary to SessionSummary; remove counts from ChangesetSummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ Spec version: `0.3.0`
   operation's execution lifecycle (`idle → running → error`) back into
   changeset state.
 - Added optional `_meta` provider metadata to `AgentCustomization`.
+- Added optional `changes` field of type `ChangesSummary` to `SessionSummary`,
+  carrying optional `additions`, `deletions`, and `files` counts so servers
+  can advertise an at-a-glance view of a session's file-change footprint.
+- Removed the `additions`, `deletions`, and `files` fields from
+  `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`;
+  per-changeset views derive their own totals from `ChangesetState.files`.
 - Renamed the `UserMessage` type to `Message` and surfaced it consistently
   across turn state (`Turn.message`, `ActiveTurn.message`, `PendingMessage.message`)
   and the actions that carry it (`session/turnStarted`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Spec version: `0.3.0`
 - Removed the `additions`, `deletions`, and `files` fields from
   `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`;
   per-changeset views derive their own totals from `ChangesetState.files`.
+- Renamed the `ChangesetSummary` interface to `Changeset` (catalogue entry
+  on `SessionSummary.changesets`). The on-the-wire shape is unchanged.
 - Renamed the `UserMessage` type to `Message` and surfaced it consistently
   across turn state (`Turn.message`, `ActiveTurn.message`, `PendingMessage.message`)
   and the actions that carry it (`session/turnStarted`,

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -22,6 +22,11 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 - `AgentCustomization._meta` provider metadata field.
 - Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
 
+
+### Changed
+
+- Renamed the `ChangesetSummary` type to `Changeset` (catalogue entry on `SessionSummary.changesets`). The on-the-wire shape is unchanged.
+
 ### Removed
 
 - Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -20,6 +20,11 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
   `changeset/operationStatusChanged` action, tracking the
   `idle → running → error` lifecycle of a changeset operation.
 - `AgentCustomization._meta` provider metadata field.
+- Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
+
+### Removed
+
+- Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.
 
 ## [0.1.0] — 2026-05-28
 

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -499,7 +499,7 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 		state.Summary.Activity = a.Activity
 		return ReduceOutcomeApplied
 	case *ahptypes.SessionChangesetsChangedAction:
-		state.Summary.Changesets = append([]ahptypes.ChangesetSummary(nil), a.Changesets...)
+		state.Summary.Changesets = append([]ahptypes.Changeset(nil), a.Changesets...)
 		return ReduceOutcomeApplied
 	case *ahptypes.SessionConfigChangedAction:
 		if state.Config == nil {

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -446,9 +446,8 @@ type SessionActivityChangedAction struct {
 // `state.summary.changesets` entirely (full-replacement semantics) — set
 // to `undefined` to clear the catalogue.
 //
-// Producers dispatch this whenever entries are added, removed, or have
-// their aggregate counts (`additions` / `deletions` / `files`) refreshed.
-// The fan-out happens through this action so observers see catalogue
+// Producers dispatch this whenever entries are added or removed. The
+// fan-out happens through this action so observers see catalogue
 // mutations in the same {@link ChangesetAction | per-changeset} action
 // stream they already follow for file-level updates.
 type SessionChangesetsChangedAction struct {

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -441,7 +441,7 @@ type SessionActivityChangedAction struct {
 	Activity *string `json:"activity,omitempty"`
 }
 
-// The {@link ChangesetSummary | catalogue of changesets} the agent host
+// The {@link Changeset | catalogue of changesets} the agent host
 // advertises for this session changed. Replaces
 // `state.summary.changesets` entirely (full-replacement semantics) — set
 // to `undefined` to clear the catalogue.
@@ -453,7 +453,7 @@ type SessionActivityChangedAction struct {
 type SessionChangesetsChangedAction struct {
 	Type ActionType `json:"type"`
 	// New catalogue, or `undefined` to clear it
-	Changesets []ChangesetSummary `json:"changesets,omitempty"`
+	Changesets []Changeset `json:"changesets,omitempty"`
 }
 
 // Server tools for this session have changed.

--- a/clients/go/ahptypes/notifications.generated.go
+++ b/clients/go/ahptypes/notifications.generated.go
@@ -191,4 +191,9 @@ type PartialSessionSummary struct {
 	// before subscribing. See {@link ChangesetSummary} for the full shape and
 	// {@link /guide/changesets | Changesets} for an overview of the model.
 	Changesets []ChangesetSummary `json:"changesets,omitempty"`
+	// Aggregate summary of file changes associated with this session. Servers
+	// may populate this to give clients a quick at-a-glance view of the
+	// session's footprint (e.g., for list rendering) without requiring the
+	// client to subscribe to a changeset.
+	Changes *ChangesSummary `json:"changes,omitempty"`
 }

--- a/clients/go/ahptypes/notifications.generated.go
+++ b/clients/go/ahptypes/notifications.generated.go
@@ -188,9 +188,9 @@ type PartialSessionSummary struct {
 	// Catalogue of changesets the server can produce for this session. Each
 	// entry advertises a subscribable view of file changes (uncommitted,
 	// session-wide, per-turn, etc.) and the URI template the client expands
-	// before subscribing. See {@link ChangesetSummary} for the full shape and
+	// before subscribing. See {@link Changeset} for the full shape and
 	// {@link /guide/changesets | Changesets} for an overview of the model.
-	Changesets []ChangesetSummary `json:"changesets,omitempty"`
+	Changesets []Changeset `json:"changesets,omitempty"`
 	// Aggregate summary of file changes associated with this session. Servers
 	// may populate this to give clients a quick at-a-glance view of the
 	// session's footprint (e.g., for list rendering) without requiring the

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -615,6 +615,24 @@ type SessionSummary struct {
 	// before subscribing. See {@link ChangesetSummary} for the full shape and
 	// {@link /guide/changesets | Changesets} for an overview of the model.
 	Changesets []ChangesetSummary `json:"changesets,omitempty"`
+	// Aggregate summary of file changes associated with this session. Servers
+	// may populate this to give clients a quick at-a-glance view of the
+	// session's footprint (e.g., for list rendering) without requiring the
+	// client to subscribe to a changeset.
+	Changes *ChangesSummary `json:"changes,omitempty"`
+}
+
+// Aggregate counts describing the file changes associated with a session.
+//
+// All fields are optional so servers can populate only the metrics they
+// cheaply have available.
+type ChangesSummary struct {
+	// Total number of inserted lines across all changed files.
+	Additions *int64 `json:"additions,omitempty"`
+	// Total number of deleted lines across all changed files.
+	Deletions *int64 `json:"deletions,omitempty"`
+	// Number of files that have changes.
+	Files *int64 `json:"files,omitempty"`
 }
 
 // Server-owned project metadata for a session.
@@ -2038,12 +2056,6 @@ type ChangesetSummary struct {
 	UriTemplate string `json:"uriTemplate"`
 	// Optional longer description.
 	Description *string `json:"description,omitempty"`
-	// Aggregate line additions across the changeset, when known.
-	Additions *int64 `json:"additions,omitempty"`
-	// Aggregate line deletions across the changeset, when known.
-	Deletions *int64 `json:"deletions,omitempty"`
-	// Number of files in the changeset, when known.
-	Files *int64 `json:"files,omitempty"`
 }
 
 // Full state for a single changeset, returned when a client subscribes to

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -612,9 +612,9 @@ type SessionSummary struct {
 	// Catalogue of changesets the server can produce for this session. Each
 	// entry advertises a subscribable view of file changes (uncommitted,
 	// session-wide, per-turn, etc.) and the URI template the client expands
-	// before subscribing. See {@link ChangesetSummary} for the full shape and
+	// before subscribing. See {@link Changeset} for the full shape and
 	// {@link /guide/changesets | Changesets} for an overview of the model.
-	Changesets []ChangesetSummary `json:"changesets,omitempty"`
+	Changesets []Changeset `json:"changesets,omitempty"`
 	// Aggregate summary of file changes associated with this session. Servers
 	// may populate this to give clients a quick at-a-glance view of the
 	// session's footprint (e.g., for list rendering) without requiring the
@@ -2035,7 +2035,7 @@ type Snapshot struct {
 // chip or list row without subscribing. Full per-changeset detail
 // ({@link ChangesetState}) lives on the subscribable URI obtained by
 // expanding {@link uriTemplate}.
-type ChangesetSummary struct {
+type Changeset struct {
 	// Human-readable label, e.g. `"Uncommitted Changes"`.
 	Label string `json:"label"`
 	// RFC 6570 URI template. Clients parse the variables directly out of the

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -21,6 +21,11 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
   `changeset/operationStatusChanged` action, tracking the
   `idle → running → error` lifecycle of a changeset operation.
 - `AgentCustomization._meta` provider metadata field.
+- Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
+
+### Removed
+
+- Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.
 
 ## [0.2.0] — 2026-05-28
 

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -23,6 +23,11 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 - `AgentCustomization._meta` provider metadata field.
 - Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
 
+
+### Changed
+
+- Renamed the `ChangesetSummary` type to `Changeset` (catalogue entry on `SessionSummary.changesets`). The on-the-wire shape is unchanged.
+
 ### Removed
 
 - Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -583,7 +583,7 @@ data class SessionChangesetsChangedAction(
     /**
      * New catalogue, or `undefined` to clear it
      */
-    val changesets: List<ChangesetSummary>? = null
+    val changesets: List<Changeset>? = null
 )
 
 @Serializable

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
@@ -199,5 +199,12 @@ data class PartialSessionSummary(
      * before subscribing. See {@link ChangesetSummary} for the full shape and
      * {@link /guide/changesets | Changesets} for an overview of the model.
      */
-    val changesets: List<ChangesetSummary>? = null
+    val changesets: List<ChangesetSummary>? = null,
+    /**
+     * Aggregate summary of file changes associated with this session. Servers
+     * may populate this to give clients a quick at-a-glance view of the
+     * session's footprint (e.g., for list rendering) without requiring the
+     * client to subscribe to a changeset.
+     */
+    val changes: ChangesSummary? = null
 )

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
@@ -196,10 +196,10 @@ data class PartialSessionSummary(
      * Catalogue of changesets the server can produce for this session. Each
      * entry advertises a subscribable view of file changes (uncommitted,
      * session-wide, per-turn, etc.) and the URI template the client expands
-     * before subscribing. See {@link ChangesetSummary} for the full shape and
+     * before subscribing. See {@link Changeset} for the full shape and
      * {@link /guide/changesets | Changesets} for an overview of the model.
      */
-    val changesets: List<ChangesetSummary>? = null,
+    val changesets: List<Changeset>? = null,
     /**
      * Aggregate summary of file changes associated with this session. Servers
      * may populate this to give clients a quick at-a-glance view of the

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -988,10 +988,10 @@ data class SessionSummary(
      * Catalogue of changesets the server can produce for this session. Each
      * entry advertises a subscribable view of file changes (uncommitted,
      * session-wide, per-turn, etc.) and the URI template the client expands
-     * before subscribing. See {@link ChangesetSummary} for the full shape and
+     * before subscribing. See {@link Changeset} for the full shape and
      * {@link /guide/changesets | Changesets} for an overview of the model.
      */
-    val changesets: List<ChangesetSummary>? = null,
+    val changesets: List<Changeset>? = null,
     /**
      * Aggregate summary of file changes associated with this session. Servers
      * may populate this to give clients a quick at-a-glance view of the
@@ -2941,7 +2941,7 @@ data class Snapshot(
 )
 
 @Serializable
-data class ChangesetSummary(
+data class Changeset(
     /**
      * Human-readable label, e.g. `"Uncommitted Changes"`.
      */

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -991,7 +991,30 @@ data class SessionSummary(
      * before subscribing. See {@link ChangesetSummary} for the full shape and
      * {@link /guide/changesets | Changesets} for an overview of the model.
      */
-    val changesets: List<ChangesetSummary>? = null
+    val changesets: List<ChangesetSummary>? = null,
+    /**
+     * Aggregate summary of file changes associated with this session. Servers
+     * may populate this to give clients a quick at-a-glance view of the
+     * session's footprint (e.g., for list rendering) without requiring the
+     * client to subscribe to a changeset.
+     */
+    val changes: ChangesSummary? = null
+)
+
+@Serializable
+data class ChangesSummary(
+    /**
+     * Total number of inserted lines across all changed files.
+     */
+    val additions: Long? = null,
+    /**
+     * Total number of deleted lines across all changed files.
+     */
+    val deletions: Long? = null,
+    /**
+     * Number of files that have changes.
+     */
+    val files: Long? = null
 )
 
 @Serializable
@@ -2944,19 +2967,7 @@ data class ChangesetSummary(
     /**
      * Optional longer description.
      */
-    val description: String? = null,
-    /**
-     * Aggregate line additions across the changeset, when known.
-     */
-    val additions: Long? = null,
-    /**
-     * Aggregate line deletions across the changeset, when known.
-     */
-    val deletions: Long? = null,
-    /**
-     * Number of files in the changeset, when known.
-     */
-    val files: Long? = null
+    val description: String? = null
 )
 
 @Serializable

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -23,6 +23,11 @@ matching `## [X.Y.Z]` heading is missing from this file.
 - `AgentCustomization._meta` provider metadata field.
 - Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
 
+
+### Changed
+
+- Renamed the `ChangesetSummary` type to `Changeset` (catalogue entry on `SessionSummary.changesets`). The on-the-wire shape is unchanged.
+
 ### Removed
 
 - Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -21,6 +21,11 @@ matching `## [X.Y.Z]` heading is missing from this file.
   `changeset/operationStatusChanged` action, tracking the
   `idle → running → error` lifecycle of a changeset operation.
 - `AgentCustomization._meta` provider metadata field.
+- Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
+
+### Removed
+
+- Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.
 
 ## [0.2.0] — 2026-05-28
 

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -12,10 +12,10 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::state::{
-    AgentInfo, AgentSelection, ChangesetFile, ChangesetOperation, ChangesetOperationStatus,
-    ChangesetStatus, ChangesetSummary, ConfirmationOption, Customization, ErrorInfo, Message,
-    ModelSelection, PendingMessageKind, ResponsePart, SessionActiveClient, SessionInputAnswer,
-    SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo,
+    AgentInfo, AgentSelection, Changeset, ChangesetFile, ChangesetOperation,
+    ChangesetOperationStatus, ChangesetStatus, ConfirmationOption, Customization, ErrorInfo,
+    Message, ModelSelection, PendingMessageKind, ResponsePart, SessionActiveClient,
+    SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo,
     ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallResult, ToolDefinition,
     ToolResultContent, UsageInfo,
 };
@@ -575,7 +575,7 @@ pub struct SessionActivityChangedAction {
     pub activity: Option<String>,
 }
 
-/// The {@link ChangesetSummary | catalogue of changesets} the agent host
+/// The {@link Changeset | catalogue of changesets} the agent host
 /// advertises for this session changed. Replaces
 /// `state.summary.changesets` entirely (full-replacement semantics) — set
 /// to `undefined` to clear the catalogue.
@@ -589,7 +589,7 @@ pub struct SessionActivityChangedAction {
 pub struct SessionChangesetsChangedAction {
     /// New catalogue, or `undefined` to clear it
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub changesets: Option<Vec<ChangesetSummary>>,
+    pub changesets: Option<Vec<Changeset>>,
 }
 
 /// Server tools for this session have changed.

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -580,9 +580,8 @@ pub struct SessionActivityChangedAction {
 /// `state.summary.changesets` entirely (full-replacement semantics) — set
 /// to `undefined` to clear the catalogue.
 ///
-/// Producers dispatch this whenever entries are added, removed, or have
-/// their aggregate counts (`additions` / `deletions` / `files`) refreshed.
-/// The fan-out happens through this action so observers see catalogue
+/// Producers dispatch this whenever entries are added or removed. The
+/// fan-out happens through this action so observers see catalogue
 /// mutations in the same {@link ChangesetAction | per-changeset} action
 /// stream they already follow for file-level updates.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -13,7 +13,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[allow(unused_imports)]
 use crate::state::{
-    AgentSelection, ChangesSummary, ChangesetSummary, FileEdit, ModelSelection, ProjectInfo,
+    AgentSelection, ChangesSummary, Changeset, FileEdit, ModelSelection, ProjectInfo,
     SessionStatus, SessionSummary,
 };
 
@@ -221,10 +221,10 @@ pub struct PartialSessionSummary {
     /// Catalogue of changesets the server can produce for this session. Each
     /// entry advertises a subscribable view of file changes (uncommitted,
     /// session-wide, per-turn, etc.) and the URI template the client expands
-    /// before subscribing. See {@link ChangesetSummary} for the full shape and
+    /// before subscribing. See {@link Changeset} for the full shape and
     /// {@link /guide/changesets | Changesets} for an overview of the model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub changesets: Option<Vec<ChangesetSummary>>,
+    pub changesets: Option<Vec<Changeset>>,
     /// Aggregate summary of file changes associated with this session. Servers
     /// may populate this to give clients a quick at-a-glance view of the
     /// session's footprint (e.g., for list rendering) without requiring the

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -13,8 +13,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[allow(unused_imports)]
 use crate::state::{
-    AgentSelection, ChangesetSummary, FileEdit, ModelSelection, ProjectInfo, SessionStatus,
-    SessionSummary,
+    AgentSelection, ChangesSummary, ChangesetSummary, FileEdit, ModelSelection, ProjectInfo,
+    SessionStatus, SessionSummary,
 };
 
 // ─── Enums ────────────────────────────────────────────────────────────

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -225,4 +225,10 @@ pub struct PartialSessionSummary {
     /// {@link /guide/changesets | Changesets} for an overview of the model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub changesets: Option<Vec<ChangesetSummary>>,
+    /// Aggregate summary of file changes associated with this session. Servers
+    /// may populate this to give clients a quick at-a-glance view of the
+    /// session's footprint (e.g., for list rendering) without requiring the
+    /// client to subscribe to a changeset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changes: Option<ChangesSummary>,
 }

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -789,6 +789,30 @@ pub struct SessionSummary {
     /// {@link /guide/changesets | Changesets} for an overview of the model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub changesets: Option<Vec<ChangesetSummary>>,
+    /// Aggregate summary of file changes associated with this session. Servers
+    /// may populate this to give clients a quick at-a-glance view of the
+    /// session's footprint (e.g., for list rendering) without requiring the
+    /// client to subscribe to a changeset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changes: Option<ChangesSummary>,
+}
+
+/// Aggregate counts describing the file changes associated with a session.
+///
+/// All fields are optional so servers can populate only the metrics they
+/// cheaply have available.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangesSummary {
+    /// Total number of inserted lines across all changed files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additions: Option<i64>,
+    /// Total number of deleted lines across all changed files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<i64>,
+    /// Number of files that have changes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub files: Option<i64>,
 }
 
 /// Server-owned project metadata for a session.
@@ -2475,15 +2499,6 @@ pub struct ChangesetSummary {
     /// Optional longer description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Aggregate line additions across the changeset, when known.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub additions: Option<i64>,
-    /// Aggregate line deletions across the changeset, when known.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deletions: Option<i64>,
-    /// Number of files in the changeset, when known.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub files: Option<i64>,
 }
 
 /// Full state for a single changeset, returned when a client subscribes to

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -785,10 +785,10 @@ pub struct SessionSummary {
     /// Catalogue of changesets the server can produce for this session. Each
     /// entry advertises a subscribable view of file changes (uncommitted,
     /// session-wide, per-turn, etc.) and the URI template the client expands
-    /// before subscribing. See {@link ChangesetSummary} for the full shape and
+    /// before subscribing. See {@link Changeset} for the full shape and
     /// {@link /guide/changesets | Changesets} for an overview of the model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub changesets: Option<Vec<ChangesetSummary>>,
+    pub changesets: Option<Vec<Changeset>>,
     /// Aggregate summary of file changes associated with this session. Servers
     /// may populate this to give clients a quick at-a-glance view of the
     /// session's footprint (e.g., for list rendering) without requiring the
@@ -2477,7 +2477,7 @@ pub struct Snapshot {
 /// expanding {@link uriTemplate}.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ChangesetSummary {
+pub struct Changeset {
     /// Human-readable label, e.g. `"Uncommitted Changes"`.
     pub label: String,
     /// RFC 6570 URI template. Clients parse the variables directly out of the

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -1220,6 +1220,7 @@ mod tests {
                 agent: None,
                 working_directory: None,
                 changesets: None,
+                changes: None,
             },
             lifecycle: SessionLifecycle::Creating,
             creation_error: None,

--- a/clients/rust/crates/ahp/tests/hosts.rs
+++ b/clients/rust/crates/ahp/tests/hosts.rs
@@ -1033,6 +1033,7 @@ fn make_summary(uri: &str, title: &str, modified_at: i64) -> ahp_types::state::S
         agent: None,
         working_directory: None,
         changesets: None,
+        changes: None,
     }
 }
 

--- a/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
+++ b/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
@@ -57,6 +57,7 @@ fn session_state(title: &str, resource: &str) -> SessionState {
             agent: None,
             working_directory: None,
             changesets: None,
+            changes: None,
         },
         lifecycle: SessionLifecycle::Ready,
         creation_error: None,
@@ -364,6 +365,7 @@ fn non_action_event_is_ignored() {
                 agent: None,
                 working_directory: None,
                 changesets: None,
+                changes: None,
             },
         }),
     };

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -704,11 +704,11 @@ public struct SessionActivityChangedAction: Codable, Sendable {
 public struct SessionChangesetsChangedAction: Codable, Sendable {
     public var type: ActionType
     /// New catalogue, or `undefined` to clear it
-    public var changesets: [ChangesetSummary]?
+    public var changesets: [Changeset]?
 
     public init(
         type: ActionType,
-        changesets: [ChangesetSummary]? = nil
+        changesets: [Changeset]? = nil
     ) {
         self.type = type
         self.changesets = changesets

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -167,9 +167,9 @@ public struct PartialSessionSummary: Codable, Sendable {
     /// Catalogue of changesets the server can produce for this session. Each
     /// entry advertises a subscribable view of file changes (uncommitted,
     /// session-wide, per-turn, etc.) and the URI template the client expands
-    /// before subscribing. See {@link ChangesetSummary} for the full shape and
+    /// before subscribing. See {@link Changeset} for the full shape and
     /// {@link /guide/changesets | Changesets} for an overview of the model.
-    public var changesets: [ChangesetSummary]?
+    public var changesets: [Changeset]?
     /// Aggregate summary of file changes associated with this session. Servers
     /// may populate this to give clients a quick at-a-glance view of the
     /// session's footprint (e.g., for list rendering) without requiring the
@@ -188,7 +188,7 @@ public struct PartialSessionSummary: Codable, Sendable {
         model: ModelSelection? = nil,
         agent: AgentSelection? = nil,
         workingDirectory: String? = nil,
-        changesets: [ChangesetSummary]? = nil,
+        changesets: [Changeset]? = nil,
         changes: ChangesSummary? = nil
     ) {
         self.resource = resource

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -170,6 +170,11 @@ public struct PartialSessionSummary: Codable, Sendable {
     /// before subscribing. See {@link ChangesetSummary} for the full shape and
     /// {@link /guide/changesets | Changesets} for an overview of the model.
     public var changesets: [ChangesetSummary]?
+    /// Aggregate summary of file changes associated with this session. Servers
+    /// may populate this to give clients a quick at-a-glance view of the
+    /// session's footprint (e.g., for list rendering) without requiring the
+    /// client to subscribe to a changeset.
+    public var changes: ChangesSummary?
 
     public init(
         resource: String? = nil,
@@ -183,7 +188,8 @@ public struct PartialSessionSummary: Codable, Sendable {
         model: ModelSelection? = nil,
         agent: AgentSelection? = nil,
         workingDirectory: String? = nil,
-        changesets: [ChangesetSummary]? = nil
+        changesets: [ChangesetSummary]? = nil,
+        changes: ChangesSummary? = nil
     ) {
         self.resource = resource
         self.provider = provider
@@ -197,5 +203,6 @@ public struct PartialSessionSummary: Codable, Sendable {
         self.agent = agent
         self.workingDirectory = workingDirectory
         self.changesets = changesets
+        self.changes = changes
     }
 }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -801,6 +801,11 @@ public struct SessionSummary: Codable, Sendable {
     /// before subscribing. See {@link ChangesetSummary} for the full shape and
     /// {@link /guide/changesets | Changesets} for an overview of the model.
     public var changesets: [ChangesetSummary]?
+    /// Aggregate summary of file changes associated with this session. Servers
+    /// may populate this to give clients a quick at-a-glance view of the
+    /// session's footprint (e.g., for list rendering) without requiring the
+    /// client to subscribe to a changeset.
+    public var changes: ChangesSummary?
 
     public init(
         resource: String,
@@ -814,7 +819,8 @@ public struct SessionSummary: Codable, Sendable {
         model: ModelSelection? = nil,
         agent: AgentSelection? = nil,
         workingDirectory: String? = nil,
-        changesets: [ChangesetSummary]? = nil
+        changesets: [ChangesetSummary]? = nil,
+        changes: ChangesSummary? = nil
     ) {
         self.resource = resource
         self.provider = provider
@@ -828,6 +834,26 @@ public struct SessionSummary: Codable, Sendable {
         self.agent = agent
         self.workingDirectory = workingDirectory
         self.changesets = changesets
+        self.changes = changes
+    }
+}
+
+public struct ChangesSummary: Codable, Sendable {
+    /// Total number of inserted lines across all changed files.
+    public var additions: Int?
+    /// Total number of deleted lines across all changed files.
+    public var deletions: Int?
+    /// Number of files that have changes.
+    public var files: Int?
+
+    public init(
+        additions: Int? = nil,
+        deletions: Int? = nil,
+        files: Int? = nil
+    ) {
+        self.additions = additions
+        self.deletions = deletions
+        self.files = files
     }
 }
 
@@ -3215,27 +3241,15 @@ public struct ChangesetSummary: Codable, Sendable {
     public var uriTemplate: String
     /// Optional longer description.
     public var description: String?
-    /// Aggregate line additions across the changeset, when known.
-    public var additions: Int?
-    /// Aggregate line deletions across the changeset, when known.
-    public var deletions: Int?
-    /// Number of files in the changeset, when known.
-    public var files: Int?
 
     public init(
         label: String,
         uriTemplate: String,
-        description: String? = nil,
-        additions: Int? = nil,
-        deletions: Int? = nil,
-        files: Int? = nil
+        description: String? = nil
     ) {
         self.label = label
         self.uriTemplate = uriTemplate
         self.description = description
-        self.additions = additions
-        self.deletions = deletions
-        self.files = files
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -798,9 +798,9 @@ public struct SessionSummary: Codable, Sendable {
     /// Catalogue of changesets the server can produce for this session. Each
     /// entry advertises a subscribable view of file changes (uncommitted,
     /// session-wide, per-turn, etc.) and the URI template the client expands
-    /// before subscribing. See {@link ChangesetSummary} for the full shape and
+    /// before subscribing. See {@link Changeset} for the full shape and
     /// {@link /guide/changesets | Changesets} for an overview of the model.
-    public var changesets: [ChangesetSummary]?
+    public var changesets: [Changeset]?
     /// Aggregate summary of file changes associated with this session. Servers
     /// may populate this to give clients a quick at-a-glance view of the
     /// session's footprint (e.g., for list rendering) without requiring the
@@ -819,7 +819,7 @@ public struct SessionSummary: Codable, Sendable {
         model: ModelSelection? = nil,
         agent: AgentSelection? = nil,
         workingDirectory: String? = nil,
-        changesets: [ChangesetSummary]? = nil,
+        changesets: [Changeset]? = nil,
         changes: ChangesSummary? = nil
     ) {
         self.resource = resource
@@ -3220,7 +3220,7 @@ public struct Snapshot: Codable, Sendable {
     }
 }
 
-public struct ChangesetSummary: Codable, Sendable {
+public struct Changeset: Codable, Sendable {
     /// Human-readable label, e.g. `"Uncommitted Changes"`.
     public var label: String
     /// RFC 6570 URI template. Clients parse the variables directly out of the

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -23,6 +23,11 @@ the tag matches the version pinned in [`VERSION`](VERSION).
   `changeset/operationStatusChanged` action, tracking the
   `idle → running → error` lifecycle of a changeset operation.
 - `AgentCustomization._meta` provider metadata field.
+- Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
+
+### Removed
+
+- Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.
 
 ## [0.2.0] — 2026-05-28
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -25,6 +25,11 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 - `AgentCustomization._meta` provider metadata field.
 - Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
 
+
+### Changed
+
+- Renamed the `ChangesetSummary` type to `Changeset` (catalogue entry on `SessionSummary.changesets`). The on-the-wire shape is unchanged.
+
 ### Removed
 
 - Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -26,6 +26,11 @@ hotfix escape hatch.
   `changeset/operationStatusChanged` action, tracking the
   `idle → running → error` lifecycle of a changeset operation.
 - `AgentCustomization._meta` provider metadata field.
+- Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
+
+### Removed
+
+- Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.
 
 ## [0.2.0] — 2026-05-28
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -28,6 +28,11 @@ hotfix escape hatch.
 - `AgentCustomization._meta` provider metadata field.
 - Optional `changes` field on `SessionSummary` (`ChangesSummary` with optional `additions`, `deletions`, and `files` counts) summarising a session's file-change footprint.
 
+
+### Changed
+
+- Renamed the `ChangesetSummary` type to `Changeset` (catalogue entry on `SessionSummary.changesets`). The on-the-wire shape is unchanged.
+
 ### Removed
 
 - Removed the `additions`, `deletions`, and `files` fields from `ChangesetSummary`. Aggregate counts now live on `SessionSummary.changes`; per-changeset views derive their own totals from `ChangesetState.files`.

--- a/docs/guide/changesets.md
+++ b/docs/guide/changesets.md
@@ -168,6 +168,6 @@ The `summary.diffs` field and the `session/diffsChanged` action were
 removed in v0.2.0. Servers that previously populated `summary.diffs`
 should expose an equivalent server-side changeset with a static
 `uriTemplate` ending in `/changeset/session` and surface its
-`additions`/`deletions`/`files` counts on the new `summary.changesets`
-catalogue entry. Clients that want a single "session-wide" diff view
-subscribe to that one changeset URI.
+aggregate counts on the new `summary.changes` field. Clients that
+want a single "session-wide" diff view subscribe to that one
+changeset URI.

--- a/docs/guide/changesets.md
+++ b/docs/guide/changesets.md
@@ -19,10 +19,10 @@ references a full subscribable `ChangesetState` by URI.
 ```typescript
 SessionSummary {
   // ...existing fields...
-  changesets?: ChangesetSummary[]
+  changesets?: Changeset[]
 }
 
-ChangesetSummary {
+Changeset {
   /** Human-readable label, e.g. `"Uncommitted Changes"`. */
   label: string
   /** RFC 6570 URI template; expand to obtain a subscribable URI. */

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -26,7 +26,7 @@ The rest of this page details the URI scheme and the lifecycle of a subscription
 | `ahp-root://` | `RootState` | Global state (agents, terminals, host config). Always present. |
 | `ahp-session:/<uuid>` | `SessionState` | Per-session state. The session's provider is carried on `SessionSummary.provider`, not in the URI scheme. |
 | `ahp-terminal:/<id>` | `TerminalState` | Per-terminal state. Server-defined id. |
-| `ahp-changeset:/<id>` | `ChangesetState` | Per-changeset state. URI is obtained by expanding a `ChangesetSummary.uriTemplate` advertised on a session; the id is server-defined. |
+| `ahp-changeset:/<id>` | `ChangesetState` | Per-changeset state. URI is obtained by expanding a `Changeset.uriTemplate` advertised on a session; the id is server-defined. |
 | `ahp-otlp:` _(authority/path host-defined)_ | _stateless_ | OpenTelemetry signal channels (logs, traces, metrics). Concrete URIs are advertised on `InitializeResult.telemetry`; clients MUST treat them as opaque. See [Telemetry Channel](/specification/telemetry-channel). |
 | `ahp-resource-watch:/<id>` | `ResourceWatchState` | Per-watch channel returned by `createResourceWatch`. Delivers `resourceWatch/changed` actions for file/directory changes under the watched URI. The id is caller-chosen. |
 

--- a/plugins/channels-migration-plugin/skills/channels-migration/SKILL.md
+++ b/plugins/channels-migration-plugin/skills/channels-migration/SKILL.md
@@ -62,7 +62,7 @@ Concretely:
 - **Terminal URI scheme** (docs/examples): `ahp-terminal:/<id>`. Server-
   defined; clients treat as opaque.
 - **Changeset URI scheme** (docs/examples): `ahp-changeset:/<id>`. Server-
-  defined; obtained by expanding a `ChangesetSummary.uriTemplate`.
+  defined; obtained by expanding a `Changeset.uriTemplate`.
   Changesets are a new channel type introduced in the same step.
 - **`channel` everywhere**: `subscribe`/`unsubscribe`/action-envelope/
   `dispatchAction`/every protocol notification AND every command has

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -809,7 +809,7 @@
     },
     "SessionChangesetsChangedAction": {
       "type": "object",
-      "description": "The {@link ChangesetSummary | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
+      "description": "The {@link Changeset | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionChangesetsChanged"
@@ -817,7 +817,7 @@
         "changesets": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ChangesetSummary"
+            "$ref": "#/$defs/Changeset"
           },
           "description": "New catalogue, or `undefined` to clear it"
         }
@@ -2285,9 +2285,9 @@
         "changesets": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ChangesetSummary"
+            "$ref": "#/$defs/Changeset"
           },
-          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link Changeset} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
         },
         "changes": {
           "$ref": "#/$defs/ChangesSummary",
@@ -4869,7 +4869,7 @@
         "isComplete"
       ]
     },
-    "ChangesetSummary": {
+    "Changeset": {
       "type": "object",
       "description": "Catalogue entry describing one changeset the server can produce for a\nsession.\n\nCatalogue entries are intentionally lightweight — just enough to render a\nchip or list row without subscribing. Full per-changeset detail\n({@link ChangesetState}) lives on the subscribable URI obtained by\nexpanding {@link uriTemplate}.",
       "properties": {

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -809,7 +809,7 @@
     },
     "SessionChangesetsChangedAction": {
       "type": "object",
-      "description": "The {@link ChangesetSummary | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added, removed, or have\ntheir aggregate counts (`additions` / `deletions` / `files`) refreshed.\nThe fan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
+      "description": "The {@link ChangesetSummary | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionChangesetsChanged"
@@ -2288,6 +2288,10 @@
             "$ref": "#/$defs/ChangesetSummary"
           },
           "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+        },
+        "changes": {
+          "$ref": "#/$defs/ChangesSummary",
+          "description": "Aggregate summary of file changes associated with this session. Servers\nmay populate this to give clients a quick at-a-glance view of the\nsession's footprint (e.g., for list rendering) without requiring the\nclient to subscribe to a changeset."
         }
       },
       "required": [
@@ -2298,6 +2302,24 @@
         "createdAt",
         "modifiedAt"
       ]
+    },
+    "ChangesSummary": {
+      "type": "object",
+      "description": "Aggregate counts describing the file changes associated with a session.\n\nAll fields are optional so servers can populate only the metrics they\ncheaply have available.",
+      "properties": {
+        "additions": {
+          "type": "number",
+          "description": "Total number of inserted lines across all changed files."
+        },
+        "deletions": {
+          "type": "number",
+          "description": "Total number of deleted lines across all changed files."
+        },
+        "files": {
+          "type": "number",
+          "description": "Number of files that have changes."
+        }
+      }
     },
     "AgentSelection": {
       "type": "object",
@@ -4862,18 +4884,6 @@
         "description": {
           "type": "string",
           "description": "Optional longer description."
-        },
-        "additions": {
-          "type": "number",
-          "description": "Aggregate line additions across the changeset, when known."
-        },
-        "deletions": {
-          "type": "number",
-          "description": "Aggregate line deletions across the changeset, when known."
-        },
-        "files": {
-          "type": "number",
-          "description": "Number of files in the changeset, when known."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1936,9 +1936,9 @@
         "changesets": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ChangesetSummary"
+            "$ref": "#/$defs/Changeset"
           },
-          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link Changeset} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
         },
         "changes": {
           "$ref": "#/$defs/ChangesSummary",
@@ -4520,7 +4520,7 @@
         "isComplete"
       ]
     },
-    "ChangesetSummary": {
+    "Changeset": {
       "type": "object",
       "description": "Catalogue entry describing one changeset the server can produce for a\nsession.\n\nCatalogue entries are intentionally lightweight — just enough to render a\nchip or list row without subscribing. Full per-changeset detail\n({@link ChangesetState}) lives on the subscribable URI obtained by\nexpanding {@link uriTemplate}.",
       "properties": {
@@ -5526,7 +5526,7 @@
     },
     "SessionChangesetsChangedAction": {
       "type": "object",
-      "description": "The {@link ChangesetSummary | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
+      "description": "The {@link Changeset | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionChangesetsChanged"
@@ -5534,7 +5534,7 @@
         "changesets": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ChangesetSummary"
+            "$ref": "#/$defs/Changeset"
           },
           "description": "New catalogue, or `undefined` to clear it"
         }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1939,6 +1939,10 @@
             "$ref": "#/$defs/ChangesetSummary"
           },
           "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+        },
+        "changes": {
+          "$ref": "#/$defs/ChangesSummary",
+          "description": "Aggregate summary of file changes associated with this session. Servers\nmay populate this to give clients a quick at-a-glance view of the\nsession's footprint (e.g., for list rendering) without requiring the\nclient to subscribe to a changeset."
         }
       },
       "required": [
@@ -1949,6 +1953,24 @@
         "createdAt",
         "modifiedAt"
       ]
+    },
+    "ChangesSummary": {
+      "type": "object",
+      "description": "Aggregate counts describing the file changes associated with a session.\n\nAll fields are optional so servers can populate only the metrics they\ncheaply have available.",
+      "properties": {
+        "additions": {
+          "type": "number",
+          "description": "Total number of inserted lines across all changed files."
+        },
+        "deletions": {
+          "type": "number",
+          "description": "Total number of deleted lines across all changed files."
+        },
+        "files": {
+          "type": "number",
+          "description": "Number of files that have changes."
+        }
+      }
     },
     "AgentSelection": {
       "type": "object",
@@ -4513,18 +4535,6 @@
         "description": {
           "type": "string",
           "description": "Optional longer description."
-        },
-        "additions": {
-          "type": "number",
-          "description": "Aggregate line additions across the changeset, when known."
-        },
-        "deletions": {
-          "type": "number",
-          "description": "Aggregate line deletions across the changeset, when known."
-        },
-        "files": {
-          "type": "number",
-          "description": "Number of files in the changeset, when known."
         }
       },
       "required": [
@@ -5516,7 +5526,7 @@
     },
     "SessionChangesetsChangedAction": {
       "type": "object",
-      "description": "The {@link ChangesetSummary | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added, removed, or have\ntheir aggregate counts (`additions` / `deletions` / `files`) refreshed.\nThe fan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
+      "description": "The {@link ChangesetSummary | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n`state.summary.changesets` entirely (full-replacement semantics) — set\nto `undefined` to clear the catalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.SessionChangesetsChanged"

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -868,9 +868,9 @@
         "changesets": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ChangesetSummary"
+            "$ref": "#/$defs/Changeset"
           },
-          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link Changeset} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
         },
         "changes": {
           "$ref": "#/$defs/ChangesSummary",
@@ -3452,7 +3452,7 @@
         "isComplete"
       ]
     },
-    "ChangesetSummary": {
+    "Changeset": {
       "type": "object",
       "description": "Catalogue entry describing one changeset the server can produce for a\nsession.\n\nCatalogue entries are intentionally lightweight — just enough to render a\nchip or list row without subscribing. Full per-changeset detail\n({@link ChangesetState}) lives on the subscribable URI obtained by\nexpanding {@link uriTemplate}.",
       "properties": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -871,6 +871,10 @@
             "$ref": "#/$defs/ChangesetSummary"
           },
           "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+        },
+        "changes": {
+          "$ref": "#/$defs/ChangesSummary",
+          "description": "Aggregate summary of file changes associated with this session. Servers\nmay populate this to give clients a quick at-a-glance view of the\nsession's footprint (e.g., for list rendering) without requiring the\nclient to subscribe to a changeset."
         }
       },
       "required": [
@@ -881,6 +885,24 @@
         "createdAt",
         "modifiedAt"
       ]
+    },
+    "ChangesSummary": {
+      "type": "object",
+      "description": "Aggregate counts describing the file changes associated with a session.\n\nAll fields are optional so servers can populate only the metrics they\ncheaply have available.",
+      "properties": {
+        "additions": {
+          "type": "number",
+          "description": "Total number of inserted lines across all changed files."
+        },
+        "deletions": {
+          "type": "number",
+          "description": "Total number of deleted lines across all changed files."
+        },
+        "files": {
+          "type": "number",
+          "description": "Number of files that have changes."
+        }
+      }
     },
     "AgentSelection": {
       "type": "object",
@@ -3445,18 +3467,6 @@
         "description": {
           "type": "string",
           "description": "Optional longer description."
-        },
-        "additions": {
-          "type": "number",
-          "description": "Aggregate line additions across the changeset, when known."
-        },
-        "deletions": {
-          "type": "number",
-          "description": "Aggregate line deletions across the changeset, when known."
-        },
-        "files": {
-          "type": "number",
-          "description": "Number of files in the changeset, when known."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -125,9 +125,9 @@
             "changesets": {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/ChangesetSummary"
+                "$ref": "#/$defs/Changeset"
               },
-              "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+              "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link Changeset} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
             },
             "changes": {
               "$ref": "#/$defs/ChangesSummary",
@@ -1000,9 +1000,9 @@
         "changesets": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ChangesetSummary"
+            "$ref": "#/$defs/Changeset"
           },
-          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link Changeset} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
         },
         "changes": {
           "$ref": "#/$defs/ChangesSummary",
@@ -3584,7 +3584,7 @@
         "isComplete"
       ]
     },
-    "ChangesetSummary": {
+    "Changeset": {
       "type": "object",
       "description": "Catalogue entry describing one changeset the server can produce for a\nsession.\n\nCatalogue entries are intentionally lightweight — just enough to render a\nchip or list row without subscribing. Full per-changeset detail\n({@link ChangesetState}) lives on the subscribable URI obtained by\nexpanding {@link uriTemplate}.",
       "properties": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -128,6 +128,10 @@
                 "$ref": "#/$defs/ChangesetSummary"
               },
               "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+            },
+            "changes": {
+              "$ref": "#/$defs/ChangesSummary",
+              "description": "Aggregate summary of file changes associated with this session. Servers\nmay populate this to give clients a quick at-a-glance view of the\nsession's footprint (e.g., for list rendering) without requiring the\nclient to subscribe to a changeset."
             }
           },
           "description": "Mutable summary fields that changed; omitted fields are unchanged.\n\nIdentity fields (`resource`, `provider`, `createdAt`) never change and\nMUST be omitted by senders; receivers SHOULD ignore them if present."
@@ -999,6 +1003,10 @@
             "$ref": "#/$defs/ChangesetSummary"
           },
           "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+        },
+        "changes": {
+          "$ref": "#/$defs/ChangesSummary",
+          "description": "Aggregate summary of file changes associated with this session. Servers\nmay populate this to give clients a quick at-a-glance view of the\nsession's footprint (e.g., for list rendering) without requiring the\nclient to subscribe to a changeset."
         }
       },
       "required": [
@@ -1009,6 +1017,24 @@
         "createdAt",
         "modifiedAt"
       ]
+    },
+    "ChangesSummary": {
+      "type": "object",
+      "description": "Aggregate counts describing the file changes associated with a session.\n\nAll fields are optional so servers can populate only the metrics they\ncheaply have available.",
+      "properties": {
+        "additions": {
+          "type": "number",
+          "description": "Total number of inserted lines across all changed files."
+        },
+        "deletions": {
+          "type": "number",
+          "description": "Total number of deleted lines across all changed files."
+        },
+        "files": {
+          "type": "number",
+          "description": "Number of files that have changes."
+        }
+      }
     },
     "AgentSelection": {
       "type": "object",
@@ -3573,18 +3599,6 @@
         "description": {
           "type": "string",
           "description": "Optional longer description."
-        },
-        "additions": {
-          "type": "number",
-          "description": "Aggregate line additions across the changeset, when known."
-        },
-        "deletions": {
-          "type": "number",
-          "description": "Aggregate line deletions across the changeset, when known."
-        },
-        "files": {
-          "type": "number",
-          "description": "Number of files in the changeset, when known."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -779,9 +779,9 @@
         "changesets": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ChangesetSummary"
+            "$ref": "#/$defs/Changeset"
           },
-          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+          "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link Changeset} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
         },
         "changes": {
           "$ref": "#/$defs/ChangesSummary",
@@ -3363,7 +3363,7 @@
         "isComplete"
       ]
     },
-    "ChangesetSummary": {
+    "Changeset": {
       "type": "object",
       "description": "Catalogue entry describing one changeset the server can produce for a\nsession.\n\nCatalogue entries are intentionally lightweight — just enough to render a\nchip or list row without subscribing. Full per-changeset detail\n({@link ChangesetState}) lives on the subscribable URI obtained by\nexpanding {@link uriTemplate}.",
       "properties": {

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -782,6 +782,10 @@
             "$ref": "#/$defs/ChangesetSummary"
           },
           "description": "Catalogue of changesets the server can produce for this session. Each\nentry advertises a subscribable view of file changes (uncommitted,\nsession-wide, per-turn, etc.) and the URI template the client expands\nbefore subscribing. See {@link ChangesetSummary} for the full shape and\n{@link /guide/changesets | Changesets} for an overview of the model."
+        },
+        "changes": {
+          "$ref": "#/$defs/ChangesSummary",
+          "description": "Aggregate summary of file changes associated with this session. Servers\nmay populate this to give clients a quick at-a-glance view of the\nsession's footprint (e.g., for list rendering) without requiring the\nclient to subscribe to a changeset."
         }
       },
       "required": [
@@ -792,6 +796,24 @@
         "createdAt",
         "modifiedAt"
       ]
+    },
+    "ChangesSummary": {
+      "type": "object",
+      "description": "Aggregate counts describing the file changes associated with a session.\n\nAll fields are optional so servers can populate only the metrics they\ncheaply have available.",
+      "properties": {
+        "additions": {
+          "type": "number",
+          "description": "Total number of inserted lines across all changed files."
+        },
+        "deletions": {
+          "type": "number",
+          "description": "Total number of deleted lines across all changed files."
+        },
+        "files": {
+          "type": "number",
+          "description": "Number of files that have changes."
+        }
+      }
     },
     "AgentSelection": {
       "type": "object",
@@ -3356,18 +3378,6 @@
         "description": {
           "type": "string",
           "description": "Optional longer description."
-        },
-        "additions": {
-          "type": "number",
-          "description": "Aggregate line additions across the changeset, when known."
-        },
-        "deletions": {
-          "type": "number",
-          "description": "Aggregate line deletions across the changeset, when known."
-        },
-        "files": {
-          "type": "number",
-          "description": "Number of files in the changeset, when known."
         }
       },
       "required": [

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -721,7 +721,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: strin
   { name: 'UsageInfo' },
   { name: 'ErrorInfo' },
   { name: 'Snapshot' },
-  { name: 'ChangesetSummary' },
+  { name: 'Changeset' },
   { name: 'ChangesetState' },
   { name: 'ChangesetFile' },
   { name: 'ChangesetOperation' },

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -648,6 +648,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: strin
   { name: 'SessionState' },
   { name: 'SessionActiveClient' },
   { name: 'SessionSummary' },
+  { name: 'ChangesSummary' },
   { name: 'ProjectInfo' },
   { name: 'SessionConfigPropertySchema' },
   { name: 'SessionConfigSchema' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -779,7 +779,7 @@ const STATE_STRUCTS = [
   'TerminalClientClaim', 'TerminalSessionClaim', 'TerminalState',
   'TerminalUnclassifiedPart', 'TerminalCommandPart',
   'UsageInfo', 'ErrorInfo', 'Snapshot',
-  'ChangesetSummary', 'ChangesetState', 'ChangesetFile', 'ChangesetOperation',
+  'Changeset', 'ChangesetState', 'ChangesetFile', 'ChangesetOperation',
   'TelemetryCapabilities',
   'ResourceWatchState', 'ResourceChange',
 ];

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -748,7 +748,7 @@ const STATE_STRUCTS = [
   'Icon', 'ProtectedResourceMetadata', 'RootState', 'RootConfigState', 'AgentInfo',
   'SessionModelInfo', 'ModelSelection', 'AgentSelection', 'ConfigPropertySchema', 'ConfigSchema',
   'PendingMessage', 'SessionState', 'SessionActiveClient',
-  'SessionSummary', 'ProjectInfo', 'SessionConfigState', 'Turn', 'ActiveTurn', 'Message',
+  'SessionSummary', 'ChangesSummary', 'ProjectInfo', 'SessionConfigState', 'Turn', 'ActiveTurn', 'Message',
   'SessionInputOption',
   'SessionInputTextAnswerValue', 'SessionInputNumberAnswerValue',
   'SessionInputBooleanAnswerValue', 'SessionInputSelectedAnswerValue',

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -621,7 +621,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'UsageInfo' },
   { name: 'ErrorInfo' },
   { name: 'Snapshot' },
-  { name: 'ChangesetSummary' },
+  { name: 'Changeset' },
   { name: 'ChangesetState' },
   { name: 'ChangesetFile' },
   { name: 'ChangesetOperation' },
@@ -968,7 +968,7 @@ pub struct SessionToolCallConfirmedAction {
 
 function generateActionsFile(project: Project): string {
   const lines: string[] = [GENERATED_HEADER];
-  lines.push('use crate::state::{AgentInfo, AgentSelection, ConfirmationOption, Customization, ErrorInfo, ModelSelection, ResponsePart, SessionActiveClient, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, Message, PendingMessageKind, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, ChangesetSummary};');
+  lines.push('use crate::state::{AgentInfo, AgentSelection, ConfirmationOption, Customization, ErrorInfo, ModelSelection, ResponsePart, SessionActiveClient, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, Message, PendingMessageKind, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, Changeset};');
   lines.push('');
 
   // ActionType enum
@@ -1176,7 +1176,7 @@ const NOTIFICATION_STRUCTS = [
 function generateNotificationsFile(project: Project): string {
   const lines: string[] = [GENERATED_HEADER];
   lines.push('#[allow(unused_imports)]');
-  lines.push('use crate::state::{AgentSelection, ChangesSummary, ChangesetSummary, FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary};');
+  lines.push('use crate::state::{AgentSelection, ChangesSummary, Changeset, FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary};');
   lines.push('');
 
   lines.push('// ─── Enums ────────────────────────────────────────────────────────────\n');

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1176,7 +1176,7 @@ const NOTIFICATION_STRUCTS = [
 function generateNotificationsFile(project: Project): string {
   const lines: string[] = [GENERATED_HEADER];
   lines.push('#[allow(unused_imports)]');
-  lines.push('use crate::state::{AgentSelection, ChangesetSummary, FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary};');
+  lines.push('use crate::state::{AgentSelection, ChangesSummary, ChangesetSummary, FileEdit, ModelSelection, ProjectInfo, SessionStatus, SessionSummary};');
   lines.push('');
 
   lines.push('// ─── Enums ────────────────────────────────────────────────────────────\n');

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -548,6 +548,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'SessionState' },
   { name: 'SessionActiveClient' },
   { name: 'SessionSummary' },
+  { name: 'ChangesSummary' },
   { name: 'ProjectInfo' },
   { name: 'SessionConfigPropertySchema' },
   { name: 'SessionConfigSchema' },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -536,7 +536,7 @@ const STATE_STRUCTS = [
   'TerminalClientClaim', 'TerminalSessionClaim', 'TerminalState',
   'TerminalUnclassifiedPart', 'TerminalCommandPart',
   'UsageInfo', 'ErrorInfo', 'Snapshot',
-  'ChangesetSummary', 'ChangesetState', 'ChangesetFile', 'ChangesetOperation',
+  'Changeset', 'ChangesetState', 'ChangesetFile', 'ChangesetOperation',
   'TelemetryCapabilities',
   'ResourceWatchState', 'ResourceChange',
 ];

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -504,7 +504,7 @@ const STATE_STRUCTS = [
   'Icon', 'ProtectedResourceMetadata', 'RootState', 'RootConfigState', 'AgentInfo',
   'SessionModelInfo', 'ModelSelection', 'AgentSelection', 'ConfigPropertySchema', 'ConfigSchema',
   'PendingMessage', 'SessionState', 'SessionActiveClient',
-  'SessionSummary', 'ProjectInfo', 'SessionConfigState', 'Turn', 'ActiveTurn', 'Message',
+  'SessionSummary', 'ChangesSummary', 'ProjectInfo', 'SessionConfigState', 'Turn', 'ActiveTurn', 'Message',
   'SessionInputOption',
   'SessionInputTextAnswerValue', 'SessionInputNumberAnswerValue',
   'SessionInputBooleanAnswerValue', 'SessionInputSelectedAnswerValue',

--- a/types/channels-changeset/state.ts
+++ b/types/channels-changeset/state.ts
@@ -20,7 +20,7 @@ import type { StringOrMarkdown, FileEdit, ErrorInfo } from '../common/state.js';
  *
  * @category Changesets
  */
-export interface ChangesetSummary {
+export interface Changeset {
   /** Human-readable label, e.g. `"Uncommitted Changes"`. */
   label: string;
   /**

--- a/types/channels-changeset/state.ts
+++ b/types/channels-changeset/state.ts
@@ -43,12 +43,6 @@ export interface ChangesetSummary {
   uriTemplate: string;
   /** Optional longer description. */
   description?: string;
-  /** Aggregate line additions across the changeset, when known. */
-  additions?: number;
-  /** Aggregate line deletions across the changeset, when known. */
-  deletions?: number;
-  /** Number of files in the changeset, when known. */
-  files?: number;
 }
 
 /**

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -26,7 +26,7 @@ import {
   ToolCallCancellationReason,
   PendingMessageKind,
 } from './state.js';
-import type { ChangesetSummary } from '../channels-changeset/state.js';
+import type { Changeset } from '../channels-changeset/state.js';
 
 // ─── Tool Call Action Base ───────────────────────────────────────────────────
 
@@ -492,7 +492,7 @@ export interface SessionActivityChangedAction {
 }
 
 /**
- * The {@link ChangesetSummary | catalogue of changesets} the agent host
+ * The {@link Changeset | catalogue of changesets} the agent host
  * advertises for this session changed. Replaces
  * `state.summary.changesets` entirely (full-replacement semantics) — set
  * to `undefined` to clear the catalogue.
@@ -508,7 +508,7 @@ export interface SessionActivityChangedAction {
 export interface SessionChangesetsChangedAction {
   type: ActionType.SessionChangesetsChanged;
   /** New catalogue, or `undefined` to clear it */
-  changesets: ChangesetSummary[] | undefined;
+  changesets: Changeset[] | undefined;
 }
 
 /**

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -497,9 +497,8 @@ export interface SessionActivityChangedAction {
  * `state.summary.changesets` entirely (full-replacement semantics) — set
  * to `undefined` to clear the catalogue.
  *
- * Producers dispatch this whenever entries are added, removed, or have
- * their aggregate counts (`additions` / `deletions` / `files`) refreshed.
- * The fan-out happens through this action so observers see catalogue
+ * Producers dispatch this whenever entries are added or removed. The
+ * fan-out happens through this action so observers see catalogue
  * mutations in the same {@link ChangesetAction | per-changeset} action
  * stream they already follow for file-level updates.
  *

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -17,7 +17,7 @@ import type {
   TextSelection,
   UsageInfo,
 } from '../common/state.js';
-import type { ChangesetSummary } from '../channels-changeset/state.js';
+import type { Changeset } from '../channels-changeset/state.js';
 import type { ModelSelection } from '../channels-root/state.js';
 
 // ─── Pending Message Types ───────────────────────────────────────────────────
@@ -212,10 +212,10 @@ export interface SessionSummary {
    * Catalogue of changesets the server can produce for this session. Each
    * entry advertises a subscribable view of file changes (uncommitted,
    * session-wide, per-turn, etc.) and the URI template the client expands
-   * before subscribing. See {@link ChangesetSummary} for the full shape and
+   * before subscribing. See {@link Changeset} for the full shape and
    * {@link /guide/changesets | Changesets} for an overview of the model.
    */
-  changesets?: ChangesetSummary[];
+  changesets?: Changeset[];
   /**
   * Aggregate summary of file changes associated with this session. Servers
   * may populate this to give clients a quick at-a-glance view of the

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -216,6 +216,30 @@ export interface SessionSummary {
    * {@link /guide/changesets | Changesets} for an overview of the model.
    */
   changesets?: ChangesetSummary[];
+  /**
+  * Aggregate summary of file changes associated with this session. Servers
+  * may populate this to give clients a quick at-a-glance view of the
+  * session's footprint (e.g., for list rendering) without requiring the
+  * client to subscribe to a changeset.
+  */
+  changes?: ChangesSummary;
+}
+
+/**
+ * Aggregate counts describing the file changes associated with a session.
+ *
+ * All fields are optional so servers can populate only the metrics they
+ * cheaply have available.
+ *
+ * @category Session State
+ */
+export interface ChangesSummary {
+  /** Total number of inserted lines across all changed files. */
+  additions?: number;
+  /** Total number of deleted lines across all changed files. */
+  deletions?: number;
+  /** Number of files that have changes. */
+  files?: number;
 }
 
 // ─── Model Selection ─────────────────────────────────────────────────────────

--- a/types/index.ts
+++ b/types/index.ts
@@ -21,6 +21,7 @@ export type {
   AgentSelection,
   SessionState,
   SessionSummary,
+  ChangesSummary,
   SessionConfigState,
   Turn,
   ActiveTurn,

--- a/types/index.ts
+++ b/types/index.ts
@@ -89,7 +89,7 @@ export type {
   TerminalContentPart,
   TerminalUnclassifiedPart,
   TerminalCommandPart,
-  ChangesetSummary,
+  Changeset,
   ChangesetState,
   ChangesetFile,
   ChangesetOperation,

--- a/types/test-cases/reducers/145-session-changesetschanged-sets-catalogue.json
+++ b/types/test-cases/reducers/145-session-changesetschanged-sets-catalogue.json
@@ -19,10 +19,7 @@
       "changesets": [
         {
           "label": "Session Changes",
-          "uriTemplate": "copilot:/test-session/changeset/session",
-          "additions": 5,
-          "deletions": 2,
-          "files": 1
+          "uriTemplate": "copilot:/test-session/changeset/session"
         }
       ]
     }
@@ -38,10 +35,7 @@
       "changesets": [
         {
           "label": "Session Changes",
-          "uriTemplate": "copilot:/test-session/changeset/session",
-          "additions": 5,
-          "deletions": 2,
-          "files": 1
+          "uriTemplate": "copilot:/test-session/changeset/session"
         }
       ]
     },


### PR DESCRIPTION
## What

- Adds a new optional `changes` field on `SessionSummary` of type `ChangesSummary`, with optional `additions`, `deletions`, and `files` counts.
- Removes the `additions`, `deletions`, and `files` fields from `ChangesetSummary`.
- Regenerates all five clients (Swift / Rust / Kotlin / TypeScript / Go) and updates the spec + per-client CHANGELOGs.

## Why

Servers need a cheap, at-a-glance way to advertise a session's overall file-change footprint for list/row rendering, without forcing clients to subscribe to a changeset and tally up files. `ChangesSummary` on `SessionSummary` provides exactly that.

The same fields previously lived on individual `ChangesetSummary` catalogue entries, but they don't really belong there — each entry is a separate subscribable view (uncommitted, session-wide, per-turn, diff between turns, …), and clients subscribing to a changeset trivially compute per-view totals from `ChangesetState.files[].edit.diff`. Keeping aggregate counts on the catalogue entries was redundant and easy to get out of sync.

## Notes for reviewers

- No new notification is required: the existing `root/sessionSummaryChanged` notification carries `Partial<SessionSummary>`, so changes to the new `changes` field flow through it for free.
- The `changesets` catalogue on `SessionSummary` is unchanged — it remains the discovery mechanism for `ahp-changeset:/...` channels via each entry's `uriTemplate`.
- Migration note in `docs/guide/changesets.md` updated to point `summary.diffs` migrators at `summary.changes` instead of the removed per-catalogue counts.
- Reducer fixture `145-session-changesetschanged-sets-catalogue.json` updated to drop the removed fields. All 235 tests pass; `typecheck` and `lint` are clean.