### PR TITLE
docs: document chat nesting depth and ancestry for tool-spawned chats

### DIFF
--- a/docs/specification/chat-channel.md
+++ b/docs/specification/chat-channel.md
@@ -58,6 +58,13 @@ Each chat advertises how it came into existence via [`ChatOrigin`](/reference/ch
 
 Clients MAY use the origin to render contextual UI (parent indicators, fork markers, "spawned by tool" badges), but origin is **not** a hierarchy — every chat is equally addressable.
 
+#### Ancestry and nesting depth
+
+A `fork` or `tool` origin names only the chat's **immediate** source chat (by URI), together with the turn or tool call that produced it. A chat's ancestry is therefore not stored directly; it is the chain you reconstruct by following `origin.chat` from one chat to the next. Because a tool-spawned chat can itself run tools that spawn further chats, these chains can be arbitrarily deep.
+
+- **No protocol-imposed depth limit.** AHP does not cap nesting depth or fan-out, and the wire carries no depth counter or maximum-depth field. Any bound is a host policy decision that the protocol neither enforces nor advertises; hosts SHOULD guard against runaway recursion or unbounded fan-out on their side.
+- **Ancestry is advisory and may be incomplete.** Every chat is a flat, equally-addressable peer in the session's [`chats`](/reference/session#sessionstate) catalog — `origin` is a rendering hint, not a structural parent link. A source chat MAY be pruned (`session/chatRemoved`) while a chat it spawned lives on, so an `origin.chat` URI is not guaranteed to resolve. Clients reconstructing ancestry MUST tolerate missing references and SHOULD guard against cycles and unbounded depth (for example, by capping how deep they walk or render).
+
 ### Active chat
 
 Once a chat exists and its session is `lifecycle: 'ready'`, the chat accepts turns. The wire shape mirrors the legacy single-chat session shape:


### PR DESCRIPTION
## What

Adds an **Ancestry and nesting depth** subsection to the Chat Channel spec's `Origin` section, addressing #243.

The spec already said "origin is **not** a hierarchy — every chat is equally addressable," but was silent on how deep tool-spawned chats may nest and how ancestry is expected to be expressed and bounded. This note fills that gap:

- A `fork`/`tool` origin names only the chat's **immediate** source chat; ancestry is reconstructed by walking `origin.chat`, and chains can be arbitrarily deep because a tool-spawned chat can itself spawn further chats.
- **No protocol-imposed depth limit** — AHP carries no depth counter or maximum-depth field; bounding depth/fan-out is a host policy concern, and hosts SHOULD guard against runaway recursion on their side.
- **Ancestry is advisory and may be incomplete** — chats stay flat peers in the session `chats` catalog; an `origin.chat` URI may not resolve (the source chat can be pruned while a spawned chat lives on), so clients MUST tolerate missing references and SHOULD guard against cycles and unbounded depth when rendering.

## Scope

Docs-only change to `docs/specification/chat-channel.md`. Per the repo's CHANGELOG guidance, pure `docs/` edits don't get a CHANGELOG entry. New links reuse anchors already used elsewhere in the same file.

Closes #243