### PR TITLE
Add chat activity changed action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 ### Added
 
+- `chat/activityChanged` action for updating a chat's current activity
+  description independently of the session summary.
 - `root/progress` (`ProgressParams`) generic host→client progress notification,
   correlated by a `progressToken` the client supplies on the originating
   request (today `createSession.progressToken`) rather than a domain object. Lets

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -21,6 +21,8 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
   sets or clears `state.Draft` without stamping `ModifiedAt`.
 - `Message.Model` and `Message.Agent` optional fields recording the model /
   agent selection a message was composed with.
+- `ChatActivityChangedAction` (wire `chat/activityChanged`) for updating a chat's
+  current activity description independently of the session summary.
 - `ProgressParams` struct (wire `root/progress`) — a generic progress notification
   correlated by a `ProgressToken` (added on `CreateSessionParams`).
   Used today for the lazy first-use download of an agent's native SDK.

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -415,6 +415,9 @@ func ApplyActionToChat(state *ahptypes.ChatState, action ahptypes.StateAction) R
 		errCopy := a.Error
 		errStatus := ahptypes.SessionStatusError
 		return endTurn(state, a.TurnId, ahptypes.TurnStateError, &errStatus, &errCopy)
+	case *ahptypes.ChatActivityChangedAction:
+		state.Activity = a.Activity
+		return ReduceOutcomeApplied
 	case *ahptypes.ChatToolCallStartAction:
 		if state.ActiveTurn == nil || state.ActiveTurn.Id != a.TurnId {
 			return ReduceOutcomeNoOp

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -40,6 +40,7 @@ const (
 	ActionTypeChatTurnComplete                  ActionType = "chat/turnComplete"
 	ActionTypeChatTurnCancelled                 ActionType = "chat/turnCancelled"
 	ActionTypeChatError                         ActionType = "chat/error"
+	ActionTypeChatActivityChanged               ActionType = "chat/activityChanged"
 	ActionTypeSessionTitleChanged               ActionType = "session/titleChanged"
 	ActionTypeChatUsage                         ActionType = "chat/usage"
 	ActionTypeChatReasoning                     ActionType = "chat/reasoning"
@@ -491,6 +492,19 @@ type ChatErrorAction struct {
 	// (such as a sub-agent acting within the turn). Mirrors the MCP `_meta`
 	// convention.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
+}
+
+// The activity description of this chat changed.
+//
+// Dispatched by the server to indicate what the chat is currently doing
+// (e.g. running a tool, thinking). Clear activity by omitting it or setting it
+// to `undefined`.
+// Producers SHOULD also update the parent session's chat catalog with
+// `session/chatUpdated` so `ChatSummary.activity` stays in sync.
+type ChatActivityChangedAction struct {
+	Type ActionType `json:"type"`
+	// Human-readable description of current activity; omit or set `undefined` to clear
+	Activity *string `json:"activity,omitempty"`
 }
 
 // Session title updated. Fired by the server when the title is auto-generated
@@ -1216,6 +1230,7 @@ func (*ChatToolCallContentChangedAction) isStateAction()        {}
 func (*ChatTurnCompleteAction) isStateAction()                  {}
 func (*ChatTurnCancelledAction) isStateAction()                 {}
 func (*ChatErrorAction) isStateAction()                         {}
+func (*ChatActivityChangedAction) isStateAction()               {}
 func (*SessionTitleChangedAction) isStateAction()               {}
 func (*ChatUsageAction) isStateAction()                         {}
 func (*ChatReasoningAction) isStateAction()                     {}
@@ -1409,6 +1424,12 @@ func (u *StateAction) UnmarshalJSON(data []byte) error {
 		u.Value = &value
 	case "chat/error":
 		var value ChatErrorAction
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "chat/activityChanged":
+		var value ChatActivityChangedAction
 		if err := json.Unmarshal(data, &value); err != nil {
 			return err
 		}

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -23,6 +23,9 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
   `modifiedAt`.
 - `Message.model` and `Message.agent` optional fields recording the model /
   agent selection a message was composed with.
+- `ChatActivityChangedAction` (`StateActionChatActivityChanged`, wire
+  `chat/activityChanged`) for updating a chat's current activity description
+  independently of the session summary.
 - `ProgressParams` data class (wire `root/progress`) — a generic progress
   notification correlated by a `progressToken` (added on `CreateSessionParams`).
   Used today for the lazy first-use download of an agent's native SDK.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -697,6 +697,9 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
     is StateActionChatError ->
         endTurn(state, action.value.turnId, TurnState.ERROR, SessionStatus.ERROR, action.value.error)
 
+    is StateActionChatActivityChanged ->
+        state.copy(activity = action.value.activity)
+
     // ── Tool Call State Machine ───────────────────────────────────────────
 
     is StateActionChatToolCallStart -> {

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -68,6 +68,8 @@ enum class ActionType {
     CHAT_TURN_CANCELLED,
     @SerialName("chat/error")
     CHAT_ERROR,
+    @SerialName("chat/activityChanged")
+    CHAT_ACTIVITY_CHANGED,
     @SerialName("session/titleChanged")
     SESSION_TITLE_CHANGED,
     @SerialName("chat/usage")
@@ -646,6 +648,15 @@ data class ChatErrorAction(
      */
     @SerialName("_meta")
     val meta: Map<String, JsonElement>? = null
+)
+
+@Serializable
+data class ChatActivityChangedAction(
+    val type: ActionType,
+    /**
+     * Human-readable description of current activity; omit or set `undefined` to clear
+     */
+    val activity: String? = null
 )
 
 @Serializable
@@ -1335,6 +1346,7 @@ sealed interface StateAction
 @JvmInline value class StateActionChatTurnComplete(val value: ChatTurnCompleteAction) : StateAction
 @JvmInline value class StateActionChatTurnCancelled(val value: ChatTurnCancelledAction) : StateAction
 @JvmInline value class StateActionChatError(val value: ChatErrorAction) : StateAction
+@JvmInline value class StateActionChatActivityChanged(val value: ChatActivityChangedAction) : StateAction
 @JvmInline value class StateActionSessionTitleChanged(val value: SessionTitleChangedAction) : StateAction
 @JvmInline value class StateActionChatUsage(val value: ChatUsageAction) : StateAction
 @JvmInline value class StateActionChatReasoning(val value: ChatReasoningAction) : StateAction
@@ -1422,6 +1434,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             "chat/turnComplete" -> StateActionChatTurnComplete(input.json.decodeFromJsonElement(ChatTurnCompleteAction.serializer(), element))
             "chat/turnCancelled" -> StateActionChatTurnCancelled(input.json.decodeFromJsonElement(ChatTurnCancelledAction.serializer(), element))
             "chat/error" -> StateActionChatError(input.json.decodeFromJsonElement(ChatErrorAction.serializer(), element))
+            "chat/activityChanged" -> StateActionChatActivityChanged(input.json.decodeFromJsonElement(ChatActivityChangedAction.serializer(), element))
             "session/titleChanged" -> StateActionSessionTitleChanged(input.json.decodeFromJsonElement(SessionTitleChangedAction.serializer(), element))
             "chat/usage" -> StateActionChatUsage(input.json.decodeFromJsonElement(ChatUsageAction.serializer(), element))
             "chat/reasoning" -> StateActionChatReasoning(input.json.decodeFromJsonElement(ChatReasoningAction.serializer(), element))
@@ -1502,6 +1515,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             is StateActionChatTurnComplete -> output.json.encodeToJsonElement(ChatTurnCompleteAction.serializer(), value.value)
             is StateActionChatTurnCancelled -> output.json.encodeToJsonElement(ChatTurnCancelledAction.serializer(), value.value)
             is StateActionChatError -> output.json.encodeToJsonElement(ChatErrorAction.serializer(), value.value)
+            is StateActionChatActivityChanged -> output.json.encodeToJsonElement(ChatActivityChangedAction.serializer(), value.value)
             is StateActionSessionTitleChanged -> output.json.encodeToJsonElement(SessionTitleChangedAction.serializer(), value.value)
             is StateActionChatUsage -> output.json.encodeToJsonElement(ChatUsageAction.serializer(), value.value)
             is StateActionChatReasoning -> output.json.encodeToJsonElement(ChatReasoningAction.serializer(), value.value)

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,6 +17,9 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- `StateAction::ChatActivityChanged` (`ChatActivityChangedAction`, wire
+  `chat/activityChanged`) for updating a chat's current activity description
+  independently of the session summary.
 - `ProgressParams` struct (wire `root/progress`) — a generic progress notification
   correlated by a `progressToken` (added on `CreateSessionParams`).
   Used today for the lazy first-use download of an agent's native SDK.

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -69,6 +69,8 @@ pub enum ActionType {
     ChatTurnCancelled,
     #[serde(rename = "chat/error")]
     ChatError,
+    #[serde(rename = "chat/activityChanged")]
+    ChatActivityChanged,
     #[serde(rename = "session/titleChanged")]
     SessionTitleChanged,
     #[serde(rename = "chat/usage")]
@@ -641,6 +643,21 @@ pub struct ChatErrorAction {
     /// convention.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<JsonObject>,
+}
+
+/// The activity description of this chat changed.
+///
+/// Dispatched by the server to indicate what the chat is currently doing
+/// (e.g. running a tool, thinking). Clear activity by omitting it or setting it
+/// to `undefined`.
+/// Producers SHOULD also update the parent session's chat catalog with
+/// `session/chatUpdated` so `ChatSummary.activity` stays in sync.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatActivityChangedAction {
+    /// Human-readable description of current activity; omit or set `undefined` to clear
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity: Option<String>,
 }
 
 /// Session title updated. Fired by the server when the title is auto-generated
@@ -1493,6 +1510,8 @@ pub enum StateAction {
     ChatTurnCancelled(ChatTurnCancelledAction),
     #[serde(rename = "chat/error")]
     ChatError(ChatErrorAction),
+    #[serde(rename = "chat/activityChanged")]
+    ChatActivityChanged(ChatActivityChangedAction),
     #[serde(rename = "session/titleChanged")]
     SessionTitleChanged(SessionTitleChangedAction),
     #[serde(rename = "chat/usage")]

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -770,6 +770,10 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
             Some(SessionStatus::Error),
             Some(a.error.clone()),
         ),
+        StateAction::ChatActivityChanged(a) => {
+            state.activity = a.activity.clone();
+            ReduceOutcome::Applied
+        }
         StateAction::ChatToolCallStart(a) => {
             let Some(active) = state.active_turn.as_mut() else {
                 return ReduceOutcome::NoOp;

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -27,6 +27,7 @@ public enum ActionType: String, Codable, Sendable {
     case chatTurnComplete = "chat/turnComplete"
     case chatTurnCancelled = "chat/turnCancelled"
     case chatError = "chat/error"
+    case chatActivityChanged = "chat/activityChanged"
     case sessionTitleChanged = "session/titleChanged"
     case chatUsage = "chat/usage"
     case chatReasoning = "chat/reasoning"
@@ -787,6 +788,20 @@ public struct ChatErrorAction: Codable, Sendable {
         self.turnId = turnId
         self.error = error
         self.meta = meta
+    }
+}
+
+public struct ChatActivityChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Human-readable description of current activity; omit or set `undefined` to clear
+    public var activity: String?
+
+    public init(
+        type: ActionType,
+        activity: String? = nil
+    ) {
+        self.type = type
+        self.activity = activity
     }
 }
 
@@ -1742,6 +1757,7 @@ public enum StateAction: Codable, Sendable {
     case chatTurnComplete(ChatTurnCompleteAction)
     case chatTurnCancelled(ChatTurnCancelledAction)
     case chatError(ChatErrorAction)
+    case chatActivityChanged(ChatActivityChangedAction)
     case sessionTitleChanged(SessionTitleChangedAction)
     case chatUsage(ChatUsageAction)
     case chatReasoning(ChatReasoningAction)
@@ -1847,6 +1863,8 @@ public enum StateAction: Codable, Sendable {
             self = .chatTurnCancelled(try ChatTurnCancelledAction(from: decoder))
         case "chat/error":
             self = .chatError(try ChatErrorAction(from: decoder))
+        case "chat/activityChanged":
+            self = .chatActivityChanged(try ChatActivityChangedAction(from: decoder))
         case "session/titleChanged":
             self = .sessionTitleChanged(try SessionTitleChangedAction(from: decoder))
         case "chat/usage":
@@ -1977,6 +1995,7 @@ public enum StateAction: Codable, Sendable {
         case .chatTurnComplete(let v): try v.encode(to: encoder)
         case .chatTurnCancelled(let v): try v.encode(to: encoder)
         case .chatError(let v): try v.encode(to: encoder)
+        case .chatActivityChanged(let v): try v.encode(to: encoder)
         case .sessionTitleChanged(let v): try v.encode(to: encoder)
         case .chatUsage(let v): try v.encode(to: encoder)
         case .chatReasoning(let v): try v.encode(to: encoder)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -124,6 +124,11 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
     case .chatError(let a):
         return endTurn(state: state, turnId: a.turnId, turnState: .error, terminalStatus: .error, error: a.error)
 
+    case .chatActivityChanged(let a):
+        var next = state
+        next.activity = a.activity
+        return next
+
     // ── Tool Call State Machine ───────────────────────────────────────────
 
     case .chatToolCallStart(let a):

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,6 +19,9 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
+- `ChatActivityChangedAction` (`StateAction.chatActivityChanged`, wire
+  `chat/activityChanged`) for updating a chat's current activity description
+  independently of the session summary.
 - `ProgressParams` struct (wire `root/progress`) — a generic progress notification
   correlated by a `progressToken` (added on `CreateSessionParams`).
   Used today for the lazy first-use download of an agent's native SDK.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -27,6 +27,8 @@ hotfix escape hatch.
   or clears `draft` without stamping `modifiedAt`.
 - `Message.model` and `Message.agent` optional fields recording the model /
   agent selection a message was composed with.
+- `ChatActivityChangedAction` (`chat/activityChanged`) for updating a chat's
+  current activity description independently of the session summary.
 - `ProgressParams` (wire `root/progress`) generic progress notification correlated by
   a `progressToken`, plus `createSession.progressToken` to opt in. Used today for
   the lazy first-use download of an agent's native SDK, so clients can show an

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -81,6 +81,7 @@ Tool calls follow a discriminated-union state machine — see [State Model — T
 |---|---|---|
 | `session/titleChanged` | **Yes** | Session title updated (auto-generated or client rename) |
 | `session/activityChanged` | No | Server updated the session's current activity description |
+| `chat/activityChanged` | No | Server updated a chat's current activity description |
 | `session/diffsChanged` | No | File diffs in the session summary changed (full replacement) |
 | `session/isReadChanged` | **Yes** | Client marked session as read or unread |
 | `session/isArchivedChanged` | **Yes** | Client archived or unarchived session |

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1077,6 +1077,22 @@
         "error"
       ]
     },
+    "ChatActivityChangedAction": {
+      "type": "object",
+      "description": "The activity description of this chat changed.\n\nDispatched by the server to indicate what the chat is currently doing\n(e.g. running a tool, thinking). Clear activity by omitting it or setting it\nto `undefined`.\nProducers SHOULD also update the parent session's chat catalog with\n`session/chatUpdated` so `ChatSummary.activity` stays in sync.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.ChatActivityChanged"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of current activity; omit or set `undefined` to clear"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
     "ChatUsageAction": {
       "type": "object",
       "description": "Token usage report for a turn.",
@@ -1841,6 +1857,9 @@
         },
         {
           "$ref": "#/$defs/ChatErrorAction"
+        },
+        {
+          "$ref": "#/$defs/ChatActivityChangedAction"
         },
         {
           "$ref": "#/$defs/ChatUsageAction"
@@ -6487,6 +6506,9 @@
         },
         {
           "$ref": "#/$defs/ChatErrorAction"
+        },
+        {
+          "$ref": "#/$defs/ChatActivityChangedAction"
         },
         {
           "$ref": "#/$defs/ChatUsageAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -6436,6 +6436,22 @@
         "error"
       ]
     },
+    "ChatActivityChangedAction": {
+      "type": "object",
+      "description": "The activity description of this chat changed.\n\nDispatched by the server to indicate what the chat is currently doing\n(e.g. running a tool, thinking). Clear activity by omitting it or setting it\nto `undefined`.\nProducers SHOULD also update the parent session's chat catalog with\n`session/chatUpdated` so `ChatSummary.activity` stays in sync.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ActionType.ChatActivityChanged"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of current activity; omit or set `undefined` to clear"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
     "ChatUsageAction": {
       "type": "object",
       "description": "Token usage report for a turn.",

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1229,6 +1229,7 @@ const ACTION_VARIANTS: {
   { type: 'chat/turnComplete', variantName: 'ChatTurnComplete', tsInterface: 'ChatTurnCompleteAction' },
   { type: 'chat/turnCancelled', variantName: 'ChatTurnCancelled', tsInterface: 'ChatTurnCancelledAction' },
   { type: 'chat/error', variantName: 'ChatError', tsInterface: 'ChatErrorAction' },
+  { type: 'chat/activityChanged', variantName: 'ChatActivityChanged', tsInterface: 'ChatActivityChangedAction' },
   { type: 'session/titleChanged', variantName: 'SessionTitleChanged', tsInterface: 'SessionTitleChangedAction' },
   { type: 'chat/usage', variantName: 'ChatUsage', tsInterface: 'ChatUsageAction' },
   { type: 'chat/reasoning', variantName: 'ChatReasoning', tsInterface: 'ChatReasoningAction' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1151,6 +1151,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'chat/turnComplete', caseName: 'ChatTurnComplete', tsInterface: 'ChatTurnCompleteAction' },
   { type: 'chat/turnCancelled', caseName: 'ChatTurnCancelled', tsInterface: 'ChatTurnCancelledAction' },
   { type: 'chat/error', caseName: 'ChatError', tsInterface: 'ChatErrorAction' },
+  { type: 'chat/activityChanged', caseName: 'ChatActivityChanged', tsInterface: 'ChatActivityChangedAction' },
   { type: 'session/titleChanged', caseName: 'SessionTitleChanged', tsInterface: 'SessionTitleChangedAction' },
   { type: 'chat/usage', caseName: 'ChatUsage', tsInterface: 'ChatUsageAction' },
   { type: 'chat/reasoning', caseName: 'ChatReasoning', tsInterface: 'ChatReasoningAction' },

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1138,6 +1138,7 @@ const ACTION_VARIANTS: {
   { type: 'chat/turnComplete', variantName: 'ChatTurnComplete', tsInterface: 'ChatTurnCompleteAction' },
   { type: 'chat/turnCancelled', variantName: 'ChatTurnCancelled', tsInterface: 'ChatTurnCancelledAction' },
   { type: 'chat/error', variantName: 'ChatError', tsInterface: 'ChatErrorAction' },
+  { type: 'chat/activityChanged', variantName: 'ChatActivityChanged', tsInterface: 'ChatActivityChangedAction' },
   { type: 'session/titleChanged', variantName: 'SessionTitleChanged', tsInterface: 'SessionTitleChangedAction' },
   { type: 'chat/usage', variantName: 'ChatUsage', tsInterface: 'ChatUsageAction' },
   { type: 'chat/reasoning', variantName: 'ChatReasoning', tsInterface: 'ChatReasoningAction' },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1055,6 +1055,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'chat/turnComplete', caseName: 'chatTurnComplete', tsInterface: 'ChatTurnCompleteAction' },
   { type: 'chat/turnCancelled', caseName: 'chatTurnCancelled', tsInterface: 'ChatTurnCancelledAction' },
   { type: 'chat/error', caseName: 'chatError', tsInterface: 'ChatErrorAction' },
+  { type: 'chat/activityChanged', caseName: 'chatActivityChanged', tsInterface: 'ChatActivityChangedAction' },
   { type: 'session/titleChanged', caseName: 'sessionTitleChanged', tsInterface: 'SessionTitleChangedAction' },
   { type: 'chat/usage', caseName: 'chatUsage', tsInterface: 'ChatUsageAction' },
   { type: 'chat/reasoning', caseName: 'chatReasoning', tsInterface: 'ChatReasoningAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -41,6 +41,7 @@ import type {
   ChatTurnCompleteAction,
   ChatTurnCancelledAction,
   ChatErrorAction,
+  ChatActivityChangedAction,
   ChatUsageAction,
   ChatReasoningAction,
   ChatPendingMessageSetAction,
@@ -170,6 +171,7 @@ export type ChatAction =
   | ChatTurnCompleteAction
   | ChatTurnCancelledAction
   | ChatErrorAction
+  | ChatActivityChangedAction
   | ChatUsageAction
   | ChatReasoningAction
   | ChatPendingMessageSetAction
@@ -208,6 +210,7 @@ export type ServerChatAction =
   | ChatToolCallReadyAction
   | ChatTurnCompleteAction
   | ChatErrorAction
+  | ChatActivityChangedAction
   | ChatUsageAction
   | ChatReasoningAction
   | ChatInputRequestedAction
@@ -357,6 +360,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.ChatTurnComplete]: false,
   [ActionType.ChatTurnCancelled]: true,
   [ActionType.ChatError]: false,
+  [ActionType.ChatActivityChanged]: false,
   [ActionType.ChatUsage]: false,
   [ActionType.ChatReasoning]: false,
   [ActionType.ChatPendingMessageSet]: true,

--- a/types/channels-chat/actions.ts
+++ b/types/channels-chat/actions.ts
@@ -399,6 +399,23 @@ export interface ChatErrorAction {
   _meta?: Record<string, unknown>;
 }
 
+/**
+ * The activity description of this chat changed.
+ *
+ * Dispatched by the server to indicate what the chat is currently doing
+ * (e.g. running a tool, thinking). Clear activity by omitting it or setting it
+ * to `undefined`.
+ * Producers SHOULD also update the parent session's chat catalog with
+ * `session/chatUpdated` so `ChatSummary.activity` stays in sync.
+ *
+ * @category Chat Actions
+ * @version 1
+ */
+export interface ChatActivityChangedAction {
+  type: ActionType.ChatActivityChanged;
+  /** Human-readable description of current activity; omit or set `undefined` to clear */
+  activity?: string;
+}
 
 /**
  * Token usage report for a turn.
@@ -639,6 +656,7 @@ export type ChatAction =
   | ChatTurnCompleteAction
   | ChatTurnCancelledAction
   | ChatErrorAction
+  | ChatActivityChangedAction
   | ChatUsageAction
   | ChatReasoningAction
   | ChatTruncatedAction

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -328,6 +328,9 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
     case ActionType.ChatError:
       return endTurn(state, action.turnId, TurnState.Error, SessionStatus.Error, action.error);
 
+    case ActionType.ChatActivityChanged:
+      return { ...state, activity: action.activity };
+
     // ── Tool Call State Machine ───────────────────────────────────────────
 
     case ActionType.ChatToolCallStart:

--- a/types/common/actions.ts
+++ b/types/common/actions.ts
@@ -53,6 +53,7 @@ import type {
   ChatTurnCompleteAction,
   ChatTurnCancelledAction,
   ChatErrorAction,
+  ChatActivityChangedAction,
   ChatUsageAction,
   ChatReasoningAction,
   ChatPendingMessageSetAction,
@@ -130,6 +131,7 @@ export const enum ActionType {
   ChatTurnComplete = 'chat/turnComplete',
   ChatTurnCancelled = 'chat/turnCancelled',
   ChatError = 'chat/error',
+  ChatActivityChanged = 'chat/activityChanged',
   SessionTitleChanged = 'session/titleChanged',
   ChatUsage = 'chat/usage',
   ChatReasoning = 'chat/reasoning',
@@ -255,6 +257,7 @@ export type StateAction =
   | ChatTurnCompleteAction
   | ChatTurnCancelledAction
   | ChatErrorAction
+  | ChatActivityChangedAction
   | ChatUsageAction
   | ChatReasoningAction
   | ChatPendingMessageSetAction

--- a/types/index.ts
+++ b/types/index.ts
@@ -160,6 +160,7 @@ export type {
   ChatTurnCompleteAction,
   ChatTurnCancelledAction,
   ChatErrorAction,
+  ChatActivityChangedAction,
   SessionTitleChangedAction,
   ChatUsageAction,
   ChatReasoningAction,

--- a/types/test-cases/reducers/223-chat-activitychanged-sets-activity.json
+++ b/types/test-cases/reducers/223-chat-activitychanged-sets-activity.json
@@ -1,0 +1,25 @@
+{
+  "description": "chat/activityChanged sets activity on chat",
+  "reducer": "chat",
+  "initial": {
+    "turns": [],
+    "resource": "copilot:/test-session/chat/main",
+    "title": "Test Chat",
+    "status": 1,
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/activityChanged",
+      "activity": "Running terminal command"
+    }
+  ],
+  "expected": {
+    "turns": [],
+    "resource": "copilot:/test-session/chat/main",
+    "title": "Test Chat",
+    "status": 1,
+    "activity": "Running terminal command",
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
+  }
+}

--- a/types/test-cases/reducers/224-chat-activitychanged-clears-activity.json
+++ b/types/test-cases/reducers/224-chat-activitychanged-clears-activity.json
@@ -1,0 +1,26 @@
+{
+  "description": "chat/activityChanged clears activity with null",
+  "reducer": "chat",
+  "initial": {
+    "turns": [],
+    "resource": "copilot:/test-session/chat/main",
+    "title": "Test Chat",
+    "status": 1,
+    "activity": "Thinking",
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/activityChanged",
+      "activity": null
+    }
+  ],
+  "expected": {
+    "turns": [],
+    "resource": "copilot:/test-session/chat/main",
+    "title": "Test Chat",
+    "status": 1,
+    "activity": null,
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -111,6 +111,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string
   [ActionType.ChatTurnComplete]: '0.4.0',
   [ActionType.ChatTurnCancelled]: '0.4.0',
   [ActionType.ChatError]: '0.4.0',
+  [ActionType.ChatActivityChanged]: '0.5.0',
   [ActionType.ChatUsage]: '0.4.0',
   [ActionType.ChatReasoning]: '0.4.0',
   [ActionType.ChatPendingMessageSet]: '0.4.0',


### PR DESCRIPTION
## Summary
- add `chat/activityChanged` to the protocol action surface
- update TypeScript/Go/Rust/Kotlin/Swift reducer handling and generated action types
- add reducer fixtures plus docs, schemas, and changelog entries

## Validation
- `npm run generate`
- `npm run test`
- `go test ./...` in `clients/go`
- `cargo test` in `clients/rust`
- `swift test`
- `./gradlew test` in `clients/kotlin` could not run locally because no Java runtime is installed in this environment

Council review was run and findings were addressed.