### PR TITLE
fix(rust): valid crates.io category for ahp-ws + dry-run all crates before publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -87,6 +87,15 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+      - name: Dry-run publish every crate
+        run: |
+          set -euo pipefail
+          for crate in ahp-types ahp ahp-ws; do
+            echo "::group::cargo publish -p $crate --dry-run"
+            cargo publish -p "$crate" --dry-run
+            echo "::endgroup::"
+          done
+
 
   publish:
     needs: validate

--- a/clients/rust/crates/ahp-ws/Cargo.toml
+++ b/clients/rust/crates/ahp-ws/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 homepage = "https://microsoft.github.io/agent-host-protocol/"
 documentation = "https://docs.rs/ahp-ws"
 keywords = ["ahp", "agent", "websocket", "transport", "tokio"]
-categories = ["api-bindings", "asynchronous", "network-programming::websocket"]
+categories = ["api-bindings", "asynchronous", "network-programming"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Problem

The AHP 0.4.0 Rust publish failed on the last crate:

```
error: failed to publish ahp-ws v0.4.0 to registry at https://crates.io
Caused by: status 400 Bad Request: The following category slugs are not
currently supported on crates.io: network-programming::websocket
```

`ahp-types` and `ahp` had already published by then, leaving a partial release. crates.io validates category slugs **server-side at publish time**, and `cargo publish --dry-run` never contacts the registry, so nothing caught this earlier.

## Changes

- **`clients/rust/crates/ahp-ws/Cargo.toml`** — replace the unsupported `network-programming::websocket` slug with the supported `network-programming` slug.
- **`.github/workflows/publish-rust.yml`** — add a `Dry-run publish every crate` step to the `validate` job (which gates `publish`), so a packaging/build failure in any crate is caught before the publish job ships any of them. Path deps resolve within the workspace, so dependents dry-run cleanly even before their dependencies exist on crates.io.

## Release note

`ahp-ws 0.4.0` is being published locally as a one-time recovery (`ahp-types` / `ahp` 0.4.0 are already live and immutable). This PR prevents a recurrence on future releases.
