### PR TITLE
Add `_meta` slot to per-turn chat actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ changes accumulate. Track in-flight protocol changes via PRs touching
   event to a specific agent (e.g. a sub-agent acting within the turn). The
   tool-call actions already exposed `_meta`; this extends the same convention
   to the remaining turn-scoped actions.
+
+### Changed
+
+- `Snapshot.state` now accepts `ResourceWatchState`, so `initialize` /
   `reconnect` / `subscribe` can seed an `ahp-resource-watch:` channel from a
   point-in-time snapshot. Existing variants (root, session, terminal,
   changeset, annotations) are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,13 @@ changes accumulate. Track in-flight protocol changes via PRs touching
   control as disabled rather than hiding it.
 - `ChangesetOperation.group` — optional identifier for grouping related
   changeset operations together in the UI.
-
-### Changed
-
-- `Snapshot.state` now accepts `ResourceWatchState`, so `initialize` /
+- `_meta` slot on the per-turn chat actions (`chat/turnStarted`, `chat/delta`,
+  `chat/responsePart`, `chat/reasoning`, `chat/usage`, `chat/turnComplete`,
+  `chat/turnCancelled`, `chat/error`) — optional provider-specific metadata so
+  agent hosts can carry portable per-event context, such as attributing an
+  event to a specific agent (e.g. a sub-agent acting within the turn). The
+  tool-call actions already exposed `_meta`; this extends the same convention
+  to the remaining turn-scoped actions.
   `reconnect` / `subscribe` can seed an `ahp-resource-watch:` channel from a
   point-in-time snapshot. Existing variants (root, session, terminal,
   changeset, annotations) are unchanged.

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -20,6 +20,12 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
   operations that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.Group` — optional identifier for grouping related
   changeset operations together in the UI.
+- `Meta` (wire `_meta`) field on the per-turn chat actions (`chat/turnStarted`,
+  `chat/delta`, `chat/responsePart`, `chat/reasoning`, `chat/usage`,
+  `chat/turnComplete`, `chat/turnCancelled`, `chat/error`) — optional
+  provider-specific metadata so hosts can carry portable per-event context,
+  such as attributing an event to a specific agent (e.g. a sub-agent acting
+  within the turn).
 
 ### Changed
 

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -209,6 +209,14 @@ type ChatTurnStartedAction struct {
 	Message Message `json:"message"`
 	// If this turn was auto-started from a queued message, the ID of that message
 	QueuedMessageId *string `json:"queuedMessageId,omitempty"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Streaming text chunk from the assistant, appended to a specific response part.
@@ -223,6 +231,14 @@ type ChatDeltaAction struct {
 	PartId string `json:"partId"`
 	// Text chunk
 	Content string `json:"content"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Structured content appended to the response.
@@ -232,6 +248,14 @@ type ChatResponsePartAction struct {
 	TurnId string `json:"turnId"`
 	// Response part (markdown or content ref)
 	Part ResponsePart `json:"part"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // A tool call begins — parameters are streaming from the LM.
@@ -425,6 +449,14 @@ type ChatTurnCompleteAction struct {
 	Type ActionType `json:"type"`
 	// Turn identifier
 	TurnId string `json:"turnId"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Turn was aborted; server stops processing.
@@ -432,6 +464,14 @@ type ChatTurnCancelledAction struct {
 	Type ActionType `json:"type"`
 	// Turn identifier
 	TurnId string `json:"turnId"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Error during turn processing.
@@ -441,6 +481,14 @@ type ChatErrorAction struct {
 	TurnId string `json:"turnId"`
 	// Error details
 	Error ErrorInfo `json:"error"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Session title updated. Fired by the server when the title is auto-generated
@@ -458,6 +506,14 @@ type ChatUsageAction struct {
 	TurnId string `json:"turnId"`
 	// Token usage data
 	Usage UsageInfo `json:"usage"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Reasoning/thinking text from the model, appended to a specific reasoning response part.
@@ -472,6 +528,14 @@ type ChatReasoningAction struct {
 	PartId string `json:"partId"`
 	// Reasoning text chunk
 	Content string `json:"content"`
+	// Additional provider-specific metadata for this action.
+	//
+	// Clients MAY look for well-known keys here to provide enhanced UI, and
+	// agent hosts MAY use it to carry per-event context that does not fit any
+	// other field — for example, attributing the event to a specific agent
+	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+	// convention.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // A pending message was set (upsert semantics: creates or replaces).

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -21,6 +21,12 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
   operations that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.group` — optional identifier for grouping related
   changeset operations together in the UI.
+- `_meta` (`meta`) field on the per-turn chat actions (`chat/turnStarted`,
+  `chat/delta`, `chat/responsePart`, `chat/reasoning`, `chat/usage`,
+  `chat/turnComplete`, `chat/turnCancelled`, `chat/error`) — optional
+  provider-specific metadata so hosts can carry portable per-event context,
+  such as attributing an event to a specific agent (e.g. a sub-agent acting
+  within the turn).
 
 ### Changed
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -283,7 +283,18 @@ data class ChatTurnStartedAction(
     /**
      * If this turn was auto-started from a queued message, the ID of that message
      */
-    val queuedMessageId: String? = null
+    val queuedMessageId: String? = null,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -300,7 +311,18 @@ data class ChatDeltaAction(
     /**
      * Text chunk
      */
-    val content: String
+    val content: String,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -313,7 +335,18 @@ data class ChatResponsePartAction(
     /**
      * Response part (markdown or content ref)
      */
-    val part: ResponsePart
+    val part: ResponsePart,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -557,7 +590,18 @@ data class ChatTurnCompleteAction(
     /**
      * Turn identifier
      */
-    val turnId: String
+    val turnId: String,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -566,7 +610,18 @@ data class ChatTurnCancelledAction(
     /**
      * Turn identifier
      */
-    val turnId: String
+    val turnId: String,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -579,7 +634,18 @@ data class ChatErrorAction(
     /**
      * Error details
      */
-    val error: ErrorInfo
+    val error: ErrorInfo,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -601,7 +667,18 @@ data class ChatUsageAction(
     /**
      * Token usage data
      */
-    val usage: UsageInfo
+    val usage: UsageInfo,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -618,7 +695,18 @@ data class ChatReasoningAction(
     /**
      * Reasoning text chunk
      */
-    val content: String
+    val content: String,
+    /**
+     * Additional provider-specific metadata for this action.
+     *
+     * Clients MAY look for well-known keys here to provide enhanced UI, and
+     * agent hosts MAY use it to carry per-event context that does not fit any
+     * other field — for example, attributing the event to a specific agent
+     * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+     * convention.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -23,6 +23,12 @@ matching `## [X.Y.Z]` heading is missing from this file.
   that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.group` — optional identifier for grouping related
   changeset operations together in the UI.
+- `_meta` (`meta`) field on the per-turn chat actions (`chat/turnStarted`,
+  `chat/delta`, `chat/responsePart`, `chat/reasoning`, `chat/usage`,
+  `chat/turnComplete`, `chat/turnCancelled`, `chat/error`) — optional
+  provider-specific metadata so hosts can carry portable per-event context,
+  such as attributing an event to a specific agent (e.g. a sub-agent acting
+  within the turn).
 
 ### Changed
 

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -311,6 +311,15 @@ pub struct ChatTurnStartedAction {
     /// If this turn was auto-started from a queued message, the ID of that message
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub queued_message_id: Option<String>,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Streaming text chunk from the assistant, appended to a specific response part.
@@ -326,6 +335,15 @@ pub struct ChatDeltaAction {
     pub part_id: String,
     /// Text chunk
     pub content: String,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Structured content appended to the response.
@@ -336,6 +354,15 @@ pub struct ChatResponsePartAction {
     pub turn_id: String,
     /// Response part (markdown or content ref)
     pub part: ResponsePart,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// A tool call begins — parameters are streaming from the LM.
@@ -566,6 +593,15 @@ pub struct ChatToolCallContentChangedAction {
 pub struct ChatTurnCompleteAction {
     /// Turn identifier
     pub turn_id: String,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Turn was aborted; server stops processing.
@@ -574,6 +610,15 @@ pub struct ChatTurnCompleteAction {
 pub struct ChatTurnCancelledAction {
     /// Turn identifier
     pub turn_id: String,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Error during turn processing.
@@ -584,6 +629,15 @@ pub struct ChatErrorAction {
     pub turn_id: String,
     /// Error details
     pub error: ErrorInfo,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Session title updated. Fired by the server when the title is auto-generated
@@ -603,6 +657,15 @@ pub struct ChatUsageAction {
     pub turn_id: String,
     /// Token usage data
     pub usage: UsageInfo,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Reasoning/thinking text from the model, appended to a specific reasoning response part.
@@ -618,6 +681,15 @@ pub struct ChatReasoningAction {
     pub part_id: String,
     /// Reasoning text chunk
     pub content: String,
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Model changed for this session.

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -1585,6 +1585,7 @@ mod tests {
             turn_id: "t1".into(),
             message: user_message("hi"),
             queued_message_id: None,
+            meta: None,
         });
         assert_eq!(
             apply_action_to_chat(&mut s, &action),
@@ -1610,6 +1611,7 @@ mod tests {
             turn_id: "t1".into(),
             part_id: "p1".into(),
             content: ", world".into(),
+            meta: None,
         });
         assert_eq!(apply_action_to_chat(&mut s, &a), ReduceOutcome::Applied);
         match &s.active_turn.unwrap().response_parts[0] {
@@ -1630,6 +1632,7 @@ mod tests {
         s.status = SessionStatus::InProgress.bits();
         let a = StateAction::ChatTurnComplete(ahp_types::actions::ChatTurnCompleteAction {
             turn_id: "t1".into(),
+            meta: None,
         });
         assert_eq!(apply_action_to_chat(&mut s, &a), ReduceOutcome::Applied);
         assert!(s.active_turn.is_none());
@@ -1700,6 +1703,7 @@ mod tests {
         // A chat-scoped action is out of scope for the session reducer.
         let turn = StateAction::ChatTurnComplete(ahp_types::actions::ChatTurnCompleteAction {
             turn_id: "t1".into(),
+            meta: None,
         });
         assert_eq!(
             apply_action_to_session(&mut s, &turn),

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -243,17 +243,35 @@ public struct ChatTurnStartedAction: Codable, Sendable {
     public var message: Message
     /// If this turn was auto-started from a queued message, the ID of that message
     public var queuedMessageId: String?
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case message
+        case queuedMessageId
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
         turnId: String,
         message: Message,
-        queuedMessageId: String? = nil
+        queuedMessageId: String? = nil,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
         self.message = message
         self.queuedMessageId = queuedMessageId
+        self.meta = meta
     }
 }
 
@@ -265,17 +283,35 @@ public struct ChatDeltaAction: Codable, Sendable {
     public var partId: String
     /// Text chunk
     public var content: String
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case partId
+        case content
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
         turnId: String,
         partId: String,
-        content: String
+        content: String,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
         self.partId = partId
         self.content = content
+        self.meta = meta
     }
 }
 
@@ -285,15 +321,32 @@ public struct ChatResponsePartAction: Codable, Sendable {
     public var turnId: String
     /// Response part (markdown or content ref)
     public var part: ResponsePart
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case part
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
         turnId: String,
-        part: ResponsePart
+        part: ResponsePart,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
         self.part = part
+        self.meta = meta
     }
 }
 
@@ -646,13 +699,29 @@ public struct ChatTurnCompleteAction: Codable, Sendable {
     public var type: ActionType
     /// Turn identifier
     public var turnId: String
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
-        turnId: String
+        turnId: String,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
+        self.meta = meta
     }
 }
 
@@ -660,13 +729,29 @@ public struct ChatTurnCancelledAction: Codable, Sendable {
     public var type: ActionType
     /// Turn identifier
     public var turnId: String
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
-        turnId: String
+        turnId: String,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
+        self.meta = meta
     }
 }
 
@@ -676,15 +761,32 @@ public struct ChatErrorAction: Codable, Sendable {
     public var turnId: String
     /// Error details
     public var error: ErrorInfo
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case error
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
         turnId: String,
-        error: ErrorInfo
+        error: ErrorInfo,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
         self.error = error
+        self.meta = meta
     }
 }
 
@@ -708,15 +810,32 @@ public struct ChatUsageAction: Codable, Sendable {
     public var turnId: String
     /// Token usage data
     public var usage: UsageInfo
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case usage
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
         turnId: String,
-        usage: UsageInfo
+        usage: UsageInfo,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
         self.usage = usage
+        self.meta = meta
     }
 }
 
@@ -728,17 +847,35 @@ public struct ChatReasoningAction: Codable, Sendable {
     public var partId: String
     /// Reasoning text chunk
     public var content: String
+    /// Additional provider-specific metadata for this action.
+    ///
+    /// Clients MAY look for well-known keys here to provide enhanced UI, and
+    /// agent hosts MAY use it to carry per-event context that does not fit any
+    /// other field — for example, attributing the event to a specific agent
+    /// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+    /// convention.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case turnId
+        case partId
+        case content
+        case meta = "_meta"
+    }
 
     public init(
         type: ActionType,
         turnId: String,
         partId: String,
-        content: String
+        content: String,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.type = type
         self.turnId = turnId
         self.partId = partId
         self.content = content
+        self.meta = meta
     }
 }
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -23,6 +23,12 @@ the tag matches the version pinned in [`VERSION`](VERSION).
   that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.group` — optional identifier for grouping related
   changeset operations together in the UI.
+- `_meta` (`meta`) field on the per-turn chat actions (`chat/turnStarted`,
+  `chat/delta`, `chat/responsePart`, `chat/reasoning`, `chat/usage`,
+  `chat/turnComplete`, `chat/turnCancelled`, `chat/error`) — optional
+  provider-specific metadata so hosts can carry portable per-event context,
+  such as attributing an event to a specific agent (e.g. a sub-agent acting
+  within the turn).
 
 ### Changed
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -26,6 +26,11 @@ hotfix escape hatch.
   operations that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.group` — optional identifier for grouping related
   changeset operations together in the UI.
+- `_meta` field on the per-turn chat actions (`chat/turnStarted`, `chat/delta`,
+  `chat/responsePart`, `chat/reasoning`, `chat/usage`, `chat/turnComplete`,
+  `chat/turnCancelled`, `chat/error`) — optional provider-specific metadata so
+  hosts can carry portable per-event context, such as attributing an event to a
+  specific agent (e.g. a sub-agent acting within the turn).
 
 ### Added
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -637,6 +637,11 @@
         "queuedMessageId": {
           "type": "string",
           "description": "If this turn was auto-started from a queued message, the ID of that message"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -663,6 +668,11 @@
         "content": {
           "type": "string",
           "description": "Text chunk"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -686,6 +696,11 @@
         "part": {
           "$ref": "#/$defs/ResponsePart",
           "description": "Response part (markdown or content ref)"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -1050,6 +1065,11 @@
         "turnId": {
           "type": "string",
           "description": "Turn identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -1067,6 +1087,11 @@
         "turnId": {
           "type": "string",
           "description": "Turn identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -1088,6 +1113,11 @@
         "error": {
           "$ref": "#/$defs/ErrorInfo",
           "description": "Error details"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -1110,6 +1140,11 @@
         "usage": {
           "$ref": "#/$defs/UsageInfo",
           "description": "Token usage data"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -1136,6 +1171,11 @@
         "content": {
           "type": "string",
           "description": "Reasoning text chunk"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -5925,6 +5925,11 @@
         "queuedMessageId": {
           "type": "string",
           "description": "If this turn was auto-started from a queued message, the ID of that message"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -5951,6 +5956,11 @@
         "content": {
           "type": "string",
           "description": "Text chunk"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -5974,6 +5984,11 @@
         "part": {
           "$ref": "#/$defs/ResponsePart",
           "description": "Response part (markdown or content ref)"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -6338,6 +6353,11 @@
         "turnId": {
           "type": "string",
           "description": "Turn identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -6355,6 +6375,11 @@
         "turnId": {
           "type": "string",
           "description": "Turn identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -6376,6 +6401,11 @@
         "error": {
           "$ref": "#/$defs/ErrorInfo",
           "description": "Error details"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -6398,6 +6428,11 @@
         "usage": {
           "$ref": "#/$defs/UsageInfo",
           "description": "Token usage data"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [
@@ -6424,6 +6459,11 @@
         "content": {
           "type": "string",
           "description": "Reasoning text chunk"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
         }
       },
       "required": [

--- a/types/channels-chat/actions.ts
+++ b/types/channels-chat/actions.ts
@@ -68,6 +68,16 @@ export interface ChatTurnStartedAction {
   message: Message;
   /** If this turn was auto-started from a queued message, the ID of that message */
   queuedMessageId?: string;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -87,6 +97,16 @@ export interface ChatDeltaAction {
   partId: string;
   /** Text chunk */
   content: string;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -101,6 +121,16 @@ export interface ChatResponsePartAction {
   turnId: string;
   /** Response part (markdown or content ref) */
   part: ResponsePart;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -308,6 +338,16 @@ export interface ChatTurnCompleteAction {
   type: ActionType.ChatTurnComplete;
   /** Turn identifier */
   turnId: string;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -321,6 +361,16 @@ export interface ChatTurnCancelledAction {
   type: ActionType.ChatTurnCancelled;
   /** Turn identifier */
   turnId: string;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -335,6 +385,16 @@ export interface ChatErrorAction {
   turnId: string;
   /** Error details */
   error: ErrorInfo;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 
@@ -350,6 +410,16 @@ export interface ChatUsageAction {
   turnId: string;
   /** Token usage data */
   usage: UsageInfo;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -369,6 +439,16 @@ export interface ChatReasoningAction {
   partId: string;
   /** Reasoning text chunk */
   content: string;
+  /**
+   * Additional provider-specific metadata for this action.
+   *
+   * Clients MAY look for well-known keys here to provide enhanced UI, and
+   * agent hosts MAY use it to carry per-event context that does not fit any
+   * other field — for example, attributing the event to a specific agent
+   * (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
+   * convention.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 


### PR DESCRIPTION
## Summary

Adds an optional, transport-level `_meta?: Record<string, unknown>` to the eight per-turn chat actions that didn't have one:

- `chat/turnStarted` (`ChatTurnStartedAction`)
- `chat/delta` (`ChatDeltaAction`)
- `chat/responsePart` (`ChatResponsePartAction`)
- `chat/reasoning` (`ChatReasoningAction`)
- `chat/usage` (`ChatUsageAction`)
- `chat/turnComplete` (`ChatTurnCompleteAction`)
- `chat/turnCancelled` (`ChatTurnCancelledAction`)
- `chat/error` (`ChatErrorAction`)

## Motivation

Tool-call actions already carry `_meta` (via `ToolCallActionBase`), and the `Message` / `UsageInfo` / `ErrorInfo` payloads each expose their own `_meta`. But the turn lifecycle and content actions above had **no** `_meta` slot, so an agent host had no portable, uniform way to stamp per-event metadata onto the action stream — for example, attributing a streamed delta, reasoning chunk, or usage report to the specific agent that produced it (such as a sub-agent acting within the turn).

This extends the existing `_meta` convention to the remaining turn-scoped actions so a client observing the action stream can read provider-specific per-event context consistently across the whole chat surface.

## Design notes

- The field is **optional and additive**, mirroring the existing MCP `_meta` convention used elsewhere in the spec.
- It is **transport-level only**: no reducer or state changes, so existing reduced-state behavior (and 100% reducer branch coverage) is unaffected.
- No protocol version bump and no new actions, so the version registry is untouched.

## Generated / docs

- Regenerated the Rust, Kotlin, Swift, Go, and TypeScript client mirrors, the JSON Schemas, release metadata, and reference docs via `npm run generate`.
- Added an `## [Unreleased]` entry to the spec `CHANGELOG.md` and to all five client changelogs (a `types/**` change ripples to every client).

## Validation

- `npm run generate` — clean.
- `npm run test` — `typecheck`, `lint`, `verify:release-metadata`, and `verify:changelog` all pass; the full reducer/version test suite passes (265/265) when run directly. The `c8` coverage wrapper crashes locally on an unrelated Node-version/`yargs` ESM incompatibility, before touching any coverage logic.