### PR TITLE
Classify client messages by transport authority

### DIFF
--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -36,6 +36,12 @@ The client initiates the connection with an `initialize` **request**. The client
 
 `locale` is an optional IETF BCP 47 language tag (e.g. `"en-US"`, `"ja"`) indicating the client's preferred language. The server SHOULD use this to localise user-facing strings such as confirmation option labels.
 
+`initialize` is a protocol-authority message. Transport bindings that support
+restricted or observe-only clients MUST still allow `initialize` so the client
+and server can negotiate the protocol version, establish the client id, and
+install any permitted initial subscriptions before the server rejects
+steering-authority messages.
+
 ### Initialize Response (Server → Client)
 
 ```json
@@ -125,6 +131,11 @@ If the gap exceeds the replay buffer, the server sends fresh snapshots instead:
 ```
 
 Protocol notifications are **not** replayed — the client SHOULD re-fetch the session list via [`listSessions`](/reference/root#listsessions). Stateless channels are simply re-subscribed; missed messages are dropped.
+
+Like `initialize`, `reconnect` is a protocol-authority message. Observe-only
+clients can use it to resume passive subscriptions without regaining authority
+to create sessions, dispatch actions, authenticate resources, or mutate host
+state.
 
 ## Unexpected Disconnection
 

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -36,6 +36,12 @@ Future channel types (LSP relay, MCP relay, …) introduce their own URI schemes
 
 `subscribe` is a JSON-RPC **request**. The result includes a snapshot for state-bearing channels and omits it for stateless ones.
 
+`subscribe` is a protocol-authority message: a client that is permitted to
+observe a channel can request the current snapshot and subsequent updates
+without also being permitted to steer the host. Servers MUST still apply the
+normal per-channel authorization checks and reject subscriptions to resources
+the client may not observe.
+
 ```jsonc
 // Client → Server
 {
@@ -76,6 +82,9 @@ After subscribing, the client receives all messages scoped to that channel — b
 ## Unsubscribe (Notification)
 
 `unsubscribe` is a fire-and-forget client → server notification. Like every wire message, its params carry the channel URI being released.
+
+`unsubscribe` is also a protocol-authority message. Restricted clients can
+release subscriptions even when they lack steering authority.
 
 ```json
 {
@@ -125,6 +134,12 @@ The client → server dispatch path uses a different method, `dispatchAction`, w
 ```
 
 See [Actions](/guide/actions) for the full list of client-dispatchable actions.
+
+`dispatchAction` requires steering authority. Even when an individual action
+looks presentation-oriented, the server treats client-dispatched actions as
+potential host mutations and MUST NOT accept them from an observe-only
+transport binding unless that binding has explicitly granted steering
+authority.
 
 ## Initial Subscriptions
 

--- a/docs/specification/transport.md
+++ b/docs/specification/transport.md
@@ -15,6 +15,36 @@ A compliant transport MUST:
 
 Any mechanism that meets these requirements is acceptable — WebSocket, TCP with a framing layer, an in-process message channel, or anything else.
 
+## Restricted client authority
+
+Some transport bindings can grant different client-to-server publish
+permissions to the same logical connection. For example, a hosted relay might
+allow a client to observe an existing session but not steer the host that owns
+it.
+
+Transport bindings MAY enforce this distinction by classifying client-to-server
+messages into two authority classes:
+
+| Authority | Meaning | Examples |
+|---|---|---|
+| `protocol` | Connection management, liveness, and passive observation. These messages do not by themselves create work or mutate host state. | `initialize`, `ping`, `reconnect`, `subscribe`, `unsubscribe`, `listSessions`, `fetchTurns` |
+| `steering` | Messages that create, mutate, authenticate, or otherwise steer host behavior. | `createSession`, `createChat`, `dispose*`, `createTerminal`, `dispatchAction`, `authenticate`, resource writes/deletes/moves, changeset operations |
+
+A restricted client that only has `protocol` authority MUST still be able to
+complete the connection lifecycle. In particular, transports MUST NOT block
+`initialize` or `reconnect` solely because the client lacks steering authority.
+
+When a restricted client attempts a `steering` message, the transport binding or
+server SHOULD reject it with `PermissionDenied` (`-32009`) when a JSON-RPC
+response is possible. Fire-and-forget steering notifications MAY be dropped or
+echoed back as rejected actions according to the channel-specific validation
+rules.
+
+The TypeScript reference types expose `CLIENT_REQUEST_AUTHORITY` and
+`CLIENT_NOTIFICATION_AUTHORITY` as a conservative method classification. A
+transport binding MAY be stricter, but SHOULD NOT classify a listed `steering`
+message as `protocol` without a binding-specific security review.
+
 ## Common Transports
 
 While AHP does not mandate a transport, **WebSocket** is the most common choice for remote and cross-process connections, and is what the VS Code implementation uses.

--- a/types/common/messages.ts
+++ b/types/common/messages.ts
@@ -220,6 +220,64 @@ export interface ClientNotificationMap {
 }
 
 /**
+ * Authority class for client → server messages.
+ *
+ * Transport bindings MAY use this classification to enforce restricted
+ * connections. For example, a relay can allow `protocol` messages for an
+ * observe-only client while requiring full steering authority for `steering`
+ * messages.
+ */
+export const enum ClientMessageAuthority {
+  /** Connection management, liveness, and passive observation. */
+  Protocol = 'protocol',
+  /** Messages that create, mutate, authenticate, or otherwise steer the host. */
+  Steering = 'steering',
+}
+
+/**
+ * Conservative classification of client → server request methods by the
+ * minimum authority a transport binding should require.
+ */
+export const CLIENT_REQUEST_AUTHORITY: { readonly [K in keyof CommandMap]: ClientMessageAuthority } = {
+  'initialize': ClientMessageAuthority.Protocol,
+  'ping': ClientMessageAuthority.Protocol,
+  'reconnect': ClientMessageAuthority.Protocol,
+  'subscribe': ClientMessageAuthority.Protocol,
+  'listSessions': ClientMessageAuthority.Protocol,
+  'fetchTurns': ClientMessageAuthority.Protocol,
+  'completions': ClientMessageAuthority.Protocol,
+  'resourceRead': ClientMessageAuthority.Protocol,
+  'resourceList': ClientMessageAuthority.Protocol,
+  'resourceResolve': ClientMessageAuthority.Protocol,
+  'createSession': ClientMessageAuthority.Steering,
+  'disposeSession': ClientMessageAuthority.Steering,
+  'createChat': ClientMessageAuthority.Steering,
+  'disposeChat': ClientMessageAuthority.Steering,
+  'createTerminal': ClientMessageAuthority.Steering,
+  'disposeTerminal': ClientMessageAuthority.Steering,
+  'createResourceWatch': ClientMessageAuthority.Steering,
+  'resourceWrite': ClientMessageAuthority.Steering,
+  'resourceCopy': ClientMessageAuthority.Steering,
+  'resourceDelete': ClientMessageAuthority.Steering,
+  'resourceMove': ClientMessageAuthority.Steering,
+  'resourceMkdir': ClientMessageAuthority.Steering,
+  'resourceRequest': ClientMessageAuthority.Steering,
+  'authenticate': ClientMessageAuthority.Steering,
+  'resolveSessionConfig': ClientMessageAuthority.Steering,
+  'sessionConfigCompletions': ClientMessageAuthority.Steering,
+  'invokeChangesetOperation': ClientMessageAuthority.Steering,
+};
+
+/**
+ * Conservative classification of client → server notification methods by the
+ * minimum authority a transport binding should require.
+ */
+export const CLIENT_NOTIFICATION_AUTHORITY: { readonly [K in keyof ClientNotificationMap]: ClientMessageAuthority } = {
+  'unsubscribe': ClientMessageAuthority.Protocol,
+  'dispatchAction': ClientMessageAuthority.Steering,
+};
+
+/**
  * Registry mapping each server → client notification method to its params type.
  *
  * Every notification's params MUST carry a top-level `channel: URI` so that

--- a/types/index.ts
+++ b/types/index.ts
@@ -353,6 +353,12 @@ export type {
   ProtocolMessage,
 } from './messages.js';
 
+export {
+  ClientMessageAuthority,
+  CLIENT_REQUEST_AUTHORITY,
+  CLIENT_NOTIFICATION_AUTHORITY,
+} from './messages.js';
+
 // Error codes
 export {
   JsonRpcErrorCodes,

--- a/types/messages.test.ts
+++ b/types/messages.test.ts
@@ -129,6 +129,26 @@ describe('CommandMap', () => {
     assert.deepStrictEqual(missing, [], `Missing from CommandMap: ${missing.join(', ')}`);
   });
 
+  describe('client message authority maps', () => {
+    const commandKeys = parseMapKeys(messagesSrc, 'CommandMap');
+    const notificationKeys = parseMapKeys(messagesSrc, 'ClientNotificationMap');
+
+    it('CLIENT_REQUEST_AUTHORITY lists exactly the CommandMap keys', () => {
+      const authorityKeys = [...messagesSrc.matchAll(/'([^']+)': ClientMessageAuthority\.(?:Protocol|Steering)/g)]
+        .map(match => match[1])
+        .filter(key => commandKeys.includes(key));
+      assert.deepStrictEqual([...new Set(authorityKeys)].sort(), commandKeys.sort());
+    });
+
+    it('CLIENT_NOTIFICATION_AUTHORITY lists exactly the ClientNotificationMap keys', () => {
+      const match = /CLIENT_NOTIFICATION_AUTHORITY[\s\S]*?= \{([\s\S]*?)\};/.exec(messagesSrc);
+      assert.ok(match, 'CLIENT_NOTIFICATION_AUTHORITY map not found');
+      const authorityKeys = [...match[1].matchAll(/'([^']+)': ClientMessageAuthority\.(?:Protocol|Steering)/g)]
+        .map(match => match[1]);
+      assert.deepStrictEqual(authorityKeys.sort(), notificationKeys.sort());
+    });
+  });
+
   it('contains no extra methods beyond commands.ts', () => {
     const extra = mapKeys.filter(m => !requests.includes(m));
     assert.deepStrictEqual(extra, [], `Extra in CommandMap: ${extra.join(', ')}`);


### PR DESCRIPTION
## Summary

Adds a protocol/steering authority taxonomy for client-to-server AHP messages so transport bindings can support observe-only/read-only clients without blocking protocol negotiation.

## Details

- documents restricted client authority in the transport spec
- clarifies that initialize/reconnect/subscribe/unsubscribe remain protocol-authority messages
- exports conservative `CLIENT_REQUEST_AUTHORITY` and `CLIENT_NOTIFICATION_AUTHORITY` maps from the TypeScript reference types
- treats `authenticate` and mutation/dispatch methods as steering-authority by default

## Stack / dependencies

This is the AHP-spec layer for a multi-repo change with companion draft PRs planned in github/copilot-host, github/github-ui, and github/copilot-mission-control.

## Validation

- `npm run typecheck`
- `npx tsx --test types/messages.test.ts`
