### PR TITLE
Add first-class `model` and `tools` fields to `AgentCustomization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 - Optional `intention` field on `chat/toolCallStart` and every `ToolCallState`
   variant, providing a human-readable description of what the invocation intends
   to do.
+- Optional `model` and `tools` fields on `AgentCustomization`, giving a custom
+  agent's pinned model and tool allowlist a first-class home instead of `_meta`.
 
 ## [0.5.1] — Unreleased
 

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -18,6 +18,8 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 - Optional `Intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
+- Optional `Model` and `Tools` fields on `AgentCustomization` for a custom
+  agent's pinned model and tool allowlist.
 
 ## [0.5.0] — 2026-06-26
 

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -2062,9 +2062,12 @@ type AgentCustomization struct {
 	// default model.
 	Model *string `json:"model,omitempty"`
 	// Allowlist of tool names the agent is scoped to, sourced from the
-	// agent file's frontmatter `tools`. When present, the agent may only
-	// use the named tools. Absent means no restriction beyond the session
-	// default (the agent may use any available tool).
+	// agent file's frontmatter `tools`. A non-empty list restricts the
+	// agent to exactly those tools. Absent — or an empty list — imposes no
+	// restriction beyond the session default: the agent may use any
+	// available tool. Producers express "no restriction" by omitting the
+	// field rather than sending an empty array, so an empty list carries no
+	// meaning distinct from absence.
 	Tools []string `json:"tools,omitempty"`
 	// Additional provider-specific metadata for this custom agent.
 	//

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -2057,6 +2057,15 @@ type AgentCustomization struct {
 	// Short description of what the agent specializes in and when to
 	// invoke it. Sourced from the agent file's frontmatter `description`.
 	Description *string `json:"description,omitempty"`
+	// Model the agent is pinned to, sourced from the agent file's
+	// frontmatter `model`. Absent means the agent inherits the session's
+	// default model.
+	Model *string `json:"model,omitempty"`
+	// Allowlist of tool names the agent is scoped to, sourced from the
+	// agent file's frontmatter `tools`. When present, the agent may only
+	// use the named tools. Absent means no restriction beyond the session
+	// default (the agent may use any available tool).
+	Tools []string `json:"tools,omitempty"`
 	// Additional provider-specific metadata for this custom agent.
 	//
 	// Mirrors the MCP `_meta` convention.

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -19,6 +19,8 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 - Optional `intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
+- Optional `model` and `tools` fields on `AgentCustomization` for a custom
+  agent's pinned model and tool allowlist.
 
 ## [0.5.0] — 2026-06-26
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -2939,6 +2939,19 @@ data class AgentCustomization(
      */
     val description: String? = null,
     /**
+     * Model the agent is pinned to, sourced from the agent file's
+     * frontmatter `model`. Absent means the agent inherits the session's
+     * default model.
+     */
+    val model: String? = null,
+    /**
+     * Allowlist of tool names the agent is scoped to, sourced from the
+     * agent file's frontmatter `tools`. When present, the agent may only
+     * use the named tools. Absent means no restriction beyond the session
+     * default (the agent may use any available tool).
+     */
+    val tools: List<String>? = null,
+    /**
      * Additional provider-specific metadata for this custom agent.
      *
      * Mirrors the MCP `_meta` convention.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -2946,9 +2946,12 @@ data class AgentCustomization(
     val model: String? = null,
     /**
      * Allowlist of tool names the agent is scoped to, sourced from the
-     * agent file's frontmatter `tools`. When present, the agent may only
-     * use the named tools. Absent means no restriction beyond the session
-     * default (the agent may use any available tool).
+     * agent file's frontmatter `tools`. A non-empty list restricts the
+     * agent to exactly those tools. Absent — or an empty list — imposes no
+     * restriction beyond the session default: the agent may use any
+     * available tool. Producers express "no restriction" by omitting the
+     * field rather than sending an empty array, so an empty list carries no
+     * meaning distinct from absence.
      */
     val tools: List<String>? = null,
     /**

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -19,6 +19,8 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 - Optional `intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
+- Optional `model` and `tools` fields on `AgentCustomization` for a custom
+  agent's pinned model and tool allowlist.
 
 ## [0.5.0] — 2026-06-26
 

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -2564,6 +2564,17 @@ pub struct AgentCustomization {
     /// invoke it. Sourced from the agent file's frontmatter `description`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Model the agent is pinned to, sourced from the agent file's
+    /// frontmatter `model`. Absent means the agent inherits the session's
+    /// default model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Allowlist of tool names the agent is scoped to, sourced from the
+    /// agent file's frontmatter `tools`. When present, the agent may only
+    /// use the named tools. Absent means no restriction beyond the session
+    /// default (the agent may use any available tool).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<String>>,
     /// Additional provider-specific metadata for this custom agent.
     ///
     /// Mirrors the MCP `_meta` convention.

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -2570,9 +2570,12 @@ pub struct AgentCustomization {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     /// Allowlist of tool names the agent is scoped to, sourced from the
-    /// agent file's frontmatter `tools`. When present, the agent may only
-    /// use the named tools. Absent means no restriction beyond the session
-    /// default (the agent may use any available tool).
+    /// agent file's frontmatter `tools`. A non-empty list restricts the
+    /// agent to exactly those tools. Absent — or an empty list — imposes no
+    /// restriction beyond the session default: the agent may use any
+    /// available tool. Producers express "no restriction" by omitting the
+    /// field rather than sending an empty array, so an empty list carries no
+    /// meaning distinct from absence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<String>>,
     /// Additional provider-specific metadata for this custom agent.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -3136,9 +3136,12 @@ public struct AgentCustomization: Codable, Sendable {
     /// default model.
     public var model: String?
     /// Allowlist of tool names the agent is scoped to, sourced from the
-    /// agent file's frontmatter `tools`. When present, the agent may only
-    /// use the named tools. Absent means no restriction beyond the session
-    /// default (the agent may use any available tool).
+    /// agent file's frontmatter `tools`. A non-empty list restricts the
+    /// agent to exactly those tools. Absent — or an empty list — imposes no
+    /// restriction beyond the session default: the agent may use any
+    /// available tool. Producers express "no restriction" by omitting the
+    /// field rather than sending an empty array, so an empty list carries no
+    /// meaning distinct from absence.
     public var tools: [String]?
     /// Additional provider-specific metadata for this custom agent.
     ///

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -3131,6 +3131,15 @@ public struct AgentCustomization: Codable, Sendable {
     /// Short description of what the agent specializes in and when to
     /// invoke it. Sourced from the agent file's frontmatter `description`.
     public var description: String?
+    /// Model the agent is pinned to, sourced from the agent file's
+    /// frontmatter `model`. Absent means the agent inherits the session's
+    /// default model.
+    public var model: String?
+    /// Allowlist of tool names the agent is scoped to, sourced from the
+    /// agent file's frontmatter `tools`. When present, the agent may only
+    /// use the named tools. Absent means no restriction beyond the session
+    /// default (the agent may use any available tool).
+    public var tools: [String]?
     /// Additional provider-specific metadata for this custom agent.
     ///
     /// Mirrors the MCP `_meta` convention.
@@ -3144,6 +3153,8 @@ public struct AgentCustomization: Codable, Sendable {
         case range
         case type
         case description
+        case model
+        case tools
         case meta = "_meta"
     }
 
@@ -3155,6 +3166,8 @@ public struct AgentCustomization: Codable, Sendable {
         range: TextRange? = nil,
         type: CustomizationType,
         description: String? = nil,
+        model: String? = nil,
+        tools: [String]? = nil,
         meta: [String: AnyCodable]? = nil
     ) {
         self.id = id
@@ -3164,6 +3177,8 @@ public struct AgentCustomization: Codable, Sendable {
         self.range = range
         self.type = type
         self.description = description
+        self.model = model
+        self.tools = tools
         self.meta = meta
     }
 }

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -21,6 +21,8 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 - Optional `intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
+- Optional `model` and `tools` fields on `AgentCustomization` for a custom
+  agent's pinned model and tool allowlist.
 
 ## [0.5.0] — 2026-06-26
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -24,6 +24,8 @@ hotfix escape hatch.
 
 - Optional `intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
+- Optional `model` and `tools` fields on `AgentCustomization` for a custom
+  agent's pinned model and tool allowlist.
 
 ## [0.5.0] — 2026-06-26
 

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -109,7 +109,7 @@ Every child carries the same base fields (`id`, `uri`, `name`, optional `icons`)
 Each child type carries optional metadata sourced from its [Open Plugins](https://open-plugins.com/plugin-builders/specification.md) component definition (typically the file's YAML frontmatter):
 
 ```typescript
-AgentCustomization        { type: 'agent';       description? }
+AgentCustomization        { type: 'agent';       description?, model?, tools? }
 SkillCustomization        { type: 'skill';       description?, disableModelInvocation? }
 PromptCustomization       { type: 'prompt';      description? }
 RuleCustomization         { type: 'rule';        description?, alwaysApply?, globs? }    // covers "instruction" formats too

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -3392,7 +3392,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. A non-empty list restricts the\nagent to exactly those tools. Absent — or an empty list — imposes no\nrestriction beyond the session default: the agent may use any\navailable tool. Producers express \"no restriction\" by omitting the\nfield rather than sending an empty array, so an empty list carries no\nmeaning distinct from absence."
         },
         "_meta": {
           "type": "object",

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -3383,6 +3383,17 @@
           "type": "string",
           "description": "Short description of what the agent specializes in and when to\ninvoke it. Sourced from the agent file's frontmatter `description`."
         },
+        "model": {
+          "type": "string",
+          "description": "Model the agent is pinned to, sourced from the agent file's\nfrontmatter `model`. Absent means the agent inherits the session's\ndefault model."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+        },
         "_meta": {
           "type": "object",
           "additionalProperties": {},

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2716,6 +2716,17 @@
           "type": "string",
           "description": "Short description of what the agent specializes in and when to\ninvoke it. Sourced from the agent file's frontmatter `description`."
         },
+        "model": {
+          "type": "string",
+          "description": "Model the agent is pinned to, sourced from the agent file's\nfrontmatter `model`. Absent means the agent inherits the session's\ndefault model."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+        },
         "_meta": {
           "type": "object",
           "additionalProperties": {},

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2725,7 +2725,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. A non-empty list restricts the\nagent to exactly those tools. Absent — or an empty list — imposes no\nrestriction beyond the session default: the agent may use any\navailable tool. Producers express \"no restriction\" by omitting the\nfield rather than sending an empty array, so an empty list carries no\nmeaning distinct from absence."
         },
         "_meta": {
           "type": "object",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -1580,6 +1580,17 @@
           "type": "string",
           "description": "Short description of what the agent specializes in and when to\ninvoke it. Sourced from the agent file's frontmatter `description`."
         },
+        "model": {
+          "type": "string",
+          "description": "Model the agent is pinned to, sourced from the agent file's\nfrontmatter `model`. Absent means the agent inherits the session's\ndefault model."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+        },
         "_meta": {
           "type": "object",
           "additionalProperties": {},

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -1589,7 +1589,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. A non-empty list restricts the\nagent to exactly those tools. Absent — or an empty list — imposes no\nrestriction beyond the session default: the agent may use any\navailable tool. Producers express \"no restriction\" by omitting the\nfield rather than sending an empty array, so an empty list carries no\nmeaning distinct from absence."
         },
         "_meta": {
           "type": "object",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1749,7 +1749,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. A non-empty list restricts the\nagent to exactly those tools. Absent — or an empty list — imposes no\nrestriction beyond the session default: the agent may use any\navailable tool. Producers express \"no restriction\" by omitting the\nfield rather than sending an empty array, so an empty list carries no\nmeaning distinct from absence."
         },
         "_meta": {
           "type": "object",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1740,6 +1740,17 @@
           "type": "string",
           "description": "Short description of what the agent specializes in and when to\ninvoke it. Sourced from the agent file's frontmatter `description`."
         },
+        "model": {
+          "type": "string",
+          "description": "Model the agent is pinned to, sourced from the agent file's\nfrontmatter `model`. Absent means the agent inherits the session's\ndefault model."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+        },
         "_meta": {
           "type": "object",
           "additionalProperties": {},

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1491,6 +1491,17 @@
           "type": "string",
           "description": "Short description of what the agent specializes in and when to\ninvoke it. Sourced from the agent file's frontmatter `description`."
         },
+        "model": {
+          "type": "string",
+          "description": "Model the agent is pinned to, sourced from the agent file's\nfrontmatter `model`. Absent means the agent inherits the session's\ndefault model."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+        },
         "_meta": {
           "type": "object",
           "additionalProperties": {},

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1500,7 +1500,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. When present, the agent may only\nuse the named tools. Absent means no restriction beyond the session\ndefault (the agent may use any available tool)."
+          "description": "Allowlist of tool names the agent is scoped to, sourced from the\nagent file's frontmatter `tools`. A non-empty list restricts the\nagent to exactly those tools. Absent — or an empty list — imposes no\nrestriction beyond the session default: the agent may use any\navailable tool. Producers express \"no restriction\" by omitting the\nfield rather than sending an empty array, so an empty list carries no\nmeaning distinct from absence."
         },
         "_meta": {
           "type": "object",

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -663,9 +663,12 @@ export interface AgentCustomization extends CustomizationBase {
   model?: string;
   /**
    * Allowlist of tool names the agent is scoped to, sourced from the
-   * agent file's frontmatter `tools`. When present, the agent may only
-   * use the named tools. Absent means no restriction beyond the session
-   * default (the agent may use any available tool).
+   * agent file's frontmatter `tools`. A non-empty list restricts the
+   * agent to exactly those tools. Absent — or an empty list — imposes no
+   * restriction beyond the session default: the agent may use any
+   * available tool. Producers express "no restriction" by omitting the
+   * field rather than sending an empty array, so an empty list carries no
+   * meaning distinct from absence.
    */
   tools?: string[];
   /**

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -656,6 +656,19 @@ export interface AgentCustomization extends CustomizationBase {
    */
   description?: string;
   /**
+   * Model the agent is pinned to, sourced from the agent file's
+   * frontmatter `model`. Absent means the agent inherits the session's
+   * default model.
+   */
+  model?: string;
+  /**
+   * Allowlist of tool names the agent is scoped to, sourced from the
+   * agent file's frontmatter `tools`. When present, the agent may only
+   * use the named tools. Absent means no restriction beyond the session
+   * default (the agent may use any available tool).
+   */
+  tools?: string[];
+  /**
    * Additional provider-specific metadata for this custom agent.
    *
    * Mirrors the MCP `_meta` convention.

--- a/types/test-cases/round-trips/027-agent-customization-model-and-tools.json
+++ b/types/test-cases/round-trips/027-agent-customization-model-and-tools.json
@@ -1,0 +1,44 @@
+{
+  "name": "agent-customization-model-and-tools",
+  "group": "A",
+  "description": "An AgentCustomization child inside a PluginCustomization carries the optional first-class `model` (string) and `tools` (string[]) fields. Both survive a decode/re-encode through the typed ChildCustomization union in every client.",
+  "type": "Customization",
+  "input": {
+    "type": "plugin",
+    "id": "plugin-1",
+    "uri": "https://example.com/plugins/coding",
+    "name": "Coding Plugin",
+    "enabled": true,
+    "children": [
+      {
+        "type": "agent",
+        "id": "agent-reviewer",
+        "uri": "file:///plugins/coding/agents/reviewer.md",
+        "name": "Reviewer",
+        "description": "Reviews diffs for correctness.",
+        "model": "claude-sonnet-4.5",
+        "tools": ["read", "grep", "edit"]
+      }
+    ]
+  },
+  "acceptableOutputs": [
+    {
+      "type": "plugin",
+      "id": "plugin-1",
+      "uri": "https://example.com/plugins/coding",
+      "name": "Coding Plugin",
+      "enabled": true,
+      "children": [
+        {
+          "type": "agent",
+          "id": "agent-reviewer",
+          "uri": "file:///plugins/coding/agents/reviewer.md",
+          "name": "Reviewer",
+          "description": "Reviews diffs for correctness.",
+          "model": "claude-sonnet-4.5",
+          "tools": ["read", "grep", "edit"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #286.

A custom agent carries two pieces of behavior that `AgentCustomization` couldn't represent natively: a **model override** and a **tool scope**. With no native field for either, a host had to drop them or stuff them into `_meta`. Both are general agent-host concepts, not vendor-specific residue, so they get first-class fields — matching the spec's established style for `RuleCustomization` (`alwaysApply`, `globs`) rather than `_meta`.

Adds two optional fields to `AgentCustomization`:

- `model?: string` — the model the agent is pinned to. Absent ⇒ inherit the session's default model.
- `tools?: string[]` — an allowlist of tool names the agent is scoped to. Absent ⇒ no restriction beyond the session default.

Both are optional, so existing producers and consumers are unaffected until they opt in.

## Validation (everything verified against the source, not the issue text)

- **Spec premise** — Confirmed `AgentCustomization` carried only `description?` + `_meta?`, and that `RuleCustomization` already models behavior with first-class type-specific fields.
- **Vendor grounding** — Confirmed in `copilot-agent-runtime`: the `session.custom_agents_updated` payload's `CustomAgentsUpdatedAgent` reports `model: string` ("Model override for this agent, if set") and `tools: string[] | null` ("List of tool names available to this agent, or null when all tools are available"), alongside `userInvocable`. So `string` and `string[]` are the real upstream shapes — no speculative structured allow/deny scope was warranted.
- **Carrier premise** — Confirmed the AHP agent host currently routes `session.custom_agents_updated` through `_meta.copilot.customAgents` because there's no native field. The issue's premise holds.
- **Reducers** — Customizations are stored wholesale via the existing upsert actions, so the new optional fields pass through with no reducer change.

## Changes

- `types/channels-session/state.ts` — the two new optional fields with JSDoc.
- Regenerated the JSON Schema and all five client mirrors (Rust, Kotlin, Swift, TypeScript, Go).
- `docs/guide/customizations.md` — updated the child-type metadata table.
- Added cross-language round-trip conformance fixture `027-agent-customization-model-and-tools.json` exercising both fields through the typed `ChildCustomization` union.
- CHANGELOG entries across the spec and every client (a `types/**` change ripples to all six).

## Tests

Ran each client's suite against the regenerated types + new fixture — all green, including the round-trip corpus in every language:

- Go `go test ./...` ✅
- Rust `cargo test` ✅
- Swift `swift test` (107 tests) ✅
- Kotlin `./gradlew test` (JDK 17) ✅ — fixture `027-...` explicitly PASSED
- TypeScript `npm test` (59 tests) ✅
- Root `npm run typecheck && lint && verify:release-metadata && verify:changelog` ✅ (266 type/reducer tests pass directly; the `c8` coverage wrapper is broken under Node v26 in this environment, unrelated to this change)

The protocol version was intentionally **not** bumped.