### PR TITLE
Add optional _meta property bag to RootState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 Spec version: `0.4.0`
 
+### Added
+
+- `RootState` now carries an optional `_meta` property bag for
+  implementation-defined metadata about the agent host itself, mirroring the
+  MCP `_meta` convention. A well-known `hostBuild` key may carry build
+  information (version, commit, date) about the program hosting the agent host.
+
 ## [0.3.0] — 2026-06-05
 
 Spec version: `0.3.0`

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -14,6 +14,13 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ## [Unreleased]
 
+### Added
+
+- `RootState` now exposes an optional `_meta` property bag (`Meta
+  map[string]json.RawMessage`) for implementation-defined agent-host metadata,
+  such as a well-known `hostBuild` key carrying the host's build
+  version/commit/date.
+
 ## [0.3.0] — 2026-06-05
 
 Implements AHP 0.3.0.

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -429,6 +429,13 @@ type RootState struct {
 	Terminals []TerminalInfo `json:"terminals,omitempty"`
 	// Agent host configuration schema and current values
 	Config *RootConfigState `json:"config,omitempty"`
+	// Additional implementation-defined metadata about the agent host itself.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI. For
+	// example, a `hostBuild` key may carry build information (version, commit,
+	// date) about the program hosting the agent host. Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Live agent-host configuration metadata.

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -431,10 +431,7 @@ type RootState struct {
 	Config *RootConfigState `json:"config,omitempty"`
 	// Additional implementation-defined metadata about the agent host itself.
 	//
-	// Clients MAY look for well-known keys here to provide enhanced UI. For
-	// example, a `hostBuild` key may carry build information (version, commit,
-	// date) about the program hosting the agent host. Mirrors the MCP `_meta`
-	// convention.
+	// Clients MAY look for well-known keys here to provide enhanced UI.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -15,6 +15,12 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ## [Unreleased]
 
+### Added
+
+- `RootState` now exposes an optional `_meta` property bag (`meta: Map<String,
+  JsonElement>?`) for implementation-defined agent-host metadata, such as a
+  well-known `hostBuild` key carrying the host's build version/commit/date.
+
 ## [0.3.0] — 2026-06-05
 
 Implements AHP 0.3.0.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -729,7 +729,17 @@ data class RootState(
     /**
      * Agent host configuration schema and current values
      */
-    val config: RootConfigState? = null
+    val config: RootConfigState? = null,
+    /**
+     * Additional implementation-defined metadata about the agent host itself.
+     * 
+     * Clients MAY look for well-known keys here to provide enhanced UI. For
+     * example, a `hostBuild` key may carry build information (version, commit,
+     * date) about the program hosting the agent host. Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -733,10 +733,7 @@ data class RootState(
     /**
      * Additional implementation-defined metadata about the agent host itself.
      * 
-     * Clients MAY look for well-known keys here to provide enhanced UI. For
-     * example, a `hostBuild` key may carry build information (version, commit,
-     * date) about the program hosting the agent host. Mirrors the MCP `_meta`
-     * convention.
+     * Clients MAY look for well-known keys here to provide enhanced UI.
      */
     @SerialName("_meta")
     val meta: Map<String, JsonElement>? = null

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -15,6 +15,12 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ## [Unreleased]
 
+### Added
+
+- `RootState` now exposes an optional `_meta` property bag (`meta:
+  Option<JsonObject>`) for implementation-defined agent-host metadata, such as
+  a well-known `hostBuild` key carrying the host's build version/commit/date.
+
 ## [0.3.0] — 2026-06-05
 
 Implements AHP 0.3.0.

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -554,10 +554,7 @@ pub struct RootState {
     pub config: Option<RootConfigState>,
     /// Additional implementation-defined metadata about the agent host itself.
     ///
-    /// Clients MAY look for well-known keys here to provide enhanced UI. For
-    /// example, a `hostBuild` key may carry build information (version, commit,
-    /// date) about the program hosting the agent host. Mirrors the MCP `_meta`
-    /// convention.
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<JsonObject>,
 }

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -552,6 +552,14 @@ pub struct RootState {
     /// Agent host configuration schema and current values
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<RootConfigState>,
+    /// Additional implementation-defined metadata about the agent host itself.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI. For
+    /// example, a `hostBuild` key may carry build information (version, commit,
+    /// date) about the program hosting the agent host. Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Live agent-host configuration metadata.

--- a/clients/rust/crates/ahp/examples/reducers_demo.rs
+++ b/clients/rust/crates/ahp/examples/reducers_demo.rs
@@ -23,6 +23,7 @@ fn main() {
         active_sessions: None,
         terminals: None,
         config: None,
+        meta: None,
     };
 
     let envelopes = vec![

--- a/clients/rust/crates/ahp/src/hosts/runtime.rs
+++ b/clients/rust/crates/ahp/src/hosts/runtime.rs
@@ -98,6 +98,7 @@ pub(super) fn spawn(
             active_sessions: None,
             terminals: None,
             config: None,
+            meta: None,
         },
         subscriptions: config.initial_subscriptions.clone(),
         completion_trigger_characters: vec![],

--- a/clients/rust/crates/ahp/src/lib.rs
+++ b/clients/rust/crates/ahp/src/lib.rs
@@ -116,6 +116,7 @@
 //!     active_sessions: None,
 //!     terminals: None,
 //!     config: None,
+//!     meta: None,
 //! };
 //!
 //! let action = StateAction::RootActiveSessionsChanged(

--- a/clients/rust/crates/ahp/src/multi_host_state_mirror.rs
+++ b/clients/rust/crates/ahp/src/multi_host_state_mirror.rs
@@ -137,6 +137,7 @@ impl MultiHostStateMirror {
                     active_sessions: None,
                     terminals: None,
                     config: None,
+                    meta: None,
                 });
             apply_action_to_root(root, &envelope.action);
             return;

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -26,6 +26,7 @@
 //!     active_sessions: None,
 //!     terminals: None,
 //!     config: None,
+//!     meta: None,
 //! };
 //!
 //! // A root-scoped action mutates `RootState`.
@@ -1342,6 +1343,7 @@ mod tests {
             active_sessions: None,
             terminals: None,
             config: None,
+            meta: None,
         };
         let a = StateAction::RootActiveSessionsChanged(
             ahp_types::actions::RootActiveSessionsChangedAction { active_sessions: 3 },

--- a/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
+++ b/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
@@ -37,6 +37,7 @@ fn root_snapshot(agents: Vec<AgentInfo>) -> Snapshot {
             active_sessions: None,
             terminals: None,
             config: None,
+            meta: None,
         })),
         from_seq: 0,
     }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -452,10 +452,7 @@ public struct RootState: Codable, Sendable {
     public var config: RootConfigState?
     /// Additional implementation-defined metadata about the agent host itself.
     /// 
-    /// Clients MAY look for well-known keys here to provide enhanced UI. For
-    /// example, a `hostBuild` key may carry build information (version, commit,
-    /// date) about the program hosting the agent host. Mirrors the MCP `_meta`
-    /// convention.
+    /// Clients MAY look for well-known keys here to provide enhanced UI.
     public var meta: [String: AnyCodable]?
 
     enum CodingKeys: String, CodingKey {

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -450,17 +450,34 @@ public struct RootState: Codable, Sendable {
     public var terminals: [TerminalInfo]?
     /// Agent host configuration schema and current values
     public var config: RootConfigState?
+    /// Additional implementation-defined metadata about the agent host itself.
+    /// 
+    /// Clients MAY look for well-known keys here to provide enhanced UI. For
+    /// example, a `hostBuild` key may carry build information (version, commit,
+    /// date) about the program hosting the agent host. Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case agents
+        case activeSessions
+        case terminals
+        case config
+        case meta = "_meta"
+    }
 
     public init(
         agents: [AgentInfo],
         activeSessions: Int? = nil,
         terminals: [TerminalInfo]? = nil,
-        config: RootConfigState? = nil
+        config: RootConfigState? = nil,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.agents = agents
         self.activeSessions = activeSessions
         self.terminals = terminals
         self.config = config
+        self.meta = meta
     }
 }
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -17,6 +17,12 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ## [Unreleased]
 
+### Added
+
+- `RootState` now exposes an optional `_meta` property bag (`meta: [String:
+  AnyCodable]?`) for implementation-defined agent-host metadata, such as a
+  well-known `hostBuild` key carrying the host's build version/commit/date.
+
 ## [0.3.0] — 2026-06-05
 
 Implements AHP 0.3.0.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -20,6 +20,12 @@ hotfix escape hatch.
 
 ## [Unreleased]
 
+### Added
+
+- `RootState` now exposes an optional `_meta` property bag (`_meta?:
+  Record<string, unknown>`) for implementation-defined agent-host metadata, such
+  as a well-known `hostBuild` key carrying the host's build version/commit/date.
+
 ## [0.3.0] — 2026-06-05
 
 Implements AHP 0.3.0.

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1986,7 +1986,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI."
         }
       },
       "required": [

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1982,6 +1982,11 @@
         "config": {
           "$ref": "#/$defs/RootConfigState",
           "description": "Agent host configuration schema and current values"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1622,6 +1622,11 @@
         "config": {
           "$ref": "#/$defs/RootConfigState",
           "description": "Agent host configuration schema and current values"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1626,7 +1626,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -539,6 +539,11 @@
         "config": {
           "$ref": "#/$defs/RootConfigState",
           "description": "Agent host configuration schema and current values"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -543,7 +543,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -664,6 +664,11 @@
         "config": {
           "$ref": "#/$defs/RootConfigState",
           "description": "Agent host configuration schema and current values"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -668,7 +668,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -454,7 +454,7 @@
         "_meta": {
           "type": "object",
           "additionalProperties": {},
-          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -450,6 +450,11 @@
         "config": {
           "$ref": "#/$defs/RootConfigState",
           "description": "Agent host configuration schema and current values"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional implementation-defined metadata about the agent host itself.\n\nClients MAY look for well-known keys here to provide enhanced UI. For\nexample, a `hostBuild` key may carry build information (version, commit,\ndate) about the program hosting the agent host. Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [

--- a/types/channels-root/state.ts
+++ b/types/channels-root/state.ts
@@ -38,6 +38,15 @@ export interface RootState {
   terminals?: TerminalInfo[];
   /** Agent host configuration schema and current values */
   config?: RootConfigState;
+  /**
+   * Additional implementation-defined metadata about the agent host itself.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI. For
+   * example, a `hostBuild` key may carry build information (version, commit,
+   * date) about the program hosting the agent host. Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**

--- a/types/channels-root/state.ts
+++ b/types/channels-root/state.ts
@@ -41,10 +41,7 @@ export interface RootState {
   /**
    * Additional implementation-defined metadata about the agent host itself.
    *
-   * Clients MAY look for well-known keys here to provide enhanced UI. For
-   * example, a `hostBuild` key may carry build information (version, commit,
-   * date) about the program hosting the agent host. Mirrors the MCP `_meta`
-   * convention.
+   * Clients MAY look for well-known keys here to provide enhanced UI.
    */
   _meta?: Record<string, unknown>;
 }


### PR DESCRIPTION
## What

Adds an open `_meta?: Record<string, unknown>` property to `RootState`, mirroring the existing MCP-style `_meta` convention already used on `SessionState`, messages, tool calls, and `SessionModelInfo`.

This gives agent hosts a place to attach implementation-defined metadata about the **host itself** (as opposed to per-session metadata). The first intended consumer is a well-known `hostBuild` key carrying the hosting program's build information (version, commit, date), so a client can see which build is hosting  useful when inspecting the output of a remote agent host.it 

## Why on `RootState`

`RootState` is the agent host's own global state, delivered as a snapshot at connect time, so any client reliably receives the metadata as part of the handshake. The protocol itself stays  the `hostBuild` key is a convention layered on top of the open `_meta` bag, exactly like the existing `git` key on `SessionState._meta`.generic 

## Changes

- `types/channels-root/state.ts`: add `_meta` to `RootState`.
- Regenerated all client artifacts (Go, Kotlin, Rust, Swift, TypeScript) and JSON schemas via `npm run generate`.
- CHANGELOG entries added to the spec (`## [0.4.0]`) and every client's `## [Unreleased]`.

## Validation

`npm test` (typecheck + lint + `verify:release-metadata` + `verify:changelog` + reducer tests, 235 passing).

(Written by Copilot)
