### PR TITLE
`root/progress` notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,15 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 ### Added
 
-- `root/downloadProgress` (`DownloadProgressParams`, `DownloadPhase`) host→client
-  notification reporting progress while the host downloads a resource on the
-  client's behalf (e.g. an agent's native SDK fetched lazily on first use), so
-  clients can show a progress indicator instead of a silent multi-second hang.
+- `root/progress` (`ProgressParams`) generic host→client progress notification,
+  correlated by a `progressToken` the client supplies on the originating
+  request (today `createSession.progressToken`) rather than a domain object. Lets
+  the host report long-running work — e.g. the lazy first-use download of an
+  agent's native SDK — so clients can show an indicator instead of a silent
+  multi-second hang. Carries monotonic `progress` and optional `total`; complete
+  when `progress === total`.
+- `createSession.progressToken` optional opt-in token for receiving `root/progress`
+  notifications about a session's bring-up.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary._meta` optional provider metadata field for lightweight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 ### Added
 
+- `root/downloadProgress` (`DownloadProgressParams`, `DownloadPhase`) host→client
+  notification reporting progress while the host downloads a resource on the
+  client's behalf (e.g. an agent's native SDK fetched lazily on first use), so
+  clients can show a progress indicator instead of a silent multi-second hang.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary._meta` optional provider metadata field for lightweight

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,9 +16,9 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
-- `DownloadProgressParams` struct and `DownloadPhase` (wire
-  `root/downloadProgress`) for reporting host-side resource download progress
-  (e.g. an agent's native SDK fetched lazily on first use).
+- `ProgressParams` struct (wire `root/progress`) — a generic progress notification
+  correlated by a `ProgressToken` (added on `CreateSessionParams`).
+  Used today for the lazy first-use download of an agent's native SDK.
 - `SessionModelInfo.MaxOutputTokens` and `SessionModelInfo.MaxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.Meta` (wire `_meta`) optional provider metadata field for

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,6 +16,9 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `DownloadProgressParams` struct and `DownloadPhase` (wire
+  `root/downloadProgress`) for reporting host-side resource download progress
+  (e.g. an agent's native SDK fetched lazily on first use).
 - `SessionModelInfo.MaxOutputTokens` and `SessionModelInfo.MaxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.Meta` (wire `_meta`) optional provider metadata field for

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -252,6 +252,17 @@ type CreateSessionParams struct {
 	// action immediately after creation. The `clientId` MUST match the
 	// `clientId` the creating client supplied in `initialize`.
 	ActiveClient *SessionActiveClient `json:"activeClient,omitempty"`
+	// Opt-in progress token. When set, the client is offering to receive
+	// `progress` notifications (see `ProgressParams`) for any long-running work
+	// the server does to bring this session up — most notably the lazy,
+	// first-use download of the provider's native SDK. The server echoes this
+	// exact token on every `progress` frame so the client can correlate it to
+	// this `createSession` call (and the UI awaiting it).
+	//
+	// The token MUST be unique across the client's active requests. The server
+	// MAY ignore it (e.g. when nothing long-running is needed), in which case no
+	// `progress` notifications are emitted.
+	ProgressToken *string `json:"progressToken,omitempty"`
 }
 
 // Disposes a session and cleans up server-side resources.

--- a/clients/go/ahptypes/notifications.generated.go
+++ b/clients/go/ahptypes/notifications.generated.go
@@ -25,20 +25,6 @@ const (
 	AuthRequiredReasonExpired AuthRequiredReason = "expired"
 )
 
-// Lifecycle phase of a single download.
-type DownloadPhase string
-
-const (
-	// The download has begun; no bytes received yet.
-	DownloadPhaseStarted DownloadPhase = "started"
-	// A throttled progress sample with bytes received so far.
-	DownloadPhaseProgress DownloadPhase = "progress"
-	// Terminal success frame; the resource is fully downloaded.
-	DownloadPhaseCompleted DownloadPhase = "completed"
-	// Terminal failure frame; see {@link DownloadProgressParams.error}.
-	DownloadPhaseFailed DownloadPhase = "failed"
-)
-
 // ─── Notification Payloads ────────────────────────────────────────────
 
 // Broadcast to all clients subscribed to the root channel when a new session
@@ -99,68 +85,52 @@ type SessionSummaryChangedParams struct {
 	Changes PartialSessionSummary `json:"changes"`
 }
 
-// Broadcast on the root channel while the host downloads a resource on the
-// client's behalf — typically a multi-MB artifact fetched lazily the first time
-// it is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets
-// clients show a progress indicator instead of a silent multi-second hang.
+// Generic progress notification for a long-running operation.
 //
-// The notification is intentionally **resource-agnostic** so the same channel
-// can report future downloads (additional agent runtimes, plugins, models, …)
-// without a new method. The `kind` discriminant categorizes the resource and
-// `resourceId` identifies it within that kind; clients that don't care can show
-// a single generic indicator driven by `displayName` + the byte counts.
+// A client opts in to progress for a request by including a `progressToken` in
+// that request (today: the `progressToken` field on `createSession`). If the
+// server does long-running work to service the request — e.g. lazily
+// downloading an agent's native SDK the first time a session of that provider
+// is materialized — it emits `progress` notifications carrying the same token.
 //
-// This is **host-level**, not session state: the artifact is shared across every
-// consumer and the host deduplicates concurrent fetches into one download (one
-// `downloadId`). The optional `session` field names the session whose action
-// triggered the fetch, purely as context — a client MAY attribute the progress
-// to that session's row, or show a single global indicator and ignore it.
+// The notification is operation-agnostic: it says nothing about *what* is
+// progressing. The client correlates `progressToken` back to the request it
+// originated from (and thus the UI surface awaiting it) and renders its own
+// localized indicator. The same channel serves any future long-running
+// operation without a new method.
 //
 // Semantics:
 //
-//   - Frames for one download share a stable `downloadId`. The first frame a
-//     client observes for a `downloadId` begins the indicator even if it is not
-//     `phase: 'started'` (a client that connects mid-download may miss the
-//     `started` frame).
-//   - `receivedBytes` is monotonically non-decreasing within a `downloadId`.
-//     `totalBytes` is present only when the host knows the size up front
+//   - `progress` is monotonically non-decreasing for a given `progressToken`.
+//   - `total` is present only when the server knows the magnitude up front
 //     (e.g. a `Content-Length`); when absent the client SHOULD show an
 //     indeterminate indicator.
-//   - Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a
-//     download. `error` carries a short, non-localized reason on failure.
+//   - The operation is complete when `progress === total`. The server MUST emit a
+//     final frame satisfying `progress === total`; when the total was never
+//     known, it sets `total` to the final `progress` on that frame. No further
+//     frames reference the token afterwards.
+//   - The server MAY emit no progress at all (e.g. the work was already done);
+//     the client then never shows an indicator.
 //   - Like all notifications this is ephemeral and is **not** replayed on
-//     reconnect. A client that never receives a terminal frame (the download
-//     finished while it was disconnected) SHOULD expire the indicator after an
-//     idle timeout.
-//   - The brand noun is carried in `displayName`; clients own the surrounding
-//     (localized) template, e.g. `"Downloading {displayName}… {pct}%"`.
-type DownloadProgressParams struct {
-	// Channel URI this notification belongs to (the root channel)
+//     reconnect. A client that never receives the terminal frame SHOULD expire
+//     the indicator after an idle timeout.
+type ProgressParams struct {
+	// Channel URI this notification belongs to (the root channel).
 	Channel URI `json:"channel"`
-	// Stable id for one download. Coalesces the frames of a single fetch and
-	// distinguishes concurrent downloads (e.g. two resources at once).
-	DownloadId string `json:"downloadId"`
-	// Category of resource being downloaded. An open string (not a closed enum)
-	// so new resource types can be reported without a protocol bump. Known
-	// values today: `'agent-sdk'` (an agent's native SDK/runtime).
-	Kind string `json:"kind"`
-	// Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
-	// or `'codex'` for an `'agent-sdk'` download.
-	ResourceId string `json:"resourceId"`
-	// Human-readable brand name for display, e.g. `'Claude'`. The host supplies
-	// the noun; the client owns the surrounding localized template.
-	DisplayName string `json:"displayName"`
-	// Lifecycle phase of this frame.
-	Phase DownloadPhase `json:"phase"`
-	// Bytes written so far. Monotonically non-decreasing within a `downloadId`.
-	ReceivedBytes int64 `json:"receivedBytes"`
-	// Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
-	TotalBytes *int64 `json:"totalBytes,omitempty"`
-	// Session whose action triggered the fetch, if any. Informational only —
-	// the download is host-level and shared across sessions.
-	Session *URI `json:"session,omitempty"`
-	// Short, non-localized failure reason; present only when `phase: 'failed'`.
-	Error *string `json:"error,omitempty"`
+	// Echoes the `progressToken` the client supplied on the originating request
+	// (e.g. the `progressToken` field of `createSession`), correlating this frame
+	// to that call. Unique across the client's active requests.
+	ProgressToken string `json:"progressToken"`
+	// Progress so far, in operation-defined units (e.g. bytes received).
+	// Monotonically non-decreasing for a given `progressToken`.
+	Progress int64 `json:"progress"`
+	// Total when known up front (e.g. from a `Content-Length`); omitted ⇒
+	// indeterminate. The operation is complete once `progress === total`.
+	Total *int64 `json:"total,omitempty"`
+	// Optional human-readable progress message. The client owns its own
+	// (localized) presentation derived from the originating request; generic
+	// clients that don't track the token MAY display this instead.
+	Message *string `json:"message,omitempty"`
 }
 
 // Sent by the server when a protected resource requires (re-)authentication.

--- a/clients/go/ahptypes/notifications.generated.go
+++ b/clients/go/ahptypes/notifications.generated.go
@@ -25,6 +25,20 @@ const (
 	AuthRequiredReasonExpired AuthRequiredReason = "expired"
 )
 
+// Lifecycle phase of a single download.
+type DownloadPhase string
+
+const (
+	// The download has begun; no bytes received yet.
+	DownloadPhaseStarted DownloadPhase = "started"
+	// A throttled progress sample with bytes received so far.
+	DownloadPhaseProgress DownloadPhase = "progress"
+	// Terminal success frame; the resource is fully downloaded.
+	DownloadPhaseCompleted DownloadPhase = "completed"
+	// Terminal failure frame; see {@link DownloadProgressParams.error}.
+	DownloadPhaseFailed DownloadPhase = "failed"
+)
+
 // ─── Notification Payloads ────────────────────────────────────────────
 
 // Broadcast to all clients subscribed to the root channel when a new session
@@ -83,6 +97,70 @@ type SessionSummaryChangedParams struct {
 	// Identity fields (`resource`, `provider`, `createdAt`) never change and
 	// MUST be omitted by senders; receivers SHOULD ignore them if present.
 	Changes PartialSessionSummary `json:"changes"`
+}
+
+// Broadcast on the root channel while the host downloads a resource on the
+// client's behalf — typically a multi-MB artifact fetched lazily the first time
+// it is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets
+// clients show a progress indicator instead of a silent multi-second hang.
+//
+// The notification is intentionally **resource-agnostic** so the same channel
+// can report future downloads (additional agent runtimes, plugins, models, …)
+// without a new method. The `kind` discriminant categorizes the resource and
+// `resourceId` identifies it within that kind; clients that don't care can show
+// a single generic indicator driven by `displayName` + the byte counts.
+//
+// This is **host-level**, not session state: the artifact is shared across every
+// consumer and the host deduplicates concurrent fetches into one download (one
+// `downloadId`). The optional `session` field names the session whose action
+// triggered the fetch, purely as context — a client MAY attribute the progress
+// to that session's row, or show a single global indicator and ignore it.
+//
+// Semantics:
+//
+//   - Frames for one download share a stable `downloadId`. The first frame a
+//     client observes for a `downloadId` begins the indicator even if it is not
+//     `phase: 'started'` (a client that connects mid-download may miss the
+//     `started` frame).
+//   - `receivedBytes` is monotonically non-decreasing within a `downloadId`.
+//     `totalBytes` is present only when the host knows the size up front
+//     (e.g. a `Content-Length`); when absent the client SHOULD show an
+//     indeterminate indicator.
+//   - Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a
+//     download. `error` carries a short, non-localized reason on failure.
+//   - Like all notifications this is ephemeral and is **not** replayed on
+//     reconnect. A client that never receives a terminal frame (the download
+//     finished while it was disconnected) SHOULD expire the indicator after an
+//     idle timeout.
+//   - The brand noun is carried in `displayName`; clients own the surrounding
+//     (localized) template, e.g. `"Downloading {displayName}… {pct}%"`.
+type DownloadProgressParams struct {
+	// Channel URI this notification belongs to (the root channel)
+	Channel URI `json:"channel"`
+	// Stable id for one download. Coalesces the frames of a single fetch and
+	// distinguishes concurrent downloads (e.g. two resources at once).
+	DownloadId string `json:"downloadId"`
+	// Category of resource being downloaded. An open string (not a closed enum)
+	// so new resource types can be reported without a protocol bump. Known
+	// values today: `'agent-sdk'` (an agent's native SDK/runtime).
+	Kind string `json:"kind"`
+	// Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
+	// or `'codex'` for an `'agent-sdk'` download.
+	ResourceId string `json:"resourceId"`
+	// Human-readable brand name for display, e.g. `'Claude'`. The host supplies
+	// the noun; the client owns the surrounding localized template.
+	DisplayName string `json:"displayName"`
+	// Lifecycle phase of this frame.
+	Phase DownloadPhase `json:"phase"`
+	// Bytes written so far. Monotonically non-decreasing within a `downloadId`.
+	ReceivedBytes int64 `json:"receivedBytes"`
+	// Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
+	TotalBytes *int64 `json:"totalBytes,omitempty"`
+	// Session whose action triggered the fetch, if any. Informational only —
+	// the download is host-level and shared across sessions.
+	Session *URI `json:"session,omitempty"`
+	// Short, non-localized failure reason; present only when `phase: 'failed'`.
+	Error *string `json:"error,omitempty"`
 }
 
 // Sent by the server when a protected resource requires (re-)authentication.

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -17,6 +17,9 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Added
 
+- `DownloadProgressParams` data class and `DownloadPhase` enum (wire
+  `root/downloadProgress`) for reporting host-side resource download progress
+  (e.g. an agent's native SDK fetched lazily on first use).
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -17,9 +17,9 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Added
 
-- `DownloadProgressParams` data class and `DownloadPhase` enum (wire
-  `root/downloadProgress`) for reporting host-side resource download progress
-  (e.g. an agent's native SDK fetched lazily on first use).
+- `ProgressParams` data class (wire `root/progress`) — a generic progress
+  notification correlated by a `progressToken` (added on `CreateSessionParams`).
+  Used today for the lazy first-use download of an agent's native SDK.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -319,7 +319,20 @@ data class CreateSessionParams(
      * action immediately after creation. The `clientId` MUST match the
      * `clientId` the creating client supplied in `initialize`.
      */
-    val activeClient: SessionActiveClient? = null
+    val activeClient: SessionActiveClient? = null,
+    /**
+     * Opt-in progress token. When set, the client is offering to receive
+     * `progress` notifications (see `ProgressParams`) for any long-running work
+     * the server does to bring this session up — most notably the lazy,
+     * first-use download of the provider's native SDK. The server echoes this
+     * exact token on every `progress` frame so the client can correlate it to
+     * this `createSession` call (and the UI awaiting it).
+     *
+     * The token MUST be unique across the client's active requests. The server
+     * MAY ignore it (e.g. when nothing long-running is needed), in which case no
+     * `progress` notifications are emitted.
+     */
+    val progressToken: String? = null
 )
 
 @Serializable

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
@@ -38,33 +38,6 @@ enum class AuthRequiredReason {
     EXPIRED
 }
 
-/**
- * Lifecycle phase of a single download.
- */
-@Serializable
-enum class DownloadPhase {
-    /**
-     * The download has begun; no bytes received yet.
-     */
-    @SerialName("started")
-    STARTED,
-    /**
-     * A throttled progress sample with bytes received so far.
-     */
-    @SerialName("progress")
-    PROGRESS,
-    /**
-     * Terminal success frame; the resource is fully downloaded.
-     */
-    @SerialName("completed")
-    COMPLETED,
-    /**
-     * Terminal failure frame; see {@link DownloadProgressParams.error}.
-     */
-    @SerialName("failed")
-    FAILED
-}
-
 // ─── Notification Types ─────────────────────────────────────────────────────
 
 @Serializable
@@ -111,53 +84,33 @@ data class SessionSummaryChangedParams(
 )
 
 @Serializable
-data class DownloadProgressParams(
+data class ProgressParams(
     /**
-     * Channel URI this notification belongs to (the root channel)
+     * Channel URI this notification belongs to (the root channel).
      */
     val channel: String,
     /**
-     * Stable id for one download. Coalesces the frames of a single fetch and
-     * distinguishes concurrent downloads (e.g. two resources at once).
+     * Echoes the `progressToken` the client supplied on the originating request
+     * (e.g. the `progressToken` field of `createSession`), correlating this frame
+     * to that call. Unique across the client's active requests.
      */
-    val downloadId: String,
+    val progressToken: String,
     /**
-     * Category of resource being downloaded. An open string (not a closed enum)
-     * so new resource types can be reported without a protocol bump. Known
-     * values today: `'agent-sdk'` (an agent's native SDK/runtime).
+     * Progress so far, in operation-defined units (e.g. bytes received).
+     * Monotonically non-decreasing for a given `progressToken`.
      */
-    val kind: String,
+    val progress: Long,
     /**
-     * Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
-     * or `'codex'` for an `'agent-sdk'` download.
+     * Total when known up front (e.g. from a `Content-Length`); omitted ⇒
+     * indeterminate. The operation is complete once `progress === total`.
      */
-    val resourceId: String,
+    val total: Long? = null,
     /**
-     * Human-readable brand name for display, e.g. `'Claude'`. The host supplies
-     * the noun; the client owns the surrounding localized template.
+     * Optional human-readable progress message. The client owns its own
+     * (localized) presentation derived from the originating request; generic
+     * clients that don't track the token MAY display this instead.
      */
-    val displayName: String,
-    /**
-     * Lifecycle phase of this frame.
-     */
-    val phase: DownloadPhase,
-    /**
-     * Bytes written so far. Monotonically non-decreasing within a `downloadId`.
-     */
-    val receivedBytes: Long,
-    /**
-     * Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
-     */
-    val totalBytes: Long? = null,
-    /**
-     * Session whose action triggered the fetch, if any. Informational only —
-     * the download is host-level and shared across sessions.
-     */
-    val session: String? = null,
-    /**
-     * Short, non-localized failure reason; present only when `phase: 'failed'`.
-     */
-    val error: String? = null
+    val message: String? = null
 )
 
 @Serializable

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
@@ -38,6 +38,33 @@ enum class AuthRequiredReason {
     EXPIRED
 }
 
+/**
+ * Lifecycle phase of a single download.
+ */
+@Serializable
+enum class DownloadPhase {
+    /**
+     * The download has begun; no bytes received yet.
+     */
+    @SerialName("started")
+    STARTED,
+    /**
+     * A throttled progress sample with bytes received so far.
+     */
+    @SerialName("progress")
+    PROGRESS,
+    /**
+     * Terminal success frame; the resource is fully downloaded.
+     */
+    @SerialName("completed")
+    COMPLETED,
+    /**
+     * Terminal failure frame; see {@link DownloadProgressParams.error}.
+     */
+    @SerialName("failed")
+    FAILED
+}
+
 // ─── Notification Types ─────────────────────────────────────────────────────
 
 @Serializable
@@ -81,6 +108,56 @@ data class SessionSummaryChangedParams(
      * MUST be omitted by senders; receivers SHOULD ignore them if present.
      */
     val changes: PartialSessionSummary
+)
+
+@Serializable
+data class DownloadProgressParams(
+    /**
+     * Channel URI this notification belongs to (the root channel)
+     */
+    val channel: String,
+    /**
+     * Stable id for one download. Coalesces the frames of a single fetch and
+     * distinguishes concurrent downloads (e.g. two resources at once).
+     */
+    val downloadId: String,
+    /**
+     * Category of resource being downloaded. An open string (not a closed enum)
+     * so new resource types can be reported without a protocol bump. Known
+     * values today: `'agent-sdk'` (an agent's native SDK/runtime).
+     */
+    val kind: String,
+    /**
+     * Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
+     * or `'codex'` for an `'agent-sdk'` download.
+     */
+    val resourceId: String,
+    /**
+     * Human-readable brand name for display, e.g. `'Claude'`. The host supplies
+     * the noun; the client owns the surrounding localized template.
+     */
+    val displayName: String,
+    /**
+     * Lifecycle phase of this frame.
+     */
+    val phase: DownloadPhase,
+    /**
+     * Bytes written so far. Monotonically non-decreasing within a `downloadId`.
+     */
+    val receivedBytes: Long,
+    /**
+     * Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
+     */
+    val totalBytes: Long? = null,
+    /**
+     * Session whose action triggered the fetch, if any. Informational only —
+     * the download is host-level and shared across sessions.
+     */
+    val session: String? = null,
+    /**
+     * Short, non-localized failure reason; present only when `phase: 'failed'`.
+     */
+    val error: String? = null
 )
 
 @Serializable

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,9 +17,9 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
-- `DownloadProgressParams` struct and `DownloadPhase` enum (wire
-  `root/downloadProgress`) for reporting host-side resource download progress
-  (e.g. an agent's native SDK fetched lazily on first use).
+- `ProgressParams` struct (wire `root/progress`) — a generic progress notification
+  correlated by a `progressToken` (added on `CreateSessionParams`).
+  Used today for the lazy first-use download of an agent's native SDK.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,6 +17,9 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `DownloadProgressParams` struct and `DownloadPhase` enum (wire
+  `root/downloadProgress`) for reporting host-side resource download progress
+  (e.g. an agent's native SDK fetched lazily on first use).
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -300,6 +300,18 @@ pub struct CreateSessionParams {
     /// `clientId` the creating client supplied in `initialize`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_client: Option<SessionActiveClient>,
+    /// Opt-in progress token. When set, the client is offering to receive
+    /// `progress` notifications (see `ProgressParams`) for any long-running work
+    /// the server does to bring this session up — most notably the lazy,
+    /// first-use download of the provider's native SDK. The server echoes this
+    /// exact token on every `progress` frame so the client can correlate it to
+    /// this `createSession` call (and the UI awaiting it).
+    ///
+    /// The token MUST be unique across the client's active requests. The server
+    /// MAY ignore it (e.g. when nothing long-running is needed), in which case no
+    /// `progress` notifications are emitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress_token: Option<String>,
 }
 
 /// Disposes a session and cleans up server-side resources.

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -30,6 +30,23 @@ pub enum AuthRequiredReason {
     Expired,
 }
 
+/// Lifecycle phase of a single download.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DownloadPhase {
+    /// The download has begun; no bytes received yet.
+    #[serde(rename = "started")]
+    Started,
+    /// A throttled progress sample with bytes received so far.
+    #[serde(rename = "progress")]
+    Progress,
+    /// Terminal success frame; the resource is fully downloaded.
+    #[serde(rename = "completed")]
+    Completed,
+    /// Terminal failure frame; see {@link DownloadProgressParams.error}.
+    #[serde(rename = "failed")]
+    Failed,
+}
+
 // ─── Notification Payloads ────────────────────────────────────────────
 
 /// Broadcast to all clients subscribed to the root channel when a new session
@@ -94,6 +111,75 @@ pub struct SessionSummaryChangedParams {
     /// Identity fields (`resource`, `provider`, `createdAt`) never change and
     /// MUST be omitted by senders; receivers SHOULD ignore them if present.
     pub changes: PartialSessionSummary,
+}
+
+/// Broadcast on the root channel while the host downloads a resource on the
+/// client's behalf — typically a multi-MB artifact fetched lazily the first time
+/// it is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets
+/// clients show a progress indicator instead of a silent multi-second hang.
+///
+/// The notification is intentionally **resource-agnostic** so the same channel
+/// can report future downloads (additional agent runtimes, plugins, models, …)
+/// without a new method. The `kind` discriminant categorizes the resource and
+/// `resourceId` identifies it within that kind; clients that don't care can show
+/// a single generic indicator driven by `displayName` + the byte counts.
+///
+/// This is **host-level**, not session state: the artifact is shared across every
+/// consumer and the host deduplicates concurrent fetches into one download (one
+/// `downloadId`). The optional `session` field names the session whose action
+/// triggered the fetch, purely as context — a client MAY attribute the progress
+/// to that session's row, or show a single global indicator and ignore it.
+///
+/// Semantics:
+///
+/// - Frames for one download share a stable `downloadId`. The first frame a
+///   client observes for a `downloadId` begins the indicator even if it is not
+///   `phase: 'started'` (a client that connects mid-download may miss the
+///   `started` frame).
+/// - `receivedBytes` is monotonically non-decreasing within a `downloadId`.
+///   `totalBytes` is present only when the host knows the size up front
+///   (e.g. a `Content-Length`); when absent the client SHOULD show an
+///   indeterminate indicator.
+/// - Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a
+///   download. `error` carries a short, non-localized reason on failure.
+/// - Like all notifications this is ephemeral and is **not** replayed on
+///   reconnect. A client that never receives a terminal frame (the download
+///   finished while it was disconnected) SHOULD expire the indicator after an
+///   idle timeout.
+/// - The brand noun is carried in `displayName`; clients own the surrounding
+///   (localized) template, e.g. `"Downloading {displayName}… {pct}%"`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadProgressParams {
+    /// Channel URI this notification belongs to (the root channel)
+    pub channel: Uri,
+    /// Stable id for one download. Coalesces the frames of a single fetch and
+    /// distinguishes concurrent downloads (e.g. two resources at once).
+    pub download_id: String,
+    /// Category of resource being downloaded. An open string (not a closed enum)
+    /// so new resource types can be reported without a protocol bump. Known
+    /// values today: `'agent-sdk'` (an agent's native SDK/runtime).
+    pub kind: String,
+    /// Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
+    /// or `'codex'` for an `'agent-sdk'` download.
+    pub resource_id: String,
+    /// Human-readable brand name for display, e.g. `'Claude'`. The host supplies
+    /// the noun; the client owns the surrounding localized template.
+    pub display_name: String,
+    /// Lifecycle phase of this frame.
+    pub phase: DownloadPhase,
+    /// Bytes written so far. Monotonically non-decreasing within a `downloadId`.
+    pub received_bytes: i64,
+    /// Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_bytes: Option<i64>,
+    /// Session whose action triggered the fetch, if any. Informational only —
+    /// the download is host-level and shared across sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<Uri>,
+    /// Short, non-localized failure reason; present only when `phase: 'failed'`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Sent by the server when a protected resource requires (re-)authentication.

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -30,23 +30,6 @@ pub enum AuthRequiredReason {
     Expired,
 }
 
-/// Lifecycle phase of a single download.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum DownloadPhase {
-    /// The download has begun; no bytes received yet.
-    #[serde(rename = "started")]
-    Started,
-    /// A throttled progress sample with bytes received so far.
-    #[serde(rename = "progress")]
-    Progress,
-    /// Terminal success frame; the resource is fully downloaded.
-    #[serde(rename = "completed")]
-    Completed,
-    /// Terminal failure frame; see {@link DownloadProgressParams.error}.
-    #[serde(rename = "failed")]
-    Failed,
-}
-
 // ─── Notification Payloads ────────────────────────────────────────────
 
 /// Broadcast to all clients subscribed to the root channel when a new session
@@ -113,73 +96,56 @@ pub struct SessionSummaryChangedParams {
     pub changes: PartialSessionSummary,
 }
 
-/// Broadcast on the root channel while the host downloads a resource on the
-/// client's behalf — typically a multi-MB artifact fetched lazily the first time
-/// it is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets
-/// clients show a progress indicator instead of a silent multi-second hang.
+/// Generic progress notification for a long-running operation.
 ///
-/// The notification is intentionally **resource-agnostic** so the same channel
-/// can report future downloads (additional agent runtimes, plugins, models, …)
-/// without a new method. The `kind` discriminant categorizes the resource and
-/// `resourceId` identifies it within that kind; clients that don't care can show
-/// a single generic indicator driven by `displayName` + the byte counts.
+/// A client opts in to progress for a request by including a `progressToken` in
+/// that request (today: the `progressToken` field on `createSession`). If the
+/// server does long-running work to service the request — e.g. lazily
+/// downloading an agent's native SDK the first time a session of that provider
+/// is materialized — it emits `progress` notifications carrying the same token.
 ///
-/// This is **host-level**, not session state: the artifact is shared across every
-/// consumer and the host deduplicates concurrent fetches into one download (one
-/// `downloadId`). The optional `session` field names the session whose action
-/// triggered the fetch, purely as context — a client MAY attribute the progress
-/// to that session's row, or show a single global indicator and ignore it.
+/// The notification is operation-agnostic: it says nothing about *what* is
+/// progressing. The client correlates `progressToken` back to the request it
+/// originated from (and thus the UI surface awaiting it) and renders its own
+/// localized indicator. The same channel serves any future long-running
+/// operation without a new method.
 ///
 /// Semantics:
 ///
-/// - Frames for one download share a stable `downloadId`. The first frame a
-///   client observes for a `downloadId` begins the indicator even if it is not
-///   `phase: 'started'` (a client that connects mid-download may miss the
-///   `started` frame).
-/// - `receivedBytes` is monotonically non-decreasing within a `downloadId`.
-///   `totalBytes` is present only when the host knows the size up front
+/// - `progress` is monotonically non-decreasing for a given `progressToken`.
+/// - `total` is present only when the server knows the magnitude up front
 ///   (e.g. a `Content-Length`); when absent the client SHOULD show an
 ///   indeterminate indicator.
-/// - Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a
-///   download. `error` carries a short, non-localized reason on failure.
+/// - The operation is complete when `progress === total`. The server MUST emit a
+///   final frame satisfying `progress === total`; when the total was never
+///   known, it sets `total` to the final `progress` on that frame. No further
+///   frames reference the token afterwards.
+/// - The server MAY emit no progress at all (e.g. the work was already done);
+///   the client then never shows an indicator.
 /// - Like all notifications this is ephemeral and is **not** replayed on
-///   reconnect. A client that never receives a terminal frame (the download
-///   finished while it was disconnected) SHOULD expire the indicator after an
-///   idle timeout.
-/// - The brand noun is carried in `displayName`; clients own the surrounding
-///   (localized) template, e.g. `"Downloading {displayName}… {pct}%"`.
+///   reconnect. A client that never receives the terminal frame SHOULD expire
+///   the indicator after an idle timeout.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DownloadProgressParams {
-    /// Channel URI this notification belongs to (the root channel)
+pub struct ProgressParams {
+    /// Channel URI this notification belongs to (the root channel).
     pub channel: Uri,
-    /// Stable id for one download. Coalesces the frames of a single fetch and
-    /// distinguishes concurrent downloads (e.g. two resources at once).
-    pub download_id: String,
-    /// Category of resource being downloaded. An open string (not a closed enum)
-    /// so new resource types can be reported without a protocol bump. Known
-    /// values today: `'agent-sdk'` (an agent's native SDK/runtime).
-    pub kind: String,
-    /// Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
-    /// or `'codex'` for an `'agent-sdk'` download.
-    pub resource_id: String,
-    /// Human-readable brand name for display, e.g. `'Claude'`. The host supplies
-    /// the noun; the client owns the surrounding localized template.
-    pub display_name: String,
-    /// Lifecycle phase of this frame.
-    pub phase: DownloadPhase,
-    /// Bytes written so far. Monotonically non-decreasing within a `downloadId`.
-    pub received_bytes: i64,
-    /// Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
+    /// Echoes the `progressToken` the client supplied on the originating request
+    /// (e.g. the `progressToken` field of `createSession`), correlating this frame
+    /// to that call. Unique across the client's active requests.
+    pub progress_token: String,
+    /// Progress so far, in operation-defined units (e.g. bytes received).
+    /// Monotonically non-decreasing for a given `progressToken`.
+    pub progress: i64,
+    /// Total when known up front (e.g. from a `Content-Length`); omitted ⇒
+    /// indeterminate. The operation is complete once `progress === total`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub total_bytes: Option<i64>,
-    /// Session whose action triggered the fetch, if any. Informational only —
-    /// the download is host-level and shared across sessions.
+    pub total: Option<i64>,
+    /// Optional human-readable progress message. The client owns its own
+    /// (localized) presentation derived from the originating request; generic
+    /// clients that don't track the token MAY display this instead.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session: Option<Uri>,
-    /// Short, non-localized failure reason; present only when `phase: 'failed'`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub message: Option<String>,
 }
 
 /// Sent by the server when a protected resource requires (re-)authentication.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -285,6 +285,17 @@ public struct CreateSessionParams: Codable, Sendable {
     /// action immediately after creation. The `clientId` MUST match the
     /// `clientId` the creating client supplied in `initialize`.
     public var activeClient: SessionActiveClient?
+    /// Opt-in progress token. When set, the client is offering to receive
+    /// `progress` notifications (see `ProgressParams`) for any long-running work
+    /// the server does to bring this session up — most notably the lazy,
+    /// first-use download of the provider's native SDK. The server echoes this
+    /// exact token on every `progress` frame so the client can correlate it to
+    /// this `createSession` call (and the UI awaiting it).
+    ///
+    /// The token MUST be unique across the client's active requests. The server
+    /// MAY ignore it (e.g. when nothing long-running is needed), in which case no
+    /// `progress` notifications are emitted.
+    public var progressToken: String?
 
     public init(
         channel: String,
@@ -294,7 +305,8 @@ public struct CreateSessionParams: Codable, Sendable {
         workingDirectory: String? = nil,
         fork: SessionForkSource? = nil,
         config: [String: AnyCodable]? = nil,
-        activeClient: SessionActiveClient? = nil
+        activeClient: SessionActiveClient? = nil,
+        progressToken: String? = nil
     ) {
         self.channel = channel
         self.provider = provider
@@ -304,6 +316,7 @@ public struct CreateSessionParams: Codable, Sendable {
         self.fork = fork
         self.config = config
         self.activeClient = activeClient
+        self.progressToken = progressToken
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -12,6 +12,18 @@ public enum AuthRequiredReason: String, Codable, Sendable {
     case expired = "expired"
 }
 
+/// Lifecycle phase of a single download.
+public enum DownloadPhase: String, Codable, Sendable {
+    /// The download has begun; no bytes received yet.
+    case started = "started"
+    /// A throttled progress sample with bytes received so far.
+    case progress = "progress"
+    /// Terminal success frame; the resource is fully downloaded.
+    case completed = "completed"
+    /// Terminal failure frame; see {@link DownloadProgressParams.error}.
+    case failed = "failed"
+}
+
 // MARK: - Notification Types
 
 public struct SessionAddedParams: Codable, Sendable {
@@ -63,6 +75,59 @@ public struct SessionSummaryChangedParams: Codable, Sendable {
         self.channel = channel
         self.session = session
         self.changes = changes
+    }
+}
+
+public struct DownloadProgressParams: Codable, Sendable {
+    /// Channel URI this notification belongs to (the root channel)
+    public var channel: String
+    /// Stable id for one download. Coalesces the frames of a single fetch and
+    /// distinguishes concurrent downloads (e.g. two resources at once).
+    public var downloadId: String
+    /// Category of resource being downloaded. An open string (not a closed enum)
+    /// so new resource types can be reported without a protocol bump. Known
+    /// values today: `'agent-sdk'` (an agent's native SDK/runtime).
+    public var kind: String
+    /// Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
+    /// or `'codex'` for an `'agent-sdk'` download.
+    public var resourceId: String
+    /// Human-readable brand name for display, e.g. `'Claude'`. The host supplies
+    /// the noun; the client owns the surrounding localized template.
+    public var displayName: String
+    /// Lifecycle phase of this frame.
+    public var phase: DownloadPhase
+    /// Bytes written so far. Monotonically non-decreasing within a `downloadId`.
+    public var receivedBytes: Int
+    /// Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
+    public var totalBytes: Int?
+    /// Session whose action triggered the fetch, if any. Informational only —
+    /// the download is host-level and shared across sessions.
+    public var session: String?
+    /// Short, non-localized failure reason; present only when `phase: 'failed'`.
+    public var error: String?
+
+    public init(
+        channel: String,
+        downloadId: String,
+        kind: String,
+        resourceId: String,
+        displayName: String,
+        phase: DownloadPhase,
+        receivedBytes: Int,
+        totalBytes: Int? = nil,
+        session: String? = nil,
+        error: String? = nil
+    ) {
+        self.channel = channel
+        self.downloadId = downloadId
+        self.kind = kind
+        self.resourceId = resourceId
+        self.displayName = displayName
+        self.phase = phase
+        self.receivedBytes = receivedBytes
+        self.totalBytes = totalBytes
+        self.session = session
+        self.error = error
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -12,18 +12,6 @@ public enum AuthRequiredReason: String, Codable, Sendable {
     case expired = "expired"
 }
 
-/// Lifecycle phase of a single download.
-public enum DownloadPhase: String, Codable, Sendable {
-    /// The download has begun; no bytes received yet.
-    case started = "started"
-    /// A throttled progress sample with bytes received so far.
-    case progress = "progress"
-    /// Terminal success frame; the resource is fully downloaded.
-    case completed = "completed"
-    /// Terminal failure frame; see {@link DownloadProgressParams.error}.
-    case failed = "failed"
-}
-
 // MARK: - Notification Types
 
 public struct SessionAddedParams: Codable, Sendable {
@@ -78,56 +66,36 @@ public struct SessionSummaryChangedParams: Codable, Sendable {
     }
 }
 
-public struct DownloadProgressParams: Codable, Sendable {
-    /// Channel URI this notification belongs to (the root channel)
+public struct ProgressParams: Codable, Sendable {
+    /// Channel URI this notification belongs to (the root channel).
     public var channel: String
-    /// Stable id for one download. Coalesces the frames of a single fetch and
-    /// distinguishes concurrent downloads (e.g. two resources at once).
-    public var downloadId: String
-    /// Category of resource being downloaded. An open string (not a closed enum)
-    /// so new resource types can be reported without a protocol bump. Known
-    /// values today: `'agent-sdk'` (an agent's native SDK/runtime).
-    public var kind: String
-    /// Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
-    /// or `'codex'` for an `'agent-sdk'` download.
-    public var resourceId: String
-    /// Human-readable brand name for display, e.g. `'Claude'`. The host supplies
-    /// the noun; the client owns the surrounding localized template.
-    public var displayName: String
-    /// Lifecycle phase of this frame.
-    public var phase: DownloadPhase
-    /// Bytes written so far. Monotonically non-decreasing within a `downloadId`.
-    public var receivedBytes: Int
-    /// Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate.
-    public var totalBytes: Int?
-    /// Session whose action triggered the fetch, if any. Informational only —
-    /// the download is host-level and shared across sessions.
-    public var session: String?
-    /// Short, non-localized failure reason; present only when `phase: 'failed'`.
-    public var error: String?
+    /// Echoes the `progressToken` the client supplied on the originating request
+    /// (e.g. the `progressToken` field of `createSession`), correlating this frame
+    /// to that call. Unique across the client's active requests.
+    public var progressToken: String
+    /// Progress so far, in operation-defined units (e.g. bytes received).
+    /// Monotonically non-decreasing for a given `progressToken`.
+    public var progress: Int
+    /// Total when known up front (e.g. from a `Content-Length`); omitted ⇒
+    /// indeterminate. The operation is complete once `progress === total`.
+    public var total: Int?
+    /// Optional human-readable progress message. The client owns its own
+    /// (localized) presentation derived from the originating request; generic
+    /// clients that don't track the token MAY display this instead.
+    public var message: String?
 
     public init(
         channel: String,
-        downloadId: String,
-        kind: String,
-        resourceId: String,
-        displayName: String,
-        phase: DownloadPhase,
-        receivedBytes: Int,
-        totalBytes: Int? = nil,
-        session: String? = nil,
-        error: String? = nil
+        progressToken: String,
+        progress: Int,
+        total: Int? = nil,
+        message: String? = nil
     ) {
         self.channel = channel
-        self.downloadId = downloadId
-        self.kind = kind
-        self.resourceId = resourceId
-        self.displayName = displayName
-        self.phase = phase
-        self.receivedBytes = receivedBytes
-        self.totalBytes = totalBytes
-        self.session = session
-        self.error = error
+        self.progressToken = progressToken
+        self.progress = progress
+        self.total = total
+        self.message = message
     }
 }
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,9 +19,9 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
-- `DownloadProgressParams` struct and `DownloadPhase` enum (wire
-  `root/downloadProgress`) for reporting host-side resource download progress
-  (e.g. an agent's native SDK fetched lazily on first use).
+- `ProgressParams` struct (wire `root/progress`) — a generic progress notification
+  correlated by a `progressToken` (added on `CreateSessionParams`).
+  Used today for the lazy first-use download of an agent's native SDK.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,6 +19,9 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
+- `DownloadProgressParams` struct and `DownloadPhase` enum (wire
+  `root/downloadProgress`) for reporting host-side resource download progress
+  (e.g. an agent's native SDK fetched lazily on first use).
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,9 +22,9 @@ hotfix escape hatch.
 
 ### Added
 
-- `root/downloadProgress` notification types (`DownloadProgressParams`,
-  `DownloadPhase`) for reporting host-side resource download progress (e.g. an
-  agent's native SDK fetched lazily on first use), so clients can show a progress
+- `ProgressParams` (wire `root/progress`) generic progress notification correlated by
+  a `progressToken`, plus `createSession.progressToken` to opt in. Used today for
+  the lazy first-use download of an agent's native SDK, so clients can show an
   indicator instead of a silent multi-second hang.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,6 +22,10 @@ hotfix escape hatch.
 
 ### Added
 
+- `root/downloadProgress` notification types (`DownloadProgressParams`,
+  `DownloadPhase`) for reporting host-side resource download progress (e.g. an
+  agent's native SDK fetched lazily on first use), so clients can show a progress
+  indicator instead of a silent multi-second hang.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary._meta` optional provider metadata field for lightweight

--- a/docs/specification/root-channel.md
+++ b/docs/specification/root-channel.md
@@ -66,6 +66,7 @@ target channel instead.
 | `root/sessionAdded` | server → client notification | Session catalogue entry created. |
 | `root/sessionRemoved` | server → client notification | Session catalogue entry removed. |
 | `root/sessionSummaryChanged` | server → client notification | Session catalogue entry mutated. |
+| `root/progress` | server → client notification | Generic progress for a long-running operation a client opted into (e.g. an SDK download). |
 | `unsubscribe` | client → server notification | Stop receiving root-channel messages. |
 | `dispatchAction` | client → server notification | Dispatch a root-scoped client action (currently `root/configChanged`). |
 
@@ -148,6 +149,26 @@ Emitted when any mutable field on an existing [`SessionSummary`](/reference/sess
 Servers MAY coalesce or debounce this notification for noisy fields — for example, rapid `modifiedAt` bumps during a streaming turn, or frequent `diffs` updates during an edit burst. Clients that have no cached entry for `session` MAY ignore the notification.
 
 Like all protocol notifications, the `root/*` events are ephemeral and are **not** replayed on reconnect. After reconnecting, clients SHOULD re-fetch the catalogue via [`listSessions`](/reference/root#listsessions).
+
+## Progress
+
+The server MAY emit `root/progress` to report incremental progress on a long-running operation a client opted into — most notably the lazy, first-use download of an agent's native SDK. A client opts in by supplying a `progressToken` on the originating request (today the `progressToken` field of [`createSession`](/reference/session#createsession)); the server echoes that token on every frame so the client can correlate progress back to the call and the UI awaiting it. The notification is operation-agnostic — it names no domain object.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "root/progress",
+  "params": {
+    "channel": "ahp-root://",
+    "progressToken": "9b2c1f7e-4a0d-4e2b-8b1a-2f7e4a0d4e2b",
+    "progress": 18874368,
+    "total": 41957498,
+    "message": "Downloading Claude agent…"
+  }
+}
+```
+
+`progress` is monotonically non-decreasing for a given `progressToken`. `total` is present only when the magnitude is known up front (e.g. a `Content-Length`); when absent, clients SHOULD show an indeterminate indicator. The operation is complete when `progress === total` — the server MUST emit a final frame satisfying this, setting `total` to the final `progress` when the total was never known, after which no further frames reference the token. An optional `message` carries a human-readable description of the work in progress; a client that tracks the token renders its own (localized) label and MAY ignore it, while a generic client MAY display `message` verbatim. The server MAY emit no progress at all (for example when the work was already done), in which case the client simply never shows an indicator. Like the catalogue events, `root/progress` is ephemeral and is **not** replayed on reconnect.
 
 ## Authentication Events
 

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -886,6 +886,10 @@
         "activeClient": {
           "$ref": "#/$defs/SessionActiveClient",
           "description": "Eagerly claim an active client role for the new session.\n\nWhen provided, the server initializes the session with this client as an\nactive client, equivalent to dispatching a `session/activeClientSet`\naction immediately after creation. The `clientId` MUST match the\n`clientId` the creating client supplied in `initialize`."
+        },
+        "progressToken": {
+          "type": "string",
+          "description": "Opt-in progress token. When set, the client is offering to receive\n`progress` notifications (see `ProgressParams`) for any long-running work\nthe server does to bring this session up — most notably the lazy,\nfirst-use download of the provider's native SDK. The server echoes this\nexact token on every `progress` frame so the client can correlate it to\nthis `createSession` call (and the UI awaiting it).\n\nThe token MUST be unique across the client's active requests. The server\nMAY ignore it (e.g. when nothing long-running is needed), in which case no\n`progress` notifications are emitted."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -5056,6 +5056,10 @@
         "activeClient": {
           "$ref": "#/$defs/SessionActiveClient",
           "description": "Eagerly claim an active client role for the new session.\n\nWhen provided, the server initializes the session with this client as an\nactive client, equivalent to dispatching a `session/activeClientSet`\naction immediately after creation. The `clientId` MUST match the\n`clientId` the creating client supplied in `initialize`."
+        },
+        "progressToken": {
+          "type": "string",
+          "description": "Opt-in progress token. When set, the client is offering to receive\n`progress` notifications (see `ProgressParams`) for any long-running work\nthe server does to bring this session up — most notably the lazy,\nfirst-use download of the provider's native SDK. The server echoes this\nexact token on every `progress` frame so the client can correlate it to\nthis `createSession` call (and the UI awaiting it).\n\nThe token MUST be unique across the client's active requests. The server\nMAY ignore it (e.g. when nothing long-running is needed), in which case no\n`progress` notifications are emitted."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -145,6 +145,61 @@
         "changes"
       ]
     },
+    "DownloadProgressParams": {
+      "type": "object",
+      "description": "Broadcast on the root channel while the host downloads a resource on the\nclient's behalf — typically a multi-MB artifact fetched lazily the first time\nit is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets\nclients show a progress indicator instead of a silent multi-second hang.\n\nThe notification is intentionally **resource-agnostic** so the same channel\ncan report future downloads (additional agent runtimes, plugins, models, …)\nwithout a new method. The `kind` discriminant categorizes the resource and\n`resourceId` identifies it within that kind; clients that don't care can show\na single generic indicator driven by `displayName` + the byte counts.\n\nThis is **host-level**, not session state: the artifact is shared across every\nconsumer and the host deduplicates concurrent fetches into one download (one\n`downloadId`). The optional `session` field names the session whose action\ntriggered the fetch, purely as context — a client MAY attribute the progress\nto that session's row, or show a single global indicator and ignore it.\n\nSemantics:\n\n- Frames for one download share a stable `downloadId`. The first frame a\n  client observes for a `downloadId` begins the indicator even if it is not\n  `phase: 'started'` (a client that connects mid-download may miss the\n  `started` frame).\n- `receivedBytes` is monotonically non-decreasing within a `downloadId`.\n  `totalBytes` is present only when the host knows the size up front\n  (e.g. a `Content-Length`); when absent the client SHOULD show an\n  indeterminate indicator.\n- Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a\n  download. `error` carries a short, non-localized reason on failure.\n- Like all notifications this is ephemeral and is **not** replayed on\n  reconnect. A client that never receives a terminal frame (the download\n  finished while it was disconnected) SHOULD expire the indicator after an\n  idle timeout.\n- The brand noun is carried in `displayName`; clients own the surrounding\n  (localized) template, e.g. `\"Downloading {displayName}… {pct}%\"`.",
+      "properties": {
+        "channel": {
+          "$ref": "#/$defs/URI",
+          "description": "Channel URI this notification belongs to (the root channel)"
+        },
+        "downloadId": {
+          "type": "string",
+          "description": "Stable id for one download. Coalesces the frames of a single fetch and\ndistinguishes concurrent downloads (e.g. two resources at once)."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Category of resource being downloaded. An open string (not a closed enum)\nso new resource types can be reported without a protocol bump. Known\nvalues today: `'agent-sdk'` (an agent's native SDK/runtime)."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Id of the resource within its {@link kind}, e.g. the provider id `'claude'`\nor `'codex'` for an `'agent-sdk'` download."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable brand name for display, e.g. `'Claude'`. The host supplies\nthe noun; the client owns the surrounding localized template."
+        },
+        "phase": {
+          "$ref": "#/$defs/DownloadPhase",
+          "description": "Lifecycle phase of this frame."
+        },
+        "receivedBytes": {
+          "type": "number",
+          "description": "Bytes written so far. Monotonically non-decreasing within a `downloadId`."
+        },
+        "totalBytes": {
+          "type": "number",
+          "description": "Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate."
+        },
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Session whose action triggered the fetch, if any. Informational only —\nthe download is host-level and shared across sessions."
+        },
+        "error": {
+          "type": "string",
+          "description": "Short, non-localized failure reason; present only when `phase: 'failed'`."
+        }
+      },
+      "required": [
+        "channel",
+        "downloadId",
+        "kind",
+        "resourceId",
+        "displayName",
+        "phase",
+        "receivedBytes"
+      ]
+    },
     "OtlpExportLogsParams": {
       "type": "object",
       "description": "Delivers a batch of OTLP log records to a client subscribed to the host's\nlogs channel (advertised on `TelemetryCapabilities.logs`).\n\nThe `payload` field is an OTLP/JSON `ExportLogsServiceRequest` value\nverbatim — i.e. an object of shape `{ resourceLogs: ResourceLogs[] }` as\ndefined by [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto).\nAHP does not redeclare the OTLP type system; clients SHOULD use an\nOpenTelemetry SDK or schema to parse it.\n\nLike all stateless-channel notifications, this is ephemeral: it is not\nreplayed on reconnect. Subscribers receive only batches emitted after\ntheir `subscribe` succeeds.",
@@ -216,6 +271,9 @@
         },
         {
           "$ref": "#/$defs/SessionSummaryChangedParams"
+        },
+        {
+          "$ref": "#/$defs/DownloadProgressParams"
         },
         {
           "$ref": "#/$defs/OtlpExportLogsParams"

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -145,59 +145,35 @@
         "changes"
       ]
     },
-    "DownloadProgressParams": {
+    "ProgressParams": {
       "type": "object",
-      "description": "Broadcast on the root channel while the host downloads a resource on the\nclient's behalf — typically a multi-MB artifact fetched lazily the first time\nit is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets\nclients show a progress indicator instead of a silent multi-second hang.\n\nThe notification is intentionally **resource-agnostic** so the same channel\ncan report future downloads (additional agent runtimes, plugins, models, …)\nwithout a new method. The `kind` discriminant categorizes the resource and\n`resourceId` identifies it within that kind; clients that don't care can show\na single generic indicator driven by `displayName` + the byte counts.\n\nThis is **host-level**, not session state: the artifact is shared across every\nconsumer and the host deduplicates concurrent fetches into one download (one\n`downloadId`). The optional `session` field names the session whose action\ntriggered the fetch, purely as context — a client MAY attribute the progress\nto that session's row, or show a single global indicator and ignore it.\n\nSemantics:\n\n- Frames for one download share a stable `downloadId`. The first frame a\n  client observes for a `downloadId` begins the indicator even if it is not\n  `phase: 'started'` (a client that connects mid-download may miss the\n  `started` frame).\n- `receivedBytes` is monotonically non-decreasing within a `downloadId`.\n  `totalBytes` is present only when the host knows the size up front\n  (e.g. a `Content-Length`); when absent the client SHOULD show an\n  indeterminate indicator.\n- Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a\n  download. `error` carries a short, non-localized reason on failure.\n- Like all notifications this is ephemeral and is **not** replayed on\n  reconnect. A client that never receives a terminal frame (the download\n  finished while it was disconnected) SHOULD expire the indicator after an\n  idle timeout.\n- The brand noun is carried in `displayName`; clients own the surrounding\n  (localized) template, e.g. `\"Downloading {displayName}… {pct}%\"`.",
+      "description": "Generic progress notification for a long-running operation.\n\nA client opts in to progress for a request by including a `progressToken` in\nthat request (today: the `progressToken` field on `createSession`). If the\nserver does long-running work to service the request — e.g. lazily\ndownloading an agent's native SDK the first time a session of that provider\nis materialized — it emits `progress` notifications carrying the same token.\n\nThe notification is operation-agnostic: it says nothing about *what* is\nprogressing. The client correlates `progressToken` back to the request it\noriginated from (and thus the UI surface awaiting it) and renders its own\nlocalized indicator. The same channel serves any future long-running\noperation without a new method.\n\nSemantics:\n\n- `progress` is monotonically non-decreasing for a given `progressToken`.\n- `total` is present only when the server knows the magnitude up front\n  (e.g. a `Content-Length`); when absent the client SHOULD show an\n  indeterminate indicator.\n- The operation is complete when `progress === total`. The server MUST emit a\n  final frame satisfying `progress === total`; when the total was never\n  known, it sets `total` to the final `progress` on that frame. No further\n  frames reference the token afterwards.\n- The server MAY emit no progress at all (e.g. the work was already done);\n  the client then never shows an indicator.\n- Like all notifications this is ephemeral and is **not** replayed on\n  reconnect. A client that never receives the terminal frame SHOULD expire\n  the indicator after an idle timeout.",
       "properties": {
         "channel": {
           "$ref": "#/$defs/URI",
-          "description": "Channel URI this notification belongs to (the root channel)"
+          "description": "Channel URI this notification belongs to (the root channel)."
         },
-        "downloadId": {
+        "progressToken": {
           "type": "string",
-          "description": "Stable id for one download. Coalesces the frames of a single fetch and\ndistinguishes concurrent downloads (e.g. two resources at once)."
+          "description": "Echoes the `progressToken` the client supplied on the originating request\n(e.g. the `progressToken` field of `createSession`), correlating this frame\nto that call. Unique across the client's active requests."
         },
-        "kind": {
-          "type": "string",
-          "description": "Category of resource being downloaded. An open string (not a closed enum)\nso new resource types can be reported without a protocol bump. Known\nvalues today: `'agent-sdk'` (an agent's native SDK/runtime)."
-        },
-        "resourceId": {
-          "type": "string",
-          "description": "Id of the resource within its {@link kind}, e.g. the provider id `'claude'`\nor `'codex'` for an `'agent-sdk'` download."
-        },
-        "displayName": {
-          "type": "string",
-          "description": "Human-readable brand name for display, e.g. `'Claude'`. The host supplies\nthe noun; the client owns the surrounding localized template."
-        },
-        "phase": {
-          "$ref": "#/$defs/DownloadPhase",
-          "description": "Lifecycle phase of this frame."
-        },
-        "receivedBytes": {
+        "progress": {
           "type": "number",
-          "description": "Bytes written so far. Monotonically non-decreasing within a `downloadId`."
+          "description": "Progress so far, in operation-defined units (e.g. bytes received).\nMonotonically non-decreasing for a given `progressToken`."
         },
-        "totalBytes": {
+        "total": {
           "type": "number",
-          "description": "Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate."
+          "description": "Total when known up front (e.g. from a `Content-Length`); omitted ⇒\nindeterminate. The operation is complete once `progress === total`."
         },
-        "session": {
-          "$ref": "#/$defs/URI",
-          "description": "Session whose action triggered the fetch, if any. Informational only —\nthe download is host-level and shared across sessions."
-        },
-        "error": {
+        "message": {
           "type": "string",
-          "description": "Short, non-localized failure reason; present only when `phase: 'failed'`."
+          "description": "Optional human-readable progress message. The client owns its own\n(localized) presentation derived from the originating request; generic\nclients that don't track the token MAY display this instead."
         }
       },
       "required": [
         "channel",
-        "downloadId",
-        "kind",
-        "resourceId",
-        "displayName",
-        "phase",
-        "receivedBytes"
+        "progressToken",
+        "progress"
       ]
     },
     "OtlpExportLogsParams": {
@@ -273,7 +249,7 @@
           "$ref": "#/$defs/SessionSummaryChangedParams"
         },
         {
-          "$ref": "#/$defs/DownloadProgressParams"
+          "$ref": "#/$defs/ProgressParams"
         },
         {
           "$ref": "#/$defs/OtlpExportLogsParams"

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1533,13 +1533,13 @@ function generateCommandsFile(project: Project): string {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
 
 const NOTIFICATION_STRUCTS = [
   'SessionAddedParams',
   'SessionRemovedParams',
   'SessionSummaryChangedParams',
-  'DownloadProgressParams',
+  'ProgressParams',
   'AuthRequiredParams',
   'OtlpExportLogsParams',
   'OtlpExportTracesParams',

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1533,12 +1533,13 @@ function generateCommandsFile(project: Project): string {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
 
 const NOTIFICATION_STRUCTS = [
   'SessionAddedParams',
   'SessionRemovedParams',
   'SessionSummaryChangedParams',
+  'DownloadProgressParams',
   'AuthRequiredParams',
   'OtlpExportLogsParams',
   'OtlpExportTracesParams',

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1516,13 +1516,13 @@ function generateCommandsFile(project: Project): string {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
 
 const NOTIFICATION_STRUCTS = [
   'SessionAddedParams',
   'SessionRemovedParams',
   'SessionSummaryChangedParams',
-  'DownloadProgressParams',
+  'ProgressParams',
   'AuthRequiredParams',
   'OtlpExportLogsParams',
   'OtlpExportTracesParams',

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1516,12 +1516,13 @@ function generateCommandsFile(project: Project): string {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
 
 const NOTIFICATION_STRUCTS = [
   'SessionAddedParams',
   'SessionRemovedParams',
   'SessionSummaryChangedParams',
+  'DownloadProgressParams',
   'AuthRequiredParams',
   'OtlpExportLogsParams',
   'OtlpExportTracesParams',

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1439,12 +1439,13 @@ pub enum ChangesetOperationTarget {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
 
 const NOTIFICATION_STRUCTS = [
   'SessionAddedParams',
   'SessionRemovedParams',
   'SessionSummaryChangedParams',
+  'DownloadProgressParams',
   'AuthRequiredParams',
   'OtlpExportLogsParams',
   'OtlpExportTracesParams',

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1439,13 +1439,13 @@ pub enum ChangesetOperationTarget {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
 
 const NOTIFICATION_STRUCTS = [
   'SessionAddedParams',
   'SessionRemovedParams',
   'SessionSummaryChangedParams',
-  'DownloadProgressParams',
+  'ProgressParams',
   'AuthRequiredParams',
   'OtlpExportLogsParams',
   'OtlpExportTracesParams',

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1438,10 +1438,10 @@ public struct ChangesetOperationRangeTarget: Codable, Sendable {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
 
 const NOTIFICATION_STRUCTS = [
-  'SessionAddedParams', 'SessionRemovedParams', 'SessionSummaryChangedParams', 'AuthRequiredParams',
+  'SessionAddedParams', 'SessionRemovedParams', 'SessionSummaryChangedParams', 'DownloadProgressParams', 'AuthRequiredParams',
   'OtlpExportLogsParams', 'OtlpExportTracesParams', 'OtlpExportMetricsParams',
 ];
 

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1438,10 +1438,10 @@ public struct ChangesetOperationRangeTarget: Codable, Sendable {
 
 // ─── Notifications File Generator ────────────────────────────────────────────
 
-const NOTIFICATION_ENUMS = ['AuthRequiredReason', 'DownloadPhase'];
+const NOTIFICATION_ENUMS = ['AuthRequiredReason'];
 
 const NOTIFICATION_STRUCTS = [
-  'SessionAddedParams', 'SessionRemovedParams', 'SessionSummaryChangedParams', 'DownloadProgressParams', 'AuthRequiredParams',
+  'SessionAddedParams', 'SessionRemovedParams', 'SessionSummaryChangedParams', 'ProgressParams', 'AuthRequiredParams',
   'OtlpExportLogsParams', 'OtlpExportTracesParams', 'OtlpExportMetricsParams',
 ];
 

--- a/types/channels-root/notifications.ts
+++ b/types/channels-root/notifications.ts
@@ -143,63 +143,41 @@ export interface SessionSummaryChangedParams {
   changes: Partial<SessionSummary>;
 }
 
-// ─── root/downloadProgress ───────────────────────────────────────────────────
+// ─── progress ────────────────────────────────────────────────────────────────
 
 /**
- * Lifecycle phase of a single download.
+ * Generic progress notification for a long-running operation.
  *
- * @category Protocol Notifications
- */
-export const enum DownloadPhase {
-  /** The download has begun; no bytes received yet. */
-  Started = 'started',
-  /** A throttled progress sample with bytes received so far. */
-  Progress = 'progress',
-  /** Terminal success frame; the resource is fully downloaded. */
-  Completed = 'completed',
-  /** Terminal failure frame; see {@link DownloadProgressParams.error}. */
-  Failed = 'failed',
-}
-
-/**
- * Broadcast on the root channel while the host downloads a resource on the
- * client's behalf — typically a multi-MB artifact fetched lazily the first time
- * it is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets
- * clients show a progress indicator instead of a silent multi-second hang.
+ * A client opts in to progress for a request by including a `progressToken` in
+ * that request (today: the `progressToken` field on `createSession`). If the
+ * server does long-running work to service the request — e.g. lazily
+ * downloading an agent's native SDK the first time a session of that provider
+ * is materialized — it emits `progress` notifications carrying the same token.
  *
- * The notification is intentionally **resource-agnostic** so the same channel
- * can report future downloads (additional agent runtimes, plugins, models, …)
- * without a new method. The `kind` discriminant categorizes the resource and
- * `resourceId` identifies it within that kind; clients that don't care can show
- * a single generic indicator driven by `displayName` + the byte counts.
- *
- * This is **host-level**, not session state: the artifact is shared across every
- * consumer and the host deduplicates concurrent fetches into one download (one
- * `downloadId`). The optional `session` field names the session whose action
- * triggered the fetch, purely as context — a client MAY attribute the progress
- * to that session's row, or show a single global indicator and ignore it.
+ * The notification is operation-agnostic: it says nothing about *what* is
+ * progressing. The client correlates `progressToken` back to the request it
+ * originated from (and thus the UI surface awaiting it) and renders its own
+ * localized indicator. The same channel serves any future long-running
+ * operation without a new method.
  *
  * Semantics:
  *
- * - Frames for one download share a stable `downloadId`. The first frame a
- *   client observes for a `downloadId` begins the indicator even if it is not
- *   `phase: 'started'` (a client that connects mid-download may miss the
- *   `started` frame).
- * - `receivedBytes` is monotonically non-decreasing within a `downloadId`.
- *   `totalBytes` is present only when the host knows the size up front
+ * - `progress` is monotonically non-decreasing for a given `progressToken`.
+ * - `total` is present only when the server knows the magnitude up front
  *   (e.g. a `Content-Length`); when absent the client SHOULD show an
  *   indeterminate indicator.
- * - Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a
- *   download. `error` carries a short, non-localized reason on failure.
+ * - The operation is complete when `progress === total`. The server MUST emit a
+ *   final frame satisfying `progress === total`; when the total was never
+ *   known, it sets `total` to the final `progress` on that frame. No further
+ *   frames reference the token afterwards.
+ * - The server MAY emit no progress at all (e.g. the work was already done);
+ *   the client then never shows an indicator.
  * - Like all notifications this is ephemeral and is **not** replayed on
- *   reconnect. A client that never receives a terminal frame (the download
- *   finished while it was disconnected) SHOULD expire the indicator after an
- *   idle timeout.
- * - The brand noun is carried in `displayName`; clients own the surrounding
- *   (localized) template, e.g. `"Downloading {displayName}… {pct}%"`.
+ *   reconnect. A client that never receives the terminal frame SHOULD expire
+ *   the indicator after an idle timeout.
  *
  * @category Protocol Notifications
- * @method root/downloadProgress
+ * @method root/progress
  * @direction Server → Client
  * @messageType Notification
  * @version 1
@@ -207,56 +185,39 @@ export const enum DownloadPhase {
  * ```json
  * {
  *   "jsonrpc": "2.0",
- *   "method": "root/downloadProgress",
+ *   "method": "root/progress",
  *   "params": {
  *     "channel": "ahp-root://",
- *     "downloadId": "d3f1c2",
- *     "kind": "agent-sdk",
- *     "resourceId": "claude",
- *     "displayName": "Claude",
- *     "phase": "progress",
- *     "receivedBytes": 18874368,
- *     "totalBytes": 41957498,
- *     "session": "ahp-session:/<uuid>"
+ *     "progressToken": "9b2c1f7e-4a0d-4e2b-8b1a-2f7e4a0d4e2b",
+ *     "progress": 18874368,
+ *     "total": 41957498
  *   }
  * }
  * ```
  */
-export interface DownloadProgressParams {
-  /** Channel URI this notification belongs to (the root channel) */
+export interface ProgressParams {
+  /** Channel URI this notification belongs to (the root channel). */
   channel: URI;
   /**
-   * Stable id for one download. Coalesces the frames of a single fetch and
-   * distinguishes concurrent downloads (e.g. two resources at once).
+   * Echoes the `progressToken` the client supplied on the originating request
+   * (e.g. the `progressToken` field of `createSession`), correlating this frame
+   * to that call. Unique across the client's active requests.
    */
-  downloadId: string;
+  progressToken: string;
   /**
-   * Category of resource being downloaded. An open string (not a closed enum)
-   * so new resource types can be reported without a protocol bump. Known
-   * values today: `'agent-sdk'` (an agent's native SDK/runtime).
+   * Progress so far, in operation-defined units (e.g. bytes received).
+   * Monotonically non-decreasing for a given `progressToken`.
    */
-  kind: string;
+  progress: number;
   /**
-   * Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
-   * or `'codex'` for an `'agent-sdk'` download.
+   * Total when known up front (e.g. from a `Content-Length`); omitted ⇒
+   * indeterminate. The operation is complete once `progress === total`.
    */
-  resourceId: string;
+  total?: number;
   /**
-   * Human-readable brand name for display, e.g. `'Claude'`. The host supplies
-   * the noun; the client owns the surrounding localized template.
+   * Optional human-readable progress message. The client owns its own
+   * (localized) presentation derived from the originating request; generic
+   * clients that don't track the token MAY display this instead.
    */
-  displayName: string;
-  /** Lifecycle phase of this frame. */
-  phase: DownloadPhase;
-  /** Bytes written so far. Monotonically non-decreasing within a `downloadId`. */
-  receivedBytes: number;
-  /** Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate. */
-  totalBytes?: number;
-  /**
-   * Session whose action triggered the fetch, if any. Informational only —
-   * the download is host-level and shared across sessions.
-   */
-  session?: URI;
-  /** Short, non-localized failure reason; present only when `phase: 'failed'`. */
-  error?: string;
+  message?: string;
 }

--- a/types/channels-root/notifications.ts
+++ b/types/channels-root/notifications.ts
@@ -142,3 +142,121 @@ export interface SessionSummaryChangedParams {
    */
   changes: Partial<SessionSummary>;
 }
+
+// ─── root/downloadProgress ───────────────────────────────────────────────────
+
+/**
+ * Lifecycle phase of a single download.
+ *
+ * @category Protocol Notifications
+ */
+export const enum DownloadPhase {
+  /** The download has begun; no bytes received yet. */
+  Started = 'started',
+  /** A throttled progress sample with bytes received so far. */
+  Progress = 'progress',
+  /** Terminal success frame; the resource is fully downloaded. */
+  Completed = 'completed',
+  /** Terminal failure frame; see {@link DownloadProgressParams.error}. */
+  Failed = 'failed',
+}
+
+/**
+ * Broadcast on the root channel while the host downloads a resource on the
+ * client's behalf — typically a multi-MB artifact fetched lazily the first time
+ * it is needed (today: an agent's native SDK/runtime, `kind: 'agent-sdk'`). Lets
+ * clients show a progress indicator instead of a silent multi-second hang.
+ *
+ * The notification is intentionally **resource-agnostic** so the same channel
+ * can report future downloads (additional agent runtimes, plugins, models, …)
+ * without a new method. The `kind` discriminant categorizes the resource and
+ * `resourceId` identifies it within that kind; clients that don't care can show
+ * a single generic indicator driven by `displayName` + the byte counts.
+ *
+ * This is **host-level**, not session state: the artifact is shared across every
+ * consumer and the host deduplicates concurrent fetches into one download (one
+ * `downloadId`). The optional `session` field names the session whose action
+ * triggered the fetch, purely as context — a client MAY attribute the progress
+ * to that session's row, or show a single global indicator and ignore it.
+ *
+ * Semantics:
+ *
+ * - Frames for one download share a stable `downloadId`. The first frame a
+ *   client observes for a `downloadId` begins the indicator even if it is not
+ *   `phase: 'started'` (a client that connects mid-download may miss the
+ *   `started` frame).
+ * - `receivedBytes` is monotonically non-decreasing within a `downloadId`.
+ *   `totalBytes` is present only when the host knows the size up front
+ *   (e.g. a `Content-Length`); when absent the client SHOULD show an
+ *   indeterminate indicator.
+ * - Exactly one terminal frame (`phase: 'completed'` or `'failed'`) ends a
+ *   download. `error` carries a short, non-localized reason on failure.
+ * - Like all notifications this is ephemeral and is **not** replayed on
+ *   reconnect. A client that never receives a terminal frame (the download
+ *   finished while it was disconnected) SHOULD expire the indicator after an
+ *   idle timeout.
+ * - The brand noun is carried in `displayName`; clients own the surrounding
+ *   (localized) template, e.g. `"Downloading {displayName}… {pct}%"`.
+ *
+ * @category Protocol Notifications
+ * @method root/downloadProgress
+ * @direction Server → Client
+ * @messageType Notification
+ * @version 1
+ * @example
+ * ```json
+ * {
+ *   "jsonrpc": "2.0",
+ *   "method": "root/downloadProgress",
+ *   "params": {
+ *     "channel": "ahp-root://",
+ *     "downloadId": "d3f1c2",
+ *     "kind": "agent-sdk",
+ *     "resourceId": "claude",
+ *     "displayName": "Claude",
+ *     "phase": "progress",
+ *     "receivedBytes": 18874368,
+ *     "totalBytes": 41957498,
+ *     "session": "ahp-session:/<uuid>"
+ *   }
+ * }
+ * ```
+ */
+export interface DownloadProgressParams {
+  /** Channel URI this notification belongs to (the root channel) */
+  channel: URI;
+  /**
+   * Stable id for one download. Coalesces the frames of a single fetch and
+   * distinguishes concurrent downloads (e.g. two resources at once).
+   */
+  downloadId: string;
+  /**
+   * Category of resource being downloaded. An open string (not a closed enum)
+   * so new resource types can be reported without a protocol bump. Known
+   * values today: `'agent-sdk'` (an agent's native SDK/runtime).
+   */
+  kind: string;
+  /**
+   * Id of the resource within its {@link kind}, e.g. the provider id `'claude'`
+   * or `'codex'` for an `'agent-sdk'` download.
+   */
+  resourceId: string;
+  /**
+   * Human-readable brand name for display, e.g. `'Claude'`. The host supplies
+   * the noun; the client owns the surrounding localized template.
+   */
+  displayName: string;
+  /** Lifecycle phase of this frame. */
+  phase: DownloadPhase;
+  /** Bytes written so far. Monotonically non-decreasing within a `downloadId`. */
+  receivedBytes: number;
+  /** Total bytes when known (e.g. from `Content-Length`); omitted ⇒ indeterminate. */
+  totalBytes?: number;
+  /**
+   * Session whose action triggered the fetch, if any. Informational only —
+   * the download is host-level and shared across sessions.
+   */
+  session?: URI;
+  /** Short, non-localized failure reason; present only when `phase: 'failed'`. */
+  error?: string;
+}

--- a/types/channels-session/commands.ts
+++ b/types/channels-session/commands.ts
@@ -98,6 +98,19 @@ export interface CreateSessionParams extends BaseParams {
    * `clientId` the creating client supplied in `initialize`.
    */
   activeClient?: SessionActiveClient;
+  /**
+   * Opt-in progress token. When set, the client is offering to receive
+   * `progress` notifications (see `ProgressParams`) for any long-running work
+   * the server does to bring this session up — most notably the lazy,
+   * first-use download of the provider's native SDK. The server echoes this
+   * exact token on every `progress` frame so the client can correlate it to
+   * this `createSession` call (and the UI awaiting it).
+   *
+   * The token MUST be unique across the client's active requests. The server
+   * MAY ignore it (e.g. when nothing long-running is needed), in which case no
+   * `progress` notifications are emitted.
+   */
+  progressToken?: string;
 }
 
 // ─── disposeSession ──────────────────────────────────────────────────────────

--- a/types/common/messages.ts
+++ b/types/common/messages.ts
@@ -76,7 +76,7 @@ import type {
   SessionAddedParams,
   SessionRemovedParams,
   SessionSummaryChangedParams,
-  DownloadProgressParams,
+  ProgressParams,
 } from '../channels-root/notifications.js';
 import type { AuthRequiredParams } from './notifications.js';
 import type {
@@ -232,7 +232,7 @@ export interface ServerNotificationMap {
   'root/sessionAdded': { params: SessionAddedParams };
   'root/sessionRemoved': { params: SessionRemovedParams };
   'root/sessionSummaryChanged': { params: SessionSummaryChangedParams };
-  'root/downloadProgress': { params: DownloadProgressParams };
+  'root/progress': { params: ProgressParams };
   'auth/required': { params: AuthRequiredParams };
   'otlp/exportLogs': { params: OtlpExportLogsParams };
   'otlp/exportTraces': { params: OtlpExportTracesParams };

--- a/types/common/messages.ts
+++ b/types/common/messages.ts
@@ -76,6 +76,7 @@ import type {
   SessionAddedParams,
   SessionRemovedParams,
   SessionSummaryChangedParams,
+  DownloadProgressParams,
 } from '../channels-root/notifications.js';
 import type { AuthRequiredParams } from './notifications.js';
 import type {
@@ -231,6 +232,7 @@ export interface ServerNotificationMap {
   'root/sessionAdded': { params: SessionAddedParams };
   'root/sessionRemoved': { params: SessionRemovedParams };
   'root/sessionSummaryChanged': { params: SessionSummaryChangedParams };
+  'root/downloadProgress': { params: DownloadProgressParams };
   'auth/required': { params: AuthRequiredParams };
   'otlp/exportLogs': { params: OtlpExportLogsParams };
   'otlp/exportTraces': { params: OtlpExportTracesParams };

--- a/types/index.ts
+++ b/types/index.ts
@@ -320,14 +320,14 @@ export type {
   SessionAddedParams,
   SessionRemovedParams,
   SessionSummaryChangedParams,
-  DownloadProgressParams,
+  ProgressParams,
   AuthRequiredParams,
   OtlpExportLogsParams,
   OtlpExportTracesParams,
   OtlpExportMetricsParams,
 } from './notifications.js';
 
-export { AuthRequiredReason, DownloadPhase } from './notifications.js';
+export { AuthRequiredReason } from './notifications.js';
 
 // Message types (JSON-RPC wire format)
 export type {

--- a/types/index.ts
+++ b/types/index.ts
@@ -320,13 +320,14 @@ export type {
   SessionAddedParams,
   SessionRemovedParams,
   SessionSummaryChangedParams,
+  DownloadProgressParams,
   AuthRequiredParams,
   OtlpExportLogsParams,
   OtlpExportTracesParams,
   OtlpExportMetricsParams,
 } from './notifications.js';
 
-export { AuthRequiredReason } from './notifications.js';
+export { AuthRequiredReason, DownloadPhase } from './notifications.js';
 
 // Message types (JSON-RPC wire format)
 export type {

--- a/types/version/message-checks.ts
+++ b/types/version/message-checks.ts
@@ -89,7 +89,7 @@ type _ExpectedServerNotifications =
   | 'root/sessionAdded'
   | 'root/sessionRemoved'
   | 'root/sessionSummaryChanged'
-  | 'root/downloadProgress'
+  | 'root/progress'
   | 'auth/required'
   | 'otlp/exportLogs'
   | 'otlp/exportTraces'

--- a/types/version/message-checks.ts
+++ b/types/version/message-checks.ts
@@ -89,6 +89,7 @@ type _ExpectedServerNotifications =
   | 'root/sessionAdded'
   | 'root/sessionRemoved'
   | 'root/sessionSummaryChanged'
+  | 'root/downloadProgress'
   | 'auth/required'
   | 'otlp/exportLogs'
   | 'otlp/exportTraces'

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -180,7 +180,7 @@ export const NOTIFICATION_INTRODUCED_IN: { readonly [K in ProtocolNotificationMe
   'root/sessionAdded': '0.1.0',
   'root/sessionRemoved': '0.1.0',
   'root/sessionSummaryChanged': '0.1.0',
-  'root/downloadProgress': '0.5.0',
+  'root/progress': '0.5.0',
   'auth/required': '0.1.0',
   'otlp/exportLogs': '0.2.0',
   'otlp/exportTraces': '0.2.0',

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -180,6 +180,7 @@ export const NOTIFICATION_INTRODUCED_IN: { readonly [K in ProtocolNotificationMe
   'root/sessionAdded': '0.1.0',
   'root/sessionRemoved': '0.1.0',
   'root/sessionSummaryChanged': '0.1.0',
+  'root/downloadProgress': '0.5.0',
   'auth/required': '0.1.0',
   'otlp/exportLogs': '0.2.0',
   'otlp/exportTraces': '0.2.0',


### PR DESCRIPTION
## Why

Hosts fetch large native agent SDK/runtime binaries (70–95 MB) lazily on first use. Today that blocks for several seconds with nothing on the wire, so a client can only show a silent hang. This adds a generic host→client progress notification so clients can render a real progress indicator.

Related
- https://github.com/microsoft/vscode-internalbacklog/issues/8176
- https://github.com/microsoft/vscode/pull/322919

## Wire shape

A generic, **operation-agnostic** progress notification rather than a download-specific one. A client opts in per request by minting a `progressToken`; the host echoes it on every frame so the client can correlate progress back to the call (and the UI awaiting it) without the protocol naming a domain object.

**Opt-in** — new optional field on `createSession` (`CreateSessionParams`):

| field | notes |
|---|---|
| `progressToken?` | client-supplied token, offered up front. The host MAY ignore it (e.g. nothing long-running to do, SDK already cached), in which case no `root/progress` frames are emitted. Unique across the client's active requests. |

**Server→client** notification on the root channel, `root/progress` (`ProgressParams`):

| field | notes |
|---|---|
| `channel` | root channel URI |
| `progressToken` | echoes the token from the originating request |
| `progress` | progress so far in operation-defined units (e.g. bytes); monotonically non-decreasing |
| `total?` | present when known up front (e.g. `Content-Length`); absent ⇒ indeterminate |
| `message?` | optional human-readable message; clients that track the token render their own localized label |

```json
{ "jsonrpc": "2.0", "method": "root/progress",
  "params": { "channel": "ahp-root://",
              "progressToken": "9b2c1f7e-4a0d-4e2b-8b1a-2f7e4a0d4e2b",
              "progress": 18874368, "total": 41957498 } }
```

**Completion** is signalled by `progress === total` — no phase/error on the wire. The host emits a terminal frame with `total === progress` (when the total was never known, it sets `total` to the final `progress` on that frame); real failures surface via the existing session-failure path. Ephemeral (not replayed on reconnect); a client that misses the terminal frame should expire its indicator after an idle timeout.

The token is anchored on `createSession`, so it survives the provisional → materialized gap: the SDK download fires lazily when a session first materializes on its opening message, and the host fans the host-level download out to each waiting session's token.

Because the notification says nothing about *what* is progressing, the same channel can report any future long-running operation (other runtimes, plugins, models) without a new method.

Introduced in the unreleased 0.5.0 spec (`NOTIFICATION_INTRODUCED_IN`). Additive, non-breaking. Includes regenerated Rust/Kotlin/Swift/Go clients + JSON schema, and spec + per-client CHANGELOG entries.
