### PR TITLE
Fix SnapshotState decoders dropping ChatState

### DIFF
--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -19,6 +19,14 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 - Optional `Intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
 
+### Fixed
+
+- `SnapshotState.UnmarshalJSON` now decodes the `Chat` variant. Variant
+  disambiguation previously probed for the removed `summary` field (a leftover
+  from before `SessionState` was flattened), so chat and session snapshots both
+  fell through to the `Root` catch-all. Sessions are now matched on `lifecycle`
+  and chats on `turns`.
+
 ## [0.5.0] — 2026-06-26
 
 Implements AHP 0.5.0.

--- a/clients/go/ahptypes/ahptypes_test.go
+++ b/clients/go/ahptypes/ahptypes_test.go
@@ -85,6 +85,64 @@ func TestStateActionUnknownVariant(t *testing.T) {
 	}
 }
 
+// TestSnapshotStateVariants confirms the SnapshotState discriminator picks the
+// right variant for each state shape — in particular that a chat snapshot
+// resolves to Chat (and not the Root catch-all) and a flattened session
+// snapshot resolves to Session.
+func TestSnapshotStateVariants(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		wire string
+		want func(SnapshotState) bool
+	}{
+		{
+			"session",
+			`{"provider":"p","title":"S","status":0,"lifecycle":"ready","activeClients":[],"chats":[]}`,
+			func(s SnapshotState) bool { return s.Session != nil },
+		},
+		{
+			"chat",
+			`{"resource":"ahp-chat:/c1","title":"C","status":0,"modifiedAt":"2025-03-10T18:42:03.123Z","turns":[]}`,
+			func(s SnapshotState) bool { return s.Chat != nil },
+		},
+		{
+			"terminal",
+			`{"title":"T","content":[],"claim":{"kind":"client","clientId":"x"}}`,
+			func(s SnapshotState) bool { return s.Terminal != nil },
+		},
+		{
+			"changeset",
+			`{"status":"open","files":[]}`,
+			func(s SnapshotState) bool { return s.Changeset != nil },
+		},
+		{
+			"resourceWatch",
+			`{"root":"file:///r","recursive":true}`,
+			func(s SnapshotState) bool { return s.ResourceWatch != nil },
+		},
+		{
+			"annotations",
+			`{"annotations":[]}`,
+			func(s SnapshotState) bool { return s.Annotations != nil },
+		},
+		{
+			"root",
+			`{"agents":[]}`,
+			func(s SnapshotState) bool { return s.Root != nil },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var s SnapshotState
+			if err := json.Unmarshal([]byte(tc.wire), &s); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !tc.want(s) {
+				t.Fatalf("wrong variant for %s snapshot: %+v", tc.name, s)
+			}
+		})
+	}
+}
+
 // TestSessionStatusBitset confirms the typed-uint32 Has/Or helpers
 // match the canonical bitset semantics.
 func TestSessionStatusBitset(t *testing.T) {

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -3999,13 +3999,13 @@ func (s *SnapshotState) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	switch {
-	case containsAll(probe, "summary", "lifecycle"):
+	case containsAll(probe, "lifecycle"):
 		var v SessionState
 		if err := json.Unmarshal(data, &v); err != nil {
 			return err
 		}
 		s.Session = &v
-	case containsAll(probe, "summary", "turns"):
+	case containsAll(probe, "turns"):
 		var v ChatState
 		if err := json.Unmarshal(data, &v); err != nil {
 			return err

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -20,6 +20,14 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 - Optional `intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
 
+### Fixed
+
+- `SnapshotState` now decodes the `Chat` variant. Its serializer previously never
+  matched `ChatState`, so chat snapshots decoded as the `Root` catch-all. Variant
+  disambiguation also no longer relies on the removed `summary` field (a leftover
+  from before `SessionState` was flattened); sessions are now matched on
+  `lifecycle`.
+
 ## [0.5.0] — 2026-06-26
 
 Implements AHP 0.5.0.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -4706,19 +4706,22 @@ internal object SnapshotStateSerializer : KSerializer<SnapshotState> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for SnapshotState")
         // Try the most distinctive shape first. SessionState has required
-        // `summary`; ChangesetState has required `status` + `files`;
-        // ResourceWatchState has required `root` + `recursive`;
-        // AnnotationsState has required `annotations`; TerminalState has `uri`
-        // / `size` / `buffer`; RootState is the catch-all.
+        // `lifecycle`; ChatState has required `turns`; ChangesetState has
+        // required `status` + `files`; ResourceWatchState has required
+        // `root` + `recursive`; AnnotationsState has required `annotations`
+        // (checked after session, whose optional annotations summary reuses the
+        // key); TerminalState has required `content`; RootState is the
+        // catch-all.
         return when {
-            obj.containsKey("summary") -> SnapshotState.Session(input.json.decodeFromJsonElement(SessionState.serializer(), element))
+            obj.containsKey("lifecycle") -> SnapshotState.Session(input.json.decodeFromJsonElement(SessionState.serializer(), element))
+            obj.containsKey("turns") -> SnapshotState.Chat(input.json.decodeFromJsonElement(ChatState.serializer(), element))
             obj.containsKey("status") && obj.containsKey("files") ->
                 SnapshotState.Changeset(input.json.decodeFromJsonElement(ChangesetState.serializer(), element))
             obj.containsKey("root") && obj.containsKey("recursive") ->
                 SnapshotState.ResourceWatch(input.json.decodeFromJsonElement(ResourceWatchState.serializer(), element))
             obj.containsKey("annotations") ->
                 SnapshotState.Annotations(input.json.decodeFromJsonElement(AnnotationsState.serializer(), element))
-            obj.containsKey("size") || obj.containsKey("uri") || obj.containsKey("buffer") ->
+            obj.containsKey("content") ->
                 SnapshotState.Terminal(input.json.decodeFromJsonElement(TerminalState.serializer(), element))
             else -> SnapshotState.Root(input.json.decodeFromJsonElement(RootState.serializer(), element))
         }

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -3727,7 +3727,7 @@ pub enum ToolCallContributor {
 /// The state payload of a snapshot — root, session, chat, terminal,
 /// changeset, resource-watch, or annotations state.
 ///
-/// Deserialized by trying session first (has required `summary`), then
+/// Deserialized by trying session first (has required `lifecycle`), then
 /// chat (has required `turns`), then terminal (has required `content`),
 /// then changeset (has required `status` and `files`), then resource-watch
 /// (has required `root` and `recursive`), then annotations (has required

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -4871,9 +4871,14 @@ public enum SnapshotState: Codable, Sendable {
     case annotations(AnnotationsState)
 
     public init(from decoder: Decoder) throws {
-        // SessionState has required `summary` field, try it first
+        // Try the most distinctive shapes first. SessionState has required
+        // `lifecycle` / `activeClients` / `chats`; ChatState has required
+        // `turns`; the remaining variants follow, with RootState as the
+        // catch-all.
         if let session = try? SessionState(from: decoder) {
             self = .session(session)
+        } else if let chat = try? ChatState(from: decoder) {
+            self = .chat(chat)
         } else if let terminal = try? TerminalState(from: decoder) {
             self = .terminal(terminal)
         } else if let changeset = try? ChangesetState(from: decoder) {

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -22,6 +22,13 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 - Optional `intention` field on `ChatToolCallStartAction` and every tool-call
   lifecycle state.
 
+### Fixed
+
+- `SnapshotState` now decodes the `chat` variant. Its decoder previously never
+  attempted `ChatState`, so chat snapshots failed to decode. Variant
+  disambiguation also no longer relies on the removed `summary` field (a leftover
+  from before `SessionState` was flattened).
+
 ## [0.5.0] — 2026-06-26
 
 Implements AHP 0.5.0.

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1080,13 +1080,13 @@ func (s *SnapshotState) UnmarshalJSON(data []byte) error {
 \t\treturn err
 \t}
 \tswitch {
-\tcase containsAll(probe, "summary", "lifecycle"):
+\tcase containsAll(probe, "lifecycle"):
 \t\tvar v SessionState
 \t\tif err := json.Unmarshal(data, &v); err != nil {
 \t\t\treturn err
 \t\t}
 \t\ts.Session = &v
-\tcase containsAll(probe, "summary", "turns"):
+\tcase containsAll(probe, "turns"):
 \t\tvar v ChatState
 \t\tif err := json.Unmarshal(data, &v); err != nil {
 \t\t\treturn err

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -684,19 +684,22 @@ internal object SnapshotStateSerializer : KSerializer<SnapshotState> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for SnapshotState")
         // Try the most distinctive shape first. SessionState has required
-        // \`summary\`; ChangesetState has required \`status\` + \`files\`;
-        // ResourceWatchState has required \`root\` + \`recursive\`;
-        // AnnotationsState has required \`annotations\`; TerminalState has \`uri\`
-        // / \`size\` / \`buffer\`; RootState is the catch-all.
+        // \`lifecycle\`; ChatState has required \`turns\`; ChangesetState has
+        // required \`status\` + \`files\`; ResourceWatchState has required
+        // \`root\` + \`recursive\`; AnnotationsState has required \`annotations\`
+        // (checked after session, whose optional annotations summary reuses the
+        // key); TerminalState has required \`content\`; RootState is the
+        // catch-all.
         return when {
-            obj.containsKey("summary") -> SnapshotState.Session(input.json.decodeFromJsonElement(SessionState.serializer(), element))
+            obj.containsKey("lifecycle") -> SnapshotState.Session(input.json.decodeFromJsonElement(SessionState.serializer(), element))
+            obj.containsKey("turns") -> SnapshotState.Chat(input.json.decodeFromJsonElement(ChatState.serializer(), element))
             obj.containsKey("status") && obj.containsKey("files") ->
                 SnapshotState.Changeset(input.json.decodeFromJsonElement(ChangesetState.serializer(), element))
             obj.containsKey("root") && obj.containsKey("recursive") ->
                 SnapshotState.ResourceWatch(input.json.decodeFromJsonElement(ResourceWatchState.serializer(), element))
             obj.containsKey("annotations") ->
                 SnapshotState.Annotations(input.json.decodeFromJsonElement(AnnotationsState.serializer(), element))
-            obj.containsKey("size") || obj.containsKey("uri") || obj.containsKey("buffer") ->
+            obj.containsKey("content") ->
                 SnapshotState.Terminal(input.json.decodeFromJsonElement(TerminalState.serializer(), element))
             else -> SnapshotState.Root(input.json.decodeFromJsonElement(RootState.serializer(), element))
         }

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1023,7 +1023,7 @@ function generateSnapshotState(): string {
   return `/// The state payload of a snapshot — root, session, chat, terminal,
 /// changeset, resource-watch, or annotations state.
 ///
-/// Deserialized by trying session first (has required \`summary\`), then
+/// Deserialized by trying session first (has required \`lifecycle\`), then
 /// chat (has required \`turns\`), then terminal (has required \`content\`),
 /// then changeset (has required \`status\` and \`files\`), then resource-watch
 /// (has required \`root\` and \`recursive\`), then annotations (has required

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -870,9 +870,14 @@ public enum SnapshotState: Codable, Sendable {
     case annotations(AnnotationsState)
 
     public init(from decoder: Decoder) throws {
-        // SessionState has required \`summary\` field, try it first
+        // Try the most distinctive shapes first. SessionState has required
+        // \`lifecycle\` / \`activeClients\` / \`chats\`; ChatState has required
+        // \`turns\`; the remaining variants follow, with RootState as the
+        // catch-all.
         if let session = try? SessionState(from: decoder) {
             self = .session(session)
+        } else if let chat = try? ChatState(from: decoder) {
+            self = .chat(chat)
         } else if let terminal = try? TerminalState(from: decoder) {
             self = .terminal(terminal)
         } else if let changeset = try? ChangesetState(from: decoder) {


### PR DESCRIPTION
## Why

`SnapshotState` is an untagged union; each client distinguishes its variants structurally by probing for distinctive required fields. Those probes still keyed off a `summary` field that was removed when `SessionState` was flattened (commit `80454fd`), breaking snapshot decoding:

- Swift and Kotlin never attempted `ChatState`, so chat snapshots failed to decode (Swift threw; Kotlin fell through to `Root`).
- Go probed for `summary` on both the session and chat branches, so both silently decoded as `Root`.

## Approach

Fixed the decoders in the generators (`scripts/generate-*.ts`) and regenerated the clients. Disambiguation now uses real required fields: session -> `lifecycle`, chat -> `turns`, terminal -> `content`, changeset -> `status` + `files`, resource-watch -> `root` + `recursive`, annotations -> `annotations`, root -> catch-all. Swift and Kotlin gained the missing `chat` branch. Rust already decoded correctly via its `#[serde(untagged)]` enum, so only its stale doc comment changed.

## Notes for reviewers

- Session is probed before annotations because `SessionState` carries an optional `annotations` summary that reuses the same key.
- Added a Go regression test (`TestSnapshotStateVariants`) round-tripping every variant.
- Verified locally: Go build + tests, Rust build, Swift build, and repo typecheck/lint/verify:changelog/type tests pass. Kotlin couldn't be compiled locally (no JVM); generated output verified by inspection.
