### PR TITLE
Allow partial updates to annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ Spec version: `0.4.0`
 
 ### Added
 
+- `annotations/updated` (`AnnotationsUpdatedAction`) — a client-dispatchable
+  action that partially updates an existing annotation's own properties
+  (`turnId`, `resource`, `range`, `resolved`) without resending its entries.
+  Resolving or re-anchoring an annotation no longer requires replacing the
+  whole annotation via `annotations/set`. Omitted fields are left unchanged;
+  the annotation's `entries`, `id`, and `_meta` are never touched.
 - `RootState` now carries an optional `_meta` property bag for
   implementation-defined metadata about the agent host itself, mirroring the
   MCP `_meta` convention. A well-known `hostBuild` key may carry build

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,6 +16,13 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `AnnotationsUpdatedAction` (`annotations/updated`) — partially updates an
+  existing annotation's `TurnID` / `Resource` / `Range` / `Resolved` without
+  resending its entries. Handled by the annotations reducer (no-op on unknown
+  id).
+
+### Added
+
 - `RootState` now exposes an optional `_meta` property bag (`Meta
   map[string]json.RawMessage`) for implementation-defined agent-host metadata,
   such as a well-known `hostBuild` key carrying the host's build

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -1177,6 +1177,7 @@ func ApplyActionToAnnotations(state *ahptypes.AnnotationsState, action ahptypes.
 	_ = state
 	switch action.Value.(type) {
 	case *ahptypes.AnnotationsSetAction,
+		*ahptypes.AnnotationsUpdatedAction,
 		*ahptypes.AnnotationsRemovedAction,
 		*ahptypes.AnnotationsEntrySetAction,
 		*ahptypes.AnnotationsEntryRemovedAction:

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -69,6 +69,7 @@ const (
 	ActionTypeChangesetOperationStatusChanged   ActionType = "changeset/operationStatusChanged"
 	ActionTypeChangesetCleared                  ActionType = "changeset/cleared"
 	ActionTypeAnnotationsSet                    ActionType = "annotations/set"
+	ActionTypeAnnotationsUpdated                ActionType = "annotations/updated"
 	ActionTypeAnnotationsRemoved                ActionType = "annotations/removed"
 	ActionTypeAnnotationsEntrySet               ActionType = "annotations/entrySet"
 	ActionTypeAnnotationsEntryRemoved           ActionType = "annotations/entryRemoved"
@@ -809,12 +810,50 @@ type ChangesetClearedAction struct {
 // dispatching client assigns the {@link Annotation.id} and the id of any
 // new entry. When replacing, the full annotation payload (including its
 // {@link Annotation.entries | entries} list) is substituted; producers
-// SHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits to
-// keep wire updates small.
+// SHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and
+// {@link AnnotationsUpdatedAction} to resolve / re-anchor an existing
+// annotation, to keep wire updates small.
 type AnnotationsSetAction struct {
 	Type ActionType `json:"type"`
 	// The new or replacement annotation. MUST contain at least one entry.
 	Annotation Annotation `json:"annotation"`
+}
+
+// Partially update an existing {@link Annotation}'s own properties — a narrow
+// alternative to {@link AnnotationsSetAction} for the common case of resolving
+// / re-opening or re-anchoring an annotation without resending its
+// {@link Annotation.entries | entries}.
+//
+// Targets one annotation by its {@link annotationId}. Only the fields present
+// on the action are written; omitted fields leave the corresponding
+// {@link Annotation} property unchanged. The annotation's
+// {@link Annotation.entries | entries}, {@link Annotation.id | id}, and
+// {@link Annotation._meta | _meta} are never touched — dispatch
+// {@link AnnotationsSetAction} to replace those, to clear {@link range}
+// (re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /
+// {@link AnnotationsEntryRemovedAction} to edit individual entries.
+//
+// If {@link annotationId} does not match any current annotation the action is
+// a no-op.
+type AnnotationsUpdatedAction struct {
+	Type ActionType `json:"type"`
+	// The {@link Annotation.id} of the annotation to update.
+	AnnotationId string `json:"annotationId"`
+	// Re-anchors the annotation to the file versions this turn produced.
+	// Matches a {@link Turn.id} on the owning session. Omit to leave the
+	// current {@link Annotation.turnId} unchanged.
+	TurnId *string `json:"turnId,omitempty"`
+	// Re-anchors the annotation to this file. Omit to leave the current
+	// {@link Annotation.resource} unchanged.
+	Resource *URI `json:"resource,omitempty"`
+	// Narrows the annotation to this range within {@link resource}. Omit to
+	// leave the current {@link Annotation.range} unchanged; this action cannot
+	// clear an existing range — dispatch {@link AnnotationsSetAction} to
+	// re-anchor to the whole file.
+	Range *TextRange `json:"range,omitempty"`
+	// Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to
+	// leave the current {@link Annotation.resolved} state unchanged.
+	Resolved *bool `json:"resolved,omitempty"`
 }
 
 // Remove an {@link Annotation} from the channel by its id.
@@ -1063,6 +1102,7 @@ func (*ChangesetOperationsChangedAction) isStateAction()        {}
 func (*ChangesetOperationStatusChangedAction) isStateAction()   {}
 func (*ChangesetClearedAction) isStateAction()                  {}
 func (*AnnotationsSetAction) isStateAction()                    {}
+func (*AnnotationsUpdatedAction) isStateAction()                {}
 func (*AnnotationsRemovedAction) isStateAction()                {}
 func (*AnnotationsEntrySetAction) isStateAction()               {}
 func (*AnnotationsEntryRemovedAction) isStateAction()           {}
@@ -1396,6 +1436,12 @@ func (u *StateAction) UnmarshalJSON(data []byte) error {
 		u.Value = &value
 	case "annotations/set":
 		var value AnnotationsSetAction
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "annotations/updated":
+		var value AnnotationsUpdatedAction
 		if err := json.Unmarshal(data, &value); err != nil {
 			return err
 		}

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -2449,8 +2449,9 @@ type Annotation struct {
 	Range *TextRange `json:"range,omitempty"`
 	// Whether the annotation has been resolved. Newly created annotations are
 	// always unresolved (`false`); a client marks an annotation resolved (or
-	// re-opens it) by dispatching an {@link AnnotationsSetAction} carrying the
-	// updated flag.
+	// re-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying
+	// the updated flag (or an {@link AnnotationsSetAction} when replacing the
+	// whole annotation).
 	Resolved bool `json:"resolved"`
 	// Entries in this annotation, in dispatch order (oldest first). MUST
 	// contain at least one entry.

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -17,6 +17,13 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Added
 
+- `AnnotationsUpdatedAction` (`annotations/updated`) — partially updates an
+  existing annotation's `turnId` / `resource` / `range` / `resolved` without
+  resending its entries. Handled by the annotations reducer (no-op on unknown
+  id).
+
+### Added
+
 - `RootState` now exposes an optional `_meta` property bag (`meta: Map<String,
   JsonElement>?`) for implementation-defined agent-host metadata, such as a
   well-known `hostBuild` key carrying the host's build version/commit/date.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -59,6 +59,7 @@ import com.microsoft.agenthostprotocol.generated.StateActionAnnotationsEntryRemo
 import com.microsoft.agenthostprotocol.generated.StateActionAnnotationsEntrySet
 import com.microsoft.agenthostprotocol.generated.StateActionAnnotationsRemoved
 import com.microsoft.agenthostprotocol.generated.StateActionAnnotationsSet
+import com.microsoft.agenthostprotocol.generated.StateActionAnnotationsUpdated
 import com.microsoft.agenthostprotocol.generated.StateActionRootActiveSessionsChanged
 import com.microsoft.agenthostprotocol.generated.StateActionRootAgentsChanged
 import com.microsoft.agenthostprotocol.generated.StateActionRootConfigChanged
@@ -1425,6 +1426,23 @@ public fun annotationsReducer(state: AnnotationsState, action: StateAction): Ann
             state.copy(annotations = state.annotations + annotation)
         } else {
             val next = state.annotations.toMutableList().also { it[idx] = annotation }
+            state.copy(annotations = next)
+        }
+    }
+
+    is StateActionAnnotationsUpdated -> {
+        val idx = state.annotations.indexOfFirst { it.id == action.value.annotationId }
+        if (idx < 0) {
+            state
+        } else {
+            val annotation = state.annotations[idx]
+            val updated = annotation.copy(
+                turnId = action.value.turnId ?: annotation.turnId,
+                resource = action.value.resource ?: annotation.resource,
+                range = action.value.range ?: annotation.range,
+                resolved = action.value.resolved ?: annotation.resolved
+            )
+            val next = state.annotations.toMutableList().also { it[idx] = updated }
             state.copy(annotations = next)
         }
     }

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -126,6 +126,8 @@ enum class ActionType {
     CHANGESET_CLEARED,
     @SerialName("annotations/set")
     ANNOTATIONS_SET,
+    @SerialName("annotations/updated")
+    ANNOTATIONS_UPDATED,
     @SerialName("annotations/removed")
     ANNOTATIONS_REMOVED,
     @SerialName("annotations/entrySet")
@@ -895,6 +897,38 @@ data class AnnotationsSetAction(
 )
 
 @Serializable
+data class AnnotationsUpdatedAction(
+    val type: ActionType,
+    /**
+     * The {@link Annotation.id} of the annotation to update.
+     */
+    val annotationId: String,
+    /**
+     * Re-anchors the annotation to the file versions this turn produced.
+     * Matches a {@link Turn.id} on the owning session. Omit to leave the
+     * current {@link Annotation.turnId} unchanged.
+     */
+    val turnId: String? = null,
+    /**
+     * Re-anchors the annotation to this file. Omit to leave the current
+     * {@link Annotation.resource} unchanged.
+     */
+    val resource: String? = null,
+    /**
+     * Narrows the annotation to this range within {@link resource}. Omit to
+     * leave the current {@link Annotation.range} unchanged; this action cannot
+     * clear an existing range — dispatch {@link AnnotationsSetAction} to
+     * re-anchor to the whole file.
+     */
+    val range: TextRange? = null,
+    /**
+     * Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to
+     * leave the current {@link Annotation.resolved} state unchanged.
+     */
+    val resolved: Boolean? = null
+)
+
+@Serializable
 data class AnnotationsRemovedAction(
     val type: ActionType,
     /**
@@ -1138,6 +1172,7 @@ sealed interface StateAction
 @JvmInline value class StateActionChangesetOperationStatusChanged(val value: ChangesetOperationStatusChangedAction) : StateAction
 @JvmInline value class StateActionChangesetCleared(val value: ChangesetClearedAction) : StateAction
 @JvmInline value class StateActionAnnotationsSet(val value: AnnotationsSetAction) : StateAction
+@JvmInline value class StateActionAnnotationsUpdated(val value: AnnotationsUpdatedAction) : StateAction
 @JvmInline value class StateActionAnnotationsRemoved(val value: AnnotationsRemovedAction) : StateAction
 @JvmInline value class StateActionAnnotationsEntrySet(val value: AnnotationsEntrySetAction) : StateAction
 @JvmInline value class StateActionAnnotationsEntryRemoved(val value: AnnotationsEntryRemovedAction) : StateAction
@@ -1220,6 +1255,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             "changeset/operationStatusChanged" -> StateActionChangesetOperationStatusChanged(input.json.decodeFromJsonElement(ChangesetOperationStatusChangedAction.serializer(), element))
             "changeset/cleared" -> StateActionChangesetCleared(input.json.decodeFromJsonElement(ChangesetClearedAction.serializer(), element))
             "annotations/set" -> StateActionAnnotationsSet(input.json.decodeFromJsonElement(AnnotationsSetAction.serializer(), element))
+            "annotations/updated" -> StateActionAnnotationsUpdated(input.json.decodeFromJsonElement(AnnotationsUpdatedAction.serializer(), element))
             "annotations/removed" -> StateActionAnnotationsRemoved(input.json.decodeFromJsonElement(AnnotationsRemovedAction.serializer(), element))
             "annotations/entrySet" -> StateActionAnnotationsEntrySet(input.json.decodeFromJsonElement(AnnotationsEntrySetAction.serializer(), element))
             "annotations/entryRemoved" -> StateActionAnnotationsEntryRemoved(input.json.decodeFromJsonElement(AnnotationsEntryRemovedAction.serializer(), element))
@@ -1295,6 +1331,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             is StateActionChangesetOperationStatusChanged -> output.json.encodeToJsonElement(ChangesetOperationStatusChangedAction.serializer(), value.value)
             is StateActionChangesetCleared -> output.json.encodeToJsonElement(ChangesetClearedAction.serializer(), value.value)
             is StateActionAnnotationsSet -> output.json.encodeToJsonElement(AnnotationsSetAction.serializer(), value.value)
+            is StateActionAnnotationsUpdated -> output.json.encodeToJsonElement(AnnotationsUpdatedAction.serializer(), value.value)
             is StateActionAnnotationsRemoved -> output.json.encodeToJsonElement(AnnotationsRemovedAction.serializer(), value.value)
             is StateActionAnnotationsEntrySet -> output.json.encodeToJsonElement(AnnotationsEntrySetAction.serializer(), value.value)
             is StateActionAnnotationsEntryRemoved -> output.json.encodeToJsonElement(AnnotationsEntryRemovedAction.serializer(), value.value)

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -3404,8 +3404,9 @@ data class Annotation(
     /**
      * Whether the annotation has been resolved. Newly created annotations are
      * always unresolved (`false`); a client marks an annotation resolved (or
-     * re-opens it) by dispatching an {@link AnnotationsSetAction} carrying the
-     * updated flag.
+     * re-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying
+     * the updated flag (or an {@link AnnotationsSetAction} when replacing the
+     * whole annotation).
      */
     val resolved: Boolean,
     /**

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,6 +17,13 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `AnnotationsUpdatedAction` (`annotations/updated`) — partially updates an
+  existing annotation's `turn_id` / `resource` / `range` / `resolved` without
+  resending its entries. Handled by the annotations reducer (no-op on unknown
+  id).
+
+### Added
+
 - `RootState` now exposes an optional `_meta` property bag (`meta:
   Option<JsonObject>`) for implementation-defined agent-host metadata, such as
   a well-known `hostBuild` key carrying the host's build version/commit/date.

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -126,6 +126,8 @@ pub enum ActionType {
     ChangesetCleared,
     #[serde(rename = "annotations/set")]
     AnnotationsSet,
+    #[serde(rename = "annotations/updated")]
+    AnnotationsUpdated,
     #[serde(rename = "annotations/removed")]
     AnnotationsRemoved,
     #[serde(rename = "annotations/entrySet")]
@@ -985,13 +987,56 @@ pub struct ChangesetClearedAction {}
 /// dispatching client assigns the {@link Annotation.id} and the id of any
 /// new entry. When replacing, the full annotation payload (including its
 /// {@link Annotation.entries | entries} list) is substituted; producers
-/// SHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits to
-/// keep wire updates small.
+/// SHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and
+/// {@link AnnotationsUpdatedAction} to resolve / re-anchor an existing
+/// annotation, to keep wire updates small.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AnnotationsSetAction {
     /// The new or replacement annotation. MUST contain at least one entry.
     pub annotation: Annotation,
+}
+
+/// Partially update an existing {@link Annotation}'s own properties — a narrow
+/// alternative to {@link AnnotationsSetAction} for the common case of resolving
+/// / re-opening or re-anchoring an annotation without resending its
+/// {@link Annotation.entries | entries}.
+///
+/// Targets one annotation by its {@link annotationId}. Only the fields present
+/// on the action are written; omitted fields leave the corresponding
+/// {@link Annotation} property unchanged. The annotation's
+/// {@link Annotation.entries | entries}, {@link Annotation.id | id}, and
+/// {@link Annotation._meta | _meta} are never touched — dispatch
+/// {@link AnnotationsSetAction} to replace those, to clear {@link range}
+/// (re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /
+/// {@link AnnotationsEntryRemovedAction} to edit individual entries.
+///
+/// If {@link annotationId} does not match any current annotation the action is
+/// a no-op.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotationsUpdatedAction {
+    /// The {@link Annotation.id} of the annotation to update.
+    pub annotation_id: String,
+    /// Re-anchors the annotation to the file versions this turn produced.
+    /// Matches a {@link Turn.id} on the owning session. Omit to leave the
+    /// current {@link Annotation.turnId} unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    /// Re-anchors the annotation to this file. Omit to leave the current
+    /// {@link Annotation.resource} unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<Uri>,
+    /// Narrows the annotation to this range within {@link resource}. Omit to
+    /// leave the current {@link Annotation.range} unchanged; this action cannot
+    /// clear an existing range — dispatch {@link AnnotationsSetAction} to
+    /// re-anchor to the whole file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range: Option<TextRange>,
+    /// Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to
+    /// leave the current {@link Annotation.resolved} state unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved: Option<bool>,
 }
 
 /// Remove an {@link Annotation} from the channel by its id.
@@ -1303,6 +1348,8 @@ pub enum StateAction {
     ChangesetCleared(ChangesetClearedAction),
     #[serde(rename = "annotations/set")]
     AnnotationsSet(AnnotationsSetAction),
+    #[serde(rename = "annotations/updated")]
+    AnnotationsUpdated(AnnotationsUpdatedAction),
     #[serde(rename = "annotations/removed")]
     AnnotationsRemoved(AnnotationsRemovedAction),
     #[serde(rename = "annotations/entrySet")]

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -16,7 +16,7 @@ use crate::state::{
     ChangesetOperation, ChangesetOperationStatus, ChangesetStatus, ConfirmationOption,
     Customization, ErrorInfo, McpServerState, Message, ModelSelection, PendingMessageKind,
     ResponsePart, SessionActiveClient, SessionInputAnswer, SessionInputRequest,
-    SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallCancellationReason,
+    SessionInputResponseKind, TerminalClaim, TerminalInfo, TextRange, ToolCallCancellationReason,
     ToolCallConfirmationReason, ToolCallContributor, ToolCallResult, ToolDefinition,
     ToolResultContent, UsageInfo,
 };

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -2942,8 +2942,9 @@ pub struct Annotation {
     pub range: Option<TextRange>,
     /// Whether the annotation has been resolved. Newly created annotations are
     /// always unresolved (`false`); a client marks an annotation resolved (or
-    /// re-opens it) by dispatching an {@link AnnotationsSetAction} carrying the
-    /// updated flag.
+    /// re-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying
+    /// the updated flag (or an {@link AnnotationsSetAction} when replacing the
+    /// whole annotation).
     pub resolved: bool,
     /// Entries in this annotation, in dispatch order (oldest first). MUST
     /// contain at least one entry.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -56,6 +56,7 @@ public enum ActionType: String, Codable, Sendable {
     case changesetOperationStatusChanged = "changeset/operationStatusChanged"
     case changesetCleared = "changeset/cleared"
     case annotationsSet = "annotations/set"
+    case annotationsUpdated = "annotations/updated"
     case annotationsRemoved = "annotations/removed"
     case annotationsEntrySet = "annotations/entrySet"
     case annotationsEntryRemoved = "annotations/entryRemoved"
@@ -1154,6 +1155,43 @@ public struct AnnotationsSetAction: Codable, Sendable {
     }
 }
 
+public struct AnnotationsUpdatedAction: Codable, Sendable {
+    public var type: ActionType
+    /// The {@link Annotation.id} of the annotation to update.
+    public var annotationId: String
+    /// Re-anchors the annotation to the file versions this turn produced.
+    /// Matches a {@link Turn.id} on the owning session. Omit to leave the
+    /// current {@link Annotation.turnId} unchanged.
+    public var turnId: String?
+    /// Re-anchors the annotation to this file. Omit to leave the current
+    /// {@link Annotation.resource} unchanged.
+    public var resource: String?
+    /// Narrows the annotation to this range within {@link resource}. Omit to
+    /// leave the current {@link Annotation.range} unchanged; this action cannot
+    /// clear an existing range — dispatch {@link AnnotationsSetAction} to
+    /// re-anchor to the whole file.
+    public var range: TextRange?
+    /// Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to
+    /// leave the current {@link Annotation.resolved} state unchanged.
+    public var resolved: Bool?
+
+    public init(
+        type: ActionType,
+        annotationId: String,
+        turnId: String? = nil,
+        resource: String? = nil,
+        range: TextRange? = nil,
+        resolved: Bool? = nil
+    ) {
+        self.type = type
+        self.annotationId = annotationId
+        self.turnId = turnId
+        self.resource = resource
+        self.range = range
+        self.resolved = resolved
+    }
+}
+
 public struct AnnotationsRemovedAction: Codable, Sendable {
     public var type: ActionType
     /// The {@link Annotation.id} of the annotation to remove.
@@ -1473,6 +1511,7 @@ public enum StateAction: Codable, Sendable {
     case changesetOperationStatusChanged(ChangesetOperationStatusChangedAction)
     case changesetCleared(ChangesetClearedAction)
     case annotationsSet(AnnotationsSetAction)
+    case annotationsUpdated(AnnotationsUpdatedAction)
     case annotationsRemoved(AnnotationsRemovedAction)
     case annotationsEntrySet(AnnotationsEntrySetAction)
     case annotationsEntryRemoved(AnnotationsEntryRemovedAction)
@@ -1599,6 +1638,8 @@ public enum StateAction: Codable, Sendable {
             self = .changesetCleared(try ChangesetClearedAction(from: decoder))
         case "annotations/set":
             self = .annotationsSet(try AnnotationsSetAction(from: decoder))
+        case "annotations/updated":
+            self = .annotationsUpdated(try AnnotationsUpdatedAction(from: decoder))
         case "annotations/removed":
             self = .annotationsRemoved(try AnnotationsRemovedAction(from: decoder))
         case "annotations/entrySet":
@@ -1690,6 +1731,7 @@ public enum StateAction: Codable, Sendable {
         case .changesetOperationStatusChanged(let v): try v.encode(to: encoder)
         case .changesetCleared(let v): try v.encode(to: encoder)
         case .annotationsSet(let v): try v.encode(to: encoder)
+        case .annotationsUpdated(let v): try v.encode(to: encoder)
         case .annotationsRemoved(let v): try v.encode(to: encoder)
         case .annotationsEntrySet(let v): try v.encode(to: encoder)
         case .annotationsEntryRemoved(let v): try v.encode(to: encoder)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -3722,8 +3722,9 @@ public struct Annotation: Codable, Sendable {
     public var range: TextRange?
     /// Whether the annotation has been resolved. Newly created annotations are
     /// always unresolved (`false`); a client marks an annotation resolved (or
-    /// re-opens it) by dispatching an {@link AnnotationsSetAction} carrying the
-    /// updated flag.
+    /// re-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying
+    /// the updated flag (or an {@link AnnotationsSetAction} when replacing the
+    /// whole annotation).
     public var resolved: Bool
     /// Entries in this annotation, in dispatch order (oldest first). MUST
     /// contain at least one entry.

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,6 +19,13 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
+- `AnnotationsUpdatedAction` (`annotations/updated`) — partially updates an
+  existing annotation's `turnId` / `resource` / `range` / `resolved` without
+  resending its entries. Handled by the annotations reducer (no-op on unknown
+  id).
+
+### Added
+
 - `RootState` now exposes an optional `_meta` property bag (`meta: [String:
   AnyCodable]?`) for implementation-defined agent-host metadata, such as a
   well-known `hostBuild` key carrying the host's build version/commit/date.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,6 +22,12 @@ hotfix escape hatch.
 
 ### Added
 
+- `AnnotationsUpdatedAction` (`annotations/updated`) — partially updates an
+  existing annotation's `turnId` / `resource` / `range` / `resolved` without
+  resending its entries. Handled by `annotationsReducer` (no-op on unknown id).
+
+### Added
+
 - `RootState` now exposes an optional `_meta` property bag (`_meta?:
   Record<string, unknown>`) for implementation-defined agent-host metadata, such
   as a well-known `hostBuild` key carrying the host's build version/commit/date.

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -156,6 +156,7 @@ Annotations actions travel on a session's annotations channel (`ahp-session:/<uu
 | Type | Client-dispatchable? | When |
 |---|---|---|
 | `annotations/set` | **Yes** | Upsert an annotation — create one with its mandatory first entry, or re-anchor / resolve an existing one |
+| `annotations/updated` | **Yes** | Partially update an annotation's own properties (resolve / re-open, re-anchor) without resending its entries |
 | `annotations/removed` | **Yes** | Remove an entire annotation (and every entry it contains) |
 | `annotations/entrySet` | **Yes** | Upsert a single entry within an annotation (add or edit) |
 | `annotations/entryRemoved` | **Yes** | Remove a single entry; dispatch `annotations/removed` instead to drop the last remaining entry |

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1502,7 +1502,7 @@
     },
     "AnnotationsSetAction": {
       "type": "object",
-      "description": "Upsert an {@link Annotation} in the annotations channel — adds a new\nannotation, or replaces an existing one identified by\n{@link Annotation.id}.\n\nDispatched by a client to create an annotation (together with its\nmandatory first entry) or to re-anchor / resolve an existing one; the\ndispatching client assigns the {@link Annotation.id} and the id of any\nnew entry. When replacing, the full annotation payload (including its\n{@link Annotation.entries | entries} list) is substituted; producers\nSHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits to\nkeep wire updates small.",
+      "description": "Upsert an {@link Annotation} in the annotations channel — adds a new\nannotation, or replaces an existing one identified by\n{@link Annotation.id}.\n\nDispatched by a client to create an annotation (together with its\nmandatory first entry) or to re-anchor / resolve an existing one; the\ndispatching client assigns the {@link Annotation.id} and the id of any\nnew entry. When replacing, the full annotation payload (including its\n{@link Annotation.entries | entries} list) is substituted; producers\nSHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and\n{@link AnnotationsUpdatedAction} to resolve / re-anchor an existing\nannotation, to keep wire updates small.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.AnnotationsSet"
@@ -1515,6 +1515,39 @@
       "required": [
         "type",
         "annotation"
+      ]
+    },
+    "AnnotationsUpdatedAction": {
+      "type": "object",
+      "description": "Partially update an existing {@link Annotation}'s own properties — a narrow\nalternative to {@link AnnotationsSetAction} for the common case of resolving\n/ re-opening or re-anchoring an annotation without resending its\n{@link Annotation.entries | entries}.\n\nTargets one annotation by its {@link annotationId}. Only the fields present\non the action are written; omitted fields leave the corresponding\n{@link Annotation} property unchanged. The annotation's\n{@link Annotation.entries | entries}, {@link Annotation.id | id}, and\n{@link Annotation._meta | _meta} are never touched — dispatch\n{@link AnnotationsSetAction} to replace those, to clear {@link range}\n(re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /\n{@link AnnotationsEntryRemovedAction} to edit individual entries.\n\nIf {@link annotationId} does not match any current annotation the action is\na no-op.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.AnnotationsUpdated"
+        },
+        "annotationId": {
+          "type": "string",
+          "description": "The {@link Annotation.id} of the annotation to update."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Re-anchors the annotation to the file versions this turn produced.\nMatches a {@link Turn.id} on the owning session. Omit to leave the\ncurrent {@link Annotation.turnId} unchanged."
+        },
+        "resource": {
+          "$ref": "#/$defs/URI",
+          "description": "Re-anchors the annotation to this file. Omit to leave the current\n{@link Annotation.resource} unchanged."
+        },
+        "range": {
+          "$ref": "#/$defs/TextRange",
+          "description": "Narrows the annotation to this range within {@link resource}. Omit to\nleave the current {@link Annotation.range} unchanged; this action cannot\nclear an existing range — dispatch {@link AnnotationsSetAction} to\nre-anchor to the whole file."
+        },
+        "resolved": {
+          "type": "boolean",
+          "description": "Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to\nleave the current {@link Annotation.resolved} state unchanged."
+        }
+      },
+      "required": [
+        "type",
+        "annotationId"
       ]
     },
     "AnnotationsRemovedAction": {
@@ -5405,7 +5438,7 @@
         },
         "resolved": {
           "type": "boolean",
-          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsSetAction} carrying the\nupdated flag."
+          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying\nthe updated flag (or an {@link AnnotationsSetAction} when replacing the\nwhole annotation)."
         },
         "entries": {
           "type": "array",
@@ -5980,6 +6013,9 @@
         },
         {
           "$ref": "#/$defs/AnnotationsSetAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsUpdatedAction"
         },
         {
           "$ref": "#/$defs/AnnotationsRemovedAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -4967,7 +4967,7 @@
         },
         "resolved": {
           "type": "boolean",
-          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsSetAction} carrying the\nupdated flag."
+          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying\nthe updated flag (or an {@link AnnotationsSetAction} when replacing the\nwhole annotation)."
         },
         "entries": {
           "type": "array",
@@ -6588,7 +6588,7 @@
     },
     "AnnotationsSetAction": {
       "type": "object",
-      "description": "Upsert an {@link Annotation} in the annotations channel — adds a new\nannotation, or replaces an existing one identified by\n{@link Annotation.id}.\n\nDispatched by a client to create an annotation (together with its\nmandatory first entry) or to re-anchor / resolve an existing one; the\ndispatching client assigns the {@link Annotation.id} and the id of any\nnew entry. When replacing, the full annotation payload (including its\n{@link Annotation.entries | entries} list) is substituted; producers\nSHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits to\nkeep wire updates small.",
+      "description": "Upsert an {@link Annotation} in the annotations channel — adds a new\nannotation, or replaces an existing one identified by\n{@link Annotation.id}.\n\nDispatched by a client to create an annotation (together with its\nmandatory first entry) or to re-anchor / resolve an existing one; the\ndispatching client assigns the {@link Annotation.id} and the id of any\nnew entry. When replacing, the full annotation payload (including its\n{@link Annotation.entries | entries} list) is substituted; producers\nSHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and\n{@link AnnotationsUpdatedAction} to resolve / re-anchor an existing\nannotation, to keep wire updates small.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ActionType.AnnotationsSet"
@@ -6601,6 +6601,39 @@
       "required": [
         "type",
         "annotation"
+      ]
+    },
+    "AnnotationsUpdatedAction": {
+      "type": "object",
+      "description": "Partially update an existing {@link Annotation}'s own properties — a narrow\nalternative to {@link AnnotationsSetAction} for the common case of resolving\n/ re-opening or re-anchoring an annotation without resending its\n{@link Annotation.entries | entries}.\n\nTargets one annotation by its {@link annotationId}. Only the fields present\non the action are written; omitted fields leave the corresponding\n{@link Annotation} property unchanged. The annotation's\n{@link Annotation.entries | entries}, {@link Annotation.id | id}, and\n{@link Annotation._meta | _meta} are never touched — dispatch\n{@link AnnotationsSetAction} to replace those, to clear {@link range}\n(re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /\n{@link AnnotationsEntryRemovedAction} to edit individual entries.\n\nIf {@link annotationId} does not match any current annotation the action is\na no-op.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.AnnotationsUpdated"
+        },
+        "annotationId": {
+          "type": "string",
+          "description": "The {@link Annotation.id} of the annotation to update."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Re-anchors the annotation to the file versions this turn produced.\nMatches a {@link Turn.id} on the owning session. Omit to leave the\ncurrent {@link Annotation.turnId} unchanged."
+        },
+        "resource": {
+          "$ref": "#/$defs/URI",
+          "description": "Re-anchors the annotation to this file. Omit to leave the current\n{@link Annotation.resource} unchanged."
+        },
+        "range": {
+          "$ref": "#/$defs/TextRange",
+          "description": "Narrows the annotation to this range within {@link resource}. Omit to\nleave the current {@link Annotation.range} unchanged; this action cannot\nclear an existing range — dispatch {@link AnnotationsSetAction} to\nre-anchor to the whole file."
+        },
+        "resolved": {
+          "type": "boolean",
+          "description": "Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to\nleave the current {@link Annotation.resolved} state unchanged."
+        }
+      },
+      "required": [
+        "type",
+        "annotationId"
       ]
     },
     "AnnotationsRemovedAction": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -3884,7 +3884,7 @@
         },
         "resolved": {
           "type": "boolean",
-          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsSetAction} carrying the\nupdated flag."
+          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying\nthe updated flag (or an {@link AnnotationsSetAction} when replacing the\nwhole annotation)."
         },
         "entries": {
           "type": "array",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -4013,7 +4013,7 @@
         },
         "resolved": {
           "type": "boolean",
-          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsSetAction} carrying the\nupdated flag."
+          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying\nthe updated flag (or an {@link AnnotationsSetAction} when replacing the\nwhole annotation)."
         },
         "entries": {
           "type": "array",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -3795,7 +3795,7 @@
         },
         "resolved": {
           "type": "boolean",
-          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsSetAction} carrying the\nupdated flag."
+          "description": "Whether the annotation has been resolved. Newly created annotations are\nalways unresolved (`false`); a client marks an annotation resolved (or\nre-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying\nthe updated flag (or an {@link AnnotationsSetAction} when replacing the\nwhole annotation)."
         },
         "entries": {
           "type": "array",

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1137,6 +1137,7 @@ const ACTION_VARIANTS: {
   { type: 'changeset/operationStatusChanged', variantName: 'ChangesetOperationStatusChanged', tsInterface: 'ChangesetOperationStatusChangedAction' },
   { type: 'changeset/cleared', variantName: 'ChangesetCleared', tsInterface: 'ChangesetClearedAction' },
   { type: 'annotations/set', variantName: 'AnnotationsSet', tsInterface: 'AnnotationsSetAction' },
+  { type: 'annotations/updated', variantName: 'AnnotationsUpdated', tsInterface: 'AnnotationsUpdatedAction' },
   { type: 'annotations/removed', variantName: 'AnnotationsRemoved', tsInterface: 'AnnotationsRemovedAction' },
   { type: 'annotations/entrySet', variantName: 'AnnotationsEntrySet', tsInterface: 'AnnotationsEntrySetAction' },
   { type: 'annotations/entryRemoved', variantName: 'AnnotationsEntryRemoved', tsInterface: 'AnnotationsEntryRemovedAction' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1092,6 +1092,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'changeset/operationStatusChanged', caseName: 'ChangesetOperationStatusChanged', tsInterface: 'ChangesetOperationStatusChangedAction' },
   { type: 'changeset/cleared', caseName: 'ChangesetCleared', tsInterface: 'ChangesetClearedAction' },
   { type: 'annotations/set', caseName: 'AnnotationsSet', tsInterface: 'AnnotationsSetAction' },
+  { type: 'annotations/updated', caseName: 'AnnotationsUpdated', tsInterface: 'AnnotationsUpdatedAction' },
   { type: 'annotations/removed', caseName: 'AnnotationsRemoved', tsInterface: 'AnnotationsRemovedAction' },
   { type: 'annotations/entrySet', caseName: 'AnnotationsEntrySet', tsInterface: 'AnnotationsEntrySetAction' },
   { type: 'annotations/entryRemoved', caseName: 'AnnotationsEntryRemoved', tsInterface: 'AnnotationsEntryRemovedAction' },

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1032,7 +1032,7 @@ pub struct SessionToolCallConfirmedAction {
 
 function generateActionsFile(project: Project): string {
   const lines: string[] = [GENERATED_HEADER];
-  lines.push('use crate::state::{AgentInfo, AgentSelection, Annotation, AnnotationEntry, ConfirmationOption, Customization, ErrorInfo, McpServerState, ModelSelection, ResponsePart, SessionActiveClient, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, ToolCallContributor, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, Message, PendingMessageKind, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, Changeset};');
+  lines.push('use crate::state::{AgentInfo, AgentSelection, Annotation, AnnotationEntry, ConfirmationOption, Customization, ErrorInfo, McpServerState, ModelSelection, ResponsePart, SessionActiveClient, SessionInputAnswer, SessionInputRequest, SessionInputResponseKind, TerminalClaim, TerminalInfo, TextRange, ToolCallContributor, ToolCallResult, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolResultContent, UsageInfo, Message, PendingMessageKind, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, Changeset};');
   lines.push('');
 
   // ActionType enum

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -978,6 +978,7 @@ const ACTION_VARIANTS: {
   { type: 'changeset/operationStatusChanged', variantName: 'ChangesetOperationStatusChanged', tsInterface: 'ChangesetOperationStatusChangedAction' },
   { type: 'changeset/cleared', variantName: 'ChangesetCleared', tsInterface: 'ChangesetClearedAction' },
   { type: 'annotations/set', variantName: 'AnnotationsSet', tsInterface: 'AnnotationsSetAction' },
+  { type: 'annotations/updated', variantName: 'AnnotationsUpdated', tsInterface: 'AnnotationsUpdatedAction' },
   { type: 'annotations/removed', variantName: 'AnnotationsRemoved', tsInterface: 'AnnotationsRemovedAction' },
   { type: 'annotations/entrySet', variantName: 'AnnotationsEntrySet', tsInterface: 'AnnotationsEntrySetAction' },
   { type: 'annotations/entryRemoved', variantName: 'AnnotationsEntryRemoved', tsInterface: 'AnnotationsEntryRemovedAction' },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -949,6 +949,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'changeset/operationStatusChanged', caseName: 'changesetOperationStatusChanged', tsInterface: 'ChangesetOperationStatusChangedAction' },
   { type: 'changeset/cleared', caseName: 'changesetCleared', tsInterface: 'ChangesetClearedAction' },
   { type: 'annotations/set', caseName: 'annotationsSet', tsInterface: 'AnnotationsSetAction' },
+  { type: 'annotations/updated', caseName: 'annotationsUpdated', tsInterface: 'AnnotationsUpdatedAction' },
   { type: 'annotations/removed', caseName: 'annotationsRemoved', tsInterface: 'AnnotationsRemovedAction' },
   { type: 'annotations/entrySet', caseName: 'annotationsEntrySet', tsInterface: 'AnnotationsEntrySetAction' },
   { type: 'annotations/entryRemoved', caseName: 'annotationsEntryRemoved', tsInterface: 'AnnotationsEntryRemovedAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -55,6 +55,7 @@ import type {
   ChangesetOperationStatusChangedAction,
   ChangesetClearedAction,
   AnnotationsSetAction,
+  AnnotationsUpdatedAction,
   AnnotationsRemovedAction,
   AnnotationsEntrySetAction,
   AnnotationsEntryRemovedAction,
@@ -252,6 +253,7 @@ export type ServerChangesetAction =
 /** Union of all annotations-scoped actions. */
 export type AnnotationsAction =
   | AnnotationsSetAction
+  | AnnotationsUpdatedAction
   | AnnotationsRemovedAction
   | AnnotationsEntrySetAction
   | AnnotationsEntryRemovedAction
@@ -260,6 +262,7 @@ export type AnnotationsAction =
 /** Union of annotations actions that clients may dispatch. */
 export type ClientAnnotationsAction =
   | AnnotationsSetAction
+  | AnnotationsUpdatedAction
   | AnnotationsRemovedAction
   | AnnotationsEntrySetAction
   | AnnotationsEntryRemovedAction
@@ -344,6 +347,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.ChangesetOperationStatusChanged]: false,
   [ActionType.ChangesetCleared]: false,
   [ActionType.AnnotationsSet]: true,
+  [ActionType.AnnotationsUpdated]: true,
   [ActionType.AnnotationsRemoved]: true,
   [ActionType.AnnotationsEntrySet]: true,
   [ActionType.AnnotationsEntryRemoved]: true,

--- a/types/channels-annotations/actions.ts
+++ b/types/channels-annotations/actions.ts
@@ -15,6 +15,7 @@
  */
 
 import { ActionType } from '../common/actions.js';
+import type { URI, TextRange } from '../common/state.js';
 import type { AnnotationEntry, Annotation } from './state.js';
 
 // ─── Annotations Actions ─────────────────────────────────────────────────────
@@ -29,8 +30,9 @@ import type { AnnotationEntry, Annotation } from './state.js';
  * dispatching client assigns the {@link Annotation.id} and the id of any
  * new entry. When replacing, the full annotation payload (including its
  * {@link Annotation.entries | entries} list) is substituted; producers
- * SHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits to
- * keep wire updates small.
+ * SHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and
+ * {@link AnnotationsUpdatedAction} to resolve / re-anchor an existing
+ * annotation, to keep wire updates small.
  *
  * @category Annotations Actions
  * @version 3
@@ -40,6 +42,57 @@ export interface AnnotationsSetAction {
   type: ActionType.AnnotationsSet;
   /** The new or replacement annotation. MUST contain at least one entry. */
   annotation: Annotation;
+}
+
+/**
+ * Partially update an existing {@link Annotation}'s own properties — a narrow
+ * alternative to {@link AnnotationsSetAction} for the common case of resolving
+ * / re-opening or re-anchoring an annotation without resending its
+ * {@link Annotation.entries | entries}.
+ *
+ * Targets one annotation by its {@link annotationId}. Only the fields present
+ * on the action are written; omitted fields leave the corresponding
+ * {@link Annotation} property unchanged. The annotation's
+ * {@link Annotation.entries | entries}, {@link Annotation.id | id}, and
+ * {@link Annotation._meta | _meta} are never touched — dispatch
+ * {@link AnnotationsSetAction} to replace those, to clear {@link range}
+ * (re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /
+ * {@link AnnotationsEntryRemovedAction} to edit individual entries.
+ *
+ * If {@link annotationId} does not match any current annotation the action is
+ * a no-op.
+ *
+ * @category Annotations Actions
+ * @version 4
+ * @clientDispatchable
+ */
+export interface AnnotationsUpdatedAction {
+  type: ActionType.AnnotationsUpdated;
+  /** The {@link Annotation.id} of the annotation to update. */
+  annotationId: string;
+  /**
+   * Re-anchors the annotation to the file versions this turn produced.
+   * Matches a {@link Turn.id} on the owning session. Omit to leave the
+   * current {@link Annotation.turnId} unchanged.
+   */
+  turnId?: string;
+  /**
+   * Re-anchors the annotation to this file. Omit to leave the current
+   * {@link Annotation.resource} unchanged.
+   */
+  resource?: URI;
+  /**
+   * Narrows the annotation to this range within {@link resource}. Omit to
+   * leave the current {@link Annotation.range} unchanged; this action cannot
+   * clear an existing range — dispatch {@link AnnotationsSetAction} to
+   * re-anchor to the whole file.
+   */
+  range?: TextRange;
+  /**
+   * Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to
+   * leave the current {@link Annotation.resolved} state unchanged.
+   */
+  resolved?: boolean;
 }
 
 /**

--- a/types/channels-annotations/reducer.ts
+++ b/types/channels-annotations/reducer.ts
@@ -36,6 +36,30 @@ export function annotationsReducer(state: AnnotationsState, action: AnnotationsA
       return { ...state, annotations: next };
     }
 
+    case ActionType.AnnotationsUpdated: {
+      const idx = state.annotations.findIndex(t => t.id === action.annotationId);
+      if (idx < 0) {
+        return state;
+      }
+      const annotation = state.annotations[idx];
+      const updated: Annotation = { ...annotation };
+      if (action.turnId !== undefined) {
+        updated.turnId = action.turnId;
+      }
+      if (action.resource !== undefined) {
+        updated.resource = action.resource;
+      }
+      if (action.range !== undefined) {
+        updated.range = action.range;
+      }
+      if (action.resolved !== undefined) {
+        updated.resolved = action.resolved;
+      }
+      const next: Annotation[] = [...state.annotations];
+      next[idx] = updated;
+      return { ...state, annotations: next };
+    }
+
     case ActionType.AnnotationsRemoved: {
       const idx = state.annotations.findIndex(t => t.id === action.annotationId);
       if (idx < 0) {

--- a/types/channels-annotations/state.ts
+++ b/types/channels-annotations/state.ts
@@ -88,8 +88,9 @@ export interface Annotation {
   /**
    * Whether the annotation has been resolved. Newly created annotations are
    * always unresolved (`false`); a client marks an annotation resolved (or
-   * re-opens it) by dispatching an {@link AnnotationsSetAction} carrying the
-   * updated flag.
+   * re-opens it) by dispatching an {@link AnnotationsUpdatedAction} carrying
+   * the updated flag (or an {@link AnnotationsSetAction} when replacing the
+   * whole annotation).
    */
   resolved: boolean;
   /**

--- a/types/common/actions.ts
+++ b/types/common/actions.ts
@@ -70,6 +70,7 @@ import type {
 
 import type {
   AnnotationsSetAction,
+  AnnotationsUpdatedAction,
   AnnotationsRemovedAction,
   AnnotationsEntrySetAction,
   AnnotationsEntryRemovedAction,
@@ -151,6 +152,7 @@ export const enum ActionType {
   ChangesetOperationStatusChanged = 'changeset/operationStatusChanged',
   ChangesetCleared = 'changeset/cleared',
   AnnotationsSet = 'annotations/set',
+  AnnotationsUpdated = 'annotations/updated',
   AnnotationsRemoved = 'annotations/removed',
   AnnotationsEntrySet = 'annotations/entrySet',
   AnnotationsEntryRemoved = 'annotations/entryRemoved',
@@ -256,6 +258,7 @@ export type StateAction =
   | ChangesetOperationStatusChangedAction
   | ChangesetClearedAction
   | AnnotationsSetAction
+  | AnnotationsUpdatedAction
   | AnnotationsRemovedAction
   | AnnotationsEntrySetAction
   | AnnotationsEntryRemovedAction

--- a/types/test-cases/reducers/216-annotations-updated-resolves-and-preserves-entries.json
+++ b/types/test-cases/reducers/216-annotations-updated-resolves-and-preserves-entries.json
@@ -1,0 +1,49 @@
+{
+  "description": "annotations/updated marks an annotation resolved while leaving its entries, range, anchor, and _meta untouched",
+  "reducer": "annotations",
+  "initial": {
+    "annotations": [
+      {
+        "id": "t-1",
+        "turnId": "turn-1",
+        "resource": "file:///src/a.ts",
+        "range": {
+          "start": { "line": 0, "character": 0 },
+          "end": { "line": 0, "character": 5 }
+        },
+        "resolved": false,
+        "entries": [
+          { "id": "c-1", "text": "original" },
+          { "id": "c-2", "text": "reply" }
+        ],
+        "_meta": { "author": "alice" }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "annotations/updated",
+      "annotationId": "t-1",
+      "resolved": true
+    }
+  ],
+  "expected": {
+    "annotations": [
+      {
+        "id": "t-1",
+        "turnId": "turn-1",
+        "resource": "file:///src/a.ts",
+        "range": {
+          "start": { "line": 0, "character": 0 },
+          "end": { "line": 0, "character": 5 }
+        },
+        "resolved": true,
+        "entries": [
+          { "id": "c-1", "text": "original" },
+          { "id": "c-2", "text": "reply" }
+        ],
+        "_meta": { "author": "alice" }
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/218-annotations-updated-reanchors-turn-and-range.json
+++ b/types/test-cases/reducers/218-annotations-updated-reanchors-turn-and-range.json
@@ -1,0 +1,50 @@
+{
+  "description": "annotations/updated re-anchors turnId, resource, and range, leaving resolved and entries unchanged when those fields are omitted",
+  "reducer": "annotations",
+  "initial": {
+    "annotations": [
+      {
+        "id": "t-1",
+        "turnId": "turn-1",
+        "resource": "file:///src/a.ts",
+        "range": {
+          "start": { "line": 0, "character": 0 },
+          "end": { "line": 0, "character": 5 }
+        },
+        "resolved": false,
+        "entries": [
+          { "id": "c-1", "text": "original" }
+        ]
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "annotations/updated",
+      "annotationId": "t-1",
+      "turnId": "turn-2",
+      "resource": "file:///src/b.ts",
+      "range": {
+        "start": { "line": 3, "character": 2 },
+        "end": { "line": 3, "character": 9 }
+      }
+    }
+  ],
+  "expected": {
+    "annotations": [
+      {
+        "id": "t-1",
+        "turnId": "turn-2",
+        "resource": "file:///src/b.ts",
+        "range": {
+          "start": { "line": 3, "character": 2 },
+          "end": { "line": 3, "character": 9 }
+        },
+        "resolved": false,
+        "entries": [
+          { "id": "c-1", "text": "original" }
+        ]
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/219-annotations-updated-unknown-annotation-is-no-op.json
+++ b/types/test-cases/reducers/219-annotations-updated-unknown-annotation-is-no-op.json
@@ -1,0 +1,37 @@
+{
+  "description": "annotations/updated for an unknown annotation id is a no-op",
+  "reducer": "annotations",
+  "initial": {
+    "annotations": [
+      {
+        "id": "t-1",
+        "turnId": "turn-1",
+        "resource": "file:///src/a.ts",
+        "resolved": false,
+        "entries": [
+          { "id": "c-1", "text": "original" }
+        ]
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "annotations/updated",
+      "annotationId": "t-2",
+      "resolved": true
+    }
+  ],
+  "expected": {
+    "annotations": [
+      {
+        "id": "t-1",
+        "turnId": "turn-1",
+        "resource": "file:///src/a.ts",
+        "resolved": false,
+        "entries": [
+          { "id": "c-1", "text": "original" }
+        ]
+      }
+    ]
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -126,6 +126,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string
   [ActionType.ChangesetOperationStatusChanged]: '0.3.0',
   [ActionType.ChangesetCleared]: '0.2.0',
   [ActionType.AnnotationsSet]: '0.3.0',
+  [ActionType.AnnotationsUpdated]: '0.4.0',
   [ActionType.AnnotationsRemoved]: '0.3.0',
   [ActionType.AnnotationsEntrySet]: '0.3.0',
   [ActionType.AnnotationsEntryRemoved]: '0.3.0',


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce `AnnotationsUpdatedAction` to partially update existing annotations without resending their entries. This action allows clients to modify properties like `turnId`, `resource`, `range`, and `resolved`.