### PR TITLE
ci: remove Rust publish dry-run

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -87,16 +87,6 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
-      - name: Dry-run publish every crate
-        run: |
-          set -euo pipefail
-          for crate in ahp-types ahp ahp-ws; do
-            echo "::group::cargo publish -p $crate --dry-run"
-            cargo publish -p "$crate" --dry-run
-            echo "::endgroup::"
-          done
-
-
   publish:
     needs: validate
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Remove the `Dry-run publish every crate` validation step from the Rust publish workflow.

## Why

The dry-run attempts to package dependent crates before their freshly tagged dependency versions exist in the crates.io index, so `cargo publish -p ahp --dry-run` fails while resolving `ahp-types = "^0.5.0"`.

The actual publish job already publishes crates in dependency order with index propagation waits between crates.

## Validation

- `git diff --check`
