### PR TITLE
docs(changelog): document ChatInteractivity for 0.4.0 across spec and clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Spec version: `0.4.0`
   the annotation's `entries`, `id`, and `_meta` are never touched.
 - `ahp-chat:` channel for per-chat conversation state; `SessionState.chats[]` catalog; `SessionState.defaultChat?` input-routing hint; `ChatOrigin` provenance union; `createChat` / `disposeChat` commands.
 - `ChatSummary.workingDirectory?` — optional per-chat working directory. When absent, chats inherit the session's `workingDirectory`. Enables agent-swarm patterns where multiple chats in one session operate on independent worktrees.
+- `ChatInteractivity` enum (`"full"` / `"read-only"` / `"hidden"`) plus the optional `ChatSummary.interactivity` / `ChatState.interactivity` field describing how the user can interact with a chat, supporting agent-team patterns where worker chats are read-only or hidden. Absent defaults to `"full"`.
 - Three discrete chat-catalog actions on the session channel — `session/chatAdded` (upsert by `summary.resource`), `session/chatRemoved`, and `session/chatUpdated` (partial-update with `Partial<ChatSummary>`) — mirroring the root-channel `root/sessionAdded` / `root/sessionRemoved` / `root/sessionSummaryChanged` pattern.
 - `session/defaultChatChanged` action — updates `SessionState.defaultChat` to steer new input to the designated chat; absent value clears the hint.
 - `ErrorInfo._meta?: Record<string, unknown>` — optional provider-specific metadata bag on error payloads, mirroring the existing `_meta` convention on `UsageInfo` and other protocol types. Clients MAY inspect well-known keys here for richer, localised error UI.

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -62,6 +62,7 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 - `ahp-chat:` channel for per-chat conversation state; `SessionState.chats[]` catalog; `SessionState.defaultChat?` input-routing hint; `ChatOrigin` provenance union; `createChat` / `disposeChat` commands.
 - `ChatSummary.WorkingDirectory` — optional per-chat working directory. Falls back to the session's `WorkingDirectory` when absent.
+- `ChatInteractivity` string enum (`ChatInteractivityFull` / `ChatInteractivityReadOnly` / `ChatInteractivityHidden`) and the optional `ChatSummary.Interactivity` / `ChatState.Interactivity` field describing how the user can interact with a chat. Absent defaults to `"full"`.
 - Three discrete chat-catalog actions on the session channel — `SessionChatAddedAction` (upsert by `Summary.Resource`), `SessionChatRemovedAction`, and `SessionChatUpdatedAction` (partial-update payload).
 - `SessionDefaultChatChangedAction` (`session/defaultChatChanged`) — updates `SessionState.DefaultChat` to steer new input to the designated chat; absent value clears the hint.
 - `ErrorInfo.Meta map[string]json.RawMessage` — optional provider-specific metadata bag on error payloads (`_meta` on the wire), mirroring the existing `Meta` field on `UsageInfo` and other protocol types.

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -57,6 +57,7 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 - `ahp-chat:` channel for per-chat conversation state; `SessionState.chats[]` catalog; `SessionState.defaultChat?` input-routing hint; `ChatOrigin` provenance union; `createChat` / `disposeChat` commands.
 - `ChatSummary.workingDirectory` — optional per-chat working directory. Falls back to the session's `workingDirectory` when absent.
+- `ChatInteractivity` enum (`Full` / `ReadOnly` / `Hidden`) and the optional `ChatSummary.interactivity` / `ChatState.interactivity` property describing how the user can interact with a chat. Absent defaults to `Full`.
 - Three discrete chat-catalog actions on the session channel — `SessionChatAddedAction` (upsert by `summary.resource`), `SessionChatRemovedAction`, and `SessionChatUpdatedAction` (partial-update payload).
 - `SessionDefaultChatChangedAction` (`session/defaultChatChanged`) — updates `SessionState.defaultChat` to steer new input to the designated chat; absent value clears the hint.
 - `ErrorInfo.meta: Map<String, JsonElement>?` — optional provider-specific metadata bag on error payloads (serialized as `_meta`), mirroring the existing `meta` field on `UsageInfo` and other protocol types. Clients MAY inspect well-known keys here for richer, localised error UI.

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -71,6 +71,7 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 - `ahp-chat:` channel for per-chat conversation state; `SessionState.chats[]` catalog; `SessionState.defaultChat?` input-routing hint; `ChatOrigin` provenance union; `createChat` / `disposeChat` commands.
 - `ChatSummary.working_directory` — optional per-chat working directory. Falls back to the session's `working_directory` when absent.
+- `ChatInteractivity` enum (`Full` / `ReadOnly` / `Hidden`) and the optional `ChatSummary.interactivity` / `ChatState.interactivity` field describing how the user can interact with a chat. Absent defaults to `Full`.
 - Three discrete chat-catalog actions on the session channel — `SessionChatAdded` (upsert by `summary.resource`), `SessionChatRemoved`, and `SessionChatUpdated` (partial-update payload).
 - `SessionDefaultChatChanged` (`session/defaultChatChanged`) — updates `SessionState.default_chat` to steer new input to the designated chat; absent value clears the hint.
 - `ErrorInfo.meta: Option<JsonObject>` — optional provider-specific metadata bag on error payloads (serialized as `_meta`), mirroring the existing `meta` field on `UsageInfo` and other protocol types.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -60,6 +60,7 @@ hotfix escape hatch.
 
 - `ahp-chat:` channel for per-chat conversation state; `SessionState.chats[]` catalog; `SessionState.defaultChat?` input-routing hint; `ChatOrigin` provenance union; `createChat` / `disposeChat` commands.
 - `ChatSummary.workingDirectory?` — optional per-chat working directory. Falls back to the session's `workingDirectory` when absent.
+- `ChatInteractivity` enum (`"full"` / `"read-only"` / `"hidden"`) and the optional `ChatSummary.interactivity` / `ChatState.interactivity` field describing how the user can interact with a chat. Absent defaults to `Full`.
 - Three discrete chat-catalog actions on the session channel — `SessionChatAddedAction` (upsert by `summary.resource`), `SessionChatRemovedAction`, and `SessionChatUpdatedAction` (partial-update with `Partial<ChatSummary>`).
 - `SessionDefaultChatChangedAction` (`session/defaultChatChanged`) — updates `SessionState.defaultChat` to steer new input to the designated chat; absent value clears the hint.
 - `ErrorInfo._meta?: Record<string, unknown>` — optional provider-specific metadata bag on error payloads, mirroring the existing `_meta` convention on `UsageInfo` and other protocol types. Clients MAY inspect well-known keys here for richer, localised error UI.


### PR DESCRIPTION
## Why

Release prep for AHP 0.4.0. While auditing client readiness, I found one protocol-surface change that ships in 0.4.0 but was missing from most CHANGELOGs.

`ChatInteractivity` and the optional `ChatSummary.interactivity` / `ChatState.interactivity` field live in [`types/channels-chat/state.ts`](../blob/main/types/channels-chat/state.ts) (introduced with the multi-chat work in #213) and generate into **every** client. Per the repo convention, a `types/**` change must land a CHANGELOG bullet in the root spec changelog and every client changelog — but `interactivity` was recorded **only** in `clients/swift/CHANGELOG.md`.

## What

Add the matching `[Unreleased]` `### Added` bullet, next to the related chat-channel entries and worded per each language's generated symbols:

- `CHANGELOG.md` (spec) — under `## [0.4.0] — Unreleased`
- `clients/rust/CHANGELOG.md`
- `clients/kotlin/CHANGELOG.md`
- `clients/typescript/CHANGELOG.md`
- `clients/go/CHANGELOG.md`

Swift already documented it, so it's untouched. No code or generated output changes — documentation only.

## Validation

- `npm run generate` — no drift
- `npm run verify:release-metadata` — ✅ (`PROTOCOL_VERSION=0.4.0`)
- `npm run verify:changelog` — ✅ (spec=0.4.0, clients=0.3.0)