### PR TITLE
Add additionalProperties to ConfigPropertySchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 ### Added
 
+- `ConfigPropertySchema.additionalProperties` — optional JSON Schema field
+  (`ConfigPropertySchema`) describing the schema for object-typed config
+  properties beyond those listed in `properties`.
 - `ChangesetOperationStatus.Disabled` — signals that a changeset operation is
   currently unavailable and cannot be invoked, so clients can render the
   control as disabled rather than hiding it.

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,6 +16,8 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `ConfigPropertySchema.AdditionalProperties` — optional field describing the
+  schema for object-typed config properties beyond those in `Properties`.
 - `ChangesetOperationStatusDisabled` — new `ChangesetOperationStatus` value for
   operations that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.Group` — optional identifier for grouping related

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -589,6 +589,8 @@ type ConfigPropertySchema struct {
 	Properties map[string]ConfigPropertySchema `json:"properties,omitempty"`
 	// JSON Schema: list of required property ids (used when `type` is `'object'`)
 	Required []string `json:"required,omitempty"`
+	// JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+	AdditionalProperties *ConfigPropertySchema `json:"additionalProperties,omitempty"`
 }
 
 // A JSON Schema object describing available configuration properties.
@@ -903,6 +905,8 @@ type SessionConfigPropertySchema struct {
 	Properties map[string]ConfigPropertySchema `json:"properties,omitempty"`
 	// JSON Schema: list of required property ids (used when `type` is `'object'`)
 	Required []string `json:"required,omitempty"`
+	// JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+	AdditionalProperties *ConfigPropertySchema `json:"additionalProperties,omitempty"`
 	// Display extension: when `true`, the full set of allowed values is too large
 	// to enumerate statically. The client SHOULD use `sessionConfigCompletions`
 	// to fetch matching values based on user input. Any values in `enum` are

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -17,6 +17,8 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Added
 
+- `ConfigPropertySchema.additionalProperties` — optional field describing the
+  schema for object-typed config properties beyond those in `properties`.
 - `ChangesetOperationStatus.Disabled` — new enum value for changeset
   operations that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.group` — optional identifier for grouping related

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -905,6 +905,10 @@ data class SessionConfigPropertySchema(
      */
     val required: List<String>? = null,
     /**
+     * JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+     */
+    val additionalProperties: ConfigPropertySchema? = null,
+    /**
      * Display extension: when `true`, the full set of allowed values is too large
      * to enumerate statically. The client SHOULD use `sessionConfigCompletions`
      * to fetch matching values based on user input. Any values in `enum` are

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -953,7 +953,11 @@ data class ConfigPropertySchema(
     /**
      * JSON Schema: list of required property ids (used when `type` is `'object'`)
      */
-    val required: List<String>? = null
+    val required: List<String>? = null,
+    /**
+     * JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+     */
+    val additionalProperties: ConfigPropertySchema? = null
 )
 
 @Serializable

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,6 +17,8 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `ConfigPropertySchema.additional_properties` — optional field describing the
+  schema for object-typed config properties beyond those in `properties`.
 - `ahp_error_codes::CONFLICT` constant (`-32011`) added to `ahp-types`; covers ETag-conflict failures from `ResourceWriteParams.if_match` checks.
 - `apply_action_to_changeset`, `apply_action_to_annotations`, and `apply_action_to_resource_watch` reducers in `ahp`; all previously-skipped conformance fixtures for the `changeset`, `annotations`, and `resourceWatch` reducer families now pass.
 - `ChangesetOperationStatus::Disabled` — new variant for changeset operations

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -817,6 +817,9 @@ pub struct ConfigPropertySchema {
     /// JSON Schema: list of required property ids (used when `type` is `'object'`)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required: Option<Vec<String>>,
+    /// JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_properties: Option<Box<ConfigPropertySchema>>,
 }
 
 /// A JSON Schema object describing available configuration properties.
@@ -1198,6 +1201,9 @@ pub struct SessionConfigPropertySchema {
     /// JSON Schema: list of required property ids (used when `type` is `'object'`)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required: Option<Vec<String>>,
+    /// JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_properties: Option<ConfigPropertySchema>,
     /// Display extension: when `true`, the full set of allowed values is too large
     /// to enumerate statically. The client SHOULD use `sessionConfigCompletions`
     /// to fetch matching values based on user input. Any values in `enum` are

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -991,6 +991,8 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
     public var properties: [String: ConfigPropertySchema]?
     /// JSON Schema: list of required property ids (used when `type` is `'object'`)
     public var required: [String]?
+    /// JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+    public var additionalProperties: ConfigPropertySchema?
     /// Display extension: when `true`, the full set of allowed values is too large
     /// to enumerate statically. The client SHOULD use `sessionConfigCompletions`
     /// to fetch matching values based on user input. Any values in `enum` are
@@ -1011,6 +1013,7 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
         case items
         case properties
         case required
+        case additionalProperties
         case enumDynamic
         case sessionMutable
     }
@@ -1027,6 +1030,7 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
         items: ConfigPropertySchema? = nil,
         properties: [String: ConfigPropertySchema]? = nil,
         required: [String]? = nil,
+        additionalProperties: ConfigPropertySchema? = nil,
         enumDynamic: Bool? = nil,
         sessionMutable: Bool? = nil
     ) {
@@ -1041,6 +1045,7 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
         self.items = items
         self.properties = properties
         self.required = required
+        self.additionalProperties = additionalProperties
         self.enumDynamic = enumDynamic
         self.sessionMutable = sessionMutable
     }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -673,6 +673,8 @@ public final class ConfigPropertySchema: Codable, @unchecked Sendable {
     public var properties: [String: ConfigPropertySchema]?
     /// JSON Schema: list of required property ids (used when `type` is `'object'`)
     public var required: [String]?
+    /// JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`).
+    public var additionalProperties: ConfigPropertySchema?
 
     enum CodingKeys: String, CodingKey {
         case type
@@ -686,6 +688,7 @@ public final class ConfigPropertySchema: Codable, @unchecked Sendable {
         case items
         case properties
         case required
+        case additionalProperties
     }
 
     public init(
@@ -699,7 +702,8 @@ public final class ConfigPropertySchema: Codable, @unchecked Sendable {
         readOnly: Bool? = nil,
         items: ConfigPropertySchema? = nil,
         properties: [String: ConfigPropertySchema]? = nil,
-        required: [String]? = nil
+        required: [String]? = nil,
+        additionalProperties: ConfigPropertySchema? = nil
     ) {
         self.type = type
         self.title = title
@@ -712,6 +716,7 @@ public final class ConfigPropertySchema: Codable, @unchecked Sendable {
         self.items = items
         self.properties = properties
         self.required = required
+        self.additionalProperties = additionalProperties
     }
 }
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,6 +19,8 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
+- `ConfigPropertySchema.additionalProperties` — optional field describing the
+  schema for object-typed config properties beyond those in `properties`.
 - `ChangesetOperationStatus.disabled` — new case for changeset operations
   that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.group` — optional identifier for grouping related

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,6 +22,9 @@ hotfix escape hatch.
 
 ### Added
 
+- `ConfigPropertySchema.additionalProperties` — optional JSON Schema field
+  (`ConfigPropertySchema`) describing the schema for object-typed config
+  properties beyond those listed in `properties`.
 - `ChangesetOperationStatus.Disabled` — new enum value for changeset
   operations that are currently unavailable and cannot be invoked.
 - `ChangesetOperation.group` — optional identifier for grouping related

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2052,6 +2052,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         }
       },
       "required": [
@@ -2752,6 +2756,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         },
         "enumDynamic": {
           "type": "boolean",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1421,6 +1421,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         }
       },
       "required": [
@@ -2121,6 +2125,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         },
         "enumDynamic": {
           "type": "boolean",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -273,6 +273,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         }
       },
       "required": [
@@ -973,6 +977,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         },
         "enumDynamic": {
           "type": "boolean",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -402,6 +402,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         }
       },
       "required": [
@@ -1102,6 +1106,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         },
         "enumDynamic": {
           "type": "boolean",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -184,6 +184,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         }
       },
       "required": [
@@ -884,6 +888,10 @@
             "type": "string"
           },
           "description": "JSON Schema: list of required property ids (used when `type` is `'object'`)"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/ConfigPropertySchema",
+          "description": "JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`)."
         },
         "enumDynamic": {
           "type": "boolean",

--- a/types/common/state.ts
+++ b/types/common/state.ts
@@ -176,6 +176,8 @@ export interface ConfigPropertySchema {
   properties?: Record<string, ConfigPropertySchema>;
   /** JSON Schema: list of required property ids (used when `type` is `'object'`) */
   required?: string[];
+  /** JSON Schema: schema for additional properties not listed in `properties` (used when `type` is `'object'`). */
+  additionalProperties?: ConfigPropertySchema;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `additionalProperties` schema field to `ConfigPropertySchema`, describing the schema for object-typed config properties beyond those listed in `properties`.

## Motivation

This is needed to express **configuration of MCP servers**, whose config shapes include open-ended object maps. Validating entries that aren't enumerated up front requires an `additionalProperties` schema on the relevant object property.

## Changes

- `types/common/state.ts`: new `additionalProperties?: ConfigPropertySchema` field.
- Regenerated all client mirrors (Rust / Swift / Kotlin / TypeScript / Go) and the JSON schemas (`oneOf`/`$ref` as appropriate; Rust boxes the self-reference).
- Updated the spec CHANGELOG and every client CHANGELOG under `[Unreleased]`.

## Validation

- `npm run generate`
- `npm run test` (typecheck, lint, release-metadata + changelog verification, 265 unit tests, 100% reducer coverage)