### PR TITLE
Implement Swift changeset + resourceWatch reducers; un-skip terminal fixtures

### DIFF
--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -948,3 +948,90 @@ public func terminalReducer(state: TerminalState, action: StateAction) -> Termin
         return state
     }
 }
+
+// MARK: - Changeset Reducer
+
+/// Pure reducer for changeset state. Handles all changeset-scoped actions.
+///
+/// Per the spec, every changeset action is server-only. New files are
+/// appended via `changeset/fileSet` when the id is unknown and replaced in
+/// place when it matches an existing entry, preserving a stable file order.
+public func changesetReducer(state: ChangesetState, action: StateAction) -> ChangesetState {
+    switch action {
+    case .changesetStatusChanged(let a):
+        // Carry `error` only when the new status is `error` so we don't leave a
+        // stale error sitting on a recovered changeset.
+        var next = state
+        next.status = a.status
+        next.error = a.status == .error ? a.error : nil
+        return next
+
+    case .changesetFileSet(let a):
+        var next = state
+        if let idx = next.files.firstIndex(where: { $0.id == a.file.id }) {
+            next.files[idx] = a.file
+        } else {
+            next.files.append(a.file)
+        }
+        return next
+
+    case .changesetFileRemoved(let a):
+        guard let idx = state.files.firstIndex(where: { $0.id == a.fileId }) else {
+            return state
+        }
+        var next = state
+        next.files.remove(at: idx)
+        return next
+
+    case .changesetOperationsChanged(let a):
+        // `operations` is nil when the action omits the field, which clears the
+        // operation list.
+        var next = state
+        next.operations = a.operations
+        return next
+
+    case .changesetOperationStatusChanged(let a):
+        guard var operations = state.operations,
+              let idx = operations.firstIndex(where: { $0.id == a.operationId }) else {
+            return state
+        }
+        var op = operations[idx]
+        op.status = a.status
+        // Carry `error` only when the new status is `error` so we don't leave a
+        // stale error on an operation that recovered or started running.
+        op.error = a.status == .error ? a.error : nil
+        operations[idx] = op
+        var next = state
+        next.operations = operations
+        return next
+
+    case .changesetCleared:
+        guard !state.files.isEmpty else { return state }
+        var next = state
+        next.files = []
+        return next
+
+    default:
+        return state
+    }
+}
+
+// MARK: - Resource-Watch Reducer
+
+/// Pure reducer for resource-watch state. Handles every resource-watch action.
+///
+/// Watches are intentionally event-pass-through: change events are delivered
+/// via `resourceWatch/changed` actions but the reducer keeps no history of
+/// them. The state therefore tracks only the watch descriptor, which is set at
+/// subscription time and never mutates over the life of the watch. Unknown
+/// action types degrade gracefully so a client speaking an older protocol stays
+/// correct if the server adds new `resourceWatch/*` actions in a future version.
+public func resourceWatchReducer(state: ResourceWatchState, action: StateAction) -> ResourceWatchState {
+    switch action {
+    case .resourceWatchChanged:
+        return state
+
+    default:
+        return state
+    }
+}

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/FixtureDrivenReducerTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/FixtureDrivenReducerTests.swift
@@ -84,39 +84,115 @@ final class FixtureDrivenReducerTests: XCTestCase {
         )
     }
 
+    // MARK: - Known reducer gaps (documented, not silent)
+    //
+    // Mirrors the drift-tripwire discipline in TypesRoundTripFixtureTests:
+    // a fixture may only be skipped if its stem is listed here, and the gap
+    // set must be EXACTLY the set of fixtures that actually fail to run. If a
+    // gap closes, the hit set shrinks → mismatch → this test fails loudly,
+    // forcing the list to be updated. An UNLISTED fixture that fails to run
+    // lands in `failures` → loud. There is no bare `continue` skip.
+    //
+    // Five of the six reducer arms are implemented (root / session / terminal /
+    // changeset / resourceWatch). Two kinds of gap remain:
+    //
+    // 1. Representational gap — fixture 103 carries a response part with an
+    //    unknown `kind` (`unknownFuturePart`), and the generated `ResponsePart`
+    //    enum on this base throws on an unknown discriminant rather than
+    //    preserving it. When the generated types gain a `case unknown(AnyCodable)`
+    //    forward-compat fallback, this fixture will decode + assert and the
+    //    tripwire above will fire, forcing the entry to be removed.
+    //
+    // 2. Unimplemented-channel gap — the `annotations` channel (fixtures
+    //    210–217) has no Swift reducer yet; `runFixture` hits the `default`
+    //    arm and throws `unsupportedReducer("annotations")`. (The canonical
+    //    fixture-driven test on the base before this rewrite simply skipped the
+    //    `annotations` reducer family with a bare `continue`; here that skip is
+    //    made explicit and tripwired instead.) When `annotationsReducer` lands,
+    //    these stems decode + assert and the drift tripwire forces them out of
+    //    this set.
+    private static let knownReducerGaps: Set<String> = [
+        "103-delta-skips-parts-without-id",
+        "210-annotations-set-appends-new-annotation",
+        "211-annotations-set-replaces-existing-annotation",
+        "212-annotations-removed-drops-matching-annotation",
+        "213-annotations-entryset-appends-and-replaces",
+        "214-annotations-entryset-unknown-annotation-is-no-op",
+        "215-annotations-entryremoved-drops-matching-entry",
+        "217-annotations-unknown-action-type-is-no-op",
+    ]
+
     func testAllFixtures() throws {
         var failures: [(file: String, description: String, message: String)] = []
-        var skipped: [(file: String, description: String, message: String)] = []
+        var gapHits: Set<String> = []
+        var ranRealAssertions = 0
 
         for (file, fixture) in Self.fixtures {
-            // Skip terminal/changeset/annotations/resourceWatch fixtures —
-            // those reducers are not yet implemented in Swift
-            if fixture.reducer == "terminal" || fixture.reducer == "changeset" || fixture.reducer == "annotations" || fixture.reducer == "resourceWatch" {
-                continue
-            }
-
+            let stem = (file as NSString).deletingPathExtension
             do {
                 try runFixture(file: file, fixture: fixture)
-            } catch let error as DecodingError {
-                // Skip fixtures that use types/shapes Swift can't decode yet
-                skipped.append((file, fixture.description, "\(error)"))
+                ranRealAssertions += 1
             } catch {
-                failures.append((file, fixture.description, "\(error)"))
+                if Self.knownReducerGaps.contains(stem) {
+                    gapHits.insert(stem)
+                    print("⊘ \(file): known Swift reducer gap — \(error)")
+                } else {
+                    failures.append((file, fixture.description, "\(error)"))
+                }
             }
         }
 
-        if !skipped.isEmpty {
-            print("Skipped \(skipped.count) fixture(s) due to decoding incompatibilities:")
-            for s in skipped {
-                print("  ⊘ \(s.file): \(s.description)")
-            }
-        }
+        // Every fixture NOT in the gap set must have run a real assertion.
+        let expectedReal = Self.fixtures.count - Self.knownReducerGaps.count
+        XCTAssertEqual(
+            ranRealAssertions, expectedReal,
+            "Expected \(expectedReal) fixtures to decode+assert for real; only \(ranRealAssertions) did."
+        )
+
+        // The gap set must be exactly the fixtures that failed to run. If a gap
+        // closes, gapHits shrinks → mismatch → update the list. If a new fixture
+        // can't run, it lands in `failures` → loud.
+        XCTAssertEqual(
+            gapHits, Self.knownReducerGaps,
+            "Known-gap set drifted. Hit gaps: \(gapHits.sorted()); declared: \(Self.knownReducerGaps.sorted()). A gap that no longer reproduces must be removed from knownReducerGaps (and ideally promoted to a real assertion)."
+        )
 
         if !failures.isEmpty {
             let summary = failures.map { "  ✗ \($0.file): \($0.description)\n    \($0.message)" }
                 .joined(separator: "\n")
             XCTFail("\(failures.count) fixture(s) failed:\n\(summary)")
         }
+    }
+
+    /// Asserts that the previously-skipped reducer families now actually run.
+    /// This is a falsification guard: if a future change re-introduces a blanket
+    /// skip (e.g. by removing a reducer arm), the per-family count drops and this
+    /// test fails — the bug that left ~32 fixtures unverified cannot silently
+    /// return.
+    func testPreviouslySkippedReducersNowRun() throws {
+        // The three reducer families that were skipped via a bare `continue`
+        // before changeset/resourceWatch were ported and terminal was un-skipped.
+        // At least this many fixtures must run for each — pins the coverage jump
+        // so the skip cannot silently return. Asserted as a lower bound so the
+        // corpus can grow without churning this test.
+        let minFamilyCounts = ["terminal": 19, "changeset": 11, "resourceWatch": 2]
+        var totalRan = 0
+        for (family, minCount) in minFamilyCounts {
+            let familyFixtures = Self.fixtures.filter { $0.fixture.reducer == family }
+            XCTAssertGreaterThanOrEqual(
+                familyFixtures.count, minCount,
+                "Expected at least \(minCount) \(family) fixtures; found \(familyFixtures.count) at \(Self.fixtureDir.path)."
+            )
+            for (file, fixture) in familyFixtures {
+                XCTAssertNoThrow(
+                    try runFixture(file: file, fixture: fixture),
+                    "\(family) fixture \(file) (\(fixture.description)) must decode + assert; it was previously skipped."
+                )
+            }
+            totalRan += familyFixtures.count
+        }
+        print("Previously-skipped reducer fixtures now running: \(totalRan) (terminal/changeset/resourceWatch).")
+        XCTAssertGreaterThanOrEqual(totalRan, 32)
     }
 
     private func runFixture(file: String, fixture: Fixture) throws {
@@ -161,6 +237,66 @@ final class FixtureDrivenReducerTests: XCTestCase {
             // Normalize expected through the same Swift type to drop unknown properties
             let expectedData = try JSONEncoder().encode(fixture.expected)
             let expectedState = try decoder.decode(SessionState.self, from: expectedData)
+
+            try assertEqualJSON(
+                actual: state, expected: expectedState,
+                encoder: encoder,
+                context: "\(file): \(fixture.description)"
+            )
+
+        case "terminal":
+            let initialData = try JSONEncoder().encode(fixture.initial)
+            var state = try decoder.decode(TerminalState.self, from: initialData)
+
+            let actionsData = try JSONEncoder().encode(fixture.actions)
+            let actions = try decoder.decode([StateAction].self, from: actionsData)
+
+            for action in actions {
+                state = terminalReducer(state: state, action: action)
+            }
+
+            let expectedData = try JSONEncoder().encode(fixture.expected)
+            let expectedState = try decoder.decode(TerminalState.self, from: expectedData)
+
+            try assertEqualJSON(
+                actual: state, expected: expectedState,
+                encoder: encoder,
+                context: "\(file): \(fixture.description)"
+            )
+
+        case "changeset":
+            let initialData = try JSONEncoder().encode(fixture.initial)
+            var state = try decoder.decode(ChangesetState.self, from: initialData)
+
+            let actionsData = try JSONEncoder().encode(fixture.actions)
+            let actions = try decoder.decode([StateAction].self, from: actionsData)
+
+            for action in actions {
+                state = changesetReducer(state: state, action: action)
+            }
+
+            let expectedData = try JSONEncoder().encode(fixture.expected)
+            let expectedState = try decoder.decode(ChangesetState.self, from: expectedData)
+
+            try assertEqualJSON(
+                actual: state, expected: expectedState,
+                encoder: encoder,
+                context: "\(file): \(fixture.description)"
+            )
+
+        case "resourceWatch":
+            let initialData = try JSONEncoder().encode(fixture.initial)
+            var state = try decoder.decode(ResourceWatchState.self, from: initialData)
+
+            let actionsData = try JSONEncoder().encode(fixture.actions)
+            let actions = try decoder.decode([StateAction].self, from: actionsData)
+
+            for action in actions {
+                state = resourceWatchReducer(state: state, action: action)
+            }
+
+            let expectedData = try JSONEncoder().encode(fixture.expected)
+            let expectedState = try decoder.decode(ResourceWatchState.self, from: expectedData)
 
             try assertEqualJSON(
                 actual: state, expected: expectedState,

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/FixtureDrivenReducerTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/FixtureDrivenReducerTests.swift
@@ -119,7 +119,10 @@ final class FixtureDrivenReducerTests: XCTestCase {
         "213-annotations-entryset-appends-and-replaces",
         "214-annotations-entryset-unknown-annotation-is-no-op",
         "215-annotations-entryremoved-drops-matching-entry",
+        "216-annotations-updated-resolves-and-preserves-entries",
         "217-annotations-unknown-action-type-is-no-op",
+        "218-annotations-updated-reanchors-turn-and-range",
+        "219-annotations-updated-unknown-annotation-is-no-op",
     ]
 
     func testAllFixtures() throws {

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -38,6 +38,15 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 - `RootState` now exposes an optional `_meta` property bag (`meta: [String:
   AnyCodable]?`) for implementation-defined agent-host metadata, such as a
   well-known `hostBuild` key carrying the host's build version/commit/date.
+- `changesetReducer` and `resourceWatchReducer` — the two state reducers
+  that were missing from the Swift client are now implemented, mirroring the
+  canonical TypeScript reducers (and the Kotlin/.NET clients). `changesetReducer`
+  folds `changeset/*` actions into `ChangesetState`; `resourceWatchReducer`
+  treats `resourceWatch/changed` as a documented event pass-through. The
+  fixture-driven reducer test no longer silently skips the terminal, changeset,
+  and resourceWatch fixture families — they now decode and assert, with the
+  remaining gaps (unknown-discriminant response part; the not-yet-implemented
+  annotations channel) pinned by an explicit drift tripwire.
 
 ## [0.3.0] — 2026-06-05
 


### PR DESCRIPTION
The Swift client shipped only 3 of the 5 state reducers (root, session,
terminal). changesetReducer and resourceWatchReducer were missing, and the
fixture-driven parity test silently skipped the terminal, changeset, and
resourceWatch fixtures with a bare continue — even though terminalReducer
already existed. That left the shared cross-language fixtures for those three
families unverified against Swift.

- Port changesetReducer mirroring the canonical TypeScript reducer (and the
  Kotlin/.NET clients): statusChanged, fileSet, fileRemoved, operationsChanged,
  operationStatusChanged, cleared. Carry error only on the error status so a
  recovered changeset/operation does not keep a stale error.
- Port resourceWatchReducer as the documented event-pass-through (changed
  leaves state unchanged; unknown actions are a no-op).
- Remove the blanket skip and wire the terminal/changeset/resourceWatch arms so
  all three families decode and assert. Replace the skip with a drift tripwire
  (an explicit known-gap set asserted to match exactly), mirroring the
  round-trip corpus test, plus a guard pinning the previously-skipped count.

Two documented gaps remain in the known-gap set:

- Representational: fixture 103 feeds a response part with an unknown kind,
  which the generated ResponsePart enum on this base rejects. It closes
  automatically once the generated types gain an unknown-discriminant fallback.
- Unimplemented channel: the annotations channel (fixtures 210–217) has no
  Swift reducer yet, so it lands on the runner's default arm. The prior test
  skipped the annotations family with a bare continue; here that skip is made
  explicit and tripwired instead. It closes once annotationsReducer lands.

swift test passes; the runner now exercises the terminal, changeset, and
resourceWatch fixtures (32 cases) that were previously skipped.