### PR TITLE
feat(ahp-ws): make WebSocket TLS backend selectable, default to rustls

### DIFF
--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -19,6 +19,17 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field
   for lightweight session-list presentation hints.
+- `ahp-ws` TLS backend is now selectable via Cargo features: `native-tls`,
+  `rustls-tls-native-roots` (default), and `rustls-tls-webpki-roots`. The crate
+  no longer forces `tokio-tungstenite/native-tls` onto the dependency graph, so
+  downstream binaries are free to choose their own WebSocket TLS stack.
+
+### Changed
+
+- `ahp-ws` now defaults to rustls (`rustls-tls-native-roots`, `ring` provider)
+  instead of `native-tls`, dropping the OpenSSL link on Linux while still
+  validating against the OS trust store. To keep the previous behaviour, depend
+  on `ahp-ws` with `default-features = false, features = ["native-tls"]`.
 
 ## [0.4.0] — 2026-06-19
 

--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -31,6 +31,7 @@ version = "0.4.0"
 dependencies = [
  "ahp",
  "futures-util",
+ "rustls",
  "serde_json",
  "thiserror",
  "tokio",
@@ -156,7 +157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -252,6 +253,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -502,7 +514,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -528,7 +540,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -718,6 +730,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,7 +753,53 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -736,7 +808,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -883,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -891,6 +963,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -924,7 +1002,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -980,7 +1058,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1005,6 +1083,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,9 +1101,14 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1088,6 +1181,8 @@ dependencies = [
  "log",
  "native-tls",
  "rand",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
 ]
@@ -1109,6 +1204,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1205,10 +1306,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1218,6 +1346,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1382,6 +1574,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/clients/rust/crates/ahp-ws/Cargo.toml
+++ b/clients/rust/crates/ahp-ws/Cargo.toml
@@ -39,8 +39,9 @@ tokio = { workspace = true, features = ["rt", "sync", "macros"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "handshake"] }
 thiserror = { workspace = true }
 url = "2"
-# Only linked by the rustls-* features. The `ring` provider keeps the build
-# portable (no C toolchain, unlike aws-lc-rs) and makes rustls 0.23's
-# `CryptoProvider::get_default()` resolve, which tokio-tungstenite's rustls
-# connector relies on — without a provider the first `wss://` dial panics.
+# Only linked by the rustls-* features. The `ring` provider builds without
+# cmake/NASM (unlike aws-lc-rs) and links no external/system TLS library
+# (no OpenSSL), and it makes rustls 0.23's `CryptoProvider::get_default()`
+# resolve, which tokio-tungstenite's rustls connector relies on — without a
+# provider the first `wss://` dial panics.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }

--- a/clients/rust/crates/ahp-ws/Cargo.toml
+++ b/clients/rust/crates/ahp-ws/Cargo.toml
@@ -16,11 +16,31 @@ categories = ["api-bindings", "asynchronous", "network-programming"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+# Default to rustls with roots loaded from the OS trust store: a pure-Rust
+# TLS stack (no OpenSSL on Linux) that still validates against the platform
+# certificate store, so dials through a TLS-intercepting egress proxy keep
+# working. Disable with `default-features = false` to pick a different
+# backend; with no backend enabled, only `ws://` works (`wss://` fails).
+default = ["rustls-tls-native-roots"]
+# Platform TLS stack (SChannel / Secure Transport / OpenSSL).
+native-tls = ["tokio-tungstenite/native-tls"]
+# rustls with roots from the OS trust store (via rustls-native-certs).
+rustls-tls-native-roots = ["tokio-tungstenite/rustls-tls-native-roots", "dep:rustls"]
+# rustls with the bundled Mozilla root set (via webpki-roots). Does not see
+# enterprise/proxy CAs that live only in the OS trust store.
+rustls-tls-webpki-roots = ["tokio-tungstenite/rustls-tls-webpki-roots", "dep:rustls"]
+
 [dependencies]
 ahp = { workspace = true }
 futures-util = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "macros"] }
-tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "handshake"] }
 thiserror = { workspace = true }
 url = "2"
+# Only linked by the rustls-* features. The `ring` provider keeps the build
+# portable (no C toolchain, unlike aws-lc-rs) and makes rustls 0.23's
+# `CryptoProvider::get_default()` resolve, which tokio-tungstenite's rustls
+# connector relies on — without a provider the first `wss://` dial panics.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }

--- a/clients/rust/crates/ahp-ws/README.md
+++ b/clients/rust/crates/ahp-ws/README.md
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
 | `rustls-tls-webpki-roots` | rustls (pure Rust) | bundled Mozilla roots |
 | `native-tls` | platform (SChannel / Secure Transport / OpenSSL) | OS trust store |
 
-With no TLS feature enabled, only `ws://` works; `wss://` fails at connect time. The rustls backends use the `ring` crypto provider.
+With no TLS feature enabled, only `ws://` works; `wss://` fails at connect time. The rustls backends use the `ring` crypto provider. If more than one backend ends up enabled (e.g. via Cargo feature unification across the dependency graph), `native-tls` takes precedence, since `tokio-tungstenite`'s automatic connector prefers it.
 
 ## See also
 

--- a/clients/rust/crates/ahp-ws/README.md
+++ b/clients/rust/crates/ahp-ws/README.md
@@ -5,7 +5,7 @@ WebSocket transport for the [Agent Host Protocol (AHP)](https://github.com/micro
 [![crates.io](https://img.shields.io/crates/v/ahp-ws.svg)](https://crates.io/crates/ahp-ws)
 [![docs.rs](https://img.shields.io/docsrs/ahp-ws)](https://docs.rs/ahp-ws)
 
-Implements [`ahp::Transport`](https://docs.rs/ahp/latest/ahp/transport/trait.Transport.html) using [`tokio-tungstenite`](https://crates.io/crates/tokio-tungstenite), supporting both `ws://` and `wss://` (TLS via `native-tls`).
+Implements [`ahp::Transport`](https://docs.rs/ahp/latest/ahp/transport/trait.Transport.html) using [`tokio-tungstenite`](https://crates.io/crates/tokio-tungstenite), supporting both `ws://` and `wss://`.
 
 ## Usage
 
@@ -41,6 +41,18 @@ async fn main() -> anyhow::Result<()> {
 
 - **[`WebSocketTransport::connect(url)`](https://docs.rs/ahp-ws/latest/ahp_ws/struct.WebSocketTransport.html#method.connect)** — open a new connection
 - **[`WebSocketTransport::from_stream(stream)`](https://docs.rs/ahp-ws/latest/ahp_ws/struct.WebSocketTransport.html#method.from_stream)** — wrap an existing `tokio-tungstenite` stream for custom TLS or connection options
+
+## TLS backends
+
+`wss://` support is selected by Cargo feature. The default is `rustls-tls-native-roots`: a pure-Rust TLS stack (no OpenSSL on Linux) with roots loaded from the OS trust store, so dials through a TLS-intercepting egress proxy keep working. Override it with `default-features = false` and pick one:
+
+| Feature | TLS stack | Trust roots |
+| --- | --- | --- |
+| `rustls-tls-native-roots` (default) | rustls (pure Rust) | OS trust store |
+| `rustls-tls-webpki-roots` | rustls (pure Rust) | bundled Mozilla roots |
+| `native-tls` | platform (SChannel / Secure Transport / OpenSSL) | OS trust store |
+
+With no TLS feature enabled, only `ws://` works; `wss://` fails at connect time. The rustls backends use the `ring` crypto provider.
 
 ## See also
 

--- a/clients/rust/crates/ahp-ws/src/lib.rs
+++ b/clients/rust/crates/ahp-ws/src/lib.rs
@@ -5,9 +5,29 @@
 //!
 //! This crate provides [`WebSocketTransport`], an implementation of
 //! [`ahp::Transport`] backed by [`tokio-tungstenite`][tt]. It supports
-//! both `ws://` and `wss://` URLs (TLS via `native-tls`).
+//! both `ws://` and `wss://` URLs.
 //!
 //! [tt]: https://crates.io/crates/tokio-tungstenite
+//!
+//! # TLS backends
+//!
+//! `wss://` support is selected by Cargo feature. The default,
+//! `rustls-tls-native-roots`, uses [rustls] (a pure-Rust stack, so no
+//! OpenSSL on Linux) with roots loaded from the OS trust store, which keeps
+//! dials working through a TLS-intercepting egress proxy whose CA lives in
+//! the platform store. Override it with `default-features = false` plus one
+//! of:
+//!
+//! - `native-tls` — the platform TLS stack (SChannel / Secure Transport /
+//!   OpenSSL).
+//! - `rustls-tls-native-roots` — rustls with OS-trust-store roots (default).
+//! - `rustls-tls-webpki-roots` — rustls with the bundled Mozilla root set;
+//!   does not see enterprise/proxy CAs that live only in the OS store.
+//!
+//! With no TLS feature enabled, only `ws://` works and `wss://` fails at
+//! connect time.
+//!
+//! [rustls]: https://crates.io/crates/rustls
 //!
 //! # Companion crates
 //!

--- a/clients/rust/crates/ahp-ws/src/lib.rs
+++ b/clients/rust/crates/ahp-ws/src/lib.rs
@@ -27,6 +27,13 @@
 //! With no TLS feature enabled, only `ws://` works and `wss://` fails at
 //! connect time.
 //!
+//! If more than one backend ends up enabled — which Cargo feature
+//! unification can do when several crates in the graph request different
+//! ones — `native-tls` takes precedence over the rustls backends, because
+//! `tokio-tungstenite`'s automatic connector prefers it. Disable the
+//! default with `default-features = false` if you need to guarantee a
+//! rustls backend.
+//!
 //! [rustls]: https://crates.io/crates/rustls
 //!
 //! # Companion crates

--- a/clients/rust/crates/ahp-ws/src/transport.rs
+++ b/clients/rust/crates/ahp-ws/src/transport.rs
@@ -46,9 +46,10 @@ pub struct WebSocketTransport {
 impl WebSocketTransport {
     /// Open a new WebSocket connection to `url`.
     ///
-    /// Both `ws://` and `wss://` schemes are accepted; TLS is handled
-    /// transparently via `native-tls`. The URL is parsed eagerly so
-    /// malformed URLs surface as
+    /// Both `ws://` and `wss://` schemes are accepted; the `wss://` TLS
+    /// backend is chosen at compile time by Cargo feature (see the crate
+    /// docs), defaulting to rustls with OS-trust-store roots. The URL is
+    /// parsed eagerly so malformed URLs surface as
     /// [`WebSocketTransportError::InvalidUrl`] before any network I/O.
     pub async fn connect(url: &str) -> Result<Self, WebSocketTransportError> {
         let _parsed = Url::parse(url)?; // validate early


### PR DESCRIPTION
## Why

`ahp-ws` unconditionally enabled `tokio-tungstenite = { features = ["native-tls"] }`. Two facts combine to make that decision leak out of this crate and onto everyone downstream:

1. **Cargo feature unification** unions features across the whole graph, so once a downstream binary shares the same `tokio-tungstenite` node, `native-tls` is compiled in for *all* consumers.
2. **tungstenite's auto-connector prefers native-tls** — its no-explicit-connector path is gated `#[cfg(feature = "native-tls")]` first, only falling through to rustls under `#[cfg(all(__rustls-tls, not(native-tls)))]`.

The upshot (documented in [github/copilot-host#298](https://github.com/github/copilot-host/pull/298)): copilotd's request for `rustls-tls-native-roots` can never win while `ahp-ws` forces `native-tls`, and `ahp-ws` drags OpenSSL onto Linux builds regardless. This moves the lever back into AHP.

## What

Gate the WebSocket TLS backend behind Cargo features instead of hard-coding it:

| Feature | TLS stack | Trust roots |
| --- | --- | --- |
| `rustls-tls-native-roots` (**default**) | rustls (pure Rust) | OS trust store |
| `rustls-tls-webpki-roots` | rustls (pure Rust) | bundled Mozilla roots |
| `native-tls` | platform (SChannel / Secure Transport / OpenSSL) | OS trust store |

- `tokio-tungstenite` now uses `default-features = false` (just `connect` + `handshake`); each feature re-exports the matching tungstenite TLS feature.
- The new default, `rustls-tls-native-roots`, is a pure-Rust stack — **no OpenSSL on Linux** — that still validates against the **OS trust store**, preserving the TLS-intercepting-egress-proxy / enterprise-CA invariant that `native-tls` provided.
- An optional `rustls` dep (`default-features = false, features = ["ring", "std", "tls12"]`) is pulled in by the rustls features so the shared rustls 0.23 node has a crypto provider. Without this, tungstenite's rustls connector calls `ClientConfig::builder()` → `CryptoProvider::get_default()` and **panics on the first `wss://` dial**. `ring` keeps the build portable (no C toolchain, unlike `aws-lc-rs`).
- With no TLS feature enabled, `ws://` still works and `wss://` fails at connect time.

Downstreams (e.g. copilotd) can now get rustls for free, or opt back into native-tls with `default-features = false, features = ["native-tls"]`.

## Validation

- Builds clean for **all four** feature combinations (default, `native-tls`, `rustls-tls-webpki-roots`, and no-TLS).
- Default dependency tree contains `ring` + `rustls` + `rustls-native-certs` and **zero** OpenSSL.
- `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, and `cargo doc` all pass.
- No MSRV regression: every new TLS crate declares MSRV ≤ 1.71, under the workspace's `rust-version = "1.75"`.

CHANGELOG updated under `clients/rust/CHANGELOG.md` (Added + Changed).