### PR TITLE
docs(chat): realign ToolResultSubagentContent.resource as a chat URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 ### Changed
 
+- `ToolResultSubagentContent.resource` is now specified as the spawned worker
+  **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
+  sub-agent is a chat. Its doc now describes the correspondence with the worker
+  chat's `ChatOrigin.Tool` record (matching `toolCallId`), which remains the
+  canonical representation of the spawn relationship.
 - `Snapshot.state` now accepts `ResourceWatchState`, so `initialize` /
   `reconnect` / `subscribe` can seed an `ahp-resource-watch:` channel from a
   point-in-time snapshot. Existing variants (root, session, terminal,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,8 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 - `ToolResultSubagentContent.resource` is now specified as the spawned worker
   **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
   sub-agent is a chat. Its doc now describes the correspondence with the worker
-  chat's `ChatOrigin.Tool` record (matching `toolCallId`), which remains the
-  canonical representation of the spawn relationship.
+  chat's `ChatOrigin` record (`kind: 'tool'`, matching `toolCallId`), which
+  remains the canonical representation of the spawn relationship.
 - `Snapshot.state` now accepts `ResourceWatchState`, so `initialize` /
   `reconnect` / `subscribe` can seed an `ahp-resource-watch:` channel from a
   point-in-time snapshot. Existing variants (root, session, terminal,

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -29,6 +29,11 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Changed
 
+- `ToolResultSubagentContent.Resource` is now specified as the spawned worker
+  **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
+  sub-agent is a chat. Its doc now describes the correspondence with the worker
+  chat's `ChatToolOrigin` record (matching `ToolCallId`), which remains the
+  canonical representation of the spawn relationship.
 - **BREAKING:** `ChangesetOperationTargetRange` is now a nested `TextRange`
   (`{start: {line, character}, end: {line, character}}`) instead of flat
   `{start, end}` `int64` fields.

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -61,11 +61,15 @@ func (s SessionStatus) Has(other SessionStatus) bool { return s&other == other }
 // Or returns s combined with the flags in other.
 func (s SessionStatus) Or(other SessionStatus) SessionStatus { return s | other }
 
+// Discriminant for {@link ChatOrigin} — how a chat came into existence.
 type ChatOriginKind string
 
 const (
+	// User created the chat explicitly (e.g. via the host UI).
 	ChatOriginKindUser ChatOriginKind = "user"
+	// Forked from an existing chat at a specific turn.
 	ChatOriginKindFork ChatOriginKind = "fork"
+	// Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
 	ChatOriginKindTool ChatOriginKind = "tool"
 )
 
@@ -1745,13 +1749,22 @@ type ToolResultTerminalContent struct {
 	Title string `json:"title"`
 }
 
-// A reference to a subagent session spawned by a tool.
+// A reference, embedded in a tool result, to a worker chat spawned by the tool
+// call (a sub-agent delegation).
 //
-// Clients can subscribe to the subagent's session URI to stream its
-// progress in real time, including inner tool calls and responses.
+// A tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat
+// URI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to
+// stream the worker's progress in real time, including its inner tool calls and
+// responses.
+//
+// This is the spawning tool call's forward view of the worker. The worker chat
+// records the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),
+// whose `toolCallId` identifies the tool call that emitted this content. The
+// `ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST
+// keep the two consistent, and clients MAY use either direction to render it.
 type ToolResultSubagentContent struct {
 	Type ToolResultContentType `json:"type"`
-	// Subagent session URI (subscribable for full session state)
+	// Worker chat URI (subscribable for full chat state)
 	Resource URI `json:"resource"`
 	// Display title for the subagent
 	Title string `json:"title"`

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -30,6 +30,11 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Changed
 
+- `ToolResultSubagentContent.resource` is now specified as the spawned worker
+  **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
+  sub-agent is a chat. Its doc now describes the correspondence with the worker
+  chat's `ChatOrigin.Tool` record (matching `toolCallId`), which remains the
+  canonical representation of the spawn relationship.
 - **BREAKING:** `SessionStatus.rawValue` is now a `UInt` (was `Int`), and the
   named flag constants are `UInt` literals. `SessionStatus` is an unsigned
   32-bit bitset on the wire; a signed `Int` could not hold a forward-compat bit

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -168,12 +168,24 @@ internal object SessionStatusSerializer : KSerializer<SessionStatus> {
         SessionStatus(decoder.decodeLong().toUInt())
 }
 
+/**
+ * Discriminant for {@link ChatOrigin} — how a chat came into existence.
+ */
 @Serializable
 enum class ChatOriginKind {
+    /**
+     * User created the chat explicitly (e.g. via the host UI).
+     */
     @SerialName("user")
     USER,
+    /**
+     * Forked from an existing chat at a specific turn.
+     */
     @SerialName("fork")
     FORK,
+    /**
+     * Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
+     */
     @SerialName("tool")
     TOOL
 }
@@ -2541,7 +2553,7 @@ data class ToolResultTerminalContent(
 data class ToolResultSubagentContent(
     val type: ToolResultContentType,
     /**
-     * Subagent session URI (subscribable for full session state)
+     * Worker chat URI (subscribable for full chat state)
      */
     val resource: String,
     /**

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -32,6 +32,11 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Changed
 
+- `ToolResultSubagentContent.resource` is now specified as the spawned worker
+  **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
+  sub-agent is a chat. Its doc now describes the correspondence with the worker
+  chat's `ChatOrigin::Tool` record (matching `tool_call_id`), which remains the
+  canonical representation of the spawn relationship.
 - **BREAKING:** `SessionStatus` is now a `u32` bitset newtype
   (`struct SessionStatus(pub u32)` with named flag constants) instead of a
   `#[repr(u32)]` enum. The wire form is a numeric bitset, so the enum could not

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -137,12 +137,16 @@ impl std::ops::Not for SessionStatus {
     }
 }
 
+/// Discriminant for {@link ChatOrigin} — how a chat came into existence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ChatOriginKind {
+    /// User created the chat explicitly (e.g. via the host UI).
     #[serde(rename = "user")]
     User,
+    /// Forked from an existing chat at a specific turn.
     #[serde(rename = "fork")]
     Fork,
+    /// Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
     #[serde(rename = "tool")]
     Tool,
 }
@@ -2208,14 +2212,23 @@ pub struct ToolResultTerminalContent {
     pub title: String,
 }
 
-/// A reference to a subagent session spawned by a tool.
+/// A reference, embedded in a tool result, to a worker chat spawned by the tool
+/// call (a sub-agent delegation).
 ///
-/// Clients can subscribe to the subagent's session URI to stream its
-/// progress in real time, including inner tool calls and responses.
+/// A tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat
+/// URI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to
+/// stream the worker's progress in real time, including its inner tool calls and
+/// responses.
+///
+/// This is the spawning tool call's forward view of the worker. The worker chat
+/// records the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),
+/// whose `toolCallId` identifies the tool call that emitted this content. The
+/// `ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST
+/// keep the two consistent, and clients MAY use either direction to render it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolResultSubagentContent {
-    /// Subagent session URI (subscribable for full session state)
+    /// Worker chat URI (subscribable for full chat state)
     pub resource: Uri,
     /// Display title for the subagent
     pub title: String,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -85,9 +85,13 @@ public struct SessionStatus: OptionSet, Codable, Sendable, Hashable {
     public static let isArchived = SessionStatus(rawValue: 64)
 }
 
+/// Discriminant for {@link ChatOrigin} — how a chat came into existence.
 public enum ChatOriginKind: String, Codable, Sendable {
+    /// User created the chat explicitly (e.g. via the host UI).
     case user = "user"
+    /// Forked from an existing chat at a specific turn.
     case fork = "fork"
+    /// Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
     case tool = "tool"
 }
 
@@ -2684,7 +2688,7 @@ public struct ToolResultTerminalContent: Codable, Sendable {
 
 public struct ToolResultSubagentContent: Codable, Sendable {
     public var type: ToolResultContentType
-    /// Subagent session URI (subscribable for full session state)
+    /// Worker chat URI (subscribable for full chat state)
     public var resource: String
     /// Display title for the subagent
     public var title: String

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -32,6 +32,11 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Changed
 
+- `ToolResultSubagentContent.resource` is now specified as the spawned worker
+  **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
+  sub-agent is a chat. Its doc now describes the correspondence with the worker
+  chat's `ChatOrigin.tool` record (matching `toolCallId`), which remains the
+  canonical representation of the spawn relationship.
 - **BREAKING:** `SessionStatus` is now an `OptionSet` with a `UInt32` rawValue
   (was `Int`), an unsigned 32-bit bitset that preserves combined and unknown
   forward-compat bits. Combine flags with set-union (`∪` / `union`) and test

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -39,8 +39,8 @@ hotfix escape hatch.
 - `ToolResultSubagentContent.resource` is now specified as the spawned worker
   **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
   sub-agent is a chat. Its doc now describes the correspondence with the worker
-  chat's `ChatOrigin.Tool` record (matching `toolCallId`), which remains the
-  canonical representation of the spawn relationship.
+  chat's `ChatOrigin` record (`kind: 'tool'`, matching `toolCallId`), which
+  remains the canonical representation of the spawn relationship.
 
 ### Added
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -32,6 +32,14 @@ hotfix escape hatch.
   hosts can carry portable per-event context, such as attributing an event to a
   specific agent (e.g. a sub-agent acting within the turn).
 
+### Changed
+
+- `ToolResultSubagentContent.resource` is now specified as the spawned worker
+  **chat** URI (`ahp-chat:/<cid>`), not a session URI — a tool-spawned
+  sub-agent is a chat. Its doc now describes the correspondence with the worker
+  chat's `ChatOrigin.Tool` record (matching `toolCallId`), which remains the
+  canonical representation of the spawn relationship.
+
 ### Added
 
 - `Snapshot.state` now accepts `ResourceWatchState`, so the existing

--- a/docs/specification/chat-channel.md
+++ b/docs/specification/chat-channel.md
@@ -58,6 +58,8 @@ Each chat advertises how it came into existence via [`ChatOrigin`](/reference/ch
 
 Clients MAY use the origin to render contextual UI (parent indicators, fork markers, "spawned by tool" badges), but origin is **not** a hierarchy — every chat is equally addressable.
 
+A tool-spawned worker is described from both ends of the same edge. The worker chat carries the canonical record via its `tool` origin (the spawning chat URI and tool call id). The spawning tool call surfaces the same relationship forward through a [`ToolResultSubagentContent`](/reference/chat#toolresultsubagentcontent) block in its result, whose `resource` is the worker **chat** URI (`ahp-chat:/<cid>`, not a session URI) and whose `toolCallId` matches the worker's origin. Hosts MUST keep the two consistent.
+
 ### Active chat
 
 Once a chat exists and its session is `lifecycle: 'ready'`, the chat accepts turns. The wire shape mirrors the legacy single-chat session shape:

--- a/docs/specification/chat-channel.md
+++ b/docs/specification/chat-channel.md
@@ -58,7 +58,7 @@ Each chat advertises how it came into existence via [`ChatOrigin`](/reference/ch
 
 Clients MAY use the origin to render contextual UI (parent indicators, fork markers, "spawned by tool" badges), but origin is **not** a hierarchy — every chat is equally addressable.
 
-A tool-spawned worker is described from both ends of the same edge. The worker chat carries the canonical record via its `tool` origin (the spawning chat URI and tool call id). The spawning tool call surfaces the same relationship forward through a [`ToolResultSubagentContent`](/reference/chat#toolresultsubagentcontent) block in its result, whose `resource` is the worker **chat** URI (`ahp-chat:/<cid>`, not a session URI) and whose `toolCallId` matches the worker's origin. Hosts MUST keep the two consistent.
+A tool-spawned worker is described from both ends of the same edge. The worker chat carries the canonical record via its `tool` origin (the spawning chat URI and tool call id). The spawning tool call surfaces the same relationship forward through a [`ToolResultSubagentContent`](/reference/chat#toolresultsubagentcontent) block in its result, whose `resource` is the worker **chat** URI (`ahp-chat:/<cid>`, not a session URI). The tool call that emits that block is the one named by the worker chat's `origin.toolCallId`; hosts MUST keep the two consistent.
 
 #### Ancestry and nesting depth
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -5393,14 +5393,14 @@
     },
     "ToolResultSubagentContent": {
       "type": "object",
-      "description": "A reference to a subagent session spawned by a tool.\n\nClients can subscribe to the subagent's session URI to stream its\nprogress in real time, including inner tool calls and responses.",
+      "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation).\n\nA tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat\nURI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to\nstream the worker's progress in real time, including its inner tool calls and\nresponses.\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content. The\n`ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST\nkeep the two consistent, and clients MAY use either direction to render it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ToolResultContentType.Subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
-          "description": "Subagent session URI (subscribable for full session state)"
+          "description": "Worker chat URI (subscribable for full chat state)"
         },
         "title": {
           "type": "string",
@@ -6097,7 +6097,8 @@
             "toolCallId"
           ]
         }
-      ]
+      ],
+      "description": "How a chat came into existence.\n\nOrigin is descriptive metadata, **not** a hierarchy — every chat is equally\naddressable regardless of how it was created. Clients MAY use it to render\ncontextual UI (parent indicators, fork markers, \"spawned by tool\" badges).\n\nThe `tool` variant records a tool-spawned worker from the worker's side: its\n`chat`/`toolCallId` identify the spawning tool call in the parent chat. This\nis the canonical record of the spawn relationship. The same edge is surfaced\nfrom the parent's side by {@link ToolResultSubagentContent}, whose `resource`\nis this chat's URI; hosts MUST keep the two consistent."
     },
     "ChatInputQuestion": {
       "oneOf": [
@@ -6243,7 +6244,7 @@
           "$ref": "#/$defs/ToolResultSubagentContent"
         }
       ],
-      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output, and\n`ToolResultSubagentContent` for subagent sessions (AHP extensions)."
+      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output, and\n`ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions)."
     },
     "TerminalClaim": {
       "oneOf": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -4762,14 +4762,14 @@
     },
     "ToolResultSubagentContent": {
       "type": "object",
-      "description": "A reference to a subagent session spawned by a tool.\n\nClients can subscribe to the subagent's session URI to stream its\nprogress in real time, including inner tool calls and responses.",
+      "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation).\n\nA tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat\nURI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to\nstream the worker's progress in real time, including its inner tool calls and\nresponses.\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content. The\n`ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST\nkeep the two consistent, and clients MAY use either direction to render it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ToolResultContentType.Subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
-          "description": "Subagent session URI (subscribable for full session state)"
+          "description": "Worker chat URI (subscribable for full chat state)"
         },
         "title": {
           "type": "string",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -3614,14 +3614,14 @@
     },
     "ToolResultSubagentContent": {
       "type": "object",
-      "description": "A reference to a subagent session spawned by a tool.\n\nClients can subscribe to the subagent's session URI to stream its\nprogress in real time, including inner tool calls and responses.",
+      "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation).\n\nA tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat\nURI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to\nstream the worker's progress in real time, including its inner tool calls and\nresponses.\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content. The\n`ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST\nkeep the two consistent, and clients MAY use either direction to render it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ToolResultContentType.Subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
-          "description": "Subagent session URI (subscribable for full session state)"
+          "description": "Worker chat URI (subscribable for full chat state)"
         },
         "title": {
           "type": "string",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -3743,14 +3743,14 @@
     },
     "ToolResultSubagentContent": {
       "type": "object",
-      "description": "A reference to a subagent session spawned by a tool.\n\nClients can subscribe to the subagent's session URI to stream its\nprogress in real time, including inner tool calls and responses.",
+      "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation).\n\nA tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat\nURI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to\nstream the worker's progress in real time, including its inner tool calls and\nresponses.\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content. The\n`ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST\nkeep the two consistent, and clients MAY use either direction to render it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ToolResultContentType.Subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
-          "description": "Subagent session URI (subscribable for full session state)"
+          "description": "Worker chat URI (subscribable for full chat state)"
         },
         "title": {
           "type": "string",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -3525,14 +3525,14 @@
     },
     "ToolResultSubagentContent": {
       "type": "object",
-      "description": "A reference to a subagent session spawned by a tool.\n\nClients can subscribe to the subagent's session URI to stream its\nprogress in real time, including inner tool calls and responses.",
+      "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation).\n\nA tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat\nURI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to\nstream the worker's progress in real time, including its inner tool calls and\nresponses.\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content. The\n`ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST\nkeep the two consistent, and clients MAY use either direction to render it.",
       "properties": {
         "type": {
           "$ref": "#/$defs/ToolResultContentType.Subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
-          "description": "Subagent session URI (subscribable for full session state)"
+          "description": "Worker chat URI (subscribable for full chat state)"
         },
         "title": {
           "type": "string",
@@ -4229,7 +4229,8 @@
             "toolCallId"
           ]
         }
-      ]
+      ],
+      "description": "How a chat came into existence.\n\nOrigin is descriptive metadata, **not** a hierarchy — every chat is equally\naddressable regardless of how it was created. Clients MAY use it to render\ncontextual UI (parent indicators, fork markers, \"spawned by tool\" badges).\n\nThe `tool` variant records a tool-spawned worker from the worker's side: its\n`chat`/`toolCallId` identify the spawning tool call in the parent chat. This\nis the canonical record of the spawn relationship. The same edge is surfaced\nfrom the parent's side by {@link ToolResultSubagentContent}, whose `resource`\nis this chat's URI; hosts MUST keep the two consistent."
     },
     "ChatInputQuestion": {
       "oneOf": [
@@ -4375,7 +4376,7 @@
           "$ref": "#/$defs/ToolResultSubagentContent"
         }
       ],
-      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output, and\n`ToolResultSubagentContent` for subagent sessions (AHP extensions)."
+      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output, and\n`ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions)."
     },
     "TerminalClaim": {
       "oneOf": [

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -1174,8 +1174,6 @@ export interface ToolResultTerminalContent {
  * This is the spawning tool call's forward view of the worker. The worker chat
  * records the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),
  * whose `toolCallId` identifies the tool call that emitted this content. The
- * `ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST
- * keep the two consistent, and clients MAY use either direction to render it.
  *
  * @category Tool Result Content
  */

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -1173,7 +1173,7 @@ export interface ToolResultTerminalContent {
  *
  * This is the spawning tool call's forward view of the worker. The worker chat
  * records the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),
- * whose `toolCallId` identifies the tool call that emitted this content. The
+ * whose `toolCallId` identifies the tool call that emitted this content.
  *
  * @category Tool Result Content
  */

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -131,12 +131,35 @@ export interface ChatSummary {
   workingDirectory?: URI;
 }
 
+/**
+ * Discriminant for {@link ChatOrigin} — how a chat came into existence.
+ *
+ * @category Chat State
+ */
 export const enum ChatOriginKind {
+  /** User created the chat explicitly (e.g. via the host UI). */
   User = 'user',
+  /** Forked from an existing chat at a specific turn. */
   Fork = 'fork',
+  /** Spawned by a tool call running in another chat (e.g. a sub-agent delegation). */
   Tool = 'tool',
 }
 
+/**
+ * How a chat came into existence.
+ *
+ * Origin is descriptive metadata, **not** a hierarchy — every chat is equally
+ * addressable regardless of how it was created. Clients MAY use it to render
+ * contextual UI (parent indicators, fork markers, "spawned by tool" badges).
+ *
+ * The `tool` variant records a tool-spawned worker from the worker's side: its
+ * `chat`/`toolCallId` identify the spawning tool call in the parent chat. This
+ * is the canonical record of the spawn relationship. The same edge is surfaced
+ * from the parent's side by {@link ToolResultSubagentContent}, whose `resource`
+ * is this chat's URI; hosts MUST keep the two consistent.
+ *
+ * @category Chat State
+ */
 export type ChatOrigin =
   | { kind: ChatOriginKind.User }
   | { kind: ChatOriginKind.Fork; chat: URI; turnId: string }
@@ -1148,16 +1171,25 @@ export interface ToolResultTerminalContent {
 }
 
 /**
- * A reference to a subagent session spawned by a tool.
+ * A reference, embedded in a tool result, to a worker chat spawned by the tool
+ * call (a sub-agent delegation).
  *
- * Clients can subscribe to the subagent's session URI to stream its
- * progress in real time, including inner tool calls and responses.
+ * A tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat
+ * URI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to
+ * stream the worker's progress in real time, including its inner tool calls and
+ * responses.
+ *
+ * This is the spawning tool call's forward view of the worker. The worker chat
+ * records the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),
+ * whose `toolCallId` identifies the tool call that emitted this content. The
+ * `ChatOrigin.Tool` record is canonical for the spawn relationship; hosts MUST
+ * keep the two consistent, and clients MAY use either direction to render it.
  *
  * @category Tool Result Content
  */
 export interface ToolResultSubagentContent {
   type: ToolResultContentType.Subagent;
-  /** Subagent session URI (subscribable for full session state) */
+  /** Worker chat URI (subscribable for full chat state) */
   resource: URI;
   /** Display title for the subagent */
   title: string;
@@ -1174,7 +1206,7 @@ export interface ToolResultSubagentContent {
  * `ToolResultResourceContent` for lazy-loading large results,
  * `ToolResultFileEditContent` for file edit diffs,
  * `ToolResultTerminalContent` for live terminal output, and
- * `ToolResultSubagentContent` for subagent sessions (AHP extensions).
+ * `ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions).
  *
  * @category Tool Result Content
  */

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -146,10 +146,7 @@ export const enum ChatOriginKind {
 }
 
 /**
- * How a chat came into existence.
- *
- * Origin is descriptive metadata, **not** a hierarchy — every chat is equally
- * addressable regardless of how it was created. Clients MAY use it to render
+ * How a chat came into existence. Clients MAY use it to render
  * contextual UI (parent indicators, fork markers, "spawned by tool" badges).
  *
  * The `tool` variant records a tool-spawned worker from the worker's side: its

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -1169,12 +1169,7 @@ export interface ToolResultTerminalContent {
 
 /**
  * A reference, embedded in a tool result, to a worker chat spawned by the tool
- * call (a sub-agent delegation).
- *
- * A tool-spawned worker is a chat ({@link ChatState}), so `resource` is a chat
- * URI (`ahp-chat:/<cid>`) — not a session URI. Clients subscribe to it to
- * stream the worker's progress in real time, including its inner tool calls and
- * responses.
+ * call (a sub-agent delegation), referenced by a chat URI (`ahp-chat:/...`).
  *
  * This is the spawning tool call's forward view of the worker. The worker chat
  * records the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),


### PR DESCRIPTION
Resolves #242.

## Problem

With multi-chat, `ChatOrigin.Tool { chat, toolCallId }` already records that a chat was spawned by a tool call. Meanwhile `ToolResultSubagentContent.resource` was documented as a *session* URI — stale and ambiguous, because a tool-spawned sub-agent is now a **chat**, not a session.

## Resolution — realign (not deprecate)

The two are complementary views of the same edge, so both are kept:

- **`ChatOrigin.Tool`** is the *reverse* pointer on the worker chat and the **canonical** record of the spawn relationship.
- **`ToolResultSubagentContent`** is the *forward* view embedded in the spawning tool call's result, carrying display metadata (title, agentName, description) plus a subscribable URI.

Changes:

- Clarify `ToolResultSubagentContent.resource` is the spawned worker **chat** URI (`ahp-chat:/<cid>`), not a session URI, and document the invariant that the referenced chat's `ChatOrigin.Tool.toolCallId` matches the tool call that emitted the content. Hosts MUST keep the two consistent.
- Add JSDoc to `ChatOrigin` / `ChatOriginKind` describing each kind and the bidirectional relationship.
- Document the same bidirectional relationship in `docs/specification/chat-channel.md`.
- Add `Changed` CHANGELOG entries to the spec and all five clients (a `types/` semantic change ripples to every client).

No structural/shape changes — the type stays a `URI`; this is a contract clarification. Generated client mirrors and schemas are regenerated (description-only diffs).

## Validation

- `npm run generate` ✅
- `npm run typecheck` ✅ / `npm run lint` ✅ / `verify:release-metadata` ✅ / `verify:changelog` ✅
- Unit tests: 265 pass (run directly via `tsx --test`; the `npm run test` c8 coverage wrapper fails to launch under Node v26 due to a pre-existing yargs/ESM incompatibility, unrelated to this change).