### PR TITLE
Add capability stability levels to the initialize handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 ### Added
 
+- `InitializeResult.featureStability` — an optional map advertising the
+  wire/schema stability (`FeatureStabilityLevel`: `stable` / `experimental` /
+  `deprecated`) of selected surfaces a host emits, keyed by surface identifier.
+  Surfaces absent from the map are `stable`.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
-- `SessionSummary._meta` optional provider metadata field for lightweight
-  session-list presentation hints.
-- `JsonPrimitive` type alias (`string | number | boolean | null`) in `types/common/state.ts`.
 - `session/activeClientRemoved` action to release a single active client from a
   session by `clientId`.
 

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,6 +16,10 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `InitializeResult.FeatureStability` — an optional
+  `map[string]FeatureStabilityLevel` advertising the wire/schema stability
+  (`stable` / `experimental` / `deprecated`) of selected surfaces a host emits,
+  keyed by surface identifier. Surfaces absent from the map are `stable`.
 - `SessionModelInfo.MaxOutputTokens` and `SessionModelInfo.MaxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.Meta` (wire `_meta`) optional provider metadata field for

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -23,6 +23,30 @@ const (
 	ReconnectResultTypeSnapshot ReconnectResultType = "snapshot"
 )
 
+// Wire/schema stability of a surface advertised in
+// {@link InitializeResult.featureStability}.
+//
+// Stability describes how settled a surface's shape is within a compatible
+// SemVer range. It is deliberately **not** a product-gating, entitlement, or
+// preview-access signal — a client uses it only to decide how defensively to
+// code against the surface.
+type FeatureStabilityLevel string
+
+const (
+	// Normal additive SemVer guarantees apply; clients MAY build on it freely.
+	// This is the default for any surface absent from
+	// {@link InitializeResult.featureStability}, so it never needs to be
+	// advertised explicitly.
+	FeatureStabilityLevelStable FeatureStabilityLevel = "stable"
+	// On the wire, but its shape MAY change or be removed within an otherwise
+	// compatible version range. Clients SHOULD parse it defensively, gate
+	// adoption behind a flag, tolerate shape changes, and not assume longevity.
+	FeatureStabilityLevelExperimental FeatureStabilityLevel = "experimental"
+	// Still emitted, but scheduled for removal in a future version. Clients
+	// SHOULD migrate off it and SHOULD NOT adopt it anew.
+	FeatureStabilityLevelDeprecated FeatureStabilityLevel = "deprecated"
+)
+
 // Encoding of fetched content data.
 type ContentEncoding string
 
@@ -137,6 +161,28 @@ type InitializeResult struct {
 	// defines a template variable, `{level}`, for subscriber-side severity
 	// filtering). Clients MAY ignore signals they cannot process.
 	Telemetry *TelemetryCapabilities `json:"telemetry,omitempty"`
+	// Wire/schema stability of selected surfaces the host emits, keyed by a
+	// surface identifier — a notification method (e.g. `"session/canvasOpened"`),
+	// a command method (e.g. `"listSessions"`), a channel URI scheme (e.g.
+	// `"ahp-otlp:"`), or a named capability.
+	//
+	// A surface absent from this map is {@link FeatureStabilityLevel.Stable |
+	// `stable`} and carries the normal additive SemVer guarantees, so hosts list
+	// **only** surfaces that are not stable. The signal is strictly about
+	// wire/schema volatility ("may change or be removed within a compatible
+	// version range") — **not** product gating, entitlement, or preview access.
+	// Clients use it only to decide how defensively to code against a surface.
+	//
+	// This is connection-level metadata negotiated once at `initialize`. A
+	// `reconnect` continues the same logical connection, so clients retain the
+	// map across reconnects rather than re-requesting it, exactly as they retain
+	// {@link InitializeResult.defaultDirectory | `defaultDirectory`} and
+	// {@link InitializeResult.telemetry | `telemetry`}.
+	//
+	// Older clients that do not understand this field ignore it and treat every
+	// surface as stable, consistent with the protocol's "ignore what you don't
+	// understand" rule.
+	FeatureStability map[string]FeatureStabilityLevel `json:"featureStability,omitempty"`
 }
 
 // Optional capabilities a client declares during `initialize`.

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -17,6 +17,10 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Added
 
+- `InitializeResult.featureStability` — an optional
+  `Map<String, FeatureStabilityLevel>` advertising the wire/schema stability
+  (`STABLE` / `EXPERIMENTAL` / `DEPRECATED`) of selected surfaces a host emits,
+  keyed by surface identifier. Surfaces absent from the map are stable.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -33,6 +33,40 @@ enum class ReconnectResultType {
 }
 
 /**
+ * Wire/schema stability of a surface advertised in
+ * {@link InitializeResult.featureStability}.
+ *
+ * Stability describes how settled a surface's shape is within a compatible
+ * SemVer range. It is deliberately **not** a product-gating, entitlement, or
+ * preview-access signal — a client uses it only to decide how defensively to
+ * code against the surface.
+ */
+@Serializable
+enum class FeatureStabilityLevel {
+    /**
+     * Normal additive SemVer guarantees apply; clients MAY build on it freely.
+     * This is the default for any surface absent from
+     * {@link InitializeResult.featureStability}, so it never needs to be
+     * advertised explicitly.
+     */
+    @SerialName("stable")
+    STABLE,
+    /**
+     * On the wire, but its shape MAY change or be removed within an otherwise
+     * compatible version range. Clients SHOULD parse it defensively, gate
+     * adoption behind a flag, tolerate shape changes, and not assume longevity.
+     */
+    @SerialName("experimental")
+    EXPERIMENTAL,
+    /**
+     * Still emitted, but scheduled for removal in a future version. Clients
+     * SHOULD migrate off it and SHOULD NOT adopt it anew.
+     */
+    @SerialName("deprecated")
+    DEPRECATED
+}
+
+/**
  * Encoding of fetched content data.
  */
 @Serializable
@@ -177,7 +211,31 @@ data class InitializeResult(
      * defines a template variable, `{level}`, for subscriber-side severity
      * filtering). Clients MAY ignore signals they cannot process.
      */
-    val telemetry: TelemetryCapabilities? = null
+    val telemetry: TelemetryCapabilities? = null,
+    /**
+     * Wire/schema stability of selected surfaces the host emits, keyed by a
+     * surface identifier — a notification method (e.g. `"session/canvasOpened"`),
+     * a command method (e.g. `"listSessions"`), a channel URI scheme (e.g.
+     * `"ahp-otlp:"`), or a named capability.
+     *
+     * A surface absent from this map is {@link FeatureStabilityLevel.Stable |
+     * `stable`} and carries the normal additive SemVer guarantees, so hosts list
+     * **only** surfaces that are not stable. The signal is strictly about
+     * wire/schema volatility ("may change or be removed within a compatible
+     * version range") — **not** product gating, entitlement, or preview access.
+     * Clients use it only to decide how defensively to code against a surface.
+     *
+     * This is connection-level metadata negotiated once at `initialize`. A
+     * `reconnect` continues the same logical connection, so clients retain the
+     * map across reconnects rather than re-requesting it, exactly as they retain
+     * {@link InitializeResult.defaultDirectory | `defaultDirectory`} and
+     * {@link InitializeResult.telemetry | `telemetry`}.
+     *
+     * Older clients that do not understand this field ignore it and treat every
+     * surface as stable, consistent with the protocol's "ignore what you don't
+     * understand" rule.
+     */
+    val featureStability: Map<String, FeatureStabilityLevel>? = null
 )
 
 @Serializable

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,6 +17,11 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `InitializeResult.feature_stability` — an optional
+  `HashMap<String, FeatureStabilityLevel>` advertising the wire/schema
+  stability (`stable` / `experimental` / `deprecated`) of selected surfaces a
+  host emits, keyed by surface identifier. Surfaces absent from the map are
+  `stable`.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -31,6 +31,32 @@ pub enum ReconnectResultType {
     Snapshot,
 }
 
+/// Wire/schema stability of a surface advertised in
+/// {@link InitializeResult.featureStability}.
+///
+/// Stability describes how settled a surface's shape is within a compatible
+/// SemVer range. It is deliberately **not** a product-gating, entitlement, or
+/// preview-access signal — a client uses it only to decide how defensively to
+/// code against the surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FeatureStabilityLevel {
+    /// Normal additive SemVer guarantees apply; clients MAY build on it freely.
+    /// This is the default for any surface absent from
+    /// {@link InitializeResult.featureStability}, so it never needs to be
+    /// advertised explicitly.
+    #[serde(rename = "stable")]
+    Stable,
+    /// On the wire, but its shape MAY change or be removed within an otherwise
+    /// compatible version range. Clients SHOULD parse it defensively, gate
+    /// adoption behind a flag, tolerate shape changes, and not assume longevity.
+    #[serde(rename = "experimental")]
+    Experimental,
+    /// Still emitted, but scheduled for removal in a future version. Clients
+    /// SHOULD migrate off it and SHOULD NOT adopt it anew.
+    #[serde(rename = "deprecated")]
+    Deprecated,
+}
+
 /// Encoding of fetched content data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ContentEncoding {
@@ -160,6 +186,29 @@ pub struct InitializeResult {
     /// filtering). Clients MAY ignore signals they cannot process.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub telemetry: Option<TelemetryCapabilities>,
+    /// Wire/schema stability of selected surfaces the host emits, keyed by a
+    /// surface identifier — a notification method (e.g. `"session/canvasOpened"`),
+    /// a command method (e.g. `"listSessions"`), a channel URI scheme (e.g.
+    /// `"ahp-otlp:"`), or a named capability.
+    ///
+    /// A surface absent from this map is {@link FeatureStabilityLevel.Stable |
+    /// `stable`} and carries the normal additive SemVer guarantees, so hosts list
+    /// **only** surfaces that are not stable. The signal is strictly about
+    /// wire/schema volatility ("may change or be removed within a compatible
+    /// version range") — **not** product gating, entitlement, or preview access.
+    /// Clients use it only to decide how defensively to code against a surface.
+    ///
+    /// This is connection-level metadata negotiated once at `initialize`. A
+    /// `reconnect` continues the same logical connection, so clients retain the
+    /// map across reconnects rather than re-requesting it, exactly as they retain
+    /// {@link InitializeResult.defaultDirectory | `defaultDirectory`} and
+    /// {@link InitializeResult.telemetry | `telemetry`}.
+    ///
+    /// Older clients that do not understand this field ignore it and treat every
+    /// surface as stable, consistent with the protocol's "ignore what you don't
+    /// understand" rule.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feature_stability: Option<std::collections::HashMap<String, FeatureStabilityLevel>>,
 }
 
 /// Optional capabilities a client declares during `initialize`.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -10,6 +10,28 @@ public enum ReconnectResultType: String, Codable, Sendable {
     case snapshot = "snapshot"
 }
 
+/// Wire/schema stability of a surface advertised in
+/// {@link InitializeResult.featureStability}.
+///
+/// Stability describes how settled a surface's shape is within a compatible
+/// SemVer range. It is deliberately **not** a product-gating, entitlement, or
+/// preview-access signal — a client uses it only to decide how defensively to
+/// code against the surface.
+public enum FeatureStabilityLevel: String, Codable, Sendable {
+    /// Normal additive SemVer guarantees apply; clients MAY build on it freely.
+    /// This is the default for any surface absent from
+    /// {@link InitializeResult.featureStability}, so it never needs to be
+    /// advertised explicitly.
+    case stable = "stable"
+    /// On the wire, but its shape MAY change or be removed within an otherwise
+    /// compatible version range. Clients SHOULD parse it defensively, gate
+    /// adoption behind a flag, tolerate shape changes, and not assume longevity.
+    case experimental = "experimental"
+    /// Still emitted, but scheduled for removal in a future version. Clients
+    /// SHOULD migrate off it and SHOULD NOT adopt it anew.
+    case deprecated = "deprecated"
+}
+
 /// Encoding of fetched content data.
 public enum ContentEncoding: String, Codable, Sendable {
     case base64 = "base64"
@@ -123,6 +145,28 @@ public struct InitializeResult: Codable, Sendable {
     /// defines a template variable, `{level}`, for subscriber-side severity
     /// filtering). Clients MAY ignore signals they cannot process.
     public var telemetry: TelemetryCapabilities?
+    /// Wire/schema stability of selected surfaces the host emits, keyed by a
+    /// surface identifier — a notification method (e.g. `"session/canvasOpened"`),
+    /// a command method (e.g. `"listSessions"`), a channel URI scheme (e.g.
+    /// `"ahp-otlp:"`), or a named capability.
+    ///
+    /// A surface absent from this map is {@link FeatureStabilityLevel.Stable |
+    /// `stable`} and carries the normal additive SemVer guarantees, so hosts list
+    /// **only** surfaces that are not stable. The signal is strictly about
+    /// wire/schema volatility ("may change or be removed within a compatible
+    /// version range") — **not** product gating, entitlement, or preview access.
+    /// Clients use it only to decide how defensively to code against a surface.
+    ///
+    /// This is connection-level metadata negotiated once at `initialize`. A
+    /// `reconnect` continues the same logical connection, so clients retain the
+    /// map across reconnects rather than re-requesting it, exactly as they retain
+    /// {@link InitializeResult.defaultDirectory | `defaultDirectory`} and
+    /// {@link InitializeResult.telemetry | `telemetry`}.
+    ///
+    /// Older clients that do not understand this field ignore it and treat every
+    /// surface as stable, consistent with the protocol's "ignore what you don't
+    /// understand" rule.
+    public var featureStability: [String: FeatureStabilityLevel]?
 
     public init(
         protocolVersion: String,
@@ -130,7 +174,8 @@ public struct InitializeResult: Codable, Sendable {
         snapshots: [Snapshot],
         defaultDirectory: String? = nil,
         completionTriggerCharacters: [String]? = nil,
-        telemetry: TelemetryCapabilities? = nil
+        telemetry: TelemetryCapabilities? = nil,
+        featureStability: [String: FeatureStabilityLevel]? = nil
     ) {
         self.protocolVersion = protocolVersion
         self.serverSeq = serverSeq
@@ -138,6 +183,7 @@ public struct InitializeResult: Codable, Sendable {
         self.defaultDirectory = defaultDirectory
         self.completionTriggerCharacters = completionTriggerCharacters
         self.telemetry = telemetry
+        self.featureStability = featureStability
     }
 }
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,6 +19,10 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
+- `InitializeResult.featureStability` — an optional
+  `[String: FeatureStabilityLevel]` advertising the wire/schema stability
+  (`.stable` / `.experimental` / `.deprecated`) of selected surfaces a host
+  emits, keyed by surface identifier. Surfaces absent from the map are stable.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary.meta` (`_meta` on the wire) optional provider metadata field

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,6 +22,10 @@ hotfix escape hatch.
 
 ### Added
 
+- `InitializeResult.featureStability` — an optional
+  `Record<string, FeatureStabilityLevel>` advertising the wire/schema stability
+  (`stable` / `experimental` / `deprecated`) of selected surfaces a host emits,
+  keyed by surface identifier. Surfaces absent from the map are `stable`.
 - `SessionModelInfo.maxOutputTokens` and `SessionModelInfo.maxPromptTokens`
   optional fields for communicating model token limits.
 - `SessionSummary._meta` optional provider metadata field for lightweight

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -61,6 +61,8 @@ The client initiates the connection with an `initialize` **request**. The client
 
 If present, `defaultDirectory` provides a server-local starting location for remote filesystem browsing.
 
+The server MAY also include `featureStability` — a map advertising which emitted surfaces are `experimental` or `deprecated` rather than `stable`. This is connection-level metadata: it is negotiated once here and retained by the client across [reconnects](#reconnection). See [Stability Levels](/specification/versioning#stability-levels) for the semantics.
+
 If the server cannot accept the connection for any other reason, it MUST return a JSON-RPC error. See [Error Codes](/reference/error-codes) for defined codes.
 
 ## Authentication

--- a/docs/specification/versioning.md
+++ b/docs/specification/versioning.md
@@ -33,6 +33,36 @@ New behavior generally lands in two stages:
 1. **Capability-gated.** A new feature is introduced as an opt-in capability advertised by a host or clients. Implementors check for the capability before exercising the feature. This lets hosts and clients adopt the feature on independent schedules without a version bump.
 2. **Required.** Once a capability has matured, a future protocol version may promote it to baseline behavior and remove the capability flag. This reduces long-term implementation complexity.
 
+## Stability Levels
+
+Capability advertisement is binary — a surface is either advertised or it isn't. But an agent host commonly wraps a fast-moving backend (a CLI, runtime, or remote service) that exposes **experimental** surfaces it reserves the right to reshape. Such a surface occupies a middle state: implemented and emitted on the wire, but with a shape that is not yet stable. A host that relays it has only two honest options without a standard signal — drop it (the client loses fidelity) or emit it silently (the client can't tell it's volatile).
+
+A stability level closes that gap. The host advertises the wire/schema stability of selected surfaces in [`InitializeResult.featureStability`](/reference/common#initializeresult) — an optional map keyed by a surface identifier (a notification method, a command method, a channel URI scheme, or a named capability):
+
+```jsonc
+{
+  "protocolVersion": "0.5.0",
+  "serverSeq": 42,
+  "snapshots": [ /* ... */ ],
+  "featureStability": {
+    "session/canvasOpened": "experimental",
+    "session/someOlderThing": "deprecated"
+  }
+}
+```
+
+| Level | Meaning | Client guidance |
+| --- | --- | --- |
+| `stable` (default / absent) | Normal SemVer additive guarantees apply. | Build on it freely. |
+| `experimental` | On the wire, but its shape may change or be removed within an otherwise-compatible version range. | Parse defensively, gate behind a flag, tolerate shape changes, don't assume longevity. |
+| `deprecated` | Still emitted, but scheduled for removal. | Migrate off; don't adopt anew. |
+
+A surface absent from the map is `stable`, so hosts list only the surfaces that are not stable. The signal is strictly about **wire/schema volatility** — *not* product gating, entitlement, or preview access; a client uses it only to decide how defensively to code against a surface.
+
+Stability is a static property of a surface, so it is advertised **once**, at the surface level, in the handshake — not stamped onto every message instance. It is connection-level metadata: a [`reconnect`](/specification/lifecycle#reconnection) continues the same logical connection, so clients retain the map rather than re-requesting it. Older clients that don't understand `featureStability` ignore it and treat every surface as stable, consistent with the [forward-compatibility](#forward-compatibility) rule.
+
+This adds a stability axis to the capability lifecycle above: a surface can be advertised **and** flagged `experimental`, giving an explicit path of `experimental → stable → (eventually) required`.
+
 ## Client and Host Update Cadence
 
 Agent hosts may be remote machines, cloud services, or other external APIs that the user does not control. Clients (IDEs, CLI tools, embedded UIs) are typically easier for a user to update than hosts.

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -105,6 +105,13 @@
         "telemetry": {
           "$ref": "#/$defs/TelemetryCapabilities",
           "description": "OTLP telemetry channels the host emits, if any. Each populated field is\neither a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a\nclient expands before subscribing (currently only the `logs` channel\ndefines a template variable, `{level}`, for subscriber-side severity\nfiltering). Clients MAY ignore signals they cannot process."
+        },
+        "featureStability": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/FeatureStabilityLevel"
+          },
+          "description": "Wire/schema stability of selected surfaces the host emits, keyed by a\nsurface identifier — a notification method (e.g. `\"session/canvasOpened\"`),\na command method (e.g. `\"listSessions\"`), a channel URI scheme (e.g.\n`\"ahp-otlp:\"`), or a named capability.\n\nA surface absent from this map is {@link FeatureStabilityLevel.Stable |\n`stable`} and carries the normal additive SemVer guarantees, so hosts list\n**only** surfaces that are not stable. The signal is strictly about\nwire/schema volatility (\"may change or be removed within a compatible\nversion range\") — **not** product gating, entitlement, or preview access.\nClients use it only to decide how defensively to code against a surface.\n\nThis is connection-level metadata negotiated once at `initialize`. A\n`reconnect` continues the same logical connection, so clients retain the\nmap across reconnects rather than re-requesting it, exactly as they retain\n{@link InitializeResult.defaultDirectory | `defaultDirectory`} and\n{@link InitializeResult.telemetry | `telemetry`}.\n\nOlder clients that do not understand this field ignore it and treat every\nsurface as stable, consistent with the protocol's \"ignore what you don't\nunderstand\" rule."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -4275,6 +4275,13 @@
         "telemetry": {
           "$ref": "#/$defs/TelemetryCapabilities",
           "description": "OTLP telemetry channels the host emits, if any. Each populated field is\neither a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a\nclient expands before subscribing (currently only the `logs` channel\ndefines a template variable, `{level}`, for subscriber-side severity\nfiltering). Clients MAY ignore signals they cannot process."
+        },
+        "featureStability": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/FeatureStabilityLevel"
+          },
+          "description": "Wire/schema stability of selected surfaces the host emits, keyed by a\nsurface identifier — a notification method (e.g. `\"session/canvasOpened\"`),\na command method (e.g. `\"listSessions\"`), a channel URI scheme (e.g.\n`\"ahp-otlp:\"`), or a named capability.\n\nA surface absent from this map is {@link FeatureStabilityLevel.Stable |\n`stable`} and carries the normal additive SemVer guarantees, so hosts list\n**only** surfaces that are not stable. The signal is strictly about\nwire/schema volatility (\"may change or be removed within a compatible\nversion range\") — **not** product gating, entitlement, or preview access.\nClients use it only to decide how defensively to code against a surface.\n\nThis is connection-level metadata negotiated once at `initialize`. A\n`reconnect` continues the same logical connection, so clients retain the\nmap across reconnects rather than re-requesting it, exactly as they retain\n{@link InitializeResult.defaultDirectory | `defaultDirectory`} and\n{@link InitializeResult.telemetry | `telemetry`}.\n\nOlder clients that do not understand this field ignore it and treat every\nsurface as stable, consistent with the protocol's \"ignore what you don't\nunderstand\" rule."
         }
       },
       "required": [

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1381,7 +1381,7 @@ function generateActionsFile(project: Project): string {
 
 // ─── Commands File Generator ─────────────────────────────────────────────────
 
-const COMMAND_ENUMS = ['ReconnectResultType', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
+const COMMAND_ENUMS = ['ReconnectResultType', 'FeatureStabilityLevel', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
 
 const COMMAND_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: string }[] = [
   { name: 'InitializeParams' }, { name: 'InitializeResult' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1359,7 +1359,7 @@ function generateActionsFile(project: Project): string {
 
 // ─── Commands File Generator ─────────────────────────────────────────────────
 
-const COMMAND_ENUMS = ['ReconnectResultType', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
+const COMMAND_ENUMS = ['ReconnectResultType', 'FeatureStabilityLevel', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
 
 const COMMAND_STRUCTS = [
   'InitializeParams', 'InitializeResult',

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1325,7 +1325,7 @@ pub struct ActionEnvelope {
 
 // ─── Commands File Generator ─────────────────────────────────────────────────
 
-const COMMAND_ENUMS = ['ReconnectResultType', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
+const COMMAND_ENUMS = ['ReconnectResultType', 'FeatureStabilityLevel', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
 
 const COMMAND_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: string }[] = [
   { name: 'InitializeParams' }, { name: 'InitializeResult' },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1273,7 +1273,7 @@ function generateActionsFile(project: Project): string {
 
 // ─── Commands File Generator ─────────────────────────────────────────────────
 
-const COMMAND_ENUMS = ['ReconnectResultType', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
+const COMMAND_ENUMS = ['ReconnectResultType', 'FeatureStabilityLevel', 'ContentEncoding', 'CompletionItemKind', 'ResourceType', 'ResourceWriteMode'];
 
 const COMMAND_STRUCTS = [
   'InitializeParams', 'InitializeResult', 'ClientCapabilities',

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -147,6 +147,65 @@ export interface InitializeResult {
    * @see {@link /specification/telemetry-channel | Telemetry Channel}
    */
   telemetry?: TelemetryCapabilities;
+  /**
+   * Wire/schema stability of selected surfaces the host emits, keyed by a
+   * surface identifier — a notification method (e.g. `"session/canvasOpened"`),
+   * a command method (e.g. `"listSessions"`), a channel URI scheme (e.g.
+   * `"ahp-otlp:"`), or a named capability.
+   *
+   * A surface absent from this map is {@link FeatureStabilityLevel.Stable |
+   * `stable`} and carries the normal additive SemVer guarantees, so hosts list
+   * **only** surfaces that are not stable. The signal is strictly about
+   * wire/schema volatility ("may change or be removed within a compatible
+   * version range") — **not** product gating, entitlement, or preview access.
+   * Clients use it only to decide how defensively to code against a surface.
+   *
+   * This is connection-level metadata negotiated once at `initialize`. A
+   * `reconnect` continues the same logical connection, so clients retain the
+   * map across reconnects rather than re-requesting it, exactly as they retain
+   * {@link InitializeResult.defaultDirectory | `defaultDirectory`} and
+   * {@link InitializeResult.telemetry | `telemetry`}.
+   *
+   * Older clients that do not understand this field ignore it and treat every
+   * surface as stable, consistent with the protocol's "ignore what you don't
+   * understand" rule.
+   *
+   * @see {@link /specification/versioning | Versioning} for the capability
+   * lifecycle this extends.
+   */
+  featureStability?: Record<string, FeatureStabilityLevel>;
+}
+
+/**
+ * Wire/schema stability of a surface advertised in
+ * {@link InitializeResult.featureStability}.
+ *
+ * Stability describes how settled a surface's shape is within a compatible
+ * SemVer range. It is deliberately **not** a product-gating, entitlement, or
+ * preview-access signal — a client uses it only to decide how defensively to
+ * code against the surface.
+ *
+ * @category Commands
+ */
+export const enum FeatureStabilityLevel {
+  /**
+   * Normal additive SemVer guarantees apply; clients MAY build on it freely.
+   * This is the default for any surface absent from
+   * {@link InitializeResult.featureStability}, so it never needs to be
+   * advertised explicitly.
+   */
+  Stable = 'stable',
+  /**
+   * On the wire, but its shape MAY change or be removed within an otherwise
+   * compatible version range. Clients SHOULD parse it defensively, gate
+   * adoption behind a flag, tolerate shape changes, and not assume longevity.
+   */
+  Experimental = 'experimental',
+  /**
+   * Still emitted, but scheduled for removal in a future version. Clients
+   * SHOULD migrate off it and SHOULD NOT adopt it anew.
+   */
+  Deprecated = 'deprecated',
 }
 
 // ─── ping ────────────────────────────────────────────────────────────────────

--- a/types/index.ts
+++ b/types/index.ts
@@ -313,7 +313,7 @@ export type {
   ChangesetOperationFollowUp,
 } from './commands.js';
 
-export { ReconnectResultType, ContentEncoding, CompletionItemKind, ResourceType, ResourceWriteMode } from './commands.js';
+export { ReconnectResultType, FeatureStabilityLevel, ContentEncoding, CompletionItemKind, ResourceType, ResourceWriteMode } from './commands.js';
 
 // Notification types
 export type {


### PR DESCRIPTION
Closes #269.

## What

Adds a standard **stability dimension** to capability advertisement, so a host can say "this surface exists, but it's experimental" and a client can decide how defensively to treat it — without inventing a per-host convention.

Concretely, this introduces:

- A `FeatureStabilityLevel` enum — `stable` / `experimental` / `deprecated`.
- An optional `InitializeResult.featureStability` map (`Record<string, FeatureStabilityLevel>`), keyed by a **surface identifier**: a notification method (e.g. `"session/canvasOpened"`), a command method (e.g. `"listSessions"`), a channel URI scheme (e.g. `"ahp-otlp:"`), or a named capability.

```jsonc
// InitializeResult (Server → Client)
{
  "protocolVersion": "0.5.0",
  "serverSeq": 42,
  "snapshots": [ /* ... */ ],
  "featureStability": {
    "session/canvasOpened": "experimental",
    "session/someOlderThing": "deprecated"
  }
}
```

| Level | Meaning | Client guidance |
|---|---|---|
| `stable` (default / absent) | Normal SemVer additive guarantees apply. | Build on it freely. |
| `experimental` | On the wire, but shape may change or be removed within a compatible version range. | Parse defensively; gate behind a flag; tolerate shape changes. |
| `deprecated` | Still emitted, but scheduled for removal. | Migrate off; don't adopt anew. |

## Design decisions (resolving the issue's open questions)

- **Attachment point → `InitializeResult`.** This matches the proposal's lead recommendation and the existing precedent of connection-level handshake metadata (`telemetry`, `defaultDirectory`, `completionTriggerCharacters`). Agent-scoped granularity on `AgentInfo` can be layered on later if a concrete need appears.
- **Granularity → surface-level** (keyed by method/command/scheme/capability name), not per-payload. Stability is a static property of a surface, so it's advertised once in the handshake rather than stamped on every message.
- **Default is `stable`.** A surface absent from the map carries the normal additive SemVer guarantees, so hosts list only the non-stable surfaces. The signal is strictly about **wire/schema volatility** — not product gating, entitlement, or preview access.
- **Carry through reconnect.** Rather than re-transmitting it (which would diverge from how other `InitializeResult` metadata behaves), the field is documented as connection-level metadata that the client **retains** across a `reconnect` — a reconnect continues the same logical connection. Older clients that don't understand the field ignore it and treat everything as stable, consistent with the existing "ignore what you don't understand" rule.

## Changes

- **`types/`** — new `FeatureStabilityLevel` enum + `InitializeResult.featureStability` field; exported from `index.ts`.
- **Generators** — registered the enum in `COMMAND_ENUMS` for the Go/Rust/Kotlin/Swift generators; regenerated all five clients, the JSON Schema, and the reference docs.
- **Spec docs** — new **Stability Levels** section in `versioning.md`; a note in the `initialize` response section of `lifecycle.md`.
- **CHANGELOGs** — `Added` entries under `[Unreleased]` in the spec changelog and all five client changelogs (a `types/` change ripples to every client).

## Validation

- `npm run typecheck`, `npm run lint`, `verify:changelog`, `verify:release-metadata` — pass.
- `npm run generate` is idempotent (clean tree after regeneration).
- Types unit tests: 267 pass.
- Per-client builds/tests: Go (build + test), Rust `ahp-types` (build + tests + doc-tests), TypeScript (typecheck + 59 tests), Swift (build), Kotlin (compile + tests) — all green. Confirms the `Record<string, FeatureStabilityLevel>` map-of-enum serializes correctly in every language.

> Note: `npm run test` fails locally only at the `c8` coverage wrapper (yargs is incompatible with the local Node v26); the underlying unit tests all pass when run directly. This is a pre-existing environmental issue unrelated to this change.

The protocol version is intentionally **not** bumped — the change is additive and lands under `[Unreleased]`.