### PR TITLE
Add AgentCapabilities to AgentInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ changes accumulate. Track in-flight protocol changes via PRs touching
   to do.
 - Optional `model` and `tools` fields on `AgentCustomization`, giving a custom
   agent's pinned model and tool allowlist a first-class home instead of `_meta`.
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
+  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
+  via advertised flags instead of provider-id switches.
 
 ## [0.5.1] — Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ changes accumulate. Track in-flight protocol changes via PRs touching
   to do.
 - Optional `model` and `tools` fields on `AgentCustomization`, giving a custom
   agent's pinned model and tool allowlist a first-class home instead of `_meta`.
-- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
-  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
-  via advertised flags instead of provider-id switches.
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with a
+  nested `multipleChats` capability carrying `fork`) so clients gate multi-chat
+  and fork via advertised capabilities instead of provider-id switches.
 
 ## [0.5.1] — Unreleased
 

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,9 +16,9 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
-- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
-  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
-  via advertised flags instead of provider-id switches.
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with a
+  nested `multipleChats` capability carrying `fork`) so clients gate multi-chat
+  and fork via advertised capabilities instead of provider-id switches.
 
 - `SessionState.InputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` union with

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,6 +16,10 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
+  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
+  via advertised flags instead of provider-id switches.
+
 - `SessionState.InputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` union with
   `SessionChatInputRequest`, `SessionToolConfirmationRequest`, and

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -544,6 +544,19 @@ type AgentInfo struct {
 	// resolved against the workspace, children are parsed) and propagated
 	// into the session's `customizations` list.
 	Customizations []Customization `json:"customizations,omitempty"`
+	// Static capability flags the agent advertises about itself. Clients use
+	// these to gate features (multi-chat, fork, sub-agent teams) instead of
+	// switching on the provider id. Absent flags default to unsupported.
+	Capabilities *AgentCapabilities `json:"capabilities,omitempty"`
+}
+
+// Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in
+// (absent -> unsupported).
+type AgentCapabilities struct {
+	// Agent can host more than one concurrent chat per session.
+	SupportsMultipleChats *bool `json:"supportsMultipleChats,omitempty"`
+	// Agent can fork a chat from a turn.
+	SupportsFork *bool `json:"supportsFork,omitempty"`
 }
 
 type SessionModelInfo struct {

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -544,19 +544,31 @@ type AgentInfo struct {
 	// resolved against the workspace, children are parsed) and propagated
 	// into the session's `customizations` list.
 	Customizations []Customization `json:"customizations,omitempty"`
-	// Static capability flags the agent advertises about itself. Clients use
-	// these to gate features (multi-chat, fork, sub-agent teams) instead of
-	// switching on the provider id. Absent flags default to unsupported.
+	// Static capabilities the agent advertises about itself. Clients use these
+	// to gate features (multi-chat, fork) instead of switching on the provider
+	// id.
 	Capabilities *AgentCapabilities `json:"capabilities,omitempty"`
 }
 
-// Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in
-// (absent -> unsupported).
+// Static capabilities an {@link AgentInfo} advertises. Modelled after MCP
+// capabilities: each field is opt-in and its presence (an empty object `{}`)
+// signals support, while absence means the feature is unsupported and the
+// corresponding client commands MUST NOT be used. Sub-fields carry
+// per-capability options.
 type AgentCapabilities struct {
-	// Agent can host more than one concurrent chat per session.
-	SupportsMultipleChats *bool `json:"supportsMultipleChats,omitempty"`
-	// Agent can fork a chat from a turn.
-	SupportsFork *bool `json:"supportsFork,omitempty"`
+	// The agent can host more than one concurrent chat per session. When absent,
+	// clients MUST NOT call `createChat` to open chats beyond the default one the
+	// session starts with. An empty object `{}` advertises multi-chat without
+	// forking; set {@link MultipleChatsCapability.fork} to also allow forking.
+	MultipleChats *MultipleChatsCapability `json:"multipleChats,omitempty"`
+}
+
+// Options for the {@link AgentCapabilities.multipleChats} capability.
+type MultipleChatsCapability struct {
+	// The agent can fork a chat from a specific turn. When absent or `false`,
+	// clients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.
+	// Forking always implies multi-chat support.
+	Fork *bool `json:"fork,omitempty"`
 }
 
 type SessionModelInfo struct {

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -17,6 +17,10 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Added
 
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
+  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
+  via advertised flags instead of provider-id switches.
+
 - `SessionState.inputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` sealed interface with
   `SessionChatInputRequest`, `SessionToolConfirmationRequest`, and

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -17,9 +17,9 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ### Added
 
-- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
-  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
-  via advertised flags instead of provider-id switches.
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with a
+  nested `multipleChats` capability carrying `fork`) so clients gate multi-chat
+  and fork via advertised capabilities instead of provider-id switches.
 
 - `SessionState.inputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` sealed interface with

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -899,7 +899,25 @@ data class AgentInfo(
      * resolved against the workspace, children are parsed) and propagated
      * into the session's `customizations` list.
      */
-    val customizations: List<Customization>? = null
+    val customizations: List<Customization>? = null,
+    /**
+     * Static capability flags the agent advertises about itself. Clients use
+     * these to gate features (multi-chat, fork, sub-agent teams) instead of
+     * switching on the provider id. Absent flags default to unsupported.
+     */
+    val capabilities: AgentCapabilities? = null
+)
+
+@Serializable
+data class AgentCapabilities(
+    /**
+     * Agent can host more than one concurrent chat per session.
+     */
+    val supportsMultipleChats: Boolean? = null,
+    /**
+     * Agent can fork a chat from a turn.
+     */
+    val supportsFork: Boolean? = null
 )
 
 @Serializable

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -901,9 +901,9 @@ data class AgentInfo(
      */
     val customizations: List<Customization>? = null,
     /**
-     * Static capability flags the agent advertises about itself. Clients use
-     * these to gate features (multi-chat, fork, sub-agent teams) instead of
-     * switching on the provider id. Absent flags default to unsupported.
+     * Static capabilities the agent advertises about itself. Clients use these
+     * to gate features (multi-chat, fork) instead of switching on the provider
+     * id.
      */
     val capabilities: AgentCapabilities? = null
 )
@@ -911,13 +911,22 @@ data class AgentInfo(
 @Serializable
 data class AgentCapabilities(
     /**
-     * Agent can host more than one concurrent chat per session.
+     * The agent can host more than one concurrent chat per session. When absent,
+     * clients MUST NOT call `createChat` to open chats beyond the default one the
+     * session starts with. An empty object `{}` advertises multi-chat without
+     * forking; set {@link MultipleChatsCapability.fork} to also allow forking.
      */
-    val supportsMultipleChats: Boolean? = null,
+    val multipleChats: MultipleChatsCapability? = null
+)
+
+@Serializable
+data class MultipleChatsCapability(
     /**
-     * Agent can fork a chat from a turn.
+     * The agent can fork a chat from a specific turn. When absent or `false`,
+     * clients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.
+     * Forking always implies multi-chat support.
      */
-    val supportsFork: Boolean? = null
+    val fork: Boolean? = null
 )
 
 @Serializable

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,9 +17,9 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
-- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
-  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
-  via advertised flags instead of provider-id switches.
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with a
+  nested `multipleChats` capability carrying `fork`) so clients gate multi-chat
+  and fork via advertised capabilities instead of provider-id switches.
 
 - `SessionState.input_needed` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` enum with

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,6 +17,10 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
+  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
+  via advertised flags instead of provider-id switches.
+
 - `SessionState.input_needed` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` enum with
   `SessionChatInputRequest`, `SessionToolConfirmationRequest`, and

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -754,6 +754,24 @@ pub struct AgentInfo {
     /// into the session's `customizations` list.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub customizations: Option<Vec<Customization>>,
+    /// Static capability flags the agent advertises about itself. Clients use
+    /// these to gate features (multi-chat, fork, sub-agent teams) instead of
+    /// switching on the provider id. Absent flags default to unsupported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<AgentCapabilities>,
+}
+
+/// Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in
+/// (absent -> unsupported).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCapabilities {
+    /// Agent can host more than one concurrent chat per session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_multiple_chats: Option<bool>,
+    /// Agent can fork a chat from a turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_fork: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -754,24 +754,38 @@ pub struct AgentInfo {
     /// into the session's `customizations` list.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub customizations: Option<Vec<Customization>>,
-    /// Static capability flags the agent advertises about itself. Clients use
-    /// these to gate features (multi-chat, fork, sub-agent teams) instead of
-    /// switching on the provider id. Absent flags default to unsupported.
+    /// Static capabilities the agent advertises about itself. Clients use these
+    /// to gate features (multi-chat, fork) instead of switching on the provider
+    /// id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<AgentCapabilities>,
 }
 
-/// Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in
-/// (absent -> unsupported).
+/// Static capabilities an {@link AgentInfo} advertises. Modelled after MCP
+/// capabilities: each field is opt-in and its presence (an empty object `{}`)
+/// signals support, while absence means the feature is unsupported and the
+/// corresponding client commands MUST NOT be used. Sub-fields carry
+/// per-capability options.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentCapabilities {
-    /// Agent can host more than one concurrent chat per session.
+    /// The agent can host more than one concurrent chat per session. When absent,
+    /// clients MUST NOT call `createChat` to open chats beyond the default one the
+    /// session starts with. An empty object `{}` advertises multi-chat without
+    /// forking; set {@link MultipleChatsCapability.fork} to also allow forking.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub supports_multiple_chats: Option<bool>,
-    /// Agent can fork a chat from a turn.
+    pub multiple_chats: Option<MultipleChatsCapability>,
+}
+
+/// Options for the {@link AgentCapabilities.multipleChats} capability.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MultipleChatsCapability {
+    /// The agent can fork a chat from a specific turn. When absent or `false`,
+    /// clients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.
+    /// Forking always implies multi-chat support.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub supports_fork: Option<bool>,
+    pub fork: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/clients/rust/crates/ahp/examples/reducers_demo.rs
+++ b/clients/rust/crates/ahp/examples/reducers_demo.rs
@@ -37,6 +37,7 @@ fn main() {
                     models: vec![],
                     protected_resources: None,
                     customizations: None,
+                    capabilities: None,
                 }],
             }),
             server_seq: 1,

--- a/clients/rust/crates/ahp/tests/hosts.rs
+++ b/clients/rust/crates/ahp/tests/hosts.rs
@@ -230,6 +230,7 @@ async fn single_constructor_yields_connected_handle() {
         models: vec![],
         protected_resources: None,
         customizations: None,
+        capabilities: None,
     };
     let state = FakeHostState::new().with_agents(vec![agent.clone()]);
     let factory = make_basic_factory(state);

--- a/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
+++ b/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
@@ -26,6 +26,7 @@ fn agent(provider: &str) -> AgentInfo {
         models: vec![],
         protected_resources: None,
         customizations: None,
+        capabilities: None,
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -583,6 +583,10 @@ public struct AgentInfo: Codable, Sendable {
     /// resolved against the workspace, children are parsed) and propagated
     /// into the session's `customizations` list.
     public var customizations: [Customization]?
+    /// Static capability flags the agent advertises about itself. Clients use
+    /// these to gate features (multi-chat, fork, sub-agent teams) instead of
+    /// switching on the provider id. Absent flags default to unsupported.
+    public var capabilities: AgentCapabilities?
 
     public init(
         provider: String,
@@ -590,7 +594,8 @@ public struct AgentInfo: Codable, Sendable {
         description: String,
         models: [SessionModelInfo],
         protectedResources: [ProtectedResourceMetadata]? = nil,
-        customizations: [Customization]? = nil
+        customizations: [Customization]? = nil,
+        capabilities: AgentCapabilities? = nil
     ) {
         self.provider = provider
         self.displayName = displayName
@@ -598,6 +603,22 @@ public struct AgentInfo: Codable, Sendable {
         self.models = models
         self.protectedResources = protectedResources
         self.customizations = customizations
+        self.capabilities = capabilities
+    }
+}
+
+public struct AgentCapabilities: Codable, Sendable {
+    /// Agent can host more than one concurrent chat per session.
+    public var supportsMultipleChats: Bool?
+    /// Agent can fork a chat from a turn.
+    public var supportsFork: Bool?
+
+    public init(
+        supportsMultipleChats: Bool? = nil,
+        supportsFork: Bool? = nil
+    ) {
+        self.supportsMultipleChats = supportsMultipleChats
+        self.supportsFork = supportsFork
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -583,9 +583,9 @@ public struct AgentInfo: Codable, Sendable {
     /// resolved against the workspace, children are parsed) and propagated
     /// into the session's `customizations` list.
     public var customizations: [Customization]?
-    /// Static capability flags the agent advertises about itself. Clients use
-    /// these to gate features (multi-chat, fork, sub-agent teams) instead of
-    /// switching on the provider id. Absent flags default to unsupported.
+    /// Static capabilities the agent advertises about itself. Clients use these
+    /// to gate features (multi-chat, fork) instead of switching on the provider
+    /// id.
     public var capabilities: AgentCapabilities?
 
     public init(
@@ -608,17 +608,29 @@ public struct AgentInfo: Codable, Sendable {
 }
 
 public struct AgentCapabilities: Codable, Sendable {
-    /// Agent can host more than one concurrent chat per session.
-    public var supportsMultipleChats: Bool?
-    /// Agent can fork a chat from a turn.
-    public var supportsFork: Bool?
+    /// The agent can host more than one concurrent chat per session. When absent,
+    /// clients MUST NOT call `createChat` to open chats beyond the default one the
+    /// session starts with. An empty object `{}` advertises multi-chat without
+    /// forking; set {@link MultipleChatsCapability.fork} to also allow forking.
+    public var multipleChats: MultipleChatsCapability?
 
     public init(
-        supportsMultipleChats: Bool? = nil,
-        supportsFork: Bool? = nil
+        multipleChats: MultipleChatsCapability? = nil
     ) {
-        self.supportsMultipleChats = supportsMultipleChats
-        self.supportsFork = supportsFork
+        self.multipleChats = multipleChats
+    }
+}
+
+public struct MultipleChatsCapability: Codable, Sendable {
+    /// The agent can fork a chat from a specific turn. When absent or `false`,
+    /// clients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.
+    /// Forking always implies multi-chat support.
+    public var fork: Bool?
+
+    public init(
+        fork: Bool? = nil
+    ) {
+        self.fork = fork
     }
 }
 

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,9 +19,9 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
-- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
-  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
-  via advertised flags instead of provider-id switches.
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with a
+  nested `multipleChats` capability carrying `fork`) so clients gate multi-chat
+  and fork via advertised capabilities instead of provider-id switches.
 
 - `SessionState.inputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` enum with

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,6 +19,10 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
+  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
+  via advertised flags instead of provider-id switches.
+
 - `SessionState.inputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` enum with
   `SessionChatInputRequest`, `SessionToolConfirmationRequest`, and

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,6 +22,10 @@ hotfix escape hatch.
 
 ### Added
 
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
+  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
+  via advertised flags instead of provider-id switches.
+
 - `SessionState.inputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` union with
   `SessionChatInputRequest`, `SessionToolConfirmationRequest`, and

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,9 +22,9 @@ hotfix escape hatch.
 
 ### Added
 
-- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with
-  `supportsMultipleChats` / `supportsFork`) so clients gate multi-chat and fork
-  via advertised flags instead of provider-id switches.
+- Optional `capabilities` field on `AgentInfo` (`AgentCapabilities` with a
+  nested `multipleChats` capability carrying `fork`) so clients gate multi-chat
+  and fork via advertised capabilities instead of provider-id switches.
 
 - `SessionState.inputNeeded` — a session-level aggregate of outstanding input
   requests across all chats (`SessionInputRequest` union with

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2443,7 +2443,7 @@
         },
         "capabilities": {
           "$ref": "#/$defs/AgentCapabilities",
-          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
+          "description": "Static capabilities the agent advertises about itself. Clients use these\nto gate features (multi-chat, fork) instead of switching on the provider\nid."
         }
       },
       "required": [
@@ -2455,15 +2455,21 @@
     },
     "AgentCapabilities": {
       "type": "object",
-      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "description": "Static capabilities an {@link AgentInfo} advertises. Modelled after MCP\ncapabilities: each field is opt-in and its presence (an empty object `{}`)\nsignals support, while absence means the feature is unsupported and the\ncorresponding client commands MUST NOT be used. Sub-fields carry\nper-capability options.",
       "properties": {
-        "supportsMultipleChats": {
+        "multipleChats": {
+          "$ref": "#/$defs/MultipleChatsCapability",
+          "description": "The agent can host more than one concurrent chat per session. When absent,\nclients MUST NOT call `createChat` to open chats beyond the default one the\nsession starts with. An empty object `{}` advertises multi-chat without\nforking; set {@link MultipleChatsCapability.fork} to also allow forking."
+        }
+      }
+    },
+    "MultipleChatsCapability": {
+      "type": "object",
+      "description": "Options for the {@link AgentCapabilities.multipleChats} capability.",
+      "properties": {
+        "fork": {
           "type": "boolean",
-          "description": "Agent can host more than one concurrent chat per session."
-        },
-        "supportsFork": {
-          "type": "boolean",
-          "description": "Agent can fork a chat from a turn."
+          "description": "The agent can fork a chat from a specific turn. When absent or `false`,\nclients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.\nForking always implies multi-chat support."
         }
       }
     },

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2440,6 +2440,10 @@
             "$ref": "#/$defs/Customization"
           },
           "description": "Customizations associated with this agent.\n\nEither container customizations —\n{@link PluginCustomization | `PluginCustomization`} entries the agent\nbundles, plus {@link DirectoryCustomization | `DirectoryCustomization`}\nentries it watches in any workspace it's used with — or top-level\n{@link McpServerCustomization | `McpServerCustomization`} entries\nthe agent host declares directly. When a session is created with\nthis agent, these entries are augmented (e.g. directory URIs are\nresolved against the workspace, children are parsed) and propagated\ninto the session's `customizations` list."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/AgentCapabilities",
+          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
         }
       },
       "required": [
@@ -2448,6 +2452,20 @@
         "description",
         "models"
       ]
+    },
+    "AgentCapabilities": {
+      "type": "object",
+      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "properties": {
+        "supportsMultipleChats": {
+          "type": "boolean",
+          "description": "Agent can host more than one concurrent chat per session."
+        },
+        "supportsFork": {
+          "type": "boolean",
+          "description": "Agent can fork a chat from a turn."
+        }
+      }
     },
     "SessionModelInfo": {
       "type": "object",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1742,7 +1742,7 @@
         },
         "capabilities": {
           "$ref": "#/$defs/AgentCapabilities",
-          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
+          "description": "Static capabilities the agent advertises about itself. Clients use these\nto gate features (multi-chat, fork) instead of switching on the provider\nid."
         }
       },
       "required": [
@@ -1754,15 +1754,21 @@
     },
     "AgentCapabilities": {
       "type": "object",
-      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "description": "Static capabilities an {@link AgentInfo} advertises. Modelled after MCP\ncapabilities: each field is opt-in and its presence (an empty object `{}`)\nsignals support, while absence means the feature is unsupported and the\ncorresponding client commands MUST NOT be used. Sub-fields carry\nper-capability options.",
       "properties": {
-        "supportsMultipleChats": {
+        "multipleChats": {
+          "$ref": "#/$defs/MultipleChatsCapability",
+          "description": "The agent can host more than one concurrent chat per session. When absent,\nclients MUST NOT call `createChat` to open chats beyond the default one the\nsession starts with. An empty object `{}` advertises multi-chat without\nforking; set {@link MultipleChatsCapability.fork} to also allow forking."
+        }
+      }
+    },
+    "MultipleChatsCapability": {
+      "type": "object",
+      "description": "Options for the {@link AgentCapabilities.multipleChats} capability.",
+      "properties": {
+        "fork": {
           "type": "boolean",
-          "description": "Agent can host more than one concurrent chat per session."
-        },
-        "supportsFork": {
-          "type": "boolean",
-          "description": "Agent can fork a chat from a turn."
+          "description": "The agent can fork a chat from a specific turn. When absent or `false`,\nclients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.\nForking always implies multi-chat support."
         }
       }
     },

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1739,6 +1739,10 @@
             "$ref": "#/$defs/Customization"
           },
           "description": "Customizations associated with this agent.\n\nEither container customizations —\n{@link PluginCustomization | `PluginCustomization`} entries the agent\nbundles, plus {@link DirectoryCustomization | `DirectoryCustomization`}\nentries it watches in any workspace it's used with — or top-level\n{@link McpServerCustomization | `McpServerCustomization`} entries\nthe agent host declares directly. When a session is created with\nthis agent, these entries are augmented (e.g. directory URIs are\nresolved against the workspace, children are parsed) and propagated\ninto the session's `customizations` list."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/AgentCapabilities",
+          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
         }
       },
       "required": [
@@ -1747,6 +1751,20 @@
         "description",
         "models"
       ]
+    },
+    "AgentCapabilities": {
+      "type": "object",
+      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "properties": {
+        "supportsMultipleChats": {
+          "type": "boolean",
+          "description": "Agent can host more than one concurrent chat per session."
+        },
+        "supportsFork": {
+          "type": "boolean",
+          "description": "Agent can fork a chat from a turn."
+        }
+      }
     },
     "SessionModelInfo": {
       "type": "object",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -603,6 +603,10 @@
             "$ref": "#/$defs/Customization"
           },
           "description": "Customizations associated with this agent.\n\nEither container customizations —\n{@link PluginCustomization | `PluginCustomization`} entries the agent\nbundles, plus {@link DirectoryCustomization | `DirectoryCustomization`}\nentries it watches in any workspace it's used with — or top-level\n{@link McpServerCustomization | `McpServerCustomization`} entries\nthe agent host declares directly. When a session is created with\nthis agent, these entries are augmented (e.g. directory URIs are\nresolved against the workspace, children are parsed) and propagated\ninto the session's `customizations` list."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/AgentCapabilities",
+          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
         }
       },
       "required": [
@@ -611,6 +615,20 @@
         "description",
         "models"
       ]
+    },
+    "AgentCapabilities": {
+      "type": "object",
+      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "properties": {
+        "supportsMultipleChats": {
+          "type": "boolean",
+          "description": "Agent can host more than one concurrent chat per session."
+        },
+        "supportsFork": {
+          "type": "boolean",
+          "description": "Agent can fork a chat from a turn."
+        }
+      }
     },
     "SessionModelInfo": {
       "type": "object",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -606,7 +606,7 @@
         },
         "capabilities": {
           "$ref": "#/$defs/AgentCapabilities",
-          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
+          "description": "Static capabilities the agent advertises about itself. Clients use these\nto gate features (multi-chat, fork) instead of switching on the provider\nid."
         }
       },
       "required": [
@@ -618,15 +618,21 @@
     },
     "AgentCapabilities": {
       "type": "object",
-      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "description": "Static capabilities an {@link AgentInfo} advertises. Modelled after MCP\ncapabilities: each field is opt-in and its presence (an empty object `{}`)\nsignals support, while absence means the feature is unsupported and the\ncorresponding client commands MUST NOT be used. Sub-fields carry\nper-capability options.",
       "properties": {
-        "supportsMultipleChats": {
+        "multipleChats": {
+          "$ref": "#/$defs/MultipleChatsCapability",
+          "description": "The agent can host more than one concurrent chat per session. When absent,\nclients MUST NOT call `createChat` to open chats beyond the default one the\nsession starts with. An empty object `{}` advertises multi-chat without\nforking; set {@link MultipleChatsCapability.fork} to also allow forking."
+        }
+      }
+    },
+    "MultipleChatsCapability": {
+      "type": "object",
+      "description": "Options for the {@link AgentCapabilities.multipleChats} capability.",
+      "properties": {
+        "fork": {
           "type": "boolean",
-          "description": "Agent can host more than one concurrent chat per session."
-        },
-        "supportsFork": {
-          "type": "boolean",
-          "description": "Agent can fork a chat from a turn."
+          "description": "The agent can fork a chat from a specific turn. When absent or `false`,\nclients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.\nForking always implies multi-chat support."
         }
       }
     },

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -763,6 +763,10 @@
             "$ref": "#/$defs/Customization"
           },
           "description": "Customizations associated with this agent.\n\nEither container customizations —\n{@link PluginCustomization | `PluginCustomization`} entries the agent\nbundles, plus {@link DirectoryCustomization | `DirectoryCustomization`}\nentries it watches in any workspace it's used with — or top-level\n{@link McpServerCustomization | `McpServerCustomization`} entries\nthe agent host declares directly. When a session is created with\nthis agent, these entries are augmented (e.g. directory URIs are\nresolved against the workspace, children are parsed) and propagated\ninto the session's `customizations` list."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/AgentCapabilities",
+          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
         }
       },
       "required": [
@@ -771,6 +775,20 @@
         "description",
         "models"
       ]
+    },
+    "AgentCapabilities": {
+      "type": "object",
+      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "properties": {
+        "supportsMultipleChats": {
+          "type": "boolean",
+          "description": "Agent can host more than one concurrent chat per session."
+        },
+        "supportsFork": {
+          "type": "boolean",
+          "description": "Agent can fork a chat from a turn."
+        }
+      }
     },
     "SessionModelInfo": {
       "type": "object",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -766,7 +766,7 @@
         },
         "capabilities": {
           "$ref": "#/$defs/AgentCapabilities",
-          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
+          "description": "Static capabilities the agent advertises about itself. Clients use these\nto gate features (multi-chat, fork) instead of switching on the provider\nid."
         }
       },
       "required": [
@@ -778,15 +778,21 @@
     },
     "AgentCapabilities": {
       "type": "object",
-      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "description": "Static capabilities an {@link AgentInfo} advertises. Modelled after MCP\ncapabilities: each field is opt-in and its presence (an empty object `{}`)\nsignals support, while absence means the feature is unsupported and the\ncorresponding client commands MUST NOT be used. Sub-fields carry\nper-capability options.",
       "properties": {
-        "supportsMultipleChats": {
+        "multipleChats": {
+          "$ref": "#/$defs/MultipleChatsCapability",
+          "description": "The agent can host more than one concurrent chat per session. When absent,\nclients MUST NOT call `createChat` to open chats beyond the default one the\nsession starts with. An empty object `{}` advertises multi-chat without\nforking; set {@link MultipleChatsCapability.fork} to also allow forking."
+        }
+      }
+    },
+    "MultipleChatsCapability": {
+      "type": "object",
+      "description": "Options for the {@link AgentCapabilities.multipleChats} capability.",
+      "properties": {
+        "fork": {
           "type": "boolean",
-          "description": "Agent can host more than one concurrent chat per session."
-        },
-        "supportsFork": {
-          "type": "boolean",
-          "description": "Agent can fork a chat from a turn."
+          "description": "The agent can fork a chat from a specific turn. When absent or `false`,\nclients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.\nForking always implies multi-chat support."
         }
       }
     },

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -514,6 +514,10 @@
             "$ref": "#/$defs/Customization"
           },
           "description": "Customizations associated with this agent.\n\nEither container customizations —\n{@link PluginCustomization | `PluginCustomization`} entries the agent\nbundles, plus {@link DirectoryCustomization | `DirectoryCustomization`}\nentries it watches in any workspace it's used with — or top-level\n{@link McpServerCustomization | `McpServerCustomization`} entries\nthe agent host declares directly. When a session is created with\nthis agent, these entries are augmented (e.g. directory URIs are\nresolved against the workspace, children are parsed) and propagated\ninto the session's `customizations` list."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/AgentCapabilities",
+          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
         }
       },
       "required": [
@@ -522,6 +526,20 @@
         "description",
         "models"
       ]
+    },
+    "AgentCapabilities": {
+      "type": "object",
+      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "properties": {
+        "supportsMultipleChats": {
+          "type": "boolean",
+          "description": "Agent can host more than one concurrent chat per session."
+        },
+        "supportsFork": {
+          "type": "boolean",
+          "description": "Agent can fork a chat from a turn."
+        }
+      }
     },
     "SessionModelInfo": {
       "type": "object",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -517,7 +517,7 @@
         },
         "capabilities": {
           "$ref": "#/$defs/AgentCapabilities",
-          "description": "Static capability flags the agent advertises about itself. Clients use\nthese to gate features (multi-chat, fork, sub-agent teams) instead of\nswitching on the provider id. Absent flags default to unsupported."
+          "description": "Static capabilities the agent advertises about itself. Clients use these\nto gate features (multi-chat, fork) instead of switching on the provider\nid."
         }
       },
       "required": [
@@ -529,15 +529,21 @@
     },
     "AgentCapabilities": {
       "type": "object",
-      "description": "Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in\n(absent -> unsupported).",
+      "description": "Static capabilities an {@link AgentInfo} advertises. Modelled after MCP\ncapabilities: each field is opt-in and its presence (an empty object `{}`)\nsignals support, while absence means the feature is unsupported and the\ncorresponding client commands MUST NOT be used. Sub-fields carry\nper-capability options.",
       "properties": {
-        "supportsMultipleChats": {
+        "multipleChats": {
+          "$ref": "#/$defs/MultipleChatsCapability",
+          "description": "The agent can host more than one concurrent chat per session. When absent,\nclients MUST NOT call `createChat` to open chats beyond the default one the\nsession starts with. An empty object `{}` advertises multi-chat without\nforking; set {@link MultipleChatsCapability.fork} to also allow forking."
+        }
+      }
+    },
+    "MultipleChatsCapability": {
+      "type": "object",
+      "description": "Options for the {@link AgentCapabilities.multipleChats} capability.",
+      "properties": {
+        "fork": {
           "type": "boolean",
-          "description": "Agent can host more than one concurrent chat per session."
-        },
-        "supportsFork": {
-          "type": "boolean",
-          "description": "Agent can fork a chat from a turn."
+          "description": "The agent can fork a chat from a specific turn. When absent or `false`,\nclients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.\nForking always implies multi-chat support."
         }
       }
     },

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -658,6 +658,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: strin
   { name: 'RootConfigState' },
   { name: 'AgentInfo' },
   { name: 'AgentCapabilities' },
+  { name: 'MultipleChatsCapability' },
   { name: 'SessionModelInfo' },
   { name: 'ModelSelection' },
   { name: 'AgentSelection' },

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -657,6 +657,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: strin
   { name: 'RootState' },
   { name: 'RootConfigState' },
   { name: 'AgentInfo' },
+  { name: 'AgentCapabilities' },
   { name: 'SessionModelInfo' },
   { name: 'ModelSelection' },
   { name: 'AgentSelection' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -797,6 +797,7 @@ const STATE_ENUMS = [
 
 const STATE_STRUCTS = [
   'Icon', 'ProtectedResourceMetadata', 'RootState', 'RootConfigState', 'AgentInfo',
+  'AgentCapabilities',
   'SessionModelInfo', 'ModelSelection', 'AgentSelection', 'ConfigPropertySchema', 'ConfigSchema',
   'PendingMessage', 'ChatState', 'ChatSummary', 'SessionState', 'SessionActiveClient',
   'SessionChatInputRequest', 'SessionToolConfirmationRequest', 'SessionToolClientExecutionRequest',

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -798,6 +798,7 @@ const STATE_ENUMS = [
 const STATE_STRUCTS = [
   'Icon', 'ProtectedResourceMetadata', 'RootState', 'RootConfigState', 'AgentInfo',
   'AgentCapabilities',
+  'MultipleChatsCapability',
   'SessionModelInfo', 'ModelSelection', 'AgentSelection', 'ConfigPropertySchema', 'ConfigSchema',
   'PendingMessage', 'ChatState', 'ChatSummary', 'SessionState', 'SessionActiveClient',
   'SessionChatInputRequest', 'SessionToolConfirmationRequest', 'SessionToolClientExecutionRequest',

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -688,6 +688,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'RootState' },
   { name: 'RootConfigState' },
   { name: 'AgentInfo' },
+  { name: 'AgentCapabilities' },
   { name: 'SessionModelInfo' },
   { name: 'ModelSelection' },
   { name: 'AgentSelection' },

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -689,6 +689,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'RootConfigState' },
   { name: 'AgentInfo' },
   { name: 'AgentCapabilities' },
+  { name: 'MultipleChatsCapability' },
   { name: 'SessionModelInfo' },
   { name: 'ModelSelection' },
   { name: 'AgentSelection' },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -551,6 +551,7 @@ const STATE_ENUMS = [
 const STATE_STRUCTS = [
   'Icon', 'ProtectedResourceMetadata', 'RootState', 'RootConfigState', 'AgentInfo',
   'AgentCapabilities',
+  'MultipleChatsCapability',
   'SessionModelInfo', 'ModelSelection', 'AgentSelection', 'ConfigPropertySchema', 'ConfigSchema',
   'PendingMessage', 'ChatState', 'ChatSummary', 'SessionState', 'SessionActiveClient',
   'SessionChatInputRequest', 'SessionToolConfirmationRequest', 'SessionToolClientExecutionRequest',

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -550,6 +550,7 @@ const STATE_ENUMS = [
 
 const STATE_STRUCTS = [
   'Icon', 'ProtectedResourceMetadata', 'RootState', 'RootConfigState', 'AgentInfo',
+  'AgentCapabilities',
   'SessionModelInfo', 'ModelSelection', 'AgentSelection', 'ConfigPropertySchema', 'ConfigSchema',
   'PendingMessage', 'ChatState', 'ChatSummary', 'SessionState', 'SessionActiveClient',
   'SessionChatInputRequest', 'SessionToolConfirmationRequest', 'SessionToolClientExecutionRequest',

--- a/types/channels-root/state.ts
+++ b/types/channels-root/state.ts
@@ -85,6 +85,25 @@ export interface AgentInfo {
    * into the session's `customizations` list.
    */
   customizations?: Customization[];
+  /**
+   * Static capability flags the agent advertises about itself. Clients use
+   * these to gate features (multi-chat, fork, sub-agent teams) instead of
+   * switching on the provider id. Absent flags default to unsupported.
+   */
+  capabilities?: AgentCapabilities;
+}
+
+/**
+ * Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in
+ * (absent -> unsupported).
+ *
+ * @category Root State
+ */
+export interface AgentCapabilities {
+  /** Agent can host more than one concurrent chat per session. */
+  supportsMultipleChats?: boolean;
+  /** Agent can fork a chat from a turn. */
+  supportsFork?: boolean;
 }
 
 /**

--- a/types/channels-root/state.ts
+++ b/types/channels-root/state.ts
@@ -86,24 +86,44 @@ export interface AgentInfo {
    */
   customizations?: Customization[];
   /**
-   * Static capability flags the agent advertises about itself. Clients use
-   * these to gate features (multi-chat, fork, sub-agent teams) instead of
-   * switching on the provider id. Absent flags default to unsupported.
+   * Static capabilities the agent advertises about itself. Clients use these
+   * to gate features (multi-chat, fork) instead of switching on the provider
+   * id.
    */
   capabilities?: AgentCapabilities;
 }
 
 /**
- * Static capability flags an {@link AgentInfo} advertises. Each flag is opt-in
- * (absent -> unsupported).
+ * Static capabilities an {@link AgentInfo} advertises. Modelled after MCP
+ * capabilities: each field is opt-in and its presence (an empty object `{}`)
+ * signals support, while absence means the feature is unsupported and the
+ * corresponding client commands MUST NOT be used. Sub-fields carry
+ * per-capability options.
  *
  * @category Root State
  */
 export interface AgentCapabilities {
-  /** Agent can host more than one concurrent chat per session. */
-  supportsMultipleChats?: boolean;
-  /** Agent can fork a chat from a turn. */
-  supportsFork?: boolean;
+  /**
+   * The agent can host more than one concurrent chat per session. When absent,
+   * clients MUST NOT call `createChat` to open chats beyond the default one the
+   * session starts with. An empty object `{}` advertises multi-chat without
+   * forking; set {@link MultipleChatsCapability.fork} to also allow forking.
+   */
+  multipleChats?: MultipleChatsCapability;
+}
+
+/**
+ * Options for the {@link AgentCapabilities.multipleChats} capability.
+ *
+ * @category Root State
+ */
+export interface MultipleChatsCapability {
+  /**
+   * The agent can fork a chat from a specific turn. When absent or `false`,
+   * clients MUST NOT pass a {@link ChatForkSource} (`source`) to `createChat`.
+   * Forking always implies multi-chat support.
+   */
+  fork?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `capabilities` field to `AgentInfo`, backed by a new `AgentCapabilities` interface, so clients can gate features (multi-chat, fork, sub-agent teams) via advertised capability flags instead of switching on the provider id. Absent flags default to unsupported.

```ts
export interface AgentCapabilities {
  /** Agent can host more than one concurrent chat per session. */
  supportsMultipleChats?: boolean;
  /** Agent can fork a chat from a turn. */
  supportsFork?: boolean;
}
```

## Motivation

vscode PR microsoft/vscode#323625 (merged) hand-edited a **generated** file — `src/vs/platform/agentHost/common/state/protocol/channels-root/state.ts` — to add this interface. That folder is auto-generated by `scripts/sync-agent-host-protocol.ts` from this repo, so the change must live here or the next sync overwrites it on vscode main. Upstreaming it here makes the vscode copy generated rather than hand-edited and closes the overwrite window.

## Changes

- `types/channels-root/state.ts`: new `capabilities?: AgentCapabilities` field on `AgentInfo` plus the `AgentCapabilities` interface.
- Registered `AgentCapabilities` in each per-language generator (`generate-go`, `generate-kotlin`, `generate-rust`, `generate-swift`).
- Regenerated all client bindings, JSON schema, and docs (`npm run generate`).
- CHANGELOG entries under `## [Unreleased]` → `### Added` in the root and every `clients/<lang>/CHANGELOG.md` (a types/ change ripples to all clients).

## Verification

`npm run generate` and `npm test` (typecheck + lint + verify:release-metadata + verify:changelog + reducer 100% branch coverage) both pass.

## Follow-up

After this merges, re-sync the vscode side (`npx tsx scripts/sync-agent-host-protocol.ts` from the vscode checkout) and confirm `channels-root/state.ts` regenerates the same `AgentCapabilities` block.