### PR TITLE
Add reducer fixtures for editedToolInput override and MCP contributor

### DIFF
--- a/types/test-cases/reducers/158-toolcallconfirmed-approved-with-editedtoolinput-overrides-original.json
+++ b/types/test-cases/reducers/158-toolcallconfirmed-approved-with-editedtoolinput-overrides-original.json
@@ -1,0 +1,100 @@
+{
+  "description": "toolCallConfirmed approved with editedToolInput overrides the original toolInput in the running state",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 8,
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "bash",
+      "displayName": "Run Command"
+    },
+    {
+      "type": "session/toolCallReady",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Run: ls -la",
+      "toolInput": "ls -la"
+    },
+    {
+      "type": "session/toolCallConfirmed",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "approved": true,
+      "confirmed": "user-action",
+      "editedToolInput": "ls -la /tmp"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Ran command"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 8,
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "completed",
+            "toolCallId": "tc-1",
+            "toolName": "bash",
+            "displayName": "Run Command",
+            "contributor": null,
+            "_meta": null,
+            "invocationMessage": "Run: ls -la",
+            "toolInput": "ls -la /tmp",
+            "confirmed": "user-action",
+            "success": true,
+            "pastTenseMessage": "Ran command"
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}

--- a/types/test-cases/reducers/163-toolcallstart-carries-mcp-contributor-through-lifecycle.json
+++ b/types/test-cases/reducers/163-toolcallstart-carries-mcp-contributor-through-lifecycle.json
@@ -1,0 +1,100 @@
+{
+  "description": "session/toolCallStart with a non-null mcp contributor carries the contributor through tcBase across ready and complete",
+  "reducer": "session",
+  "initial": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 8,
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "session/toolCallStart",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "toolName": "search",
+      "displayName": "Search Files",
+      "contributor": {
+        "kind": "mcp",
+        "customizationId": "mcp-1"
+      }
+    },
+    {
+      "type": "session/toolCallReady",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "invocationMessage": "Search: foo",
+      "toolInput": "foo",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "session/toolCallComplete",
+      "turnId": "turn-1",
+      "toolCallId": "tc-1",
+      "result": {
+        "success": true,
+        "pastTenseMessage": "Searched files"
+      }
+    }
+  ],
+  "expected": {
+    "summary": {
+      "resource": "copilot:/test-session",
+      "provider": "copilot",
+      "title": "Test Session",
+      "status": 8,
+      "createdAt": 1000,
+      "modifiedAt": 2000
+    },
+    "lifecycle": "ready",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "completed",
+            "toolCallId": "tc-1",
+            "toolName": "search",
+            "displayName": "Search Files",
+            "contributor": {
+              "kind": "mcp",
+              "customizationId": "mcp-1"
+            },
+            "_meta": null,
+            "invocationMessage": "Search: foo",
+            "toolInput": "foo",
+            "confirmed": "not-needed",
+            "success": true,
+            "pastTenseMessage": "Searched files"
+          }
+        }
+      ],
+      "usage": null
+    }
+  }
+}


### PR DESCRIPTION
Two shared, language-neutral reducer fixtures that the cross-language fixture-driven reducer suites pick up automatically:

- `158` toolCallConfirmed approved with `editedToolInput` overrides the original tool input (this path — a user editing a tool's input in the approve dialog — was previously set in 0 of 124 session fixtures).
- `163` toolCallStart with a non-null MCP `contributor` carries the contributor through `tcBase` across the ready and complete transitions.

Both pass against the existing reducers; no client source changes.