### PR TITLE
fix: make generated JSON Schemas self-contained and strict-oneOf-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ Spec version: `0.5.2`
   `id` and sets that entry's `enabled`; the effective state of a child is
   `container.enabled && (child.enabled ?? true)`.
 
+### Fixed
+
+- The generated JSON Schema artifacts (`schema/*.json`) are now self-contained
+  and strict-`oneOf`-safe. The generator no longer emits an empty `{}` branch in
+  a union type alias's `oneOf` (which matched any value and defeated strict
+  `oneOf` validation), backfills the `enum`, enum-member, and type-alias `$ref`s
+  that were previously dangling across all five schema files, and renders `null`
+  members as `{ "type": "null" }` (#302).
+
 ## [0.5.1] — 2026-07-02
 
 Spec version: `0.5.1`

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs:preview": "vitepress preview docs",
     "typecheck": "tsc --noEmit -p types/tsconfig.json",
     "lint": "eslint",
-    "test": "npm run typecheck && npm run lint && npm run verify:release-metadata && npm run verify:changelog && npx c8 --include types/reducers.ts --check-coverage --branches 100 tsx --test types/*.test.ts types/version/*.test.ts"
+    "test": "npm run typecheck && npm run lint && npm run verify:release-metadata && npm run verify:changelog && npx c8 --include types/reducers.ts --check-coverage --branches 100 tsx --test types/*.test.ts types/version/*.test.ts scripts/*.test.ts"
   },
   "repository": {
     "type": "git",

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -54,7 +54,7 @@
       "description": "Fired when available agent backends or their models change.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootAgentsChanged"
+          "const": "root/agentsChanged"
         },
         "agents": {
           "type": "array",
@@ -74,7 +74,7 @@
       "description": "Fired when the number of active sessions changes.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootActiveSessionsChanged"
+          "const": "root/activeSessionsChanged"
         },
         "activeSessions": {
           "type": "number",
@@ -91,7 +91,7 @@
       "description": "Fired when the list of known terminals changes.\n\nFull-replacement semantics: the `terminals` array replaces the previous\n`terminals` entirely.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootTerminalsChanged"
+          "const": "root/terminalsChanged"
         },
         "terminals": {
           "type": "array",
@@ -111,7 +111,7 @@
       "description": "Fired when agent-host configuration values change.\n\nBy default, the reducer merges the new values into `state.config.values`.\nSet `replace` to `true` to replace all values instead of merging.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootConfigChanged"
+          "const": "root/configChanged"
         },
         "config": {
           "type": "object",
@@ -133,7 +133,7 @@
       "description": "Session backend initialized successfully.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionReady"
+          "const": "session/ready"
         }
       },
       "required": [
@@ -145,7 +145,7 @@
       "description": "Session backend failed to initialize.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCreationFailed"
+          "const": "session/creationFailed"
         },
         "error": {
           "$ref": "#/$defs/ErrorInfo",
@@ -162,7 +162,7 @@
       "description": "A chat was added to this session's catalog. Upsert semantics: if a chat\nwith the same `summary.resource` already exists, the existing entry is\nreplaced.\n\nMirrors the root-channel `root/sessionAdded` notification.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChatAdded"
+          "const": "session/chatAdded"
         },
         "summary": {
           "$ref": "#/$defs/ChatSummary",
@@ -179,7 +179,7 @@
       "description": "A chat was removed from this session's catalog. No-op when no entry matches.\n\nMirrors the root-channel `root/sessionRemoved` notification.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChatRemoved"
+          "const": "session/chatRemoved"
         },
         "chat": {
           "$ref": "#/$defs/URI",
@@ -196,7 +196,7 @@
       "description": "One existing chat's summary fields changed.\n\nPartial-update semantics: only fields present in `changes` are written;\nomitted fields are preserved. Identity fields (`resource`) MUST NOT be\ncarried in `changes`. No-op when no entry with `chat` exists — clients\nSHOULD then wait for a {@link SessionChatAddedAction | `session/chatAdded`}.\n\nMirrors the root-channel `root/sessionSummaryChanged` notification.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChatUpdated"
+          "const": "session/chatUpdated"
         },
         "chat": {
           "$ref": "#/$defs/URI",
@@ -252,7 +252,7 @@
       "description": "The default chat input-routing hint for this session changed.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionDefaultChatChanged"
+          "const": "session/defaultChatChanged"
         },
         "defaultChat": {
           "$ref": "#/$defs/URI",
@@ -268,7 +268,7 @@
       "description": "Session title updated. Fired by the server when the title is auto-generated\nfrom conversation, or dispatched by a client to rename a session.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionTitleChanged"
+          "const": "session/titleChanged"
         },
         "title": {
           "type": "string",
@@ -285,7 +285,7 @@
       "description": "The read state of the session changed.\n\nDispatched by a client to mark a session as read (e.g. after viewing it)\nor unread (e.g. after new activity since the client last looked at it).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionIsReadChanged"
+          "const": "session/isReadChanged"
         },
         "isRead": {
           "type": "boolean",
@@ -302,7 +302,7 @@
       "description": "The archived state of the session changed.\n\nDispatched by a client to archive a session (e.g. the task is\ncomplete) or to unarchive it.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionIsArchivedChanged"
+          "const": "session/isArchivedChanged"
         },
         "isArchived": {
           "type": "boolean",
@@ -319,7 +319,7 @@
       "description": "The activity description of the session changed.\n\nDispatched by the server to indicate what the session is currently doing\n(e.g. running a tool, thinking). Clear activity by setting it to `undefined`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionActivityChanged"
+          "const": "session/activityChanged"
         },
         "activity": {
           "type": "string",
@@ -336,7 +336,7 @@
       "description": "The {@link Changeset | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n{@link SessionState.changesets | `state.changesets`} entirely\n(full-replacement semantics) — set to `undefined` to clear the\ncatalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChangesetsChanged"
+          "const": "session/changesetsChanged"
         },
         "changesets": {
           "type": "array",
@@ -356,7 +356,7 @@
       "description": "Server tools for this session have changed.\n\nFull-replacement semantics: the `tools` array replaces the previous `serverTools` entirely.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionServerToolsChanged"
+          "const": "session/serverToolsChanged"
         },
         "tools": {
           "type": "array",
@@ -376,7 +376,7 @@
       "description": "An active client for this session was added or updated.\n\nUpsert semantics keyed by {@link SessionActiveClient.clientId | `clientId`}:\na client dispatches this action with its own `SessionActiveClient` to join\nthe session's active clients or refresh its entry, replacing any existing\nentry that has the same `clientId`. Multiple clients may be active at once.\nThis is also how a client updates its published tools or customizations —\nre-dispatch with the full, updated entry. Use\n{@link SessionActiveClientRemovedAction | `session/activeClientRemoved`} to\nleave. The server SHOULD automatically dispatch that removal when an active\nclient disconnects.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionActiveClientSet"
+          "const": "session/activeClientSet"
         },
         "activeClient": {
           "$ref": "#/$defs/SessionActiveClient",
@@ -393,7 +393,7 @@
       "description": "An active client was removed from this session.\n\nRemoves the entry for the client identified by `clientId` from\n{@link SessionState.activeClients}; a no-op when no entry matches.\n\nThe host SHOULD dispatch this automatically when a client stops participating\nin the session — for example when it unsubscribes from the session channel,\nwhen it disconnects and does not reconnect within a host-defined grace\nperiod, or when a `reconnect` command's `subscriptions` omit a session the\nclient was still active in. When removing a client, the host SHOULD also\ncancel that client's in-flight tool calls — those whose tool call state\ncarries a client `ToolCallContributor` with the matching `clientId` — by\ndispatching `chat/toolCallComplete` with `result.success = false`. (There is\nno per-tool-call server cancel; a failed completion is the cancellation\nmechanism, and the call ends in `completed` status with a failed result.)",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionActiveClientRemoved"
+          "const": "session/activeClientRemoved"
         },
         "clientId": {
           "type": "string",
@@ -410,7 +410,7 @@
       "description": "A session-level input request was added or updated.\n\nUpsert semantics keyed by {@link SessionInputRequest.id | `request.id`}: the\nhost dispatches this with the full {@link SessionInputRequest} to append a new\nentry to {@link SessionState.inputNeeded} or replace the existing entry with\nthe same `id`.\n\nServer-originated: the host mirrors chat-level requests (elicitations, tool\nconfirmations, client-tool executions) into the session aggregate so clients\nsubscribed only to the session channel can discover them. Clients respond by\ndispatching the ordinary `chat/*` action to the entry's `chat` channel — see\n{@link SessionInputRequest}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionInputNeededSet"
+          "const": "session/inputNeededSet"
         },
         "request": {
           "$ref": "#/$defs/SessionInputRequest",
@@ -427,7 +427,7 @@
       "description": "A session-level input request was removed.\n\nRemoves the entry identified by `id` from\n{@link SessionState.inputNeeded}; a no-op when no entry matches.\n\nServer-originated: the host dispatches this once the underlying request\nresolves (the user answers, the tool call is confirmed, or the client\nreports its result).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionInputNeededRemoved"
+          "const": "session/inputNeededRemoved"
         },
         "id": {
           "type": "string",
@@ -444,7 +444,7 @@
       "description": "The session's customizations have changed.\n\nFull-replacement semantics: the `customizations` array replaces the\nprevious `customizations` entirely.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationsChanged"
+          "const": "session/customizationsChanged"
         },
         "customizations": {
           "type": "array",
@@ -464,7 +464,7 @@
       "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationToggled"
+          "const": "session/customizationToggled"
         },
         "id": {
           "type": "string",
@@ -486,7 +486,7 @@
       "description": "Upserts a top-level customization (plugin or directory).\n\nThe reducer locates the existing entry by `customization.id`:\n\n- If found, the entry is replaced entirely with `customization`,\n  including its `children` array. To preserve existing children, the\n  host must include them on the payload.\n- If not found, the entry is appended.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationUpdated"
+          "const": "session/customizationUpdated"
         },
         "customization": {
           "$ref": "#/$defs/Customization",
@@ -503,7 +503,7 @@
       "description": "Removes a customization by id.\n\nSearches every container and its children for the entry. If the entry\nis a container, its children are removed with it. Is a no-op when no\nmatching id is found.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationRemoved"
+          "const": "session/customizationRemoved"
         },
         "id": {
           "type": "string",
@@ -520,7 +520,7 @@
       "description": "Updates the runtime fields of an existing\n{@link McpServerCustomization} — narrow alternative to\n{@link SessionCustomizationUpdatedAction} for the high-frequency\n`starting` ↔ `ready` ↔ `authRequired` transitions.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container.\nReplaces the entry's {@link McpServerCustomization.state | `state`}\nand {@link McpServerCustomization.channel | `channel`}\n(full-replacement semantics: omit `channel` to clear an existing\nchannel URI). Other fields of the customization are preserved.\n\nIs a no-op when no matching `McpServerCustomization` is found. To\nupdate any other field (name, icons, `mcpApp` capabilities, etc.) use\n{@link SessionCustomizationUpdatedAction} instead.\n\nWhen the transition is to {@link McpServerStatus.AuthRequired}\nbecause of a request issued mid-turn, the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session — see\n{@link McpServerAuthRequiredState} for the rationale.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionMcpServerStateChanged"
+          "const": "session/mcpServerStateChanged"
         },
         "id": {
           "type": "string",
@@ -546,7 +546,7 @@
       "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionConfigChanged"
+          "const": "session/configChanged"
         },
         "config": {
           "type": "object",
@@ -568,7 +568,7 @@
       "description": "The session's `_meta` side-channel changed. Replaces `state._meta`\nentirely (full-replacement semantics). Producers SHOULD merge any\nkeys they wish to preserve into the new value before dispatching.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionMetaChanged"
+          "const": "session/metaChanged"
         },
         "_meta": {
           "type": "object",
@@ -609,7 +609,7 @@
       "description": "A new message has been sent to the agent, and a new turn starts.\n\nA client is only allowed to send {@link MessageKind.User} messages.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnStarted"
+          "const": "chat/turnStarted"
         },
         "turnId": {
           "type": "string",
@@ -640,7 +640,7 @@
       "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatDelta"
+          "const": "chat/delta"
         },
         "turnId": {
           "type": "string",
@@ -672,7 +672,7 @@
       "description": "Structured content appended to the response.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatResponsePart"
+          "const": "chat/responsePart"
         },
         "turnId": {
           "type": "string",
@@ -712,7 +712,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallStart"
+          "const": "chat/toolCallStart"
         },
         "toolName": {
           "type": "string",
@@ -757,7 +757,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallDelta"
+          "const": "chat/toolCallDelta"
         },
         "content": {
           "type": "string",
@@ -793,7 +793,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallReady"
+          "const": "chat/toolCallReady"
         },
         "invocationMessage": {
           "$ref": "#/$defs/StringOrMarkdown",
@@ -860,7 +860,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallConfirmed"
+          "const": "chat/toolCallConfirmed"
         },
         "approved": {
           "description": "The tool call was approved"
@@ -904,7 +904,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallConfirmed"
+          "const": "chat/toolCallConfirmed"
         },
         "approved": {
           "description": "The tool call was denied"
@@ -912,10 +912,10 @@
         "reason": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ToolCallCancellationReason.Denied"
+              "const": "denied"
             },
             {
-              "$ref": "#/$defs/ToolCallCancellationReason.Skipped"
+              "const": "skipped"
             }
           ],
           "description": "Why the tool was cancelled"
@@ -959,7 +959,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallComplete"
+          "const": "chat/toolCallComplete"
         },
         "result": {
           "$ref": "#/$defs/ToolCallResult",
@@ -995,7 +995,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallResultConfirmed"
+          "const": "chat/toolCallResultConfirmed"
         },
         "approved": {
           "type": "boolean",
@@ -1027,7 +1027,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallContentChanged"
+          "const": "chat/toolCallContentChanged"
         },
         "content": {
           "type": "array",
@@ -1049,7 +1049,7 @@
       "description": "Turn finished — the assistant is idle.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnComplete"
+          "const": "chat/turnComplete"
         },
         "turnId": {
           "type": "string",
@@ -1071,7 +1071,7 @@
       "description": "Turn was aborted; server stops processing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnCancelled"
+          "const": "chat/turnCancelled"
         },
         "turnId": {
           "type": "string",
@@ -1093,7 +1093,7 @@
       "description": "Error during turn processing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatError"
+          "const": "chat/error"
         },
         "turnId": {
           "type": "string",
@@ -1120,7 +1120,7 @@
       "description": "The activity description of this chat changed.\n\nDispatched by the server to indicate what the chat is currently doing\n(e.g. running a tool, thinking). Clear activity by omitting it or setting it\nto `undefined`.\nProducers SHOULD also update the parent session's chat catalog with\n`session/chatUpdated` so `ChatSummary.activity` stays in sync.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatActivityChanged"
+          "const": "chat/activityChanged"
         },
         "activity": {
           "type": "string",
@@ -1136,7 +1136,7 @@
       "description": "Token usage report for a turn.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatUsage"
+          "const": "chat/usage"
         },
         "turnId": {
           "type": "string",
@@ -1163,7 +1163,7 @@
       "description": "Reasoning/thinking text from the model, appended to a specific reasoning response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\nreasoning part, then use this action to append text to it.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatReasoning"
+          "const": "chat/reasoning"
         },
         "turnId": {
           "type": "string",
@@ -1195,7 +1195,7 @@
       "description": "Truncates a session's history. If `turnId` is provided, all turns after that\nturn are removed and the specified turn is kept. If `turnId` is omitted, all\nturns are removed.\n\nIf there is an active turn it is silently dropped and the chat status\nreturns to `idle`.\n\nCommon use-case: truncate old data then dispatch a new\n`chat/turnStarted` with an edited message.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTruncated"
+          "const": "chat/truncated"
         },
         "turnId": {
           "type": "string",
@@ -1211,7 +1211,7 @@
       "description": "Loads older completed turns into this chat's state.\n\nHosts dispatch this before responding to `fetchTurns`, and before applying\nany operation that references a turn older than the currently loaded window.\n`turns` is ordered oldest-first and is prepended to the current `turns`\nwindow. `turnsNextCursor` replaces the state's cursor; omit it when all\nretained turns are now loaded.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnsLoaded"
+          "const": "chat/turnsLoaded"
         },
         "turns": {
           "type": "array",
@@ -1235,7 +1235,7 @@
       "description": "A pending message was set (upsert semantics: creates or replaces).\n\nFor steering messages, this always replaces the single steering message.\nFor queued messages, if a message with the given `id` already exists it is\nupdated in place; otherwise it is appended to the queue. If the chat is\nidle when a queued message is set, the server SHOULD immediately consume it\nand start a new turn.\n\nA client is only allowed to send {@link MessageKind.User} messages.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatPendingMessageSet"
+          "const": "chat/pendingMessageSet"
         },
         "kind": {
           "$ref": "#/$defs/PendingMessageKind",
@@ -1262,7 +1262,7 @@
       "description": "A pending message was removed (steering or queued).\n\nDispatched by clients to cancel a pending message, or by the server when\nit consumes a message (e.g. starting a turn from a queued message or\ninjecting a steering message into the current turn).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatPendingMessageRemoved"
+          "const": "chat/pendingMessageRemoved"
         },
         "kind": {
           "$ref": "#/$defs/PendingMessageKind",
@@ -1284,7 +1284,7 @@
       "description": "Reorder the queued messages.\n\nThe `order` array contains the IDs of queued messages in their new\ndesired order. IDs not present in the current queue are ignored.\nQueued messages whose IDs are absent from `order` are appended at\nthe end in their original relative order (so a client with a stale\nview of the queue never silently drops messages).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatQueuedMessagesReordered"
+          "const": "chat/queuedMessagesReordered"
         },
         "order": {
           "type": "array",
@@ -1304,7 +1304,7 @@
       "description": "The chat's draft input changed.\n\nClients MAY periodically sync their local input state — the message the user\nis composing, including its {@link Message.model | model} /\n{@link Message.agent | agent} selection and attachments — into the chat's\n{@link ChatState.draft | `draft`} so it survives reloads and is visible to\nother clients viewing the same chat. Eager syncing is **not** required;\nclients SHOULD debounce and MAY sync only at convenient points. Set `draft`\nto `undefined` to clear it (e.g. once the message is sent).\n\nA client is only allowed to draft {@link MessageKind.User} messages.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatDraftChanged"
+          "const": "chat/draftChanged"
         },
         "draft": {
           "$ref": "#/$defs/Message",
@@ -1320,7 +1320,7 @@
       "description": "A session requested input from the user.\n\nFull-request upsert semantics: the `request` replaces any existing request\nwith the same `id`, or is appended if it is new. Answer drafts are preserved\nunless `request.answers` is provided.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatInputRequested"
+          "const": "chat/inputRequested"
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
@@ -1337,7 +1337,7 @@
       "description": "A client updated, submitted, skipped, or removed a single in-progress answer.\n\nDispatching with `answer: undefined` removes that question's answer draft.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatInputAnswerChanged"
+          "const": "chat/inputAnswerChanged"
         },
         "requestId": {
           "type": "string",
@@ -1363,7 +1363,7 @@
       "description": "A client accepted, declined, or cancelled a session input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatInputCompleted"
+          "const": "chat/inputCompleted"
         },
         "requestId": {
           "type": "string",
@@ -1392,7 +1392,7 @@
       "description": "Terminal output data (pty → client direction).\n\nAppends `data` to the terminal's `content` in the reducer.\n\n`terminal/data` and `terminal/input` are intentionally separate actions\nbecause standard write-ahead reconciliation is not safe for terminal I/O.\nA pty is a stateful, mutable process — optimistically applying input or\npredicting output would produce incorrect state. Instead, `terminal/input`\nis a side-effect-only action (client → server → pty), and `terminal/data`\nis server-authoritative output (pty → server → client).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalData"
+          "const": "terminal/data"
         },
         "data": {
           "type": "string",
@@ -1409,7 +1409,7 @@
       "description": "Keyboard input sent to the terminal process (client → pty direction).\n\nThis is a side-effect-only action: the server forwards the data to the\nterminal's pty. The reducer treats this as a no-op since `terminal/data`\nactions will reflect any resulting output.\n\nSee `terminal/data` for why these two actions are kept separate.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalInput"
+          "const": "terminal/input"
         },
         "data": {
           "type": "string",
@@ -1426,7 +1426,7 @@
       "description": "Terminal dimensions changed.\n\nDispatchable by clients to request a resize, or by the server to inform\nclients of the actual terminal dimensions.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalResized"
+          "const": "terminal/resized"
         },
         "cols": {
           "type": "number",
@@ -1448,7 +1448,7 @@
       "description": "Terminal claim changed. A client or session transfers ownership of the terminal.\n\nThe server SHOULD reject if the dispatching client does not currently hold\nthe claim.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalClaimed"
+          "const": "terminal/claimed"
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -1465,7 +1465,7 @@
       "description": "Terminal title changed.\n\nFired by the server when the terminal process updates its title (e.g. via\nescape sequences), or dispatched by a client to rename a terminal.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalTitleChanged"
+          "const": "terminal/titleChanged"
         },
         "title": {
           "type": "string",
@@ -1482,7 +1482,7 @@
       "description": "Terminal working directory changed.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCwdChanged"
+          "const": "terminal/cwdChanged"
         },
         "cwd": {
           "$ref": "#/$defs/URI",
@@ -1499,7 +1499,7 @@
       "description": "Terminal process exited.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalExited"
+          "const": "terminal/exited"
         },
         "exitCode": {
           "type": "number",
@@ -1515,7 +1515,7 @@
       "description": "Terminal scrollback buffer cleared.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCleared"
+          "const": "terminal/cleared"
         }
       },
       "required": [
@@ -1527,7 +1527,7 @@
       "description": "Shell integration has loaded and the terminal now supports command\ndetection. The server dispatches this when shell integration becomes\navailable (which may happen asynchronously after the terminal is created).\n\nClients MUST NOT assume command detection is available until this action\n(or `terminal/commandExecuted`) has been received.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCommandDetectionAvailable"
+          "const": "terminal/commandDetectionAvailable"
         }
       },
       "required": [
@@ -1539,7 +1539,7 @@
       "description": "A command has been submitted to the shell and is now executing.\nAll subsequent `terminal/data` actions (until the matching\n`terminal/commandFinished`) constitute this command's output.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCommandExecuted"
+          "const": "terminal/commandExecuted"
         },
         "commandId": {
           "type": "string",
@@ -1566,7 +1566,7 @@
       "description": "A command has finished executing.\n\nThe sequence of `terminal/data` actions between the preceding\n`terminal/commandExecuted` (same `commandId`) and this action constitutes\nthe complete output of the command.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCommandFinished"
+          "const": "terminal/commandFinished"
         },
         "commandId": {
           "type": "string",
@@ -1591,7 +1591,7 @@
       "description": "The {@link ChangesetState.status} for this changeset transitioned (e.g.\n`computing → ready`). The error payload is set together with `status`\nwhenever it transitions to {@link ChangesetStatus.Error | Error}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetStatusChanged"
+          "const": "changeset/statusChanged"
         },
         "status": {
           "$ref": "#/$defs/ChangesetStatus",
@@ -1612,7 +1612,7 @@
       "description": "Upsert a {@link ChangesetFile} in the changeset — adds a new entry, or\nreplaces an existing one identified by {@link ChangesetFile.id}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFileSet"
+          "const": "changeset/fileSet"
         },
         "file": {
           "$ref": "#/$defs/ChangesetFile",
@@ -1629,7 +1629,7 @@
       "description": "Remove a {@link ChangesetFile} from the changeset by its id.\n\nTypically dispatched when a file is reverted, staged out, or otherwise\nno longer in scope (e.g. a renamed file is replaced by a new entry).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFileRemoved"
+          "const": "changeset/fileRemoved"
         },
         "fileId": {
           "type": "string",
@@ -1646,7 +1646,7 @@
       "description": "The changeset's full content changed. Full replacement semantics: `files`\nreplaces the previous file list, and `operations`, when present, replaces\nthe previous operation list.\n\nProducers SHOULD use this action for initial snapshots and bulk refreshes;\nuse {@link ChangesetFileSetAction}, {@link ChangesetFileRemovedAction}, and\n{@link ChangesetOperationsChangedAction} for incremental updates.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetContentChanged"
+          "const": "changeset/contentChanged"
         },
         "files": {
           "type": "array",
@@ -1677,7 +1677,7 @@
       "description": "The set of operations available on this changeset changed. Full\nreplacement semantics: `operations` replaces the previous list (or\nremoves it entirely when `operations` is `undefined`).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetOperationsChanged"
+          "const": "changeset/operationsChanged"
         },
         "operations": {
           "type": "array",
@@ -1697,7 +1697,7 @@
       "description": "The {@link ChangesetOperation.status} for a single operation transitioned\n(e.g. `idle → running → idle`, or `running → error`). The error payload\nis set together with `status` whenever it transitions to\n{@link ChangesetOperationStatus.Error | Error}, and cleared on any other\ntransition.\n\nTargets one operation by its {@link ChangesetOperation.id}. If no\noperation with that id is currently present in the changeset, the action\nis a no-op. Use {@link ChangesetOperationsChangedAction} to add, remove,\nor otherwise replace the operation list itself.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetOperationStatusChanged"
+          "const": "changeset/operationStatusChanged"
         },
         "operationId": {
           "type": "string",
@@ -1723,7 +1723,7 @@
       "description": "Drop every file from the changeset.\n\nTwo cases use this:\n1. The underlying source moved (branch switched, fork point invalidated,\n   …) and the server is recomputing from scratch — subsequent\n   {@link ChangesetFileSetAction} entries will repopulate it.\n2. The owning session has ended and the URI is becoming\n   un-subscribable — the server will unsubscribe all clients shortly\n   after dispatching this action.\n\nClients SHOULD release any references on receipt and SHOULD NOT\ndistinguish the two cases from the action alone — instead, react to\nthe corresponding session-level lifecycle signal (e.g.\n`root/sessionRemoved`) for the \"going away\" case.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetCleared"
+          "const": "changeset/cleared"
         }
       },
       "required": [
@@ -1735,7 +1735,7 @@
       "description": "Upsert an {@link Annotation} in the annotations channel — adds a new\nannotation, or replaces an existing one identified by\n{@link Annotation.id}.\n\nDispatched by a client to create an annotation (together with its\nmandatory first entry) or to re-anchor / resolve an existing one; the\ndispatching client assigns the {@link Annotation.id} and the id of any\nnew entry. When replacing, the full annotation payload (including its\n{@link Annotation.entries | entries} list) is substituted; producers\nSHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and\n{@link AnnotationsUpdatedAction} to resolve / re-anchor an existing\nannotation, to keep wire updates small.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsSet"
+          "const": "annotations/set"
         },
         "annotation": {
           "$ref": "#/$defs/Annotation",
@@ -1752,7 +1752,7 @@
       "description": "Partially update an existing {@link Annotation}'s own properties — a narrow\nalternative to {@link AnnotationsSetAction} for the common case of resolving\n/ re-opening or re-anchoring an annotation without resending its\n{@link Annotation.entries | entries}.\n\nTargets one annotation by its {@link annotationId}. Only the fields present\non the action are written; omitted fields leave the corresponding\n{@link Annotation} property unchanged. The annotation's\n{@link Annotation.entries | entries}, {@link Annotation.id | id}, and\n{@link Annotation._meta | _meta} are never touched — dispatch\n{@link AnnotationsSetAction} to replace those, to clear {@link range}\n(re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /\n{@link AnnotationsEntryRemovedAction} to edit individual entries.\n\nIf {@link annotationId} does not match any current annotation the action is\na no-op.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsUpdated"
+          "const": "annotations/updated"
         },
         "annotationId": {
           "type": "string",
@@ -1785,7 +1785,7 @@
       "description": "Remove an {@link Annotation} from the channel by its id.\n\nDispatched to delete an entire annotation and every entry it contains.\nBecause the protocol forbids empty annotations, a client that wants to\nremove the last remaining entry dispatches this action — collapsing the\nannotation — rather than {@link AnnotationsEntryRemovedAction}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsRemoved"
+          "const": "annotations/removed"
         },
         "annotationId": {
           "type": "string",
@@ -1802,7 +1802,7 @@
       "description": "Upsert an {@link AnnotationEntry} within an existing annotation — adds a\nnew entry, or replaces one identified by {@link AnnotationEntry.id}. The\ndispatching client assigns the {@link AnnotationEntry.id} of a new entry.\nIf {@link annotationId} does not match any current annotation the action\nis a no-op.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsEntrySet"
+          "const": "annotations/entrySet"
         },
         "annotationId": {
           "type": "string",
@@ -1824,7 +1824,7 @@
       "description": "Remove a single {@link AnnotationEntry} from an annotation without\ncollapsing the annotation itself. Used when more than one entry remains —\nto remove the last entry a client dispatches {@link AnnotationsRemovedAction}\ninstead, since the protocol forbids empty annotations.\n\nIf either {@link annotationId} or {@link entryId} does not match the\ncurrent state the action is a no-op.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsEntryRemoved"
+          "const": "annotations/entryRemoved"
         },
         "annotationId": {
           "type": "string",
@@ -1846,7 +1846,7 @@
       "description": "A batch of resource changes observed by the watcher.\n\nWatch events are coalesced into batches by the server to keep the\naction stream tractable; an empty `changes.items` list MUST NOT be\ndispatched. The reducer does not retain change history — these\nactions exist purely to deliver events to subscribers, who consume\nthem directly off the action stream and apply their own logic.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ResourceWatchChanged"
+          "const": "resourceWatch/changed"
         },
         "changes": {
           "type": "object",
@@ -1868,7 +1868,6 @@
     },
     "ChatToolCallConfirmedAction": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ChatToolCallApprovedAction"
         },
@@ -1880,7 +1879,6 @@
     },
     "ChatAction": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ChatTurnStartedAction"
         },
@@ -2801,7 +2799,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ChatInput"
+          "const": "chatInput"
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
@@ -2828,7 +2826,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolConfirmation"
+          "const": "toolConfirmation"
         },
         "turnId": {
           "type": "string",
@@ -2860,7 +2858,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolClientExecution"
+          "const": "toolClientExecution"
         },
         "turnId": {
           "type": "string",
@@ -3264,7 +3262,7 @@
       "description": "Container is being loaded by the host.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loading"
+          "const": "loading"
         }
       },
       "required": [
@@ -3276,7 +3274,7 @@
       "description": "Container loaded successfully.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loaded"
+          "const": "loaded"
         }
       },
       "required": [
@@ -3288,7 +3286,7 @@
       "description": "Container partially loaded but has warnings.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Degraded"
+          "const": "degraded"
         },
         "message": {
           "type": "string",
@@ -3305,7 +3303,7 @@
       "description": "Container failed to load.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Error"
+          "const": "error"
         },
         "message": {
           "type": "string",
@@ -3418,7 +3416,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         }
       },
       "required": [
@@ -3476,7 +3474,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         },
         "nonce": {
           "type": "string",
@@ -3538,7 +3536,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Directory"
+          "const": "directory"
         },
         "contents": {
           "$ref": "#/$defs/ChildCustomizationType",
@@ -3629,7 +3627,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Agent"
+          "const": "agent"
         },
         "description": {
           "type": "string",
@@ -3699,7 +3697,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Skill"
+          "const": "skill"
         },
         "description": {
           "type": "string",
@@ -3753,7 +3751,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Prompt"
+          "const": "prompt"
         },
         "description": {
           "type": "string",
@@ -3799,7 +3797,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Rule"
+          "const": "rule"
         },
         "description": {
           "type": "string",
@@ -3856,7 +3854,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Hook"
+          "const": "hook"
         }
       },
       "required": [
@@ -3894,7 +3892,7 @@
           "description": "Optional span within {@link CustomizationBase.uri | `uri`} when this\ncustomization is a subset of a larger file (for example, one entry\nin an inline `mcpServers` block of a `plugins.json` manifest).\nAbsent when the customization covers the whole resource."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.McpServer"
+          "const": "mcpServer"
         },
         "enabled": {
           "type": "boolean",
@@ -3978,7 +3976,7 @@
       "description": "Server is registered with the host but has not yet started.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Starting"
+          "const": "starting"
         }
       },
       "required": [
@@ -3990,7 +3988,7 @@
       "description": "Server is running and serving requests.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Ready"
+          "const": "ready"
         }
       },
       "required": [
@@ -4002,7 +4000,7 @@
       "description": "Server is reachable but cannot serve requests until the client\nauthenticates. Mirrors the discovery flow defined by\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)\n(Protected Resource Metadata) and the OAuth 2.1 / RFC 6750 challenge\nsemantics required by the MCP authorization spec.\n\nClients react to this state by calling the existing `authenticate`\ncommand with the {@link ProtectedResourceMetadata.resource | resource}\ncarried here. There is **no** `notify/authRequired` notification for\nMCP servers — the action stream is the single source of truth.\n\nWhen the transition is triggered by a request issued during a turn\n— most commonly\n{@link McpAuthRequiredReason.InsufficientScope | `InsufficientScope`}\nsurfacing mid-tool-call — the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session so the block is\nvisible at the summary level. Clients SHOULD watch this status on\nany MCP server backing a running tool call and surface an explicit\naffordance (e.g. a \"grant additional access\" prompt) tied to that\ntool call, rather than relying on the user to notice the\ncustomization’s status badge.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.AuthRequired"
+          "const": "authRequired"
         },
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -4035,7 +4033,7 @@
       "description": "Server failed to start, crashed, or otherwise transitioned to a\nnon-recoverable error. Use {@link McpServerStatus.AuthRequired}\nfor authentication failures.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Error"
+          "const": "error"
         },
         "error": {
           "$ref": "#/$defs/ErrorInfo",
@@ -4052,7 +4050,7 @@
       "description": "Server has been shut down. The host MAY remove the server from the\nsession entirely shortly after this state.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Stopped"
+          "const": "stopped"
         }
       },
       "required": [
@@ -4280,7 +4278,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Text"
+          "const": "text"
         },
         "format": {
           "type": "string",
@@ -4328,10 +4326,10 @@
         "kind": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Number"
+              "const": "number"
             },
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Integer"
+              "const": "integer"
             }
           ]
         },
@@ -4375,7 +4373,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Boolean"
+          "const": "boolean"
         },
         "defaultValue": {
           "type": "boolean",
@@ -4409,7 +4407,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.SingleSelect"
+          "const": "single-select"
         },
         "options": {
           "type": "array",
@@ -4451,7 +4449,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.MultiSelect"
+          "const": "multi-select"
         },
         "options": {
           "type": "array",
@@ -4520,7 +4518,7 @@
       "description": "Value captured for one answer.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Text"
+          "const": "text"
         },
         "value": {
           "type": "string"
@@ -4535,7 +4533,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Number"
+          "const": "number"
         },
         "value": {
           "type": "number"
@@ -4550,7 +4548,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Boolean"
+          "const": "boolean"
         },
         "value": {
           "type": "boolean"
@@ -4565,7 +4563,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Selected"
+          "const": "selected"
         },
         "value": {
           "type": "string"
@@ -4587,7 +4585,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.SelectedMany"
+          "const": "selected-many"
         },
         "value": {
           "type": "array",
@@ -4614,10 +4612,10 @@
         "state": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Draft"
+              "const": "draft"
             },
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Submitted"
+              "const": "submitted"
             }
           ],
           "description": "Answer state"
@@ -4636,7 +4634,7 @@
       "type": "object",
       "properties": {
         "state": {
-          "$ref": "#/$defs/ChatInputAnswerState.Skipped",
+          "const": "skipped",
           "description": "Answer state"
         },
         "freeformValues": {
@@ -4821,7 +4819,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Simple",
+          "const": "simple",
           "description": "Discriminant"
         },
         "modelRepresentation": {
@@ -4856,7 +4854,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.EmbeddedResource",
+          "const": "embeddedResource",
           "description": "Discriminant"
         },
         "data": {
@@ -4917,7 +4915,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Resource",
+          "const": "resource",
           "description": "Discriminant"
         },
         "selection": {
@@ -4953,7 +4951,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Annotations",
+          "const": "annotations",
           "description": "Discriminant"
         },
         "resource": {
@@ -4978,7 +4976,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Markdown",
+          "const": "markdown",
           "description": "Discriminant"
         },
         "id": {
@@ -5017,7 +5015,7 @@
           "description": "Content nonce"
         },
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ContentRef",
+          "const": "contentRef",
           "description": "Discriminant"
         }
       },
@@ -5031,7 +5029,7 @@
       "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "const": "toolCall",
           "description": "Discriminant"
         },
         "toolCall": {
@@ -5049,7 +5047,7 @@
       "description": "Reasoning/thinking content from the model.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "const": "reasoning",
           "description": "Discriminant"
         },
         "id": {
@@ -5072,7 +5070,7 @@
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "const": "systemNotification",
           "description": "Discriminant"
         },
         "content": {
@@ -5116,7 +5114,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.Client"
+          "const": "client"
         },
         "clientId": {
           "type": "string",
@@ -5132,7 +5130,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.MCP"
+          "const": "mcp"
         },
         "customizationId": {
           "type": "string",
@@ -5272,7 +5270,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nThis MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)\n`McpUiToolMeta` found in MCP tool calls, which may be used in combination\nwith the {@link contributor} to serve MCP Apps."
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Streaming"
+          "const": "streaming"
         },
         "partialInput": {
           "type": "string",
@@ -5328,7 +5326,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+          "const": "pending-confirmation"
         },
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
@@ -5404,7 +5402,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Running"
+          "const": "running"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -5504,7 +5502,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingResultConfirmation"
+          "const": "pending-result-confirmation"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -5599,7 +5597,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Completed"
+          "const": "completed"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -5659,7 +5657,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Cancelled"
+          "const": "cancelled"
         },
         "reason": {
           "$ref": "#/$defs/ToolCallCancellationReason",
@@ -5692,7 +5690,7 @@
       "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Text"
+          "const": "text"
         },
         "text": {
           "type": "string",
@@ -5709,7 +5707,7 @@
       "description": "Base64-encoded binary content embedded in a tool result.\n\nMirrors MCP `EmbeddedResource` for inline binary data.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.EmbeddedResource"
+          "const": "embeddedResource"
         },
         "data": {
           "type": "string",
@@ -5747,7 +5745,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Resource"
+          "const": "resource"
         }
       },
       "required": [
@@ -5804,7 +5802,7 @@
           "description": "Optional diff display metadata"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
+          "const": "fileEdit"
         }
       },
       "required": [
@@ -5816,7 +5814,7 @@
       "description": "A reference to a terminal whose output is relevant to this tool result.\n\nClients can subscribe to the terminal's URI to stream its output in real\ntime, providing live feedback while a tool is executing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Terminal"
+          "const": "terminal"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -5838,7 +5836,7 @@
       "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation), referenced by a chat URI (`ahp-chat:/...`).\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Subagent"
+          "const": "subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -5895,7 +5893,7 @@
       "description": "A terminal claimed by a connected client.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Client",
+          "const": "client",
           "description": "Discriminant"
         },
         "clientId": {
@@ -5913,7 +5911,7 @@
       "description": "A terminal claimed by a session, optionally scoped to a specific turn or tool call.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Session",
+          "const": "session",
           "description": "Discriminant"
         },
         "session": {
@@ -6396,13 +6394,14 @@
         {
           "type": "boolean"
         },
-        {}
+        {
+          "type": "null"
+        }
       ],
       "description": "A primitive JSON value: a string, number, boolean, or `null`."
     },
     "SessionInputRequest": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/SessionChatInputRequest"
         },
@@ -6417,31 +6416,29 @@
     },
     "ChildCustomizationType": {
       "oneOf": [
-        {},
         {
-          "$ref": "#/$defs/CustomizationType.Agent"
+          "const": "agent"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Skill"
+          "const": "skill"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Prompt"
+          "const": "prompt"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Rule"
+          "const": "rule"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Hook"
+          "const": "hook"
         },
         {
-          "$ref": "#/$defs/CustomizationType.McpServer"
+          "const": "mcpServer"
         }
       ],
       "description": "Customization types that appear as children of a\n{@link PluginCustomization} or {@link DirectoryCustomization}."
     },
     "CustomizationLoadState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/CustomizationLoadingState"
         },
@@ -6459,7 +6456,6 @@
     },
     "ChildCustomization": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/AgentCustomization"
         },
@@ -6483,7 +6479,6 @@
     },
     "Customization": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/PluginCustomization"
         },
@@ -6498,7 +6493,6 @@
     },
     "McpServerState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/McpServerStartingState"
         },
@@ -6519,7 +6513,6 @@
     },
     "ChatOrigin": {
       "oneOf": [
-        {},
         {
           "type": "object",
           "properties": {
@@ -6624,7 +6617,6 @@
     },
     "MessageAttachment": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/SimpleMessageAttachment"
         },
@@ -6642,7 +6634,6 @@
     },
     "ResponsePart": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/MarkdownResponsePart"
         },
@@ -6672,7 +6663,6 @@
     },
     "ToolCallState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ToolCallStreamingState"
         },
@@ -6696,7 +6686,6 @@
     },
     "ToolCallConfirmationState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ToolCallPendingConfirmationState"
         },
@@ -6708,7 +6697,6 @@
     },
     "ToolResultContent": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ToolResultTextContent"
         },
@@ -6743,7 +6731,6 @@
     },
     "TerminalContentPart": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/TerminalUnclassifiedPart"
         },
@@ -6988,6 +6975,157 @@
           "$ref": "#/$defs/ResourceWatchChangedAction"
         }
       ]
+    },
+    "URI": {
+      "type": "string",
+      "description": "A URI string (e.g. `ahp-root://`, `ahp-session:/<uuid>`, or `ahp-chat:/<uuid>`)."
+    },
+    "SessionStatus": {
+      "enum": [
+        1,
+        2,
+        8,
+        24,
+        32,
+        64
+      ],
+      "type": "number",
+      "description": "Bitset of summary-level session status flags.\n\nUse bitwise checks instead of equality for non-terminal activity. For example,\n`status & SessionStatus.InProgress` matches both ordinary in-progress turns\nand turns that are paused waiting for input."
+    },
+    "ChatInteractivity": {
+      "enum": [
+        "full",
+        "read-only",
+        "hidden"
+      ],
+      "type": "string",
+      "description": "How a user can interact with a chat.\n\n- `Full` — user can send messages and watch (default when absent)\n- `ReadOnly` — user can watch but not send messages (e.g. agent team workers)\n- `Hidden` — internal worker not shown in UI at all\n\nSupports the agent-team pattern where a lead chat is fully interactive and\nworker chats are read-only (visible for observability) or hidden (internal\nimplementation detail). The harness sets this based on the chat's role;\nthe UI uses it to show appropriate controls."
+    },
+    "ToolCallConfirmationReason": {
+      "enum": [
+        "not-needed",
+        "user-action",
+        "setting"
+      ],
+      "type": "string",
+      "description": "How a tool call was confirmed for execution.\n\n- `NotNeeded` — No confirmation required (auto-approved)\n- `UserAction` — User explicitly approved\n- `Setting` — Approved by a persistent user setting"
+    },
+    "PendingMessageKind": {
+      "enum": [
+        "steering",
+        "queued"
+      ],
+      "type": "string",
+      "description": "Discriminant for pending message kinds."
+    },
+    "ChatInputResponseKind": {
+      "enum": [
+        "accept",
+        "decline",
+        "cancel"
+      ],
+      "type": "string",
+      "description": "How a client completed an input request."
+    },
+    "ChangesetStatus": {
+      "enum": [
+        "computing",
+        "ready",
+        "error"
+      ],
+      "type": "string",
+      "description": "Computation lifecycle of a {@link ChangesetState}."
+    },
+    "ChangesetOperationStatus": {
+      "enum": [
+        "idle",
+        "running",
+        "error",
+        "disabled"
+      ],
+      "type": "string",
+      "description": "Execution lifecycle of a {@link ChangesetOperation}.\n\nAn operation is invoked imperatively via `invokeChangesetOperation`, but\nits progress and outcome are reflected back into changeset state so that\nevery subscriber observes a consistent view (e.g. a spinner on a \"Create\nPull Request\" button, or an inline error after a failed \"revert\")."
+    },
+    "PolicyState": {
+      "enum": [
+        "enabled",
+        "disabled",
+        "unconfigured"
+      ],
+      "type": "string",
+      "description": "Policy configuration state for a model."
+    },
+    "SessionLifecycle": {
+      "enum": [
+        "creating",
+        "ready",
+        "creationFailed"
+      ],
+      "type": "string",
+      "description": "Session initialization state."
+    },
+    "McpAuthRequiredReason": {
+      "enum": [
+        "required",
+        "expired",
+        "insufficientScope"
+      ],
+      "type": "string",
+      "description": "Why an MCP server is currently in the {@link McpServerStatus.AuthRequired}\nstate. Mirrors the three failure modes defined by the\n[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md)."
+    },
+    "TurnState": {
+      "enum": [
+        "complete",
+        "cancelled",
+        "error"
+      ],
+      "type": "string",
+      "description": "How a turn ended."
+    },
+    "MessageKind": {
+      "enum": [
+        "user",
+        "agent",
+        "tool",
+        "systemNotification"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "ConfirmationOptionKind": {
+      "enum": [
+        "approve",
+        "deny"
+      ],
+      "type": "string",
+      "description": "Whether a confirmation option represents an approval or denial action."
+    },
+    "ToolCallCancellationReason": {
+      "enum": [
+        "denied",
+        "skipped",
+        "result-denied"
+      ],
+      "type": "string",
+      "description": "Why a tool call was cancelled."
+    },
+    "ChangesetOperationScope": {
+      "enum": [
+        "changeset",
+        "resource",
+        "range"
+      ],
+      "type": "string",
+      "description": "Where a {@link ChangesetOperation} can be invoked."
+    },
+    "ResourceChangeType": {
+      "enum": [
+        "added",
+        "updated",
+        "deleted"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link ResourceChange.type}."
     }
   }
 }

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -190,7 +190,7 @@
       "description": "Reconnect result when the server can replay from the requested sequence.\n\nThe server MUST include all replayed data in the response.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ReconnectResultType.Replay",
+          "const": "replay",
           "description": "Discriminant"
         },
         "actions": {
@@ -219,7 +219,7 @@
       "description": "Reconnect result when the gap exceeds the replay buffer.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ReconnectResultType.Snapshot",
+          "const": "snapshot",
           "description": "Discriminant"
         },
         "snapshots": {
@@ -2113,7 +2113,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ChatInput"
+          "const": "chatInput"
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
@@ -2140,7 +2140,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolConfirmation"
+          "const": "toolConfirmation"
         },
         "turnId": {
           "type": "string",
@@ -2172,7 +2172,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolClientExecution"
+          "const": "toolClientExecution"
         },
         "turnId": {
           "type": "string",
@@ -2576,7 +2576,7 @@
       "description": "Container is being loaded by the host.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loading"
+          "const": "loading"
         }
       },
       "required": [
@@ -2588,7 +2588,7 @@
       "description": "Container loaded successfully.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loaded"
+          "const": "loaded"
         }
       },
       "required": [
@@ -2600,7 +2600,7 @@
       "description": "Container partially loaded but has warnings.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Degraded"
+          "const": "degraded"
         },
         "message": {
           "type": "string",
@@ -2617,7 +2617,7 @@
       "description": "Container failed to load.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Error"
+          "const": "error"
         },
         "message": {
           "type": "string",
@@ -2730,7 +2730,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         }
       },
       "required": [
@@ -2788,7 +2788,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         },
         "nonce": {
           "type": "string",
@@ -2850,7 +2850,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Directory"
+          "const": "directory"
         },
         "contents": {
           "$ref": "#/$defs/ChildCustomizationType",
@@ -2941,7 +2941,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Agent"
+          "const": "agent"
         },
         "description": {
           "type": "string",
@@ -3011,7 +3011,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Skill"
+          "const": "skill"
         },
         "description": {
           "type": "string",
@@ -3065,7 +3065,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Prompt"
+          "const": "prompt"
         },
         "description": {
           "type": "string",
@@ -3111,7 +3111,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Rule"
+          "const": "rule"
         },
         "description": {
           "type": "string",
@@ -3168,7 +3168,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Hook"
+          "const": "hook"
         }
       },
       "required": [
@@ -3206,7 +3206,7 @@
           "description": "Optional span within {@link CustomizationBase.uri | `uri`} when this\ncustomization is a subset of a larger file (for example, one entry\nin an inline `mcpServers` block of a `plugins.json` manifest).\nAbsent when the customization covers the whole resource."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.McpServer"
+          "const": "mcpServer"
         },
         "enabled": {
           "type": "boolean",
@@ -3290,7 +3290,7 @@
       "description": "Server is registered with the host but has not yet started.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Starting"
+          "const": "starting"
         }
       },
       "required": [
@@ -3302,7 +3302,7 @@
       "description": "Server is running and serving requests.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Ready"
+          "const": "ready"
         }
       },
       "required": [
@@ -3314,7 +3314,7 @@
       "description": "Server is reachable but cannot serve requests until the client\nauthenticates. Mirrors the discovery flow defined by\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)\n(Protected Resource Metadata) and the OAuth 2.1 / RFC 6750 challenge\nsemantics required by the MCP authorization spec.\n\nClients react to this state by calling the existing `authenticate`\ncommand with the {@link ProtectedResourceMetadata.resource | resource}\ncarried here. There is **no** `notify/authRequired` notification for\nMCP servers — the action stream is the single source of truth.\n\nWhen the transition is triggered by a request issued during a turn\n— most commonly\n{@link McpAuthRequiredReason.InsufficientScope | `InsufficientScope`}\nsurfacing mid-tool-call — the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session so the block is\nvisible at the summary level. Clients SHOULD watch this status on\nany MCP server backing a running tool call and surface an explicit\naffordance (e.g. a \"grant additional access\" prompt) tied to that\ntool call, rather than relying on the user to notice the\ncustomization’s status badge.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.AuthRequired"
+          "const": "authRequired"
         },
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -3347,7 +3347,7 @@
       "description": "Server failed to start, crashed, or otherwise transitioned to a\nnon-recoverable error. Use {@link McpServerStatus.AuthRequired}\nfor authentication failures.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Error"
+          "const": "error"
         },
         "error": {
           "$ref": "#/$defs/ErrorInfo",
@@ -3364,7 +3364,7 @@
       "description": "Server has been shut down. The host MAY remove the server from the\nsession entirely shortly after this state.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Stopped"
+          "const": "stopped"
         }
       },
       "required": [
@@ -3592,7 +3592,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Text"
+          "const": "text"
         },
         "format": {
           "type": "string",
@@ -3640,10 +3640,10 @@
         "kind": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Number"
+              "const": "number"
             },
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Integer"
+              "const": "integer"
             }
           ]
         },
@@ -3687,7 +3687,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Boolean"
+          "const": "boolean"
         },
         "defaultValue": {
           "type": "boolean",
@@ -3721,7 +3721,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.SingleSelect"
+          "const": "single-select"
         },
         "options": {
           "type": "array",
@@ -3763,7 +3763,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.MultiSelect"
+          "const": "multi-select"
         },
         "options": {
           "type": "array",
@@ -3832,7 +3832,7 @@
       "description": "Value captured for one answer.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Text"
+          "const": "text"
         },
         "value": {
           "type": "string"
@@ -3847,7 +3847,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Number"
+          "const": "number"
         },
         "value": {
           "type": "number"
@@ -3862,7 +3862,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Boolean"
+          "const": "boolean"
         },
         "value": {
           "type": "boolean"
@@ -3877,7 +3877,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Selected"
+          "const": "selected"
         },
         "value": {
           "type": "string"
@@ -3899,7 +3899,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.SelectedMany"
+          "const": "selected-many"
         },
         "value": {
           "type": "array",
@@ -3926,10 +3926,10 @@
         "state": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Draft"
+              "const": "draft"
             },
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Submitted"
+              "const": "submitted"
             }
           ],
           "description": "Answer state"
@@ -3948,7 +3948,7 @@
       "type": "object",
       "properties": {
         "state": {
-          "$ref": "#/$defs/ChatInputAnswerState.Skipped",
+          "const": "skipped",
           "description": "Answer state"
         },
         "freeformValues": {
@@ -4133,7 +4133,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Simple",
+          "const": "simple",
           "description": "Discriminant"
         },
         "modelRepresentation": {
@@ -4168,7 +4168,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.EmbeddedResource",
+          "const": "embeddedResource",
           "description": "Discriminant"
         },
         "data": {
@@ -4229,7 +4229,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Resource",
+          "const": "resource",
           "description": "Discriminant"
         },
         "selection": {
@@ -4265,7 +4265,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Annotations",
+          "const": "annotations",
           "description": "Discriminant"
         },
         "resource": {
@@ -4290,7 +4290,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Markdown",
+          "const": "markdown",
           "description": "Discriminant"
         },
         "id": {
@@ -4329,7 +4329,7 @@
           "description": "Content nonce"
         },
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ContentRef",
+          "const": "contentRef",
           "description": "Discriminant"
         }
       },
@@ -4343,7 +4343,7 @@
       "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "const": "toolCall",
           "description": "Discriminant"
         },
         "toolCall": {
@@ -4361,7 +4361,7 @@
       "description": "Reasoning/thinking content from the model.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "const": "reasoning",
           "description": "Discriminant"
         },
         "id": {
@@ -4384,7 +4384,7 @@
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "const": "systemNotification",
           "description": "Discriminant"
         },
         "content": {
@@ -4428,7 +4428,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.Client"
+          "const": "client"
         },
         "clientId": {
           "type": "string",
@@ -4444,7 +4444,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.MCP"
+          "const": "mcp"
         },
         "customizationId": {
           "type": "string",
@@ -4584,7 +4584,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nThis MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)\n`McpUiToolMeta` found in MCP tool calls, which may be used in combination\nwith the {@link contributor} to serve MCP Apps."
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Streaming"
+          "const": "streaming"
         },
         "partialInput": {
           "type": "string",
@@ -4640,7 +4640,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+          "const": "pending-confirmation"
         },
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
@@ -4716,7 +4716,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Running"
+          "const": "running"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -4816,7 +4816,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingResultConfirmation"
+          "const": "pending-result-confirmation"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -4911,7 +4911,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Completed"
+          "const": "completed"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -4971,7 +4971,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Cancelled"
+          "const": "cancelled"
         },
         "reason": {
           "$ref": "#/$defs/ToolCallCancellationReason",
@@ -5004,7 +5004,7 @@
       "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Text"
+          "const": "text"
         },
         "text": {
           "type": "string",
@@ -5021,7 +5021,7 @@
       "description": "Base64-encoded binary content embedded in a tool result.\n\nMirrors MCP `EmbeddedResource` for inline binary data.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.EmbeddedResource"
+          "const": "embeddedResource"
         },
         "data": {
           "type": "string",
@@ -5059,7 +5059,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Resource"
+          "const": "resource"
         }
       },
       "required": [
@@ -5116,7 +5116,7 @@
           "description": "Optional diff display metadata"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
+          "const": "fileEdit"
         }
       },
       "required": [
@@ -5128,7 +5128,7 @@
       "description": "A reference to a terminal whose output is relevant to this tool result.\n\nClients can subscribe to the terminal's URI to stream its output in real\ntime, providing live feedback while a tool is executing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Terminal"
+          "const": "terminal"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -5150,7 +5150,7 @@
       "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation), referenced by a chat URI (`ahp-chat:/...`).\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Subagent"
+          "const": "subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -5207,7 +5207,7 @@
       "description": "A terminal claimed by a connected client.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Client",
+          "const": "client",
           "description": "Discriminant"
         },
         "clientId": {
@@ -5225,7 +5225,7 @@
       "description": "A terminal claimed by a session, optionally scoped to a specific turn or tool call.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Session",
+          "const": "session",
           "description": "Discriminant"
         },
         "session": {
@@ -5727,7 +5727,7 @@
       "description": "Fired when available agent backends or their models change.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootAgentsChanged"
+          "const": "root/agentsChanged"
         },
         "agents": {
           "type": "array",
@@ -5747,7 +5747,7 @@
       "description": "Fired when the number of active sessions changes.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootActiveSessionsChanged"
+          "const": "root/activeSessionsChanged"
         },
         "activeSessions": {
           "type": "number",
@@ -5764,7 +5764,7 @@
       "description": "Fired when the list of known terminals changes.\n\nFull-replacement semantics: the `terminals` array replaces the previous\n`terminals` entirely.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootTerminalsChanged"
+          "const": "root/terminalsChanged"
         },
         "terminals": {
           "type": "array",
@@ -5784,7 +5784,7 @@
       "description": "Fired when agent-host configuration values change.\n\nBy default, the reducer merges the new values into `state.config.values`.\nSet `replace` to `true` to replace all values instead of merging.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.RootConfigChanged"
+          "const": "root/configChanged"
         },
         "config": {
           "type": "object",
@@ -5806,7 +5806,7 @@
       "description": "Session backend initialized successfully.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionReady"
+          "const": "session/ready"
         }
       },
       "required": [
@@ -5818,7 +5818,7 @@
       "description": "Session backend failed to initialize.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCreationFailed"
+          "const": "session/creationFailed"
         },
         "error": {
           "$ref": "#/$defs/ErrorInfo",
@@ -5835,7 +5835,7 @@
       "description": "A chat was added to this session's catalog. Upsert semantics: if a chat\nwith the same `summary.resource` already exists, the existing entry is\nreplaced.\n\nMirrors the root-channel `root/sessionAdded` notification.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChatAdded"
+          "const": "session/chatAdded"
         },
         "summary": {
           "$ref": "#/$defs/ChatSummary",
@@ -5852,7 +5852,7 @@
       "description": "A chat was removed from this session's catalog. No-op when no entry matches.\n\nMirrors the root-channel `root/sessionRemoved` notification.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChatRemoved"
+          "const": "session/chatRemoved"
         },
         "chat": {
           "$ref": "#/$defs/URI",
@@ -5869,7 +5869,7 @@
       "description": "One existing chat's summary fields changed.\n\nPartial-update semantics: only fields present in `changes` are written;\nomitted fields are preserved. Identity fields (`resource`) MUST NOT be\ncarried in `changes`. No-op when no entry with `chat` exists — clients\nSHOULD then wait for a {@link SessionChatAddedAction | `session/chatAdded`}.\n\nMirrors the root-channel `root/sessionSummaryChanged` notification.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChatUpdated"
+          "const": "session/chatUpdated"
         },
         "chat": {
           "$ref": "#/$defs/URI",
@@ -5925,7 +5925,7 @@
       "description": "The default chat input-routing hint for this session changed.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionDefaultChatChanged"
+          "const": "session/defaultChatChanged"
         },
         "defaultChat": {
           "$ref": "#/$defs/URI",
@@ -5941,7 +5941,7 @@
       "description": "Session title updated. Fired by the server when the title is auto-generated\nfrom conversation, or dispatched by a client to rename a session.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionTitleChanged"
+          "const": "session/titleChanged"
         },
         "title": {
           "type": "string",
@@ -5958,7 +5958,7 @@
       "description": "The read state of the session changed.\n\nDispatched by a client to mark a session as read (e.g. after viewing it)\nor unread (e.g. after new activity since the client last looked at it).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionIsReadChanged"
+          "const": "session/isReadChanged"
         },
         "isRead": {
           "type": "boolean",
@@ -5975,7 +5975,7 @@
       "description": "The archived state of the session changed.\n\nDispatched by a client to archive a session (e.g. the task is\ncomplete) or to unarchive it.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionIsArchivedChanged"
+          "const": "session/isArchivedChanged"
         },
         "isArchived": {
           "type": "boolean",
@@ -5992,7 +5992,7 @@
       "description": "The activity description of the session changed.\n\nDispatched by the server to indicate what the session is currently doing\n(e.g. running a tool, thinking). Clear activity by setting it to `undefined`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionActivityChanged"
+          "const": "session/activityChanged"
         },
         "activity": {
           "type": "string",
@@ -6009,7 +6009,7 @@
       "description": "The {@link Changeset | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n{@link SessionState.changesets | `state.changesets`} entirely\n(full-replacement semantics) — set to `undefined` to clear the\ncatalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionChangesetsChanged"
+          "const": "session/changesetsChanged"
         },
         "changesets": {
           "type": "array",
@@ -6029,7 +6029,7 @@
       "description": "Server tools for this session have changed.\n\nFull-replacement semantics: the `tools` array replaces the previous `serverTools` entirely.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionServerToolsChanged"
+          "const": "session/serverToolsChanged"
         },
         "tools": {
           "type": "array",
@@ -6049,7 +6049,7 @@
       "description": "An active client for this session was added or updated.\n\nUpsert semantics keyed by {@link SessionActiveClient.clientId | `clientId`}:\na client dispatches this action with its own `SessionActiveClient` to join\nthe session's active clients or refresh its entry, replacing any existing\nentry that has the same `clientId`. Multiple clients may be active at once.\nThis is also how a client updates its published tools or customizations —\nre-dispatch with the full, updated entry. Use\n{@link SessionActiveClientRemovedAction | `session/activeClientRemoved`} to\nleave. The server SHOULD automatically dispatch that removal when an active\nclient disconnects.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionActiveClientSet"
+          "const": "session/activeClientSet"
         },
         "activeClient": {
           "$ref": "#/$defs/SessionActiveClient",
@@ -6066,7 +6066,7 @@
       "description": "An active client was removed from this session.\n\nRemoves the entry for the client identified by `clientId` from\n{@link SessionState.activeClients}; a no-op when no entry matches.\n\nThe host SHOULD dispatch this automatically when a client stops participating\nin the session — for example when it unsubscribes from the session channel,\nwhen it disconnects and does not reconnect within a host-defined grace\nperiod, or when a `reconnect` command's `subscriptions` omit a session the\nclient was still active in. When removing a client, the host SHOULD also\ncancel that client's in-flight tool calls — those whose tool call state\ncarries a client `ToolCallContributor` with the matching `clientId` — by\ndispatching `chat/toolCallComplete` with `result.success = false`. (There is\nno per-tool-call server cancel; a failed completion is the cancellation\nmechanism, and the call ends in `completed` status with a failed result.)",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionActiveClientRemoved"
+          "const": "session/activeClientRemoved"
         },
         "clientId": {
           "type": "string",
@@ -6083,7 +6083,7 @@
       "description": "A session-level input request was added or updated.\n\nUpsert semantics keyed by {@link SessionInputRequest.id | `request.id`}: the\nhost dispatches this with the full {@link SessionInputRequest} to append a new\nentry to {@link SessionState.inputNeeded} or replace the existing entry with\nthe same `id`.\n\nServer-originated: the host mirrors chat-level requests (elicitations, tool\nconfirmations, client-tool executions) into the session aggregate so clients\nsubscribed only to the session channel can discover them. Clients respond by\ndispatching the ordinary `chat/*` action to the entry's `chat` channel — see\n{@link SessionInputRequest}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionInputNeededSet"
+          "const": "session/inputNeededSet"
         },
         "request": {
           "$ref": "#/$defs/SessionInputRequest",
@@ -6100,7 +6100,7 @@
       "description": "A session-level input request was removed.\n\nRemoves the entry identified by `id` from\n{@link SessionState.inputNeeded}; a no-op when no entry matches.\n\nServer-originated: the host dispatches this once the underlying request\nresolves (the user answers, the tool call is confirmed, or the client\nreports its result).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionInputNeededRemoved"
+          "const": "session/inputNeededRemoved"
         },
         "id": {
           "type": "string",
@@ -6117,7 +6117,7 @@
       "description": "The session's customizations have changed.\n\nFull-replacement semantics: the `customizations` array replaces the\nprevious `customizations` entirely.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationsChanged"
+          "const": "session/customizationsChanged"
         },
         "customizations": {
           "type": "array",
@@ -6137,7 +6137,7 @@
       "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationToggled"
+          "const": "session/customizationToggled"
         },
         "id": {
           "type": "string",
@@ -6159,7 +6159,7 @@
       "description": "Upserts a top-level customization (plugin or directory).\n\nThe reducer locates the existing entry by `customization.id`:\n\n- If found, the entry is replaced entirely with `customization`,\n  including its `children` array. To preserve existing children, the\n  host must include them on the payload.\n- If not found, the entry is appended.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationUpdated"
+          "const": "session/customizationUpdated"
         },
         "customization": {
           "$ref": "#/$defs/Customization",
@@ -6176,7 +6176,7 @@
       "description": "Removes a customization by id.\n\nSearches every container and its children for the entry. If the entry\nis a container, its children are removed with it. Is a no-op when no\nmatching id is found.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionCustomizationRemoved"
+          "const": "session/customizationRemoved"
         },
         "id": {
           "type": "string",
@@ -6193,7 +6193,7 @@
       "description": "Updates the runtime fields of an existing\n{@link McpServerCustomization} — narrow alternative to\n{@link SessionCustomizationUpdatedAction} for the high-frequency\n`starting` ↔ `ready` ↔ `authRequired` transitions.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container.\nReplaces the entry's {@link McpServerCustomization.state | `state`}\nand {@link McpServerCustomization.channel | `channel`}\n(full-replacement semantics: omit `channel` to clear an existing\nchannel URI). Other fields of the customization are preserved.\n\nIs a no-op when no matching `McpServerCustomization` is found. To\nupdate any other field (name, icons, `mcpApp` capabilities, etc.) use\n{@link SessionCustomizationUpdatedAction} instead.\n\nWhen the transition is to {@link McpServerStatus.AuthRequired}\nbecause of a request issued mid-turn, the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session — see\n{@link McpServerAuthRequiredState} for the rationale.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionMcpServerStateChanged"
+          "const": "session/mcpServerStateChanged"
         },
         "id": {
           "type": "string",
@@ -6219,7 +6219,7 @@
       "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionConfigChanged"
+          "const": "session/configChanged"
         },
         "config": {
           "type": "object",
@@ -6241,7 +6241,7 @@
       "description": "The session's `_meta` side-channel changed. Replaces `state._meta`\nentirely (full-replacement semantics). Producers SHOULD merge any\nkeys they wish to preserve into the new value before dispatching.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.SessionMetaChanged"
+          "const": "session/metaChanged"
         },
         "_meta": {
           "type": "object",
@@ -6282,7 +6282,7 @@
       "description": "A new message has been sent to the agent, and a new turn starts.\n\nA client is only allowed to send {@link MessageKind.User} messages.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnStarted"
+          "const": "chat/turnStarted"
         },
         "turnId": {
           "type": "string",
@@ -6313,7 +6313,7 @@
       "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatDelta"
+          "const": "chat/delta"
         },
         "turnId": {
           "type": "string",
@@ -6345,7 +6345,7 @@
       "description": "Structured content appended to the response.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatResponsePart"
+          "const": "chat/responsePart"
         },
         "turnId": {
           "type": "string",
@@ -6385,7 +6385,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallStart"
+          "const": "chat/toolCallStart"
         },
         "toolName": {
           "type": "string",
@@ -6430,7 +6430,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallDelta"
+          "const": "chat/toolCallDelta"
         },
         "content": {
           "type": "string",
@@ -6466,7 +6466,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallReady"
+          "const": "chat/toolCallReady"
         },
         "invocationMessage": {
           "$ref": "#/$defs/StringOrMarkdown",
@@ -6533,7 +6533,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallConfirmed"
+          "const": "chat/toolCallConfirmed"
         },
         "approved": {
           "description": "The tool call was approved"
@@ -6577,7 +6577,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallConfirmed"
+          "const": "chat/toolCallConfirmed"
         },
         "approved": {
           "description": "The tool call was denied"
@@ -6585,10 +6585,10 @@
         "reason": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ToolCallCancellationReason.Denied"
+              "const": "denied"
             },
             {
-              "$ref": "#/$defs/ToolCallCancellationReason.Skipped"
+              "const": "skipped"
             }
           ],
           "description": "Why the tool was cancelled"
@@ -6632,7 +6632,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallComplete"
+          "const": "chat/toolCallComplete"
         },
         "result": {
           "$ref": "#/$defs/ToolCallResult",
@@ -6668,7 +6668,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallResultConfirmed"
+          "const": "chat/toolCallResultConfirmed"
         },
         "approved": {
           "type": "boolean",
@@ -6700,7 +6700,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
         },
         "type": {
-          "$ref": "#/$defs/ActionType.ChatToolCallContentChanged"
+          "const": "chat/toolCallContentChanged"
         },
         "content": {
           "type": "array",
@@ -6722,7 +6722,7 @@
       "description": "Turn finished — the assistant is idle.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnComplete"
+          "const": "chat/turnComplete"
         },
         "turnId": {
           "type": "string",
@@ -6744,7 +6744,7 @@
       "description": "Turn was aborted; server stops processing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnCancelled"
+          "const": "chat/turnCancelled"
         },
         "turnId": {
           "type": "string",
@@ -6766,7 +6766,7 @@
       "description": "Error during turn processing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatError"
+          "const": "chat/error"
         },
         "turnId": {
           "type": "string",
@@ -6793,7 +6793,7 @@
       "description": "The activity description of this chat changed.\n\nDispatched by the server to indicate what the chat is currently doing\n(e.g. running a tool, thinking). Clear activity by omitting it or setting it\nto `undefined`.\nProducers SHOULD also update the parent session's chat catalog with\n`session/chatUpdated` so `ChatSummary.activity` stays in sync.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatActivityChanged"
+          "const": "chat/activityChanged"
         },
         "activity": {
           "type": "string",
@@ -6809,7 +6809,7 @@
       "description": "Token usage report for a turn.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatUsage"
+          "const": "chat/usage"
         },
         "turnId": {
           "type": "string",
@@ -6836,7 +6836,7 @@
       "description": "Reasoning/thinking text from the model, appended to a specific reasoning response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\nreasoning part, then use this action to append text to it.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatReasoning"
+          "const": "chat/reasoning"
         },
         "turnId": {
           "type": "string",
@@ -6868,7 +6868,7 @@
       "description": "Truncates a session's history. If `turnId` is provided, all turns after that\nturn are removed and the specified turn is kept. If `turnId` is omitted, all\nturns are removed.\n\nIf there is an active turn it is silently dropped and the chat status\nreturns to `idle`.\n\nCommon use-case: truncate old data then dispatch a new\n`chat/turnStarted` with an edited message.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTruncated"
+          "const": "chat/truncated"
         },
         "turnId": {
           "type": "string",
@@ -6884,7 +6884,7 @@
       "description": "Loads older completed turns into this chat's state.\n\nHosts dispatch this before responding to `fetchTurns`, and before applying\nany operation that references a turn older than the currently loaded window.\n`turns` is ordered oldest-first and is prepended to the current `turns`\nwindow. `turnsNextCursor` replaces the state's cursor; omit it when all\nretained turns are now loaded.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatTurnsLoaded"
+          "const": "chat/turnsLoaded"
         },
         "turns": {
           "type": "array",
@@ -6908,7 +6908,7 @@
       "description": "A pending message was set (upsert semantics: creates or replaces).\n\nFor steering messages, this always replaces the single steering message.\nFor queued messages, if a message with the given `id` already exists it is\nupdated in place; otherwise it is appended to the queue. If the chat is\nidle when a queued message is set, the server SHOULD immediately consume it\nand start a new turn.\n\nA client is only allowed to send {@link MessageKind.User} messages.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatPendingMessageSet"
+          "const": "chat/pendingMessageSet"
         },
         "kind": {
           "$ref": "#/$defs/PendingMessageKind",
@@ -6935,7 +6935,7 @@
       "description": "A pending message was removed (steering or queued).\n\nDispatched by clients to cancel a pending message, or by the server when\nit consumes a message (e.g. starting a turn from a queued message or\ninjecting a steering message into the current turn).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatPendingMessageRemoved"
+          "const": "chat/pendingMessageRemoved"
         },
         "kind": {
           "$ref": "#/$defs/PendingMessageKind",
@@ -6957,7 +6957,7 @@
       "description": "Reorder the queued messages.\n\nThe `order` array contains the IDs of queued messages in their new\ndesired order. IDs not present in the current queue are ignored.\nQueued messages whose IDs are absent from `order` are appended at\nthe end in their original relative order (so a client with a stale\nview of the queue never silently drops messages).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatQueuedMessagesReordered"
+          "const": "chat/queuedMessagesReordered"
         },
         "order": {
           "type": "array",
@@ -6977,7 +6977,7 @@
       "description": "The chat's draft input changed.\n\nClients MAY periodically sync their local input state — the message the user\nis composing, including its {@link Message.model | model} /\n{@link Message.agent | agent} selection and attachments — into the chat's\n{@link ChatState.draft | `draft`} so it survives reloads and is visible to\nother clients viewing the same chat. Eager syncing is **not** required;\nclients SHOULD debounce and MAY sync only at convenient points. Set `draft`\nto `undefined` to clear it (e.g. once the message is sent).\n\nA client is only allowed to draft {@link MessageKind.User} messages.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatDraftChanged"
+          "const": "chat/draftChanged"
         },
         "draft": {
           "$ref": "#/$defs/Message",
@@ -6993,7 +6993,7 @@
       "description": "A session requested input from the user.\n\nFull-request upsert semantics: the `request` replaces any existing request\nwith the same `id`, or is appended if it is new. Answer drafts are preserved\nunless `request.answers` is provided.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatInputRequested"
+          "const": "chat/inputRequested"
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
@@ -7010,7 +7010,7 @@
       "description": "A client updated, submitted, skipped, or removed a single in-progress answer.\n\nDispatching with `answer: undefined` removes that question's answer draft.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatInputAnswerChanged"
+          "const": "chat/inputAnswerChanged"
         },
         "requestId": {
           "type": "string",
@@ -7036,7 +7036,7 @@
       "description": "A client accepted, declined, or cancelled a session input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChatInputCompleted"
+          "const": "chat/inputCompleted"
         },
         "requestId": {
           "type": "string",
@@ -7065,7 +7065,7 @@
       "description": "Terminal output data (pty → client direction).\n\nAppends `data` to the terminal's `content` in the reducer.\n\n`terminal/data` and `terminal/input` are intentionally separate actions\nbecause standard write-ahead reconciliation is not safe for terminal I/O.\nA pty is a stateful, mutable process — optimistically applying input or\npredicting output would produce incorrect state. Instead, `terminal/input`\nis a side-effect-only action (client → server → pty), and `terminal/data`\nis server-authoritative output (pty → server → client).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalData"
+          "const": "terminal/data"
         },
         "data": {
           "type": "string",
@@ -7082,7 +7082,7 @@
       "description": "Keyboard input sent to the terminal process (client → pty direction).\n\nThis is a side-effect-only action: the server forwards the data to the\nterminal's pty. The reducer treats this as a no-op since `terminal/data`\nactions will reflect any resulting output.\n\nSee `terminal/data` for why these two actions are kept separate.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalInput"
+          "const": "terminal/input"
         },
         "data": {
           "type": "string",
@@ -7099,7 +7099,7 @@
       "description": "Terminal dimensions changed.\n\nDispatchable by clients to request a resize, or by the server to inform\nclients of the actual terminal dimensions.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalResized"
+          "const": "terminal/resized"
         },
         "cols": {
           "type": "number",
@@ -7121,7 +7121,7 @@
       "description": "Terminal claim changed. A client or session transfers ownership of the terminal.\n\nThe server SHOULD reject if the dispatching client does not currently hold\nthe claim.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalClaimed"
+          "const": "terminal/claimed"
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -7138,7 +7138,7 @@
       "description": "Terminal title changed.\n\nFired by the server when the terminal process updates its title (e.g. via\nescape sequences), or dispatched by a client to rename a terminal.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalTitleChanged"
+          "const": "terminal/titleChanged"
         },
         "title": {
           "type": "string",
@@ -7155,7 +7155,7 @@
       "description": "Terminal working directory changed.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCwdChanged"
+          "const": "terminal/cwdChanged"
         },
         "cwd": {
           "$ref": "#/$defs/URI",
@@ -7172,7 +7172,7 @@
       "description": "Terminal process exited.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalExited"
+          "const": "terminal/exited"
         },
         "exitCode": {
           "type": "number",
@@ -7188,7 +7188,7 @@
       "description": "Terminal scrollback buffer cleared.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCleared"
+          "const": "terminal/cleared"
         }
       },
       "required": [
@@ -7200,7 +7200,7 @@
       "description": "Shell integration has loaded and the terminal now supports command\ndetection. The server dispatches this when shell integration becomes\navailable (which may happen asynchronously after the terminal is created).\n\nClients MUST NOT assume command detection is available until this action\n(or `terminal/commandExecuted`) has been received.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCommandDetectionAvailable"
+          "const": "terminal/commandDetectionAvailable"
         }
       },
       "required": [
@@ -7212,7 +7212,7 @@
       "description": "A command has been submitted to the shell and is now executing.\nAll subsequent `terminal/data` actions (until the matching\n`terminal/commandFinished`) constitute this command's output.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCommandExecuted"
+          "const": "terminal/commandExecuted"
         },
         "commandId": {
           "type": "string",
@@ -7239,7 +7239,7 @@
       "description": "A command has finished executing.\n\nThe sequence of `terminal/data` actions between the preceding\n`terminal/commandExecuted` (same `commandId`) and this action constitutes\nthe complete output of the command.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.TerminalCommandFinished"
+          "const": "terminal/commandFinished"
         },
         "commandId": {
           "type": "string",
@@ -7264,7 +7264,7 @@
       "description": "The {@link ChangesetState.status} for this changeset transitioned (e.g.\n`computing → ready`). The error payload is set together with `status`\nwhenever it transitions to {@link ChangesetStatus.Error | Error}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetStatusChanged"
+          "const": "changeset/statusChanged"
         },
         "status": {
           "$ref": "#/$defs/ChangesetStatus",
@@ -7285,7 +7285,7 @@
       "description": "Upsert a {@link ChangesetFile} in the changeset — adds a new entry, or\nreplaces an existing one identified by {@link ChangesetFile.id}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFileSet"
+          "const": "changeset/fileSet"
         },
         "file": {
           "$ref": "#/$defs/ChangesetFile",
@@ -7302,7 +7302,7 @@
       "description": "Remove a {@link ChangesetFile} from the changeset by its id.\n\nTypically dispatched when a file is reverted, staged out, or otherwise\nno longer in scope (e.g. a renamed file is replaced by a new entry).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFileRemoved"
+          "const": "changeset/fileRemoved"
         },
         "fileId": {
           "type": "string",
@@ -7319,7 +7319,7 @@
       "description": "The changeset's full content changed. Full replacement semantics: `files`\nreplaces the previous file list, and `operations`, when present, replaces\nthe previous operation list.\n\nProducers SHOULD use this action for initial snapshots and bulk refreshes;\nuse {@link ChangesetFileSetAction}, {@link ChangesetFileRemovedAction}, and\n{@link ChangesetOperationsChangedAction} for incremental updates.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetContentChanged"
+          "const": "changeset/contentChanged"
         },
         "files": {
           "type": "array",
@@ -7350,7 +7350,7 @@
       "description": "The set of operations available on this changeset changed. Full\nreplacement semantics: `operations` replaces the previous list (or\nremoves it entirely when `operations` is `undefined`).",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetOperationsChanged"
+          "const": "changeset/operationsChanged"
         },
         "operations": {
           "type": "array",
@@ -7370,7 +7370,7 @@
       "description": "The {@link ChangesetOperation.status} for a single operation transitioned\n(e.g. `idle → running → idle`, or `running → error`). The error payload\nis set together with `status` whenever it transitions to\n{@link ChangesetOperationStatus.Error | Error}, and cleared on any other\ntransition.\n\nTargets one operation by its {@link ChangesetOperation.id}. If no\noperation with that id is currently present in the changeset, the action\nis a no-op. Use {@link ChangesetOperationsChangedAction} to add, remove,\nor otherwise replace the operation list itself.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetOperationStatusChanged"
+          "const": "changeset/operationStatusChanged"
         },
         "operationId": {
           "type": "string",
@@ -7396,7 +7396,7 @@
       "description": "Drop every file from the changeset.\n\nTwo cases use this:\n1. The underlying source moved (branch switched, fork point invalidated,\n   …) and the server is recomputing from scratch — subsequent\n   {@link ChangesetFileSetAction} entries will repopulate it.\n2. The owning session has ended and the URI is becoming\n   un-subscribable — the server will unsubscribe all clients shortly\n   after dispatching this action.\n\nClients SHOULD release any references on receipt and SHOULD NOT\ndistinguish the two cases from the action alone — instead, react to\nthe corresponding session-level lifecycle signal (e.g.\n`root/sessionRemoved`) for the \"going away\" case.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetCleared"
+          "const": "changeset/cleared"
         }
       },
       "required": [
@@ -7408,7 +7408,7 @@
       "description": "Upsert an {@link Annotation} in the annotations channel — adds a new\nannotation, or replaces an existing one identified by\n{@link Annotation.id}.\n\nDispatched by a client to create an annotation (together with its\nmandatory first entry) or to re-anchor / resolve an existing one; the\ndispatching client assigns the {@link Annotation.id} and the id of any\nnew entry. When replacing, the full annotation payload (including its\n{@link Annotation.entries | entries} list) is substituted; producers\nSHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and\n{@link AnnotationsUpdatedAction} to resolve / re-anchor an existing\nannotation, to keep wire updates small.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsSet"
+          "const": "annotations/set"
         },
         "annotation": {
           "$ref": "#/$defs/Annotation",
@@ -7425,7 +7425,7 @@
       "description": "Partially update an existing {@link Annotation}'s own properties — a narrow\nalternative to {@link AnnotationsSetAction} for the common case of resolving\n/ re-opening or re-anchoring an annotation without resending its\n{@link Annotation.entries | entries}.\n\nTargets one annotation by its {@link annotationId}. Only the fields present\non the action are written; omitted fields leave the corresponding\n{@link Annotation} property unchanged. The annotation's\n{@link Annotation.entries | entries}, {@link Annotation.id | id}, and\n{@link Annotation._meta | _meta} are never touched — dispatch\n{@link AnnotationsSetAction} to replace those, to clear {@link range}\n(re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /\n{@link AnnotationsEntryRemovedAction} to edit individual entries.\n\nIf {@link annotationId} does not match any current annotation the action is\na no-op.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsUpdated"
+          "const": "annotations/updated"
         },
         "annotationId": {
           "type": "string",
@@ -7458,7 +7458,7 @@
       "description": "Remove an {@link Annotation} from the channel by its id.\n\nDispatched to delete an entire annotation and every entry it contains.\nBecause the protocol forbids empty annotations, a client that wants to\nremove the last remaining entry dispatches this action — collapsing the\nannotation — rather than {@link AnnotationsEntryRemovedAction}.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsRemoved"
+          "const": "annotations/removed"
         },
         "annotationId": {
           "type": "string",
@@ -7475,7 +7475,7 @@
       "description": "Upsert an {@link AnnotationEntry} within an existing annotation — adds a\nnew entry, or replaces one identified by {@link AnnotationEntry.id}. The\ndispatching client assigns the {@link AnnotationEntry.id} of a new entry.\nIf {@link annotationId} does not match any current annotation the action\nis a no-op.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsEntrySet"
+          "const": "annotations/entrySet"
         },
         "annotationId": {
           "type": "string",
@@ -7497,7 +7497,7 @@
       "description": "Remove a single {@link AnnotationEntry} from an annotation without\ncollapsing the annotation itself. Used when more than one entry remains —\nto remove the last entry a client dispatches {@link AnnotationsRemovedAction}\ninstead, since the protocol forbids empty annotations.\n\nIf either {@link annotationId} or {@link entryId} does not match the\ncurrent state the action is a no-op.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.AnnotationsEntryRemoved"
+          "const": "annotations/entryRemoved"
         },
         "annotationId": {
           "type": "string",
@@ -7519,7 +7519,7 @@
       "description": "A batch of resource changes observed by the watcher.\n\nWatch events are coalesced into batches by the server to keep the\naction stream tractable; an empty `changes.items` list MUST NOT be\ndispatched. The reducer does not retain change history — these\nactions exist purely to deliver events to subscribers, who consume\nthem directly off the action stream and apply their own logic.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ResourceWatchChanged"
+          "const": "resourceWatch/changed"
         },
         "changes": {
           "type": "object",
@@ -7538,6 +7538,855 @@
         "type",
         "changes"
       ]
+    },
+    "URI": {
+      "type": "string",
+      "description": "A URI string (e.g. `ahp-root://`, `ahp-session:/<uuid>`, or `ahp-chat:/<uuid>`)."
+    },
+    "StateAction": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/RootAgentsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/RootActiveSessionsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/RootTerminalsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/RootConfigChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionReadyAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCreationFailedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChatAddedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChatRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChatUpdatedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionDefaultChatChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionTitleChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionServerToolsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionActiveClientSetAction"
+        },
+        {
+          "$ref": "#/$defs/SessionActiveClientRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionInputNeededSetAction"
+        },
+        {
+          "$ref": "#/$defs/SessionInputNeededRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationToggledAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationUpdatedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMcpServerStateChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionIsReadChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionIsArchivedChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionActivityChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChangesetsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionConfigChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMetaChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnStartedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatDeltaAction"
+        },
+        {
+          "$ref": "#/$defs/ChatResponsePartAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallStartAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallDeltaAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallReadyAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallConfirmedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallCompleteAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallResultConfirmedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallContentChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnCompleteAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnCancelledAction"
+        },
+        {
+          "$ref": "#/$defs/ChatErrorAction"
+        },
+        {
+          "$ref": "#/$defs/ChatActivityChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatUsageAction"
+        },
+        {
+          "$ref": "#/$defs/ChatReasoningAction"
+        },
+        {
+          "$ref": "#/$defs/ChatPendingMessageSetAction"
+        },
+        {
+          "$ref": "#/$defs/ChatPendingMessageRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatQueuedMessagesReorderedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatDraftChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatInputRequestedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatInputAnswerChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatInputCompletedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTruncatedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnsLoadedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetStatusChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetFileSetAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetFileRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetContentChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetOperationsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetOperationStatusChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetClearedAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsSetAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsUpdatedAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsEntrySetAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsEntryRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalDataAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalInputAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalResizedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalClaimedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalTitleChangedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCwdChangedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalExitedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalClearedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandDetectionAvailableAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandExecutedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandFinishedAction"
+        },
+        {
+          "$ref": "#/$defs/ResourceWatchChangedAction"
+        }
+      ],
+      "description": "Discriminated union of all state actions."
+    },
+    "ContentEncoding": {
+      "enum": [
+        "base64",
+        "utf-8"
+      ],
+      "type": "string",
+      "description": "Encoding of fetched content data."
+    },
+    "ResourceWriteMode": {
+      "enum": [
+        "truncate",
+        "append",
+        "insert"
+      ],
+      "type": "string",
+      "description": "How {@link ResourceWriteParams.data} is placed within the target file.\n\nEach mode interprets {@link ResourceWriteParams.position} differently:\n\n- `truncate` (default): rooted at the **start** of the file. The file is\n  truncated at `position` (0 by default) and `data` is written from that\n  offset, so the resulting file is `existing[0..position] + data`. With\n  `position` omitted this is a full overwrite.\n- `append`: rooted at the **end** of the file. `position` counts bytes\n  backwards from EOF, so `position: 0` (the default) writes at EOF —\n  POSIX append — and `position: 5` inserts `data` 5 bytes before the\n  current EOF, shifting those trailing 5 bytes after the inserted region.\n  The server MUST evaluate the effective EOF and write atomically with\n  respect to other appenders so concurrent `append` writes do not\n  clobber each other.\n- `insert`: rooted at the **start** of the file. `position` (0 by default)\n  is the byte offset at which `data` is spliced in; bytes at or after\n  `position` are shifted right by `data.length`. `insert` always grows\n  the file — use `truncate` to overwrite bytes in place."
+    },
+    "ResourceType": {
+      "enum": [
+        "file",
+        "directory",
+        "symlink"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link ResourceResolveResult.type}."
+    },
+    "CompletionItemKind": {
+      "enum": [
+        "userMessage"
+      ],
+      "type": "string",
+      "description": "The kind of completion items being requested."
+    },
+    "MessageAttachment": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SimpleMessageAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageEmbeddedResourceAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageResourceAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageAnnotationsAttachment"
+        }
+      ],
+      "description": "An attachment associated with a {@link Message}."
+    },
+    "TerminalClaim": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalClientClaim"
+        },
+        {
+          "$ref": "#/$defs/TerminalSessionClaim"
+        }
+      ],
+      "description": "Describes who currently holds a terminal. A terminal may be claimed by\neither a connected client or a session (e.g. during a tool call)."
+    },
+    "ChangesetOperationTarget": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "resource": {
+              "type": "string"
+            },
+            "side": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "resource"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "resource": {
+              "type": "string"
+            },
+            "side": {
+              "type": "string"
+            },
+            "range": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "resource",
+            "range"
+          ]
+        }
+      ],
+      "description": "Identifies the file or range a {@link ChangesetOperation} should act on.\n\nThe `kind` MUST match one of the operation's declared\n{@link ChangesetOperation.scopes}."
+    },
+    "StringOrMarkdown": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "markdown": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "markdown"
+          ]
+        }
+      ],
+      "description": "A string that may optionally be rendered as Markdown.\n\n- A plain `string` is rendered as-is (no Markdown processing).\n- An object with `{ markdown: string }` is rendered with Markdown formatting."
+    },
+    "JsonPrimitive": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A primitive JSON value: a string, number, boolean, or `null`."
+    },
+    "Customization": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/PluginCustomization"
+        },
+        {
+          "$ref": "#/$defs/DirectoryCustomization"
+        },
+        {
+          "$ref": "#/$defs/McpServerCustomization"
+        }
+      ],
+      "description": "A top-level customization active in a session. Either a container\n({@link PluginCustomization} or {@link DirectoryCustomization}) whose\nleaf customizations live in its\n{@link ContainerCustomizationBase.children | `children`} array, or a\nbare {@link McpServerCustomization} surfaced directly by the host."
+    },
+    "PolicyState": {
+      "enum": [
+        "enabled",
+        "disabled",
+        "unconfigured"
+      ],
+      "type": "string",
+      "description": "Policy configuration state for a model."
+    },
+    "SessionStatus": {
+      "enum": [
+        1,
+        2,
+        8,
+        24,
+        32,
+        64
+      ],
+      "type": "number",
+      "description": "Bitset of summary-level session status flags.\n\nUse bitwise checks instead of equality for non-terminal activity. For example,\n`status & SessionStatus.InProgress` matches both ordinary in-progress turns\nand turns that are paused waiting for input."
+    },
+    "SessionLifecycle": {
+      "enum": [
+        "creating",
+        "ready",
+        "creationFailed"
+      ],
+      "type": "string",
+      "description": "Session initialization state."
+    },
+    "SessionInputRequest": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SessionChatInputRequest"
+        },
+        {
+          "$ref": "#/$defs/SessionToolConfirmationRequest"
+        },
+        {
+          "$ref": "#/$defs/SessionToolClientExecutionRequest"
+        }
+      ],
+      "description": "One outstanding piece of input a session is blocked on, aggregated across all\nchats in {@link SessionState.inputNeeded}.\n\nEach entry is self-sufficient: it carries the owning\n{@link SessionInputRequestBase.chat | `chat`} URI plus every identifier needed\nto construct the response, so a client can answer by dispatching the ordinary\n`chat/*` action (`chat/inputCompleted`, `chat/toolCallConfirmed`,\n`chat/toolCallComplete`, …) to that chat's channel **without having subscribed\nto the chat**. The host removes the entry with `session/inputNeededRemoved`\nonce the underlying request resolves."
+    },
+    "ToolCallConfirmationState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        }
+      ],
+      "description": "The two tool-call states that block on a client confirmation: parameter\nconfirmation before execution ({@link ToolCallPendingConfirmationState}) and\nresult confirmation after execution\n({@link ToolCallPendingResultConfirmationState}).\n\nSurfaced at the session level by {@link SessionToolConfirmationRequest}."
+    },
+    "ToolCallState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallStreamingState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallRunningState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCompletedState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCancelledState"
+        }
+      ],
+      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
+    },
+    "CustomizationLoadState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/CustomizationLoadingState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationLoadedState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationDegradedState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationErrorState"
+        }
+      ],
+      "description": "Discriminated load state for a container customization\n({@link PluginCustomization} or {@link DirectoryCustomization})."
+    },
+    "ChildCustomization": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/AgentCustomization"
+        },
+        {
+          "$ref": "#/$defs/SkillCustomization"
+        },
+        {
+          "$ref": "#/$defs/PromptCustomization"
+        },
+        {
+          "$ref": "#/$defs/RuleCustomization"
+        },
+        {
+          "$ref": "#/$defs/HookCustomization"
+        },
+        {
+          "$ref": "#/$defs/McpServerCustomization"
+        }
+      ],
+      "description": "Child customizations that live inside a {@link PluginCustomization} or\n{@link DirectoryCustomization}."
+    },
+    "ChildCustomizationType": {
+      "oneOf": [
+        {
+          "const": "agent"
+        },
+        {
+          "const": "skill"
+        },
+        {
+          "const": "prompt"
+        },
+        {
+          "const": "rule"
+        },
+        {
+          "const": "hook"
+        },
+        {
+          "const": "mcpServer"
+        }
+      ],
+      "description": "Customization types that appear as children of a\n{@link PluginCustomization} or {@link DirectoryCustomization}."
+    },
+    "McpServerState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/McpServerStartingState"
+        },
+        {
+          "$ref": "#/$defs/McpServerReadyState"
+        },
+        {
+          "$ref": "#/$defs/McpServerAuthRequiredState"
+        },
+        {
+          "$ref": "#/$defs/McpServerErrorState"
+        },
+        {
+          "$ref": "#/$defs/McpServerStoppedState"
+        }
+      ],
+      "description": "Discriminated union of all MCP server lifecycle states.\nDiscriminated by `kind` (a {@link McpServerStatus} value)."
+    },
+    "McpAuthRequiredReason": {
+      "enum": [
+        "required",
+        "expired",
+        "insufficientScope"
+      ],
+      "type": "string",
+      "description": "Why an MCP server is currently in the {@link McpServerStatus.AuthRequired}\nstate. Mirrors the three failure modes defined by the\n[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md)."
+    },
+    "ChatOrigin": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "chat": {
+              "type": "string"
+            },
+            "turnId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "chat",
+            "turnId"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "chat": {
+              "type": "string"
+            },
+            "toolCallId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "chat",
+            "toolCallId"
+          ]
+        }
+      ],
+      "description": "How a chat came into existence. Clients MAY use it to render\ncontextual UI (parent indicators, fork markers, \"spawned by tool\" badges).\n\nThe `tool` variant records a tool-spawned worker from the worker's side: its\n`chat`/`toolCallId` identify the spawning tool call in the parent chat. This\nis the canonical record of the spawn relationship. The same edge is surfaced\nfrom the parent's side by {@link ToolResultSubagentContent}, whose `resource`\nis this chat's URI; hosts MUST keep the two consistent."
+    },
+    "ChatInteractivity": {
+      "enum": [
+        "full",
+        "read-only",
+        "hidden"
+      ],
+      "type": "string",
+      "description": "How a user can interact with a chat.\n\n- `Full` — user can send messages and watch (default when absent)\n- `ReadOnly` — user can watch but not send messages (e.g. agent team workers)\n- `Hidden` — internal worker not shown in UI at all\n\nSupports the agent-team pattern where a lead chat is fully interactive and\nworker chats are read-only (visible for observability) or hidden (internal\nimplementation detail). The harness sets this based on the chat's role;\nthe UI uses it to show appropriate controls."
+    },
+    "ChatInputQuestion": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputTextQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputNumberQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputBooleanQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSingleSelectQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputMultiSelectQuestion"
+        }
+      ],
+      "description": "One question within a chat input request."
+    },
+    "ChatInputAnswer": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputAnswered"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSkipped"
+        }
+      ],
+      "description": "Draft, submitted, or skipped answer for one question."
+    },
+    "ChatInputAnswerValue": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputTextAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputNumberAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputBooleanAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSelectedAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSelectedManyAnswerValue"
+        }
+      ]
+    },
+    "ResponsePart": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/MarkdownResponsePart"
+        },
+        {
+          "$ref": "#/$defs/ResourceReponsePart"
+        },
+        {
+          "$ref": "#/$defs/ToolCallResponsePart"
+        },
+        {
+          "$ref": "#/$defs/ReasoningResponsePart"
+        },
+        {
+          "$ref": "#/$defs/SystemNotificationResponsePart"
+        }
+      ]
+    },
+    "TurnState": {
+      "enum": [
+        "complete",
+        "cancelled",
+        "error"
+      ],
+      "type": "string",
+      "description": "How a turn ended."
+    },
+    "MessageKind": {
+      "enum": [
+        "user",
+        "agent",
+        "tool",
+        "systemNotification"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "ConfirmationOptionKind": {
+      "enum": [
+        "approve",
+        "deny"
+      ],
+      "type": "string",
+      "description": "Whether a confirmation option represents an approval or denial action."
+    },
+    "ToolCallContributor": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallClientContributor"
+        },
+        {
+          "$ref": "#/$defs/ToolCallMcpContributor"
+        }
+      ]
+    },
+    "ToolResultContent": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolResultTextContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultEmbeddedResourceContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultResourceContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultFileEditContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultTerminalContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultSubagentContent"
+        }
+      ],
+      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output, and\n`ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions)."
+    },
+    "ToolCallConfirmationReason": {
+      "enum": [
+        "not-needed",
+        "user-action",
+        "setting"
+      ],
+      "type": "string",
+      "description": "How a tool call was confirmed for execution.\n\n- `NotNeeded` — No confirmation required (auto-approved)\n- `UserAction` — User explicitly approved\n- `Setting` — Approved by a persistent user setting"
+    },
+    "ToolCallCancellationReason": {
+      "enum": [
+        "denied",
+        "skipped",
+        "result-denied"
+      ],
+      "type": "string",
+      "description": "Why a tool call was cancelled."
+    },
+    "TerminalContentPart": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalUnclassifiedPart"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandPart"
+        }
+      ],
+      "description": "A content part within terminal output."
+    },
+    "ChangesetStatus": {
+      "enum": [
+        "computing",
+        "ready",
+        "error"
+      ],
+      "type": "string",
+      "description": "Computation lifecycle of a {@link ChangesetState}."
+    },
+    "ChangesetOperationScope": {
+      "enum": [
+        "changeset",
+        "resource",
+        "range"
+      ],
+      "type": "string",
+      "description": "Where a {@link ChangesetOperation} can be invoked."
+    },
+    "ChangesetOperationStatus": {
+      "enum": [
+        "idle",
+        "running",
+        "error",
+        "disabled"
+      ],
+      "type": "string",
+      "description": "Execution lifecycle of a {@link ChangesetOperation}.\n\nAn operation is invoked imperatively via `invokeChangesetOperation`, but\nits progress and outcome are reflected back into changeset state so that\nevery subscriber observes a consistent view (e.g. a spinner on a \"Create\nPull Request\" button, or an inline error after a failed \"revert\")."
+    },
+    "ResourceChangeType": {
+      "enum": [
+        "added",
+        "updated",
+        "deleted"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link ResourceChange.type}."
+    },
+    "PendingMessageKind": {
+      "enum": [
+        "steering",
+        "queued"
+      ],
+      "type": "string",
+      "description": "Discriminant for pending message kinds."
+    },
+    "ChatInputResponseKind": {
+      "enum": [
+        "accept",
+        "decline",
+        "cancel"
+      ],
+      "type": "string",
+      "description": "How a client completed an input request."
+    },
+    "ChatToolCallConfirmedAction": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatToolCallApprovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallDeniedAction"
+        }
+      ],
+      "description": "Client confirms or denies a pending tool call."
     }
   }
 }

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -937,7 +937,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ChatInput"
+          "const": "chatInput"
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
@@ -964,7 +964,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolConfirmation"
+          "const": "toolConfirmation"
         },
         "turnId": {
           "type": "string",
@@ -996,7 +996,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolClientExecution"
+          "const": "toolClientExecution"
         },
         "turnId": {
           "type": "string",
@@ -1400,7 +1400,7 @@
       "description": "Container is being loaded by the host.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loading"
+          "const": "loading"
         }
       },
       "required": [
@@ -1412,7 +1412,7 @@
       "description": "Container loaded successfully.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loaded"
+          "const": "loaded"
         }
       },
       "required": [
@@ -1424,7 +1424,7 @@
       "description": "Container partially loaded but has warnings.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Degraded"
+          "const": "degraded"
         },
         "message": {
           "type": "string",
@@ -1441,7 +1441,7 @@
       "description": "Container failed to load.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Error"
+          "const": "error"
         },
         "message": {
           "type": "string",
@@ -1554,7 +1554,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         }
       },
       "required": [
@@ -1612,7 +1612,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         },
         "nonce": {
           "type": "string",
@@ -1674,7 +1674,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Directory"
+          "const": "directory"
         },
         "contents": {
           "$ref": "#/$defs/ChildCustomizationType",
@@ -1765,7 +1765,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Agent"
+          "const": "agent"
         },
         "description": {
           "type": "string",
@@ -1835,7 +1835,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Skill"
+          "const": "skill"
         },
         "description": {
           "type": "string",
@@ -1889,7 +1889,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Prompt"
+          "const": "prompt"
         },
         "description": {
           "type": "string",
@@ -1935,7 +1935,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Rule"
+          "const": "rule"
         },
         "description": {
           "type": "string",
@@ -1992,7 +1992,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Hook"
+          "const": "hook"
         }
       },
       "required": [
@@ -2030,7 +2030,7 @@
           "description": "Optional span within {@link CustomizationBase.uri | `uri`} when this\ncustomization is a subset of a larger file (for example, one entry\nin an inline `mcpServers` block of a `plugins.json` manifest).\nAbsent when the customization covers the whole resource."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.McpServer"
+          "const": "mcpServer"
         },
         "enabled": {
           "type": "boolean",
@@ -2114,7 +2114,7 @@
       "description": "Server is registered with the host but has not yet started.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Starting"
+          "const": "starting"
         }
       },
       "required": [
@@ -2126,7 +2126,7 @@
       "description": "Server is running and serving requests.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Ready"
+          "const": "ready"
         }
       },
       "required": [
@@ -2138,7 +2138,7 @@
       "description": "Server is reachable but cannot serve requests until the client\nauthenticates. Mirrors the discovery flow defined by\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)\n(Protected Resource Metadata) and the OAuth 2.1 / RFC 6750 challenge\nsemantics required by the MCP authorization spec.\n\nClients react to this state by calling the existing `authenticate`\ncommand with the {@link ProtectedResourceMetadata.resource | resource}\ncarried here. There is **no** `notify/authRequired` notification for\nMCP servers — the action stream is the single source of truth.\n\nWhen the transition is triggered by a request issued during a turn\n— most commonly\n{@link McpAuthRequiredReason.InsufficientScope | `InsufficientScope`}\nsurfacing mid-tool-call — the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session so the block is\nvisible at the summary level. Clients SHOULD watch this status on\nany MCP server backing a running tool call and surface an explicit\naffordance (e.g. a \"grant additional access\" prompt) tied to that\ntool call, rather than relying on the user to notice the\ncustomization’s status badge.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.AuthRequired"
+          "const": "authRequired"
         },
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -2171,7 +2171,7 @@
       "description": "Server failed to start, crashed, or otherwise transitioned to a\nnon-recoverable error. Use {@link McpServerStatus.AuthRequired}\nfor authentication failures.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Error"
+          "const": "error"
         },
         "error": {
           "$ref": "#/$defs/ErrorInfo",
@@ -2188,7 +2188,7 @@
       "description": "Server has been shut down. The host MAY remove the server from the\nsession entirely shortly after this state.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Stopped"
+          "const": "stopped"
         }
       },
       "required": [
@@ -2416,7 +2416,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Text"
+          "const": "text"
         },
         "format": {
           "type": "string",
@@ -2464,10 +2464,10 @@
         "kind": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Number"
+              "const": "number"
             },
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Integer"
+              "const": "integer"
             }
           ]
         },
@@ -2511,7 +2511,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Boolean"
+          "const": "boolean"
         },
         "defaultValue": {
           "type": "boolean",
@@ -2545,7 +2545,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.SingleSelect"
+          "const": "single-select"
         },
         "options": {
           "type": "array",
@@ -2587,7 +2587,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.MultiSelect"
+          "const": "multi-select"
         },
         "options": {
           "type": "array",
@@ -2656,7 +2656,7 @@
       "description": "Value captured for one answer.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Text"
+          "const": "text"
         },
         "value": {
           "type": "string"
@@ -2671,7 +2671,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Number"
+          "const": "number"
         },
         "value": {
           "type": "number"
@@ -2686,7 +2686,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Boolean"
+          "const": "boolean"
         },
         "value": {
           "type": "boolean"
@@ -2701,7 +2701,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Selected"
+          "const": "selected"
         },
         "value": {
           "type": "string"
@@ -2723,7 +2723,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.SelectedMany"
+          "const": "selected-many"
         },
         "value": {
           "type": "array",
@@ -2750,10 +2750,10 @@
         "state": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Draft"
+              "const": "draft"
             },
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Submitted"
+              "const": "submitted"
             }
           ],
           "description": "Answer state"
@@ -2772,7 +2772,7 @@
       "type": "object",
       "properties": {
         "state": {
-          "$ref": "#/$defs/ChatInputAnswerState.Skipped",
+          "const": "skipped",
           "description": "Answer state"
         },
         "freeformValues": {
@@ -2957,7 +2957,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Simple",
+          "const": "simple",
           "description": "Discriminant"
         },
         "modelRepresentation": {
@@ -2992,7 +2992,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.EmbeddedResource",
+          "const": "embeddedResource",
           "description": "Discriminant"
         },
         "data": {
@@ -3053,7 +3053,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Resource",
+          "const": "resource",
           "description": "Discriminant"
         },
         "selection": {
@@ -3089,7 +3089,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Annotations",
+          "const": "annotations",
           "description": "Discriminant"
         },
         "resource": {
@@ -3114,7 +3114,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Markdown",
+          "const": "markdown",
           "description": "Discriminant"
         },
         "id": {
@@ -3153,7 +3153,7 @@
           "description": "Content nonce"
         },
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ContentRef",
+          "const": "contentRef",
           "description": "Discriminant"
         }
       },
@@ -3167,7 +3167,7 @@
       "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "const": "toolCall",
           "description": "Discriminant"
         },
         "toolCall": {
@@ -3185,7 +3185,7 @@
       "description": "Reasoning/thinking content from the model.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "const": "reasoning",
           "description": "Discriminant"
         },
         "id": {
@@ -3208,7 +3208,7 @@
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "const": "systemNotification",
           "description": "Discriminant"
         },
         "content": {
@@ -3252,7 +3252,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.Client"
+          "const": "client"
         },
         "clientId": {
           "type": "string",
@@ -3268,7 +3268,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.MCP"
+          "const": "mcp"
         },
         "customizationId": {
           "type": "string",
@@ -3408,7 +3408,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nThis MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)\n`McpUiToolMeta` found in MCP tool calls, which may be used in combination\nwith the {@link contributor} to serve MCP Apps."
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Streaming"
+          "const": "streaming"
         },
         "partialInput": {
           "type": "string",
@@ -3464,7 +3464,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+          "const": "pending-confirmation"
         },
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
@@ -3540,7 +3540,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Running"
+          "const": "running"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3640,7 +3640,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingResultConfirmation"
+          "const": "pending-result-confirmation"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3735,7 +3735,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Completed"
+          "const": "completed"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3795,7 +3795,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Cancelled"
+          "const": "cancelled"
         },
         "reason": {
           "$ref": "#/$defs/ToolCallCancellationReason",
@@ -3828,7 +3828,7 @@
       "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Text"
+          "const": "text"
         },
         "text": {
           "type": "string",
@@ -3845,7 +3845,7 @@
       "description": "Base64-encoded binary content embedded in a tool result.\n\nMirrors MCP `EmbeddedResource` for inline binary data.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.EmbeddedResource"
+          "const": "embeddedResource"
         },
         "data": {
           "type": "string",
@@ -3883,7 +3883,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Resource"
+          "const": "resource"
         }
       },
       "required": [
@@ -3940,7 +3940,7 @@
           "description": "Optional diff display metadata"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
+          "const": "fileEdit"
         }
       },
       "required": [
@@ -3952,7 +3952,7 @@
       "description": "A reference to a terminal whose output is relevant to this tool result.\n\nClients can subscribe to the terminal's URI to stream its output in real\ntime, providing live feedback while a tool is executing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Terminal"
+          "const": "terminal"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -3974,7 +3974,7 @@
       "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation), referenced by a chat URI (`ahp-chat:/...`).\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Subagent"
+          "const": "subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -4031,7 +4031,7 @@
       "description": "A terminal claimed by a connected client.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Client",
+          "const": "client",
           "description": "Discriminant"
         },
         "clientId": {
@@ -4049,7 +4049,7 @@
       "description": "A terminal claimed by a session, optionally scoped to a specific turn or tool call.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Session",
+          "const": "session",
           "description": "Discriminant"
         },
         "session": {
@@ -4687,7 +4687,7 @@
       "description": "Reconnect result when the server can replay from the requested sequence.\n\nThe server MUST include all replayed data in the response.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ReconnectResultType.Replay",
+          "const": "replay",
           "description": "Discriminant"
         },
         "actions": {
@@ -4716,7 +4716,7 @@
       "description": "Reconnect result when the gap exceeds the replay buffer.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ReconnectResultType.Snapshot",
+          "const": "snapshot",
           "description": "Discriminant"
         },
         "snapshots": {
@@ -5766,6 +5766,2693 @@
       "required": [
         "channel"
       ]
+    },
+    "URI": {
+      "type": "string",
+      "description": "A URI string (e.g. `ahp-root://`, `ahp-session:/<uuid>`, or `ahp-chat:/<uuid>`)."
+    },
+    "JsonPrimitive": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A primitive JSON value: a string, number, boolean, or `null`."
+    },
+    "Customization": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/PluginCustomization"
+        },
+        {
+          "$ref": "#/$defs/DirectoryCustomization"
+        },
+        {
+          "$ref": "#/$defs/McpServerCustomization"
+        }
+      ],
+      "description": "A top-level customization active in a session. Either a container\n({@link PluginCustomization} or {@link DirectoryCustomization}) whose\nleaf customizations live in its\n{@link ContainerCustomizationBase.children | `children`} array, or a\nbare {@link McpServerCustomization} surfaced directly by the host."
+    },
+    "PolicyState": {
+      "enum": [
+        "enabled",
+        "disabled",
+        "unconfigured"
+      ],
+      "type": "string",
+      "description": "Policy configuration state for a model."
+    },
+    "SessionStatus": {
+      "enum": [
+        1,
+        2,
+        8,
+        24,
+        32,
+        64
+      ],
+      "type": "number",
+      "description": "Bitset of summary-level session status flags.\n\nUse bitwise checks instead of equality for non-terminal activity. For example,\n`status & SessionStatus.InProgress` matches both ordinary in-progress turns\nand turns that are paused waiting for input."
+    },
+    "SessionLifecycle": {
+      "enum": [
+        "creating",
+        "ready",
+        "creationFailed"
+      ],
+      "type": "string",
+      "description": "Session initialization state."
+    },
+    "SessionInputRequest": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SessionChatInputRequest"
+        },
+        {
+          "$ref": "#/$defs/SessionToolConfirmationRequest"
+        },
+        {
+          "$ref": "#/$defs/SessionToolClientExecutionRequest"
+        }
+      ],
+      "description": "One outstanding piece of input a session is blocked on, aggregated across all\nchats in {@link SessionState.inputNeeded}.\n\nEach entry is self-sufficient: it carries the owning\n{@link SessionInputRequestBase.chat | `chat`} URI plus every identifier needed\nto construct the response, so a client can answer by dispatching the ordinary\n`chat/*` action (`chat/inputCompleted`, `chat/toolCallConfirmed`,\n`chat/toolCallComplete`, …) to that chat's channel **without having subscribed\nto the chat**. The host removes the entry with `session/inputNeededRemoved`\nonce the underlying request resolves."
+    },
+    "ToolCallConfirmationState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        }
+      ],
+      "description": "The two tool-call states that block on a client confirmation: parameter\nconfirmation before execution ({@link ToolCallPendingConfirmationState}) and\nresult confirmation after execution\n({@link ToolCallPendingResultConfirmationState}).\n\nSurfaced at the session level by {@link SessionToolConfirmationRequest}."
+    },
+    "ToolCallState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallStreamingState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallRunningState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCompletedState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCancelledState"
+        }
+      ],
+      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
+    },
+    "CustomizationLoadState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/CustomizationLoadingState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationLoadedState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationDegradedState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationErrorState"
+        }
+      ],
+      "description": "Discriminated load state for a container customization\n({@link PluginCustomization} or {@link DirectoryCustomization})."
+    },
+    "ChildCustomization": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/AgentCustomization"
+        },
+        {
+          "$ref": "#/$defs/SkillCustomization"
+        },
+        {
+          "$ref": "#/$defs/PromptCustomization"
+        },
+        {
+          "$ref": "#/$defs/RuleCustomization"
+        },
+        {
+          "$ref": "#/$defs/HookCustomization"
+        },
+        {
+          "$ref": "#/$defs/McpServerCustomization"
+        }
+      ],
+      "description": "Child customizations that live inside a {@link PluginCustomization} or\n{@link DirectoryCustomization}."
+    },
+    "ChildCustomizationType": {
+      "oneOf": [
+        {
+          "const": "agent"
+        },
+        {
+          "const": "skill"
+        },
+        {
+          "const": "prompt"
+        },
+        {
+          "const": "rule"
+        },
+        {
+          "const": "hook"
+        },
+        {
+          "const": "mcpServer"
+        }
+      ],
+      "description": "Customization types that appear as children of a\n{@link PluginCustomization} or {@link DirectoryCustomization}."
+    },
+    "McpServerState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/McpServerStartingState"
+        },
+        {
+          "$ref": "#/$defs/McpServerReadyState"
+        },
+        {
+          "$ref": "#/$defs/McpServerAuthRequiredState"
+        },
+        {
+          "$ref": "#/$defs/McpServerErrorState"
+        },
+        {
+          "$ref": "#/$defs/McpServerStoppedState"
+        }
+      ],
+      "description": "Discriminated union of all MCP server lifecycle states.\nDiscriminated by `kind` (a {@link McpServerStatus} value)."
+    },
+    "McpAuthRequiredReason": {
+      "enum": [
+        "required",
+        "expired",
+        "insufficientScope"
+      ],
+      "type": "string",
+      "description": "Why an MCP server is currently in the {@link McpServerStatus.AuthRequired}\nstate. Mirrors the three failure modes defined by the\n[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md)."
+    },
+    "ChatOrigin": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "chat": {
+              "type": "string"
+            },
+            "turnId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "chat",
+            "turnId"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "chat": {
+              "type": "string"
+            },
+            "toolCallId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "chat",
+            "toolCallId"
+          ]
+        }
+      ],
+      "description": "How a chat came into existence. Clients MAY use it to render\ncontextual UI (parent indicators, fork markers, \"spawned by tool\" badges).\n\nThe `tool` variant records a tool-spawned worker from the worker's side: its\n`chat`/`toolCallId` identify the spawning tool call in the parent chat. This\nis the canonical record of the spawn relationship. The same edge is surfaced\nfrom the parent's side by {@link ToolResultSubagentContent}, whose `resource`\nis this chat's URI; hosts MUST keep the two consistent."
+    },
+    "ChatInteractivity": {
+      "enum": [
+        "full",
+        "read-only",
+        "hidden"
+      ],
+      "type": "string",
+      "description": "How a user can interact with a chat.\n\n- `Full` — user can send messages and watch (default when absent)\n- `ReadOnly` — user can watch but not send messages (e.g. agent team workers)\n- `Hidden` — internal worker not shown in UI at all\n\nSupports the agent-team pattern where a lead chat is fully interactive and\nworker chats are read-only (visible for observability) or hidden (internal\nimplementation detail). The harness sets this based on the chat's role;\nthe UI uses it to show appropriate controls."
+    },
+    "ChatInputQuestion": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputTextQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputNumberQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputBooleanQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSingleSelectQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputMultiSelectQuestion"
+        }
+      ],
+      "description": "One question within a chat input request."
+    },
+    "ChatInputAnswer": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputAnswered"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSkipped"
+        }
+      ],
+      "description": "Draft, submitted, or skipped answer for one question."
+    },
+    "ChatInputAnswerValue": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputTextAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputNumberAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputBooleanAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSelectedAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSelectedManyAnswerValue"
+        }
+      ]
+    },
+    "ResponsePart": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/MarkdownResponsePart"
+        },
+        {
+          "$ref": "#/$defs/ResourceReponsePart"
+        },
+        {
+          "$ref": "#/$defs/ToolCallResponsePart"
+        },
+        {
+          "$ref": "#/$defs/ReasoningResponsePart"
+        },
+        {
+          "$ref": "#/$defs/SystemNotificationResponsePart"
+        }
+      ]
+    },
+    "TurnState": {
+      "enum": [
+        "complete",
+        "cancelled",
+        "error"
+      ],
+      "type": "string",
+      "description": "How a turn ended."
+    },
+    "MessageKind": {
+      "enum": [
+        "user",
+        "agent",
+        "tool",
+        "systemNotification"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "MessageAttachment": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SimpleMessageAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageEmbeddedResourceAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageResourceAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageAnnotationsAttachment"
+        }
+      ],
+      "description": "An attachment associated with a {@link Message}."
+    },
+    "StringOrMarkdown": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "markdown": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "markdown"
+          ]
+        }
+      ],
+      "description": "A string that may optionally be rendered as Markdown.\n\n- A plain `string` is rendered as-is (no Markdown processing).\n- An object with `{ markdown: string }` is rendered with Markdown formatting."
+    },
+    "ConfirmationOptionKind": {
+      "enum": [
+        "approve",
+        "deny"
+      ],
+      "type": "string",
+      "description": "Whether a confirmation option represents an approval or denial action."
+    },
+    "ToolCallContributor": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallClientContributor"
+        },
+        {
+          "$ref": "#/$defs/ToolCallMcpContributor"
+        }
+      ]
+    },
+    "ToolResultContent": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolResultTextContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultEmbeddedResourceContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultResourceContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultFileEditContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultTerminalContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultSubagentContent"
+        }
+      ],
+      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output, and\n`ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions)."
+    },
+    "ToolCallConfirmationReason": {
+      "enum": [
+        "not-needed",
+        "user-action",
+        "setting"
+      ],
+      "type": "string",
+      "description": "How a tool call was confirmed for execution.\n\n- `NotNeeded` — No confirmation required (auto-approved)\n- `UserAction` — User explicitly approved\n- `Setting` — Approved by a persistent user setting"
+    },
+    "ToolCallCancellationReason": {
+      "enum": [
+        "denied",
+        "skipped",
+        "result-denied"
+      ],
+      "type": "string",
+      "description": "Why a tool call was cancelled."
+    },
+    "TerminalClaim": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalClientClaim"
+        },
+        {
+          "$ref": "#/$defs/TerminalSessionClaim"
+        }
+      ],
+      "description": "Describes who currently holds a terminal. A terminal may be claimed by\neither a connected client or a session (e.g. during a tool call)."
+    },
+    "TerminalContentPart": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalUnclassifiedPart"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandPart"
+        }
+      ],
+      "description": "A content part within terminal output."
+    },
+    "ChangesetStatus": {
+      "enum": [
+        "computing",
+        "ready",
+        "error"
+      ],
+      "type": "string",
+      "description": "Computation lifecycle of a {@link ChangesetState}."
+    },
+    "ChangesetOperationScope": {
+      "enum": [
+        "changeset",
+        "resource",
+        "range"
+      ],
+      "type": "string",
+      "description": "Where a {@link ChangesetOperation} can be invoked."
+    },
+    "ChangesetOperationStatus": {
+      "enum": [
+        "idle",
+        "running",
+        "error",
+        "disabled"
+      ],
+      "type": "string",
+      "description": "Execution lifecycle of a {@link ChangesetOperation}.\n\nAn operation is invoked imperatively via `invokeChangesetOperation`, but\nits progress and outcome are reflected back into changeset state so that\nevery subscriber observes a consistent view (e.g. a spinner on a \"Create\nPull Request\" button, or an inline error after a failed \"revert\")."
+    },
+    "ResourceChangeType": {
+      "enum": [
+        "added",
+        "updated",
+        "deleted"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link ResourceChange.type}."
+    },
+    "ActionEnvelope": {
+      "type": "object",
+      "description": "Every action is wrapped in an `ActionEnvelope`.\n\nThe envelope identifies the channel the action belongs to (e.g.\n`ahp-root://` for root actions, the session URI for session actions, the\nterminal URI for terminal actions). Individual action payloads carry only\nfields that are intrinsic to the action; the channel comes from the\nenvelope so that any subscribable resource can route its actions uniformly.",
+      "properties": {
+        "channel": {
+          "$ref": "#/$defs/URI",
+          "description": "Channel URI this action belongs to."
+        },
+        "action": {
+          "$ref": "#/$defs/StateAction"
+        },
+        "serverSeq": {
+          "type": "number"
+        },
+        "origin": {
+          "$ref": "#/$defs/ActionOrigin"
+        },
+        "rejectionReason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel",
+        "action",
+        "serverSeq",
+        "origin"
+      ]
+    },
+    "StateAction": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/RootAgentsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/RootActiveSessionsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/RootTerminalsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/RootConfigChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionReadyAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCreationFailedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChatAddedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChatRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChatUpdatedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionDefaultChatChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionTitleChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionServerToolsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionActiveClientSetAction"
+        },
+        {
+          "$ref": "#/$defs/SessionActiveClientRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionInputNeededSetAction"
+        },
+        {
+          "$ref": "#/$defs/SessionInputNeededRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationToggledAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationUpdatedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionCustomizationRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMcpServerStateChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionIsReadChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionIsArchivedChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionActivityChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionChangesetsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionConfigChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMetaChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnStartedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatDeltaAction"
+        },
+        {
+          "$ref": "#/$defs/ChatResponsePartAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallStartAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallDeltaAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallReadyAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallConfirmedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallCompleteAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallResultConfirmedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallContentChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnCompleteAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnCancelledAction"
+        },
+        {
+          "$ref": "#/$defs/ChatErrorAction"
+        },
+        {
+          "$ref": "#/$defs/ChatActivityChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatUsageAction"
+        },
+        {
+          "$ref": "#/$defs/ChatReasoningAction"
+        },
+        {
+          "$ref": "#/$defs/ChatPendingMessageSetAction"
+        },
+        {
+          "$ref": "#/$defs/ChatPendingMessageRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatQueuedMessagesReorderedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatDraftChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatInputRequestedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatInputAnswerChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatInputCompletedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTruncatedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatTurnsLoadedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetStatusChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetFileSetAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetFileRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetContentChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetOperationsChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetOperationStatusChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetClearedAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsSetAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsUpdatedAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsEntrySetAction"
+        },
+        {
+          "$ref": "#/$defs/AnnotationsEntryRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalDataAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalInputAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalResizedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalClaimedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalTitleChangedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCwdChangedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalExitedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalClearedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandDetectionAvailableAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandExecutedAction"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandFinishedAction"
+        },
+        {
+          "$ref": "#/$defs/ResourceWatchChangedAction"
+        }
+      ],
+      "description": "Discriminated union of all state actions."
+    },
+    "ContentEncoding": {
+      "enum": [
+        "base64",
+        "utf-8"
+      ],
+      "type": "string",
+      "description": "Encoding of fetched content data."
+    },
+    "ResourceWriteMode": {
+      "enum": [
+        "truncate",
+        "append",
+        "insert"
+      ],
+      "type": "string",
+      "description": "How {@link ResourceWriteParams.data} is placed within the target file.\n\nEach mode interprets {@link ResourceWriteParams.position} differently:\n\n- `truncate` (default): rooted at the **start** of the file. The file is\n  truncated at `position` (0 by default) and `data` is written from that\n  offset, so the resulting file is `existing[0..position] + data`. With\n  `position` omitted this is a full overwrite.\n- `append`: rooted at the **end** of the file. `position` counts bytes\n  backwards from EOF, so `position: 0` (the default) writes at EOF —\n  POSIX append — and `position: 5` inserts `data` 5 bytes before the\n  current EOF, shifting those trailing 5 bytes after the inserted region.\n  The server MUST evaluate the effective EOF and write atomically with\n  respect to other appenders so concurrent `append` writes do not\n  clobber each other.\n- `insert`: rooted at the **start** of the file. `position` (0 by default)\n  is the byte offset at which `data` is spliced in; bytes at or after\n  `position` are shifted right by `data.length`. `insert` always grows\n  the file — use `truncate` to overwrite bytes in place."
+    },
+    "ResourceType": {
+      "enum": [
+        "file",
+        "directory",
+        "symlink"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link ResourceResolveResult.type}."
+    },
+    "CompletionItemKind": {
+      "enum": [
+        "userMessage"
+      ],
+      "type": "string",
+      "description": "The kind of completion items being requested."
+    },
+    "ChangesetOperationTarget": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "resource": {
+              "type": "string"
+            },
+            "side": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "resource"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "resource": {
+              "type": "string"
+            },
+            "side": {
+              "type": "string"
+            },
+            "range": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "resource",
+            "range"
+          ]
+        }
+      ],
+      "description": "Identifies the file or range a {@link ChangesetOperation} should act on.\n\nThe `kind` MUST match one of the operation's declared\n{@link ChangesetOperation.scopes}."
+    },
+    "ActionOrigin": {
+      "type": "object",
+      "description": "Identifies the client that originally dispatched an action.",
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "clientSeq": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "clientId",
+        "clientSeq"
+      ]
+    },
+    "RootAgentsChangedAction": {
+      "type": "object",
+      "description": "Fired when available agent backends or their models change.",
+      "properties": {
+        "type": {
+          "const": "root/agentsChanged"
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AgentInfo"
+          },
+          "description": "Updated agent list"
+        }
+      },
+      "required": [
+        "type",
+        "agents"
+      ]
+    },
+    "RootActiveSessionsChangedAction": {
+      "type": "object",
+      "description": "Fired when the number of active sessions changes.",
+      "properties": {
+        "type": {
+          "const": "root/activeSessionsChanged"
+        },
+        "activeSessions": {
+          "type": "number",
+          "description": "Current count of active sessions"
+        }
+      },
+      "required": [
+        "type",
+        "activeSessions"
+      ]
+    },
+    "RootTerminalsChangedAction": {
+      "type": "object",
+      "description": "Fired when the list of known terminals changes.\n\nFull-replacement semantics: the `terminals` array replaces the previous\n`terminals` entirely.",
+      "properties": {
+        "type": {
+          "const": "root/terminalsChanged"
+        },
+        "terminals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TerminalInfo"
+          },
+          "description": "Updated terminal list (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "terminals"
+      ]
+    },
+    "RootConfigChangedAction": {
+      "type": "object",
+      "description": "Fired when agent-host configuration values change.\n\nBy default, the reducer merges the new values into `state.config.values`.\nSet `replace` to `true` to replace all values instead of merging.",
+      "properties": {
+        "type": {
+          "const": "root/configChanged"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Updated config values"
+        },
+        "replace": {
+          "type": "boolean",
+          "description": "When `true`, replaces all config values instead of merging"
+        }
+      },
+      "required": [
+        "type",
+        "config"
+      ]
+    },
+    "SessionReadyAction": {
+      "type": "object",
+      "description": "Session backend initialized successfully.",
+      "properties": {
+        "type": {
+          "const": "session/ready"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "SessionCreationFailedAction": {
+      "type": "object",
+      "description": "Session backend failed to initialize.",
+      "properties": {
+        "type": {
+          "const": "session/creationFailed"
+        },
+        "error": {
+          "$ref": "#/$defs/ErrorInfo",
+          "description": "Error details"
+        }
+      },
+      "required": [
+        "type",
+        "error"
+      ]
+    },
+    "SessionChatAddedAction": {
+      "type": "object",
+      "description": "A chat was added to this session's catalog. Upsert semantics: if a chat\nwith the same `summary.resource` already exists, the existing entry is\nreplaced.\n\nMirrors the root-channel `root/sessionAdded` notification.",
+      "properties": {
+        "type": {
+          "const": "session/chatAdded"
+        },
+        "summary": {
+          "$ref": "#/$defs/ChatSummary",
+          "description": "The full summary of the newly added (or upserted) chat."
+        }
+      },
+      "required": [
+        "type",
+        "summary"
+      ]
+    },
+    "SessionChatRemovedAction": {
+      "type": "object",
+      "description": "A chat was removed from this session's catalog. No-op when no entry matches.\n\nMirrors the root-channel `root/sessionRemoved` notification.",
+      "properties": {
+        "type": {
+          "const": "session/chatRemoved"
+        },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "The URI of the chat to remove."
+        }
+      },
+      "required": [
+        "type",
+        "chat"
+      ]
+    },
+    "SessionChatUpdatedAction": {
+      "type": "object",
+      "description": "One existing chat's summary fields changed.\n\nPartial-update semantics: only fields present in `changes` are written;\nomitted fields are preserved. Identity fields (`resource`) MUST NOT be\ncarried in `changes`. No-op when no entry with `chat` exists — clients\nSHOULD then wait for a {@link SessionChatAddedAction | `session/chatAdded`}.\n\nMirrors the root-channel `root/sessionSummaryChanged` notification.",
+      "properties": {
+        "type": {
+          "const": "session/chatUpdated"
+        },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "The URI of the chat whose summary changed."
+        },
+        "changes": {
+          "type": "object",
+          "properties": {
+            "resource": {
+              "$ref": "#/$defs/URI",
+              "description": "Chat URI"
+            },
+            "title": {
+              "type": "string",
+              "description": "Chat title"
+            },
+            "status": {
+              "$ref": "#/$defs/SessionStatus",
+              "description": "Current chat status (reuses SessionStatus shape)"
+            },
+            "activity": {
+              "type": "string",
+              "description": "Human-readable description of what the chat is currently doing"
+            },
+            "modifiedAt": {
+              "type": "string",
+              "description": "Last modification timestamp (ISO 8601, e.g. `\"2025-03-10T18:42:03.123Z\"`)"
+            },
+            "origin": {
+              "$ref": "#/$defs/ChatOrigin",
+              "description": "How this chat came into existence"
+            },
+            "interactivity": {
+              "$ref": "#/$defs/ChatInteractivity",
+              "description": "How the user can interact with this chat. See {@link ChatInteractivity}.\n\nSupports agent-team patterns where worker chats are read-only or hidden.\nAbsence defaults to {@link ChatInteractivity.Full} for backward\ncompatibility."
+            },
+            "workingDirectory": {
+              "$ref": "#/$defs/URI",
+              "description": "Optional per-chat working directory.\n\nIf absent, the chat inherits\n{@link SessionSummary.workingDirectory | the session's working directory}.\nSee {@link ChatState.workingDirectory} for usage notes."
+            }
+          },
+          "description": "Mutable summary fields that changed; omitted fields are unchanged.\n\nIdentity fields (`resource`) never change and MUST be omitted by\nsenders; receivers SHOULD ignore them if present."
+        }
+      },
+      "required": [
+        "type",
+        "chat",
+        "changes"
+      ]
+    },
+    "SessionDefaultChatChangedAction": {
+      "type": "object",
+      "description": "The default chat input-routing hint for this session changed.",
+      "properties": {
+        "type": {
+          "const": "session/defaultChatChanged"
+        },
+        "defaultChat": {
+          "$ref": "#/$defs/URI",
+          "description": "New default chat URI, or `undefined` to clear the hint."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "SessionTitleChangedAction": {
+      "type": "object",
+      "description": "Session title updated. Fired by the server when the title is auto-generated\nfrom conversation, or dispatched by a client to rename a session.",
+      "properties": {
+        "type": {
+          "const": "session/titleChanged"
+        },
+        "title": {
+          "type": "string",
+          "description": "New title"
+        }
+      },
+      "required": [
+        "type",
+        "title"
+      ]
+    },
+    "SessionServerToolsChangedAction": {
+      "type": "object",
+      "description": "Server tools for this session have changed.\n\nFull-replacement semantics: the `tools` array replaces the previous `serverTools` entirely.",
+      "properties": {
+        "type": {
+          "const": "session/serverToolsChanged"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolDefinition"
+          },
+          "description": "Updated server tools list (full replacement)"
+        }
+      },
+      "required": [
+        "type",
+        "tools"
+      ]
+    },
+    "SessionActiveClientSetAction": {
+      "type": "object",
+      "description": "An active client for this session was added or updated.\n\nUpsert semantics keyed by {@link SessionActiveClient.clientId | `clientId`}:\na client dispatches this action with its own `SessionActiveClient` to join\nthe session's active clients or refresh its entry, replacing any existing\nentry that has the same `clientId`. Multiple clients may be active at once.\nThis is also how a client updates its published tools or customizations —\nre-dispatch with the full, updated entry. Use\n{@link SessionActiveClientRemovedAction | `session/activeClientRemoved`} to\nleave. The server SHOULD automatically dispatch that removal when an active\nclient disconnects.",
+      "properties": {
+        "type": {
+          "const": "session/activeClientSet"
+        },
+        "activeClient": {
+          "$ref": "#/$defs/SessionActiveClient",
+          "description": "The active client to add or update, matched by `clientId`."
+        }
+      },
+      "required": [
+        "type",
+        "activeClient"
+      ]
+    },
+    "SessionActiveClientRemovedAction": {
+      "type": "object",
+      "description": "An active client was removed from this session.\n\nRemoves the entry for the client identified by `clientId` from\n{@link SessionState.activeClients}; a no-op when no entry matches.\n\nThe host SHOULD dispatch this automatically when a client stops participating\nin the session — for example when it unsubscribes from the session channel,\nwhen it disconnects and does not reconnect within a host-defined grace\nperiod, or when a `reconnect` command's `subscriptions` omit a session the\nclient was still active in. When removing a client, the host SHOULD also\ncancel that client's in-flight tool calls — those whose tool call state\ncarries a client `ToolCallContributor` with the matching `clientId` — by\ndispatching `chat/toolCallComplete` with `result.success = false`. (There is\nno per-tool-call server cancel; a failed completion is the cancellation\nmechanism, and the call ends in `completed` status with a failed result.)",
+      "properties": {
+        "type": {
+          "const": "session/activeClientRemoved"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The `clientId` of the active client to remove."
+        }
+      },
+      "required": [
+        "type",
+        "clientId"
+      ]
+    },
+    "SessionInputNeededSetAction": {
+      "type": "object",
+      "description": "A session-level input request was added or updated.\n\nUpsert semantics keyed by {@link SessionInputRequest.id | `request.id`}: the\nhost dispatches this with the full {@link SessionInputRequest} to append a new\nentry to {@link SessionState.inputNeeded} or replace the existing entry with\nthe same `id`.\n\nServer-originated: the host mirrors chat-level requests (elicitations, tool\nconfirmations, client-tool executions) into the session aggregate so clients\nsubscribed only to the session channel can discover them. Clients respond by\ndispatching the ordinary `chat/*` action to the entry's `chat` channel — see\n{@link SessionInputRequest}.",
+      "properties": {
+        "type": {
+          "const": "session/inputNeededSet"
+        },
+        "request": {
+          "$ref": "#/$defs/SessionInputRequest",
+          "description": "The input request to add or update, matched by `id`."
+        }
+      },
+      "required": [
+        "type",
+        "request"
+      ]
+    },
+    "SessionInputNeededRemovedAction": {
+      "type": "object",
+      "description": "A session-level input request was removed.\n\nRemoves the entry identified by `id` from\n{@link SessionState.inputNeeded}; a no-op when no entry matches.\n\nServer-originated: the host dispatches this once the underlying request\nresolves (the user answers, the tool call is confirmed, or the client\nreports its result).",
+      "properties": {
+        "type": {
+          "const": "session/inputNeededRemoved"
+        },
+        "id": {
+          "type": "string",
+          "description": "The `id` of the input request to remove."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "SessionCustomizationsChangedAction": {
+      "type": "object",
+      "description": "The session's customizations have changed.\n\nFull-replacement semantics: the `customizations` array replaces the\nprevious `customizations` entirely.",
+      "properties": {
+        "type": {
+          "const": "session/customizationsChanged"
+        },
+        "customizations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Customization"
+          },
+          "description": "Updated customization list (full replacement)."
+        }
+      },
+      "required": [
+        "type",
+        "customizations"
+      ]
+    },
+    "SessionCustomizationToggledAction": {
+      "type": "object",
+      "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.",
+      "properties": {
+        "type": {
+          "const": "session/customizationToggled"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the container or child to toggle."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable or disable the targeted customization."
+        }
+      },
+      "required": [
+        "type",
+        "id",
+        "enabled"
+      ]
+    },
+    "SessionCustomizationUpdatedAction": {
+      "type": "object",
+      "description": "Upserts a top-level customization (plugin or directory).\n\nThe reducer locates the existing entry by `customization.id`:\n\n- If found, the entry is replaced entirely with `customization`,\n  including its `children` array. To preserve existing children, the\n  host must include them on the payload.\n- If not found, the entry is appended.",
+      "properties": {
+        "type": {
+          "const": "session/customizationUpdated"
+        },
+        "customization": {
+          "$ref": "#/$defs/Customization",
+          "description": "The customization to upsert (matched by `customization.id`)."
+        }
+      },
+      "required": [
+        "type",
+        "customization"
+      ]
+    },
+    "SessionCustomizationRemovedAction": {
+      "type": "object",
+      "description": "Removes a customization by id.\n\nSearches every container and its children for the entry. If the entry\nis a container, its children are removed with it. Is a no-op when no\nmatching id is found.",
+      "properties": {
+        "type": {
+          "const": "session/customizationRemoved"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the customization to remove."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "SessionMcpServerStateChangedAction": {
+      "type": "object",
+      "description": "Updates the runtime fields of an existing\n{@link McpServerCustomization} — narrow alternative to\n{@link SessionCustomizationUpdatedAction} for the high-frequency\n`starting` ↔ `ready` ↔ `authRequired` transitions.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container.\nReplaces the entry's {@link McpServerCustomization.state | `state`}\nand {@link McpServerCustomization.channel | `channel`}\n(full-replacement semantics: omit `channel` to clear an existing\nchannel URI). Other fields of the customization are preserved.\n\nIs a no-op when no matching `McpServerCustomization` is found. To\nupdate any other field (name, icons, `mcpApp` capabilities, etc.) use\n{@link SessionCustomizationUpdatedAction} instead.\n\nWhen the transition is to {@link McpServerStatus.AuthRequired}\nbecause of a request issued mid-turn, the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session — see\n{@link McpServerAuthRequiredState} for the rationale.",
+      "properties": {
+        "type": {
+          "const": "session/mcpServerStateChanged"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the {@link McpServerCustomization} to update."
+        },
+        "state": {
+          "$ref": "#/$defs/McpServerState",
+          "description": "The new lifecycle state."
+        },
+        "channel": {
+          "$ref": "#/$defs/URI",
+          "description": "Updated `mcp://` side-channel URI. Full-replacement: omit to clear\nan existing channel (typical when leaving\n{@link McpServerStatus.Ready | `Ready`})."
+        }
+      },
+      "required": [
+        "type",
+        "id",
+        "state"
+      ]
+    },
+    "SessionIsReadChangedAction": {
+      "type": "object",
+      "description": "The read state of the session changed.\n\nDispatched by a client to mark a session as read (e.g. after viewing it)\nor unread (e.g. after new activity since the client last looked at it).",
+      "properties": {
+        "type": {
+          "const": "session/isReadChanged"
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "Whether the session has been read"
+        }
+      },
+      "required": [
+        "type",
+        "isRead"
+      ]
+    },
+    "SessionIsArchivedChangedAction": {
+      "type": "object",
+      "description": "The archived state of the session changed.\n\nDispatched by a client to archive a session (e.g. the task is\ncomplete) or to unarchive it.",
+      "properties": {
+        "type": {
+          "const": "session/isArchivedChanged"
+        },
+        "isArchived": {
+          "type": "boolean",
+          "description": "Whether the session is archived"
+        }
+      },
+      "required": [
+        "type",
+        "isArchived"
+      ]
+    },
+    "SessionActivityChangedAction": {
+      "type": "object",
+      "description": "The activity description of the session changed.\n\nDispatched by the server to indicate what the session is currently doing\n(e.g. running a tool, thinking). Clear activity by setting it to `undefined`.",
+      "properties": {
+        "type": {
+          "const": "session/activityChanged"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of current activity, or `undefined` to clear"
+        }
+      },
+      "required": [
+        "type",
+        "activity"
+      ]
+    },
+    "SessionChangesetsChangedAction": {
+      "type": "object",
+      "description": "The {@link Changeset | catalogue of changesets} the agent host\nadvertises for this session changed. Replaces\n{@link SessionState.changesets | `state.changesets`} entirely\n(full-replacement semantics) — set to `undefined` to clear the\ncatalogue.\n\nProducers dispatch this whenever entries are added or removed. The\nfan-out happens through this action so observers see catalogue\nmutations in the same {@link ChangesetAction | per-changeset} action\nstream they already follow for file-level updates.",
+      "properties": {
+        "type": {
+          "const": "session/changesetsChanged"
+        },
+        "changesets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Changeset"
+          },
+          "description": "New catalogue, or `undefined` to clear it"
+        }
+      },
+      "required": [
+        "type",
+        "changesets"
+      ]
+    },
+    "SessionConfigChangedAction": {
+      "type": "object",
+      "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
+      "properties": {
+        "type": {
+          "const": "session/configChanged"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Updated config values"
+        },
+        "replace": {
+          "type": "boolean",
+          "description": "When `true`, replaces all config values instead of merging"
+        }
+      },
+      "required": [
+        "type",
+        "config"
+      ]
+    },
+    "SessionMetaChangedAction": {
+      "type": "object",
+      "description": "The session's `_meta` side-channel changed. Replaces `state._meta`\nentirely (full-replacement semantics). Producers SHOULD merge any\nkeys they wish to preserve into the new value before dispatching.",
+      "properties": {
+        "type": {
+          "const": "session/metaChanged"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "New `_meta` payload, or `undefined` to clear it"
+        }
+      },
+      "required": [
+        "type",
+        "_meta"
+      ]
+    },
+    "ChatTurnStartedAction": {
+      "type": "object",
+      "description": "A new message has been sent to the agent, and a new turn starts.\n\nA client is only allowed to send {@link MessageKind.User} messages.",
+      "properties": {
+        "type": {
+          "const": "chat/turnStarted"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "message": {
+          "$ref": "#/$defs/Message",
+          "description": "The new message"
+        },
+        "queuedMessageId": {
+          "type": "string",
+          "description": "If this turn was auto-started from a queued message, the ID of that message"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId",
+        "message"
+      ]
+    },
+    "ChatDeltaAction": {
+      "type": "object",
+      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
+      "properties": {
+        "type": {
+          "const": "chat/delta"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "partId": {
+          "type": "string",
+          "description": "Identifier of the response part to append to"
+        },
+        "content": {
+          "type": "string",
+          "description": "Text chunk"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId",
+        "partId",
+        "content"
+      ]
+    },
+    "ChatResponsePartAction": {
+      "type": "object",
+      "description": "Structured content appended to the response.",
+      "properties": {
+        "type": {
+          "const": "chat/responsePart"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "part": {
+          "$ref": "#/$defs/ResponsePart",
+          "description": "Response part (markdown or content ref)"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId",
+        "part"
+      ]
+    },
+    "ChatToolCallStartAction": {
+      "type": "object",
+      "description": "A tool call begins — parameters are streaming from the LM.\n\nThe server sets {@link ToolCallContributor | `contributor`} to identify\nthe origin of the tool. For client-provided tools, the named client is\nresponsible for executing the tool once it reaches the `running` state\nand dispatching `chat/toolCallComplete`. For MCP-served tools, the\nserver executes the call against the named `McpServerCustomization`.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallStart"
+        },
+        "toolName": {
+          "type": "string",
+          "description": "Internal tool name (for debugging/logging)"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable tool name"
+        },
+        "intention": {
+          "type": "string",
+          "description": "Human-readable description of what the tool invocation intends to do"
+        },
+        "contributor": {
+          "$ref": "#/$defs/ToolCallContributor",
+          "description": "Reference to the contributor of the tool being called. Absent for\nserver-side tools that are not contributed by a client or MCP server."
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "toolName",
+        "displayName"
+      ]
+    },
+    "ChatToolCallDeltaAction": {
+      "type": "object",
+      "description": "Streaming partial parameters for a tool call.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallDelta"
+        },
+        "content": {
+          "type": "string",
+          "description": "Partial parameter content to append"
+        },
+        "invocationMessage": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Updated progress message"
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "content"
+      ]
+    },
+    "ChatToolCallReadyAction": {
+      "type": "object",
+      "description": "Tool call parameters are complete, or a running tool requires re-confirmation.\n\nWhen dispatched for a `streaming` tool call, transitions to `pending-confirmation`\nor directly to `running` if `confirmed` is set.\n\nWhen dispatched for a `running` tool call (e.g. mid-execution permission needed),\ntransitions back to `pending-confirmation`. The `invocationMessage` and `_meta`\nSHOULD be updated to describe the specific confirmation needed. Clients use the\nstandard `chat/toolCallConfirmed` flow to approve or deny.\n\nFor client-provided tools, the server typically sets `confirmed` to\n`'not-needed'` so the tool transitions directly to `running`, where the\nowning client can begin execution immediately.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallReady"
+        },
+        "invocationMessage": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Message describing what the tool will do or what confirmation is needed"
+        },
+        "toolInput": {
+          "type": "string",
+          "description": "Raw tool input"
+        },
+        "confirmationTitle": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Short title for the confirmation prompt (e.g. `\"Run in terminal\"`, `\"Write file\"`)"
+        },
+        "edits": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "File edits that this tool call will perform, for preview before confirmation"
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Whether the agent host allows the client to edit the tool's input parameters before confirming"
+        },
+        "confirmed": {
+          "$ref": "#/$defs/ToolCallConfirmationReason",
+          "description": "If set, the tool was auto-confirmed and transitions directly to `running`"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ConfirmationOption"
+          },
+          "description": "Options the server offers for this confirmation. When present, the client\nSHOULD render these instead of a plain approve/deny UI. Each option\nbelongs to a {@link ConfirmationOptionGroup} so the client can still\ncategorise the choices."
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "invocationMessage"
+      ]
+    },
+    "ChatToolCallConfirmedAction": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatToolCallApprovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatToolCallDeniedAction"
+        }
+      ],
+      "description": "Client confirms or denies a pending tool call."
+    },
+    "ChatToolCallCompleteAction": {
+      "type": "object",
+      "description": "Tool execution finished. Transitions to `completed` or `pending-result-confirmation`\nif `requiresResultConfirmation` is `true`.\n\nFor client-provided tools (whose tool call state carries a client\n`ToolCallContributor` with a `clientId`), the owning client dispatches this\naction with the execution result. The server SHOULD reject this action if the\ndispatching client does not match the contributor's `clientId`.\n\nServers waiting on a client tool call MAY time out after a reasonable duration\nif the implementing client disconnects or becomes unresponsive, and dispatch\nthis action with `result.success = false` and an appropriate error.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallComplete"
+        },
+        "result": {
+          "$ref": "#/$defs/ToolCallResult",
+          "description": "Execution result"
+        },
+        "requiresResultConfirmation": {
+          "type": "boolean",
+          "description": "If true, the result requires client approval before finalizing"
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "result"
+      ]
+    },
+    "ChatToolCallResultConfirmedAction": {
+      "type": "object",
+      "description": "Client approves or denies a tool's result.\n\nIf `approved` is `false`, the tool transitions to `cancelled` with reason `result-denied`.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallResultConfirmed"
+        },
+        "approved": {
+          "type": "boolean",
+          "description": "Whether the result was approved"
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "approved"
+      ]
+    },
+    "ChatToolCallContentChangedAction": {
+      "type": "object",
+      "description": "Partial content produced while a tool is still executing.\n\nReplaces the `content` array on the running tool call state. Clients can\nuse this to display live feedback (e.g. a terminal reference) before the\ntool completes.\n\nFor client-provided tools (whose tool call state carries a client\n`ToolCallContributor` with a `clientId`), the owning client dispatches this\naction to stream intermediate content while executing. The server SHOULD\nreject this action if the dispatching client does not match the contributor's\n`clientId`.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallContentChanged"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolResultContent"
+          },
+          "description": "The current partial content for the running tool call"
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "content"
+      ]
+    },
+    "ChatTurnCompleteAction": {
+      "type": "object",
+      "description": "Turn finished — the assistant is idle.",
+      "properties": {
+        "type": {
+          "const": "chat/turnComplete"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId"
+      ]
+    },
+    "ChatTurnCancelledAction": {
+      "type": "object",
+      "description": "Turn was aborted; server stops processing.",
+      "properties": {
+        "type": {
+          "const": "chat/turnCancelled"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId"
+      ]
+    },
+    "ChatErrorAction": {
+      "type": "object",
+      "description": "Error during turn processing.",
+      "properties": {
+        "type": {
+          "const": "chat/error"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "error": {
+          "$ref": "#/$defs/ErrorInfo",
+          "description": "Error details"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId",
+        "error"
+      ]
+    },
+    "ChatActivityChangedAction": {
+      "type": "object",
+      "description": "The activity description of this chat changed.\n\nDispatched by the server to indicate what the chat is currently doing\n(e.g. running a tool, thinking). Clear activity by omitting it or setting it\nto `undefined`.\nProducers SHOULD also update the parent session's chat catalog with\n`session/chatUpdated` so `ChatSummary.activity` stays in sync.",
+      "properties": {
+        "type": {
+          "const": "chat/activityChanged"
+        },
+        "activity": {
+          "type": "string",
+          "description": "Human-readable description of current activity; omit or set `undefined` to clear"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ChatUsageAction": {
+      "type": "object",
+      "description": "Token usage report for a turn.",
+      "properties": {
+        "type": {
+          "const": "chat/usage"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "usage": {
+          "$ref": "#/$defs/UsageInfo",
+          "description": "Token usage data"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId",
+        "usage"
+      ]
+    },
+    "ChatReasoningAction": {
+      "type": "object",
+      "description": "Reasoning/thinking text from the model, appended to a specific reasoning response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\nreasoning part, then use this action to append text to it.",
+      "properties": {
+        "type": {
+          "const": "chat/reasoning"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "partId": {
+          "type": "string",
+          "description": "Identifier of the reasoning response part to append to"
+        },
+        "content": {
+          "type": "string",
+          "description": "Reasoning text chunk"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this action.\n\nClients MAY look for well-known keys here to provide enhanced UI, and\nagent hosts MAY use it to carry per-event context that does not fit any\nother field — for example, attributing the event to a specific agent\n(such as a sub-agent acting within the turn). Mirrors the MCP `_meta`\nconvention."
+        }
+      },
+      "required": [
+        "type",
+        "turnId",
+        "partId",
+        "content"
+      ]
+    },
+    "ChatPendingMessageSetAction": {
+      "type": "object",
+      "description": "A pending message was set (upsert semantics: creates or replaces).\n\nFor steering messages, this always replaces the single steering message.\nFor queued messages, if a message with the given `id` already exists it is\nupdated in place; otherwise it is appended to the queue. If the chat is\nidle when a queued message is set, the server SHOULD immediately consume it\nand start a new turn.\n\nA client is only allowed to send {@link MessageKind.User} messages.",
+      "properties": {
+        "type": {
+          "const": "chat/pendingMessageSet"
+        },
+        "kind": {
+          "$ref": "#/$defs/PendingMessageKind",
+          "description": "Whether this is a steering or queued message"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this pending message"
+        },
+        "message": {
+          "$ref": "#/$defs/Message",
+          "description": "The message content"
+        }
+      },
+      "required": [
+        "type",
+        "kind",
+        "id",
+        "message"
+      ]
+    },
+    "ChatPendingMessageRemovedAction": {
+      "type": "object",
+      "description": "A pending message was removed (steering or queued).\n\nDispatched by clients to cancel a pending message, or by the server when\nit consumes a message (e.g. starting a turn from a queued message or\ninjecting a steering message into the current turn).",
+      "properties": {
+        "type": {
+          "const": "chat/pendingMessageRemoved"
+        },
+        "kind": {
+          "$ref": "#/$defs/PendingMessageKind",
+          "description": "Whether this is a steering or queued message"
+        },
+        "id": {
+          "type": "string",
+          "description": "Identifier of the pending message to remove"
+        }
+      },
+      "required": [
+        "type",
+        "kind",
+        "id"
+      ]
+    },
+    "ChatQueuedMessagesReorderedAction": {
+      "type": "object",
+      "description": "Reorder the queued messages.\n\nThe `order` array contains the IDs of queued messages in their new\ndesired order. IDs not present in the current queue are ignored.\nQueued messages whose IDs are absent from `order` are appended at\nthe end in their original relative order (so a client with a stale\nview of the queue never silently drops messages).",
+      "properties": {
+        "type": {
+          "const": "chat/queuedMessagesReordered"
+        },
+        "order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Queued message IDs in the desired order"
+        }
+      },
+      "required": [
+        "type",
+        "order"
+      ]
+    },
+    "ChatDraftChangedAction": {
+      "type": "object",
+      "description": "The chat's draft input changed.\n\nClients MAY periodically sync their local input state — the message the user\nis composing, including its {@link Message.model | model} /\n{@link Message.agent | agent} selection and attachments — into the chat's\n{@link ChatState.draft | `draft`} so it survives reloads and is visible to\nother clients viewing the same chat. Eager syncing is **not** required;\nclients SHOULD debounce and MAY sync only at convenient points. Set `draft`\nto `undefined` to clear it (e.g. once the message is sent).\n\nA client is only allowed to draft {@link MessageKind.User} messages.",
+      "properties": {
+        "type": {
+          "const": "chat/draftChanged"
+        },
+        "draft": {
+          "$ref": "#/$defs/Message",
+          "description": "New draft message, or `undefined` to clear it"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ChatInputRequestedAction": {
+      "type": "object",
+      "description": "A session requested input from the user.\n\nFull-request upsert semantics: the `request` replaces any existing request\nwith the same `id`, or is appended if it is new. Answer drafts are preserved\nunless `request.answers` is provided.",
+      "properties": {
+        "type": {
+          "const": "chat/inputRequested"
+        },
+        "request": {
+          "$ref": "#/$defs/ChatInputRequest",
+          "description": "Input request to create or replace"
+        }
+      },
+      "required": [
+        "type",
+        "request"
+      ]
+    },
+    "ChatInputAnswerChangedAction": {
+      "type": "object",
+      "description": "A client updated, submitted, skipped, or removed a single in-progress answer.\n\nDispatching with `answer: undefined` removes that question's answer draft.",
+      "properties": {
+        "type": {
+          "const": "chat/inputAnswerChanged"
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Input request identifier"
+        },
+        "questionId": {
+          "type": "string",
+          "description": "Question identifier within the input request"
+        },
+        "answer": {
+          "$ref": "#/$defs/ChatInputAnswer",
+          "description": "Updated answer, or `undefined` to clear an answer draft"
+        }
+      },
+      "required": [
+        "type",
+        "requestId",
+        "questionId"
+      ]
+    },
+    "ChatInputCompletedAction": {
+      "type": "object",
+      "description": "A client accepted, declined, or cancelled a session input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation.",
+      "properties": {
+        "type": {
+          "const": "chat/inputCompleted"
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Input request identifier"
+        },
+        "response": {
+          "$ref": "#/$defs/ChatInputResponseKind",
+          "description": "Completion outcome"
+        },
+        "answers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ChatInputAnswer"
+          },
+          "description": "Optional final answer replacement, keyed by question ID"
+        }
+      },
+      "required": [
+        "type",
+        "requestId",
+        "response"
+      ]
+    },
+    "ChatTruncatedAction": {
+      "type": "object",
+      "description": "Truncates a session's history. If `turnId` is provided, all turns after that\nturn are removed and the specified turn is kept. If `turnId` is omitted, all\nturns are removed.\n\nIf there is an active turn it is silently dropped and the chat status\nreturns to `idle`.\n\nCommon use-case: truncate old data then dispatch a new\n`chat/turnStarted` with an edited message.",
+      "properties": {
+        "type": {
+          "const": "chat/truncated"
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Keep turns up to and including this turn. Omit to clear all turns."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ChatTurnsLoadedAction": {
+      "type": "object",
+      "description": "Loads older completed turns into this chat's state.\n\nHosts dispatch this before responding to `fetchTurns`, and before applying\nany operation that references a turn older than the currently loaded window.\n`turns` is ordered oldest-first and is prepended to the current `turns`\nwindow. `turnsNextCursor` replaces the state's cursor; omit it when all\nretained turns are now loaded.",
+      "properties": {
+        "type": {
+          "const": "chat/turnsLoaded"
+        },
+        "turns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Turn"
+          },
+          "description": "Older completed turns loaded into the state, ordered oldest-first."
+        },
+        "turnsNextCursor": {
+          "type": "string",
+          "description": "Opaque cursor for loading the next older page, if one remains."
+        }
+      },
+      "required": [
+        "type",
+        "turns"
+      ]
+    },
+    "ChangesetStatusChangedAction": {
+      "type": "object",
+      "description": "The {@link ChangesetState.status} for this changeset transitioned (e.g.\n`computing → ready`). The error payload is set together with `status`\nwhenever it transitions to {@link ChangesetStatus.Error | Error}.",
+      "properties": {
+        "type": {
+          "const": "changeset/statusChanged"
+        },
+        "status": {
+          "$ref": "#/$defs/ChangesetStatus",
+          "description": "New computation lifecycle status."
+        },
+        "error": {
+          "$ref": "#/$defs/ErrorInfo",
+          "description": "Cause when `status === ChangesetStatus.Error`; otherwise omitted."
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ]
+    },
+    "ChangesetFileSetAction": {
+      "type": "object",
+      "description": "Upsert a {@link ChangesetFile} in the changeset — adds a new entry, or\nreplaces an existing one identified by {@link ChangesetFile.id}.",
+      "properties": {
+        "type": {
+          "const": "changeset/fileSet"
+        },
+        "file": {
+          "$ref": "#/$defs/ChangesetFile",
+          "description": "The new or replacement file entry."
+        }
+      },
+      "required": [
+        "type",
+        "file"
+      ]
+    },
+    "ChangesetFileRemovedAction": {
+      "type": "object",
+      "description": "Remove a {@link ChangesetFile} from the changeset by its id.\n\nTypically dispatched when a file is reverted, staged out, or otherwise\nno longer in scope (e.g. a renamed file is replaced by a new entry).",
+      "properties": {
+        "type": {
+          "const": "changeset/fileRemoved"
+        },
+        "fileId": {
+          "type": "string",
+          "description": "The {@link ChangesetFile.id} of the file to remove."
+        }
+      },
+      "required": [
+        "type",
+        "fileId"
+      ]
+    },
+    "ChangesetContentChangedAction": {
+      "type": "object",
+      "description": "The changeset's full content changed. Full replacement semantics: `files`\nreplaces the previous file list, and `operations`, when present, replaces\nthe previous operation list.\n\nProducers SHOULD use this action for initial snapshots and bulk refreshes;\nuse {@link ChangesetFileSetAction}, {@link ChangesetFileRemovedAction}, and\n{@link ChangesetOperationsChangedAction} for incremental updates.",
+      "properties": {
+        "type": {
+          "const": "changeset/contentChanged"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChangesetFile"
+          },
+          "description": "Full replacement file list."
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChangesetOperation"
+          },
+          "description": "Full replacement operation list. Omit when operations are unchanged."
+        },
+        "error": {
+          "$ref": "#/$defs/ErrorInfo",
+          "description": "Error information, if the changeset content change failed."
+        }
+      },
+      "required": [
+        "type",
+        "files"
+      ]
+    },
+    "ChangesetOperationsChangedAction": {
+      "type": "object",
+      "description": "The set of operations available on this changeset changed. Full\nreplacement semantics: `operations` replaces the previous list (or\nremoves it entirely when `operations` is `undefined`).",
+      "properties": {
+        "type": {
+          "const": "changeset/operationsChanged"
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChangesetOperation"
+          },
+          "description": "Updated operation list. Pass `undefined` to clear all operations."
+        }
+      },
+      "required": [
+        "type",
+        "operations"
+      ]
+    },
+    "ChangesetOperationStatusChangedAction": {
+      "type": "object",
+      "description": "The {@link ChangesetOperation.status} for a single operation transitioned\n(e.g. `idle → running → idle`, or `running → error`). The error payload\nis set together with `status` whenever it transitions to\n{@link ChangesetOperationStatus.Error | Error}, and cleared on any other\ntransition.\n\nTargets one operation by its {@link ChangesetOperation.id}. If no\noperation with that id is currently present in the changeset, the action\nis a no-op. Use {@link ChangesetOperationsChangedAction} to add, remove,\nor otherwise replace the operation list itself.",
+      "properties": {
+        "type": {
+          "const": "changeset/operationStatusChanged"
+        },
+        "operationId": {
+          "type": "string",
+          "description": "The {@link ChangesetOperation.id} whose status changed."
+        },
+        "status": {
+          "$ref": "#/$defs/ChangesetOperationStatus",
+          "description": "New execution status."
+        },
+        "error": {
+          "$ref": "#/$defs/ErrorInfo",
+          "description": "Cause when `status === ChangesetOperationStatus.Error`; otherwise omitted."
+        }
+      },
+      "required": [
+        "type",
+        "operationId",
+        "status"
+      ]
+    },
+    "ChangesetClearedAction": {
+      "type": "object",
+      "description": "Drop every file from the changeset.\n\nTwo cases use this:\n1. The underlying source moved (branch switched, fork point invalidated,\n   …) and the server is recomputing from scratch — subsequent\n   {@link ChangesetFileSetAction} entries will repopulate it.\n2. The owning session has ended and the URI is becoming\n   un-subscribable — the server will unsubscribe all clients shortly\n   after dispatching this action.\n\nClients SHOULD release any references on receipt and SHOULD NOT\ndistinguish the two cases from the action alone — instead, react to\nthe corresponding session-level lifecycle signal (e.g.\n`root/sessionRemoved`) for the \"going away\" case.",
+      "properties": {
+        "type": {
+          "const": "changeset/cleared"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "AnnotationsSetAction": {
+      "type": "object",
+      "description": "Upsert an {@link Annotation} in the annotations channel — adds a new\nannotation, or replaces an existing one identified by\n{@link Annotation.id}.\n\nDispatched by a client to create an annotation (together with its\nmandatory first entry) or to re-anchor / resolve an existing one; the\ndispatching client assigns the {@link Annotation.id} and the id of any\nnew entry. When replacing, the full annotation payload (including its\n{@link Annotation.entries | entries} list) is substituted; producers\nSHOULD prefer {@link AnnotationsEntrySetAction} for per-entry edits, and\n{@link AnnotationsUpdatedAction} to resolve / re-anchor an existing\nannotation, to keep wire updates small.",
+      "properties": {
+        "type": {
+          "const": "annotations/set"
+        },
+        "annotation": {
+          "$ref": "#/$defs/Annotation",
+          "description": "The new or replacement annotation. MUST contain at least one entry."
+        }
+      },
+      "required": [
+        "type",
+        "annotation"
+      ]
+    },
+    "AnnotationsUpdatedAction": {
+      "type": "object",
+      "description": "Partially update an existing {@link Annotation}'s own properties — a narrow\nalternative to {@link AnnotationsSetAction} for the common case of resolving\n/ re-opening or re-anchoring an annotation without resending its\n{@link Annotation.entries | entries}.\n\nTargets one annotation by its {@link annotationId}. Only the fields present\non the action are written; omitted fields leave the corresponding\n{@link Annotation} property unchanged. The annotation's\n{@link Annotation.entries | entries}, {@link Annotation.id | id}, and\n{@link Annotation._meta | _meta} are never touched — dispatch\n{@link AnnotationsSetAction} to replace those, to clear {@link range}\n(re-anchor to the whole file), or {@link AnnotationsEntrySetAction} /\n{@link AnnotationsEntryRemovedAction} to edit individual entries.\n\nIf {@link annotationId} does not match any current annotation the action is\na no-op.",
+      "properties": {
+        "type": {
+          "const": "annotations/updated"
+        },
+        "annotationId": {
+          "type": "string",
+          "description": "The {@link Annotation.id} of the annotation to update."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Re-anchors the annotation to the file versions this turn produced.\nMatches a {@link Turn.id} on the owning session. Omit to leave the\ncurrent {@link Annotation.turnId} unchanged."
+        },
+        "resource": {
+          "$ref": "#/$defs/URI",
+          "description": "Re-anchors the annotation to this file. Omit to leave the current\n{@link Annotation.resource} unchanged."
+        },
+        "range": {
+          "$ref": "#/$defs/TextRange",
+          "description": "Narrows the annotation to this range within {@link resource}. Omit to\nleave the current {@link Annotation.range} unchanged; this action cannot\nclear an existing range — dispatch {@link AnnotationsSetAction} to\nre-anchor to the whole file."
+        },
+        "resolved": {
+          "type": "boolean",
+          "description": "Marks the annotation resolved (`true`) or re-opens it (`false`). Omit to\nleave the current {@link Annotation.resolved} state unchanged."
+        }
+      },
+      "required": [
+        "type",
+        "annotationId"
+      ]
+    },
+    "AnnotationsRemovedAction": {
+      "type": "object",
+      "description": "Remove an {@link Annotation} from the channel by its id.\n\nDispatched to delete an entire annotation and every entry it contains.\nBecause the protocol forbids empty annotations, a client that wants to\nremove the last remaining entry dispatches this action — collapsing the\nannotation — rather than {@link AnnotationsEntryRemovedAction}.",
+      "properties": {
+        "type": {
+          "const": "annotations/removed"
+        },
+        "annotationId": {
+          "type": "string",
+          "description": "The {@link Annotation.id} of the annotation to remove."
+        }
+      },
+      "required": [
+        "type",
+        "annotationId"
+      ]
+    },
+    "AnnotationsEntrySetAction": {
+      "type": "object",
+      "description": "Upsert an {@link AnnotationEntry} within an existing annotation — adds a\nnew entry, or replaces one identified by {@link AnnotationEntry.id}. The\ndispatching client assigns the {@link AnnotationEntry.id} of a new entry.\nIf {@link annotationId} does not match any current annotation the action\nis a no-op.",
+      "properties": {
+        "type": {
+          "const": "annotations/entrySet"
+        },
+        "annotationId": {
+          "type": "string",
+          "description": "The {@link Annotation.id} the entry belongs to."
+        },
+        "entry": {
+          "$ref": "#/$defs/AnnotationEntry",
+          "description": "The new or replacement entry."
+        }
+      },
+      "required": [
+        "type",
+        "annotationId",
+        "entry"
+      ]
+    },
+    "AnnotationsEntryRemovedAction": {
+      "type": "object",
+      "description": "Remove a single {@link AnnotationEntry} from an annotation without\ncollapsing the annotation itself. Used when more than one entry remains —\nto remove the last entry a client dispatches {@link AnnotationsRemovedAction}\ninstead, since the protocol forbids empty annotations.\n\nIf either {@link annotationId} or {@link entryId} does not match the\ncurrent state the action is a no-op.",
+      "properties": {
+        "type": {
+          "const": "annotations/entryRemoved"
+        },
+        "annotationId": {
+          "type": "string",
+          "description": "The {@link Annotation.id} the entry belongs to."
+        },
+        "entryId": {
+          "type": "string",
+          "description": "The {@link AnnotationEntry.id} to remove."
+        }
+      },
+      "required": [
+        "type",
+        "annotationId",
+        "entryId"
+      ]
+    },
+    "TerminalDataAction": {
+      "type": "object",
+      "description": "Terminal output data (pty → client direction).\n\nAppends `data` to the terminal's `content` in the reducer.\n\n`terminal/data` and `terminal/input` are intentionally separate actions\nbecause standard write-ahead reconciliation is not safe for terminal I/O.\nA pty is a stateful, mutable process — optimistically applying input or\npredicting output would produce incorrect state. Instead, `terminal/input`\nis a side-effect-only action (client → server → pty), and `terminal/data`\nis server-authoritative output (pty → server → client).",
+      "properties": {
+        "type": {
+          "const": "terminal/data"
+        },
+        "data": {
+          "type": "string",
+          "description": "Output data (may contain ANSI escape sequences)"
+        }
+      },
+      "required": [
+        "type",
+        "data"
+      ]
+    },
+    "TerminalInputAction": {
+      "type": "object",
+      "description": "Keyboard input sent to the terminal process (client → pty direction).\n\nThis is a side-effect-only action: the server forwards the data to the\nterminal's pty. The reducer treats this as a no-op since `terminal/data`\nactions will reflect any resulting output.\n\nSee `terminal/data` for why these two actions are kept separate.",
+      "properties": {
+        "type": {
+          "const": "terminal/input"
+        },
+        "data": {
+          "type": "string",
+          "description": "Input data to send to the pty"
+        }
+      },
+      "required": [
+        "type",
+        "data"
+      ]
+    },
+    "TerminalResizedAction": {
+      "type": "object",
+      "description": "Terminal dimensions changed.\n\nDispatchable by clients to request a resize, or by the server to inform\nclients of the actual terminal dimensions.",
+      "properties": {
+        "type": {
+          "const": "terminal/resized"
+        },
+        "cols": {
+          "type": "number",
+          "description": "Terminal width in columns"
+        },
+        "rows": {
+          "type": "number",
+          "description": "Terminal height in rows"
+        }
+      },
+      "required": [
+        "type",
+        "cols",
+        "rows"
+      ]
+    },
+    "TerminalClaimedAction": {
+      "type": "object",
+      "description": "Terminal claim changed. A client or session transfers ownership of the terminal.\n\nThe server SHOULD reject if the dispatching client does not currently hold\nthe claim.",
+      "properties": {
+        "type": {
+          "const": "terminal/claimed"
+        },
+        "claim": {
+          "$ref": "#/$defs/TerminalClaim",
+          "description": "The new claim"
+        }
+      },
+      "required": [
+        "type",
+        "claim"
+      ]
+    },
+    "TerminalTitleChangedAction": {
+      "type": "object",
+      "description": "Terminal title changed.\n\nFired by the server when the terminal process updates its title (e.g. via\nescape sequences), or dispatched by a client to rename a terminal.",
+      "properties": {
+        "type": {
+          "const": "terminal/titleChanged"
+        },
+        "title": {
+          "type": "string",
+          "description": "New terminal title"
+        }
+      },
+      "required": [
+        "type",
+        "title"
+      ]
+    },
+    "TerminalCwdChangedAction": {
+      "type": "object",
+      "description": "Terminal working directory changed.",
+      "properties": {
+        "type": {
+          "const": "terminal/cwdChanged"
+        },
+        "cwd": {
+          "$ref": "#/$defs/URI",
+          "description": "New working directory"
+        }
+      },
+      "required": [
+        "type",
+        "cwd"
+      ]
+    },
+    "TerminalExitedAction": {
+      "type": "object",
+      "description": "Terminal process exited.",
+      "properties": {
+        "type": {
+          "const": "terminal/exited"
+        },
+        "exitCode": {
+          "type": "number",
+          "description": "Process exit code. `undefined` if the process was killed without an exit code."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "TerminalClearedAction": {
+      "type": "object",
+      "description": "Terminal scrollback buffer cleared.",
+      "properties": {
+        "type": {
+          "const": "terminal/cleared"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "TerminalCommandDetectionAvailableAction": {
+      "type": "object",
+      "description": "Shell integration has loaded and the terminal now supports command\ndetection. The server dispatches this when shell integration becomes\navailable (which may happen asynchronously after the terminal is created).\n\nClients MUST NOT assume command detection is available until this action\n(or `terminal/commandExecuted`) has been received.",
+      "properties": {
+        "type": {
+          "const": "terminal/commandDetectionAvailable"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "TerminalCommandExecutedAction": {
+      "type": "object",
+      "description": "A command has been submitted to the shell and is now executing.\nAll subsequent `terminal/data` actions (until the matching\n`terminal/commandFinished`) constitute this command's output.",
+      "properties": {
+        "type": {
+          "const": "terminal/commandExecuted"
+        },
+        "commandId": {
+          "type": "string",
+          "description": "Stable identifier for this command, scoped to the terminal URI.\nAllows correlating `commandExecuted` → `commandFinished` pairs."
+        },
+        "commandLine": {
+          "type": "string",
+          "description": "The command line text that was submitted"
+        },
+        "timestamp": {
+          "type": "number",
+          "description": "Unix timestamp (ms) of when the command started executing, as measured\non the server."
+        }
+      },
+      "required": [
+        "type",
+        "commandId",
+        "commandLine",
+        "timestamp"
+      ]
+    },
+    "TerminalCommandFinishedAction": {
+      "type": "object",
+      "description": "A command has finished executing.\n\nThe sequence of `terminal/data` actions between the preceding\n`terminal/commandExecuted` (same `commandId`) and this action constitutes\nthe complete output of the command.",
+      "properties": {
+        "type": {
+          "const": "terminal/commandFinished"
+        },
+        "commandId": {
+          "type": "string",
+          "description": "Matches the `commandId` from the corresponding `commandExecuted`"
+        },
+        "exitCode": {
+          "type": "number",
+          "description": "Shell exit code. `undefined` if the shell did not report one."
+        },
+        "durationMs": {
+          "type": "number",
+          "description": "Wall-clock duration of the command in milliseconds, as measured by the\nshell integration script on the server side."
+        }
+      },
+      "required": [
+        "type",
+        "commandId"
+      ]
+    },
+    "ResourceWatchChangedAction": {
+      "type": "object",
+      "description": "A batch of resource changes observed by the watcher.\n\nWatch events are coalesced into batches by the server to keep the\naction stream tractable; an empty `changes.items` list MUST NOT be\ndispatched. The reducer does not retain change history — these\nactions exist purely to deliver events to subscribers, who consume\nthem directly off the action stream and apply their own logic.",
+      "properties": {
+        "type": {
+          "const": "resourceWatch/changed"
+        },
+        "changes": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items"
+          ],
+          "description": "The set of changes in this batch, wrapped for forward compatibility."
+        }
+      },
+      "required": [
+        "type",
+        "changes"
+      ]
+    },
+    "ChatToolCallApprovedAction": {
+      "type": "object",
+      "description": "Client approves a pending tool call. The tool transitions to `running`.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallConfirmed"
+        },
+        "approved": {
+          "description": "The tool call was approved"
+        },
+        "confirmed": {
+          "$ref": "#/$defs/ToolCallConfirmationReason",
+          "description": "How the tool was confirmed"
+        },
+        "editedToolInput": {
+          "type": "string",
+          "description": "Edited tool input parameters, if the client modified them before confirming"
+        },
+        "selectedOptionId": {
+          "type": "string",
+          "description": "ID of the selected confirmation option, if the server provided options"
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "approved",
+        "confirmed"
+      ]
+    },
+    "ChatToolCallDeniedAction": {
+      "type": "object",
+      "description": "Client denies a pending tool call. The tool transitions to `cancelled`.\n\nFor client-provided tools, the owning client MUST dispatch this if it does\nnot recognize the tool or cannot execute it.",
+      "properties": {
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier"
+        },
+        "toolCallId": {
+          "type": "string",
+          "description": "Tool call identifier"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this tool call.\n\nClients MAY look for well-known keys here to provide enhanced UI.\nFor example, a `ptyTerminal` key with `{ input: string; output: string }`\nindicates the tool operated on a terminal (both `input` and `output` may\ncontain escape sequences)."
+        },
+        "type": {
+          "const": "chat/toolCallConfirmed"
+        },
+        "approved": {
+          "description": "The tool call was denied"
+        },
+        "reason": {
+          "oneOf": [
+            {
+              "const": "denied"
+            },
+            {
+              "const": "skipped"
+            }
+          ],
+          "description": "Why the tool was cancelled"
+        },
+        "userSuggestion": {
+          "$ref": "#/$defs/Message",
+          "description": "What the user suggested doing instead"
+        },
+        "reasonMessage": {
+          "$ref": "#/$defs/StringOrMarkdown",
+          "description": "Optional explanation for the denial"
+        },
+        "selectedOptionId": {
+          "type": "string",
+          "description": "ID of the selected confirmation option, if the server provided options"
+        }
+      },
+      "required": [
+        "turnId",
+        "toolCallId",
+        "type",
+        "approved",
+        "reason"
+      ]
+    },
+    "PendingMessageKind": {
+      "enum": [
+        "steering",
+        "queued"
+      ],
+      "type": "string",
+      "description": "Discriminant for pending message kinds."
+    },
+    "ChatInputResponseKind": {
+      "enum": [
+        "accept",
+        "decline",
+        "cancel"
+      ],
+      "type": "string",
+      "description": "How a client completed an input request."
     }
   }
 }

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1097,7 +1097,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ChatInput"
+          "const": "chatInput"
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
@@ -1124,7 +1124,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolConfirmation"
+          "const": "toolConfirmation"
         },
         "turnId": {
           "type": "string",
@@ -1156,7 +1156,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolClientExecution"
+          "const": "toolClientExecution"
         },
         "turnId": {
           "type": "string",
@@ -1560,7 +1560,7 @@
       "description": "Container is being loaded by the host.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loading"
+          "const": "loading"
         }
       },
       "required": [
@@ -1572,7 +1572,7 @@
       "description": "Container loaded successfully.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loaded"
+          "const": "loaded"
         }
       },
       "required": [
@@ -1584,7 +1584,7 @@
       "description": "Container partially loaded but has warnings.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Degraded"
+          "const": "degraded"
         },
         "message": {
           "type": "string",
@@ -1601,7 +1601,7 @@
       "description": "Container failed to load.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Error"
+          "const": "error"
         },
         "message": {
           "type": "string",
@@ -1714,7 +1714,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         }
       },
       "required": [
@@ -1772,7 +1772,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         },
         "nonce": {
           "type": "string",
@@ -1834,7 +1834,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Directory"
+          "const": "directory"
         },
         "contents": {
           "$ref": "#/$defs/ChildCustomizationType",
@@ -1925,7 +1925,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Agent"
+          "const": "agent"
         },
         "description": {
           "type": "string",
@@ -1995,7 +1995,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Skill"
+          "const": "skill"
         },
         "description": {
           "type": "string",
@@ -2049,7 +2049,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Prompt"
+          "const": "prompt"
         },
         "description": {
           "type": "string",
@@ -2095,7 +2095,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Rule"
+          "const": "rule"
         },
         "description": {
           "type": "string",
@@ -2152,7 +2152,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Hook"
+          "const": "hook"
         }
       },
       "required": [
@@ -2190,7 +2190,7 @@
           "description": "Optional span within {@link CustomizationBase.uri | `uri`} when this\ncustomization is a subset of a larger file (for example, one entry\nin an inline `mcpServers` block of a `plugins.json` manifest).\nAbsent when the customization covers the whole resource."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.McpServer"
+          "const": "mcpServer"
         },
         "enabled": {
           "type": "boolean",
@@ -2274,7 +2274,7 @@
       "description": "Server is registered with the host but has not yet started.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Starting"
+          "const": "starting"
         }
       },
       "required": [
@@ -2286,7 +2286,7 @@
       "description": "Server is running and serving requests.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Ready"
+          "const": "ready"
         }
       },
       "required": [
@@ -2298,7 +2298,7 @@
       "description": "Server is reachable but cannot serve requests until the client\nauthenticates. Mirrors the discovery flow defined by\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)\n(Protected Resource Metadata) and the OAuth 2.1 / RFC 6750 challenge\nsemantics required by the MCP authorization spec.\n\nClients react to this state by calling the existing `authenticate`\ncommand with the {@link ProtectedResourceMetadata.resource | resource}\ncarried here. There is **no** `notify/authRequired` notification for\nMCP servers — the action stream is the single source of truth.\n\nWhen the transition is triggered by a request issued during a turn\n— most commonly\n{@link McpAuthRequiredReason.InsufficientScope | `InsufficientScope`}\nsurfacing mid-tool-call — the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session so the block is\nvisible at the summary level. Clients SHOULD watch this status on\nany MCP server backing a running tool call and surface an explicit\naffordance (e.g. a \"grant additional access\" prompt) tied to that\ntool call, rather than relying on the user to notice the\ncustomization’s status badge.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.AuthRequired"
+          "const": "authRequired"
         },
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -2331,7 +2331,7 @@
       "description": "Server failed to start, crashed, or otherwise transitioned to a\nnon-recoverable error. Use {@link McpServerStatus.AuthRequired}\nfor authentication failures.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Error"
+          "const": "error"
         },
         "error": {
           "$ref": "#/$defs/ErrorInfo",
@@ -2348,7 +2348,7 @@
       "description": "Server has been shut down. The host MAY remove the server from the\nsession entirely shortly after this state.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Stopped"
+          "const": "stopped"
         }
       },
       "required": [
@@ -2576,7 +2576,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Text"
+          "const": "text"
         },
         "format": {
           "type": "string",
@@ -2624,10 +2624,10 @@
         "kind": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Number"
+              "const": "number"
             },
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Integer"
+              "const": "integer"
             }
           ]
         },
@@ -2671,7 +2671,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Boolean"
+          "const": "boolean"
         },
         "defaultValue": {
           "type": "boolean",
@@ -2705,7 +2705,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.SingleSelect"
+          "const": "single-select"
         },
         "options": {
           "type": "array",
@@ -2747,7 +2747,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.MultiSelect"
+          "const": "multi-select"
         },
         "options": {
           "type": "array",
@@ -2816,7 +2816,7 @@
       "description": "Value captured for one answer.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Text"
+          "const": "text"
         },
         "value": {
           "type": "string"
@@ -2831,7 +2831,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Number"
+          "const": "number"
         },
         "value": {
           "type": "number"
@@ -2846,7 +2846,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Boolean"
+          "const": "boolean"
         },
         "value": {
           "type": "boolean"
@@ -2861,7 +2861,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Selected"
+          "const": "selected"
         },
         "value": {
           "type": "string"
@@ -2883,7 +2883,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.SelectedMany"
+          "const": "selected-many"
         },
         "value": {
           "type": "array",
@@ -2910,10 +2910,10 @@
         "state": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Draft"
+              "const": "draft"
             },
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Submitted"
+              "const": "submitted"
             }
           ],
           "description": "Answer state"
@@ -2932,7 +2932,7 @@
       "type": "object",
       "properties": {
         "state": {
-          "$ref": "#/$defs/ChatInputAnswerState.Skipped",
+          "const": "skipped",
           "description": "Answer state"
         },
         "freeformValues": {
@@ -3117,7 +3117,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Simple",
+          "const": "simple",
           "description": "Discriminant"
         },
         "modelRepresentation": {
@@ -3152,7 +3152,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.EmbeddedResource",
+          "const": "embeddedResource",
           "description": "Discriminant"
         },
         "data": {
@@ -3213,7 +3213,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Resource",
+          "const": "resource",
           "description": "Discriminant"
         },
         "selection": {
@@ -3249,7 +3249,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Annotations",
+          "const": "annotations",
           "description": "Discriminant"
         },
         "resource": {
@@ -3274,7 +3274,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Markdown",
+          "const": "markdown",
           "description": "Discriminant"
         },
         "id": {
@@ -3313,7 +3313,7 @@
           "description": "Content nonce"
         },
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ContentRef",
+          "const": "contentRef",
           "description": "Discriminant"
         }
       },
@@ -3327,7 +3327,7 @@
       "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "const": "toolCall",
           "description": "Discriminant"
         },
         "toolCall": {
@@ -3345,7 +3345,7 @@
       "description": "Reasoning/thinking content from the model.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "const": "reasoning",
           "description": "Discriminant"
         },
         "id": {
@@ -3368,7 +3368,7 @@
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "const": "systemNotification",
           "description": "Discriminant"
         },
         "content": {
@@ -3412,7 +3412,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.Client"
+          "const": "client"
         },
         "clientId": {
           "type": "string",
@@ -3428,7 +3428,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.MCP"
+          "const": "mcp"
         },
         "customizationId": {
           "type": "string",
@@ -3568,7 +3568,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nThis MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)\n`McpUiToolMeta` found in MCP tool calls, which may be used in combination\nwith the {@link contributor} to serve MCP Apps."
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Streaming"
+          "const": "streaming"
         },
         "partialInput": {
           "type": "string",
@@ -3624,7 +3624,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+          "const": "pending-confirmation"
         },
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
@@ -3700,7 +3700,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Running"
+          "const": "running"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3800,7 +3800,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingResultConfirmation"
+          "const": "pending-result-confirmation"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3895,7 +3895,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Completed"
+          "const": "completed"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3955,7 +3955,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Cancelled"
+          "const": "cancelled"
         },
         "reason": {
           "$ref": "#/$defs/ToolCallCancellationReason",
@@ -3988,7 +3988,7 @@
       "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Text"
+          "const": "text"
         },
         "text": {
           "type": "string",
@@ -4005,7 +4005,7 @@
       "description": "Base64-encoded binary content embedded in a tool result.\n\nMirrors MCP `EmbeddedResource` for inline binary data.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.EmbeddedResource"
+          "const": "embeddedResource"
         },
         "data": {
           "type": "string",
@@ -4043,7 +4043,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Resource"
+          "const": "resource"
         }
       },
       "required": [
@@ -4100,7 +4100,7 @@
           "description": "Optional diff display metadata"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
+          "const": "fileEdit"
         }
       },
       "required": [
@@ -4112,7 +4112,7 @@
       "description": "A reference to a terminal whose output is relevant to this tool result.\n\nClients can subscribe to the terminal's URI to stream its output in real\ntime, providing live feedback while a tool is executing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Terminal"
+          "const": "terminal"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -4134,7 +4134,7 @@
       "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation), referenced by a chat URI (`ahp-chat:/...`).\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Subagent"
+          "const": "subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -4191,7 +4191,7 @@
       "description": "A terminal claimed by a connected client.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Client",
+          "const": "client",
           "description": "Discriminant"
         },
         "clientId": {
@@ -4209,7 +4209,7 @@
       "description": "A terminal claimed by a session, optionally scoped to a specific turn or tool call.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Session",
+          "const": "session",
           "description": "Discriminant"
         },
         "session": {
@@ -4661,6 +4661,524 @@
         "uri",
         "type"
       ]
+    },
+    "URI": {
+      "type": "string",
+      "description": "A URI string (e.g. `ahp-root://`, `ahp-session:/<uuid>`, or `ahp-chat:/<uuid>`)."
+    },
+    "AuthRequiredReason": {
+      "enum": [
+        "required",
+        "expired"
+      ],
+      "type": "string",
+      "description": "Reason why authentication is required."
+    },
+    "SessionStatus": {
+      "enum": [
+        1,
+        2,
+        8,
+        24,
+        32,
+        64
+      ],
+      "type": "number",
+      "description": "Bitset of summary-level session status flags.\n\nUse bitwise checks instead of equality for non-terminal activity. For example,\n`status & SessionStatus.InProgress` matches both ordinary in-progress turns\nand turns that are paused waiting for input."
+    },
+    "JsonPrimitive": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A primitive JSON value: a string, number, boolean, or `null`."
+    },
+    "Customization": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/PluginCustomization"
+        },
+        {
+          "$ref": "#/$defs/DirectoryCustomization"
+        },
+        {
+          "$ref": "#/$defs/McpServerCustomization"
+        }
+      ],
+      "description": "A top-level customization active in a session. Either a container\n({@link PluginCustomization} or {@link DirectoryCustomization}) whose\nleaf customizations live in its\n{@link ContainerCustomizationBase.children | `children`} array, or a\nbare {@link McpServerCustomization} surfaced directly by the host."
+    },
+    "PolicyState": {
+      "enum": [
+        "enabled",
+        "disabled",
+        "unconfigured"
+      ],
+      "type": "string",
+      "description": "Policy configuration state for a model."
+    },
+    "SessionLifecycle": {
+      "enum": [
+        "creating",
+        "ready",
+        "creationFailed"
+      ],
+      "type": "string",
+      "description": "Session initialization state."
+    },
+    "SessionInputRequest": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SessionChatInputRequest"
+        },
+        {
+          "$ref": "#/$defs/SessionToolConfirmationRequest"
+        },
+        {
+          "$ref": "#/$defs/SessionToolClientExecutionRequest"
+        }
+      ],
+      "description": "One outstanding piece of input a session is blocked on, aggregated across all\nchats in {@link SessionState.inputNeeded}.\n\nEach entry is self-sufficient: it carries the owning\n{@link SessionInputRequestBase.chat | `chat`} URI plus every identifier needed\nto construct the response, so a client can answer by dispatching the ordinary\n`chat/*` action (`chat/inputCompleted`, `chat/toolCallConfirmed`,\n`chat/toolCallComplete`, …) to that chat's channel **without having subscribed\nto the chat**. The host removes the entry with `session/inputNeededRemoved`\nonce the underlying request resolves."
+    },
+    "ToolCallConfirmationState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        }
+      ],
+      "description": "The two tool-call states that block on a client confirmation: parameter\nconfirmation before execution ({@link ToolCallPendingConfirmationState}) and\nresult confirmation after execution\n({@link ToolCallPendingResultConfirmationState}).\n\nSurfaced at the session level by {@link SessionToolConfirmationRequest}."
+    },
+    "ToolCallState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallStreamingState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallRunningState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCompletedState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCancelledState"
+        }
+      ],
+      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
+    },
+    "CustomizationLoadState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/CustomizationLoadingState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationLoadedState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationDegradedState"
+        },
+        {
+          "$ref": "#/$defs/CustomizationErrorState"
+        }
+      ],
+      "description": "Discriminated load state for a container customization\n({@link PluginCustomization} or {@link DirectoryCustomization})."
+    },
+    "ChildCustomization": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/AgentCustomization"
+        },
+        {
+          "$ref": "#/$defs/SkillCustomization"
+        },
+        {
+          "$ref": "#/$defs/PromptCustomization"
+        },
+        {
+          "$ref": "#/$defs/RuleCustomization"
+        },
+        {
+          "$ref": "#/$defs/HookCustomization"
+        },
+        {
+          "$ref": "#/$defs/McpServerCustomization"
+        }
+      ],
+      "description": "Child customizations that live inside a {@link PluginCustomization} or\n{@link DirectoryCustomization}."
+    },
+    "ChildCustomizationType": {
+      "oneOf": [
+        {
+          "const": "agent"
+        },
+        {
+          "const": "skill"
+        },
+        {
+          "const": "prompt"
+        },
+        {
+          "const": "rule"
+        },
+        {
+          "const": "hook"
+        },
+        {
+          "const": "mcpServer"
+        }
+      ],
+      "description": "Customization types that appear as children of a\n{@link PluginCustomization} or {@link DirectoryCustomization}."
+    },
+    "McpServerState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/McpServerStartingState"
+        },
+        {
+          "$ref": "#/$defs/McpServerReadyState"
+        },
+        {
+          "$ref": "#/$defs/McpServerAuthRequiredState"
+        },
+        {
+          "$ref": "#/$defs/McpServerErrorState"
+        },
+        {
+          "$ref": "#/$defs/McpServerStoppedState"
+        }
+      ],
+      "description": "Discriminated union of all MCP server lifecycle states.\nDiscriminated by `kind` (a {@link McpServerStatus} value)."
+    },
+    "McpAuthRequiredReason": {
+      "enum": [
+        "required",
+        "expired",
+        "insufficientScope"
+      ],
+      "type": "string",
+      "description": "Why an MCP server is currently in the {@link McpServerStatus.AuthRequired}\nstate. Mirrors the three failure modes defined by the\n[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md)."
+    },
+    "ChatOrigin": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "chat": {
+              "type": "string"
+            },
+            "turnId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "chat",
+            "turnId"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "chat": {
+              "type": "string"
+            },
+            "toolCallId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "chat",
+            "toolCallId"
+          ]
+        }
+      ],
+      "description": "How a chat came into existence. Clients MAY use it to render\ncontextual UI (parent indicators, fork markers, \"spawned by tool\" badges).\n\nThe `tool` variant records a tool-spawned worker from the worker's side: its\n`chat`/`toolCallId` identify the spawning tool call in the parent chat. This\nis the canonical record of the spawn relationship. The same edge is surfaced\nfrom the parent's side by {@link ToolResultSubagentContent}, whose `resource`\nis this chat's URI; hosts MUST keep the two consistent."
+    },
+    "ChatInteractivity": {
+      "enum": [
+        "full",
+        "read-only",
+        "hidden"
+      ],
+      "type": "string",
+      "description": "How a user can interact with a chat.\n\n- `Full` — user can send messages and watch (default when absent)\n- `ReadOnly` — user can watch but not send messages (e.g. agent team workers)\n- `Hidden` — internal worker not shown in UI at all\n\nSupports the agent-team pattern where a lead chat is fully interactive and\nworker chats are read-only (visible for observability) or hidden (internal\nimplementation detail). The harness sets this based on the chat's role;\nthe UI uses it to show appropriate controls."
+    },
+    "ChatInputQuestion": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputTextQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputNumberQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputBooleanQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSingleSelectQuestion"
+        },
+        {
+          "$ref": "#/$defs/ChatInputMultiSelectQuestion"
+        }
+      ],
+      "description": "One question within a chat input request."
+    },
+    "ChatInputAnswer": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputAnswered"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSkipped"
+        }
+      ],
+      "description": "Draft, submitted, or skipped answer for one question."
+    },
+    "ChatInputAnswerValue": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ChatInputTextAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputNumberAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputBooleanAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSelectedAnswerValue"
+        },
+        {
+          "$ref": "#/$defs/ChatInputSelectedManyAnswerValue"
+        }
+      ]
+    },
+    "ResponsePart": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/MarkdownResponsePart"
+        },
+        {
+          "$ref": "#/$defs/ResourceReponsePart"
+        },
+        {
+          "$ref": "#/$defs/ToolCallResponsePart"
+        },
+        {
+          "$ref": "#/$defs/ReasoningResponsePart"
+        },
+        {
+          "$ref": "#/$defs/SystemNotificationResponsePart"
+        }
+      ]
+    },
+    "TurnState": {
+      "enum": [
+        "complete",
+        "cancelled",
+        "error"
+      ],
+      "type": "string",
+      "description": "How a turn ended."
+    },
+    "MessageKind": {
+      "enum": [
+        "user",
+        "agent",
+        "tool",
+        "systemNotification"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "MessageAttachment": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SimpleMessageAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageEmbeddedResourceAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageResourceAttachment"
+        },
+        {
+          "$ref": "#/$defs/MessageAnnotationsAttachment"
+        }
+      ],
+      "description": "An attachment associated with a {@link Message}."
+    },
+    "StringOrMarkdown": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "markdown": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "markdown"
+          ]
+        }
+      ],
+      "description": "A string that may optionally be rendered as Markdown.\n\n- A plain `string` is rendered as-is (no Markdown processing).\n- An object with `{ markdown: string }` is rendered with Markdown formatting."
+    },
+    "ConfirmationOptionKind": {
+      "enum": [
+        "approve",
+        "deny"
+      ],
+      "type": "string",
+      "description": "Whether a confirmation option represents an approval or denial action."
+    },
+    "ToolCallContributor": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallClientContributor"
+        },
+        {
+          "$ref": "#/$defs/ToolCallMcpContributor"
+        }
+      ]
+    },
+    "ToolResultContent": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolResultTextContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultEmbeddedResourceContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultResourceContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultFileEditContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultTerminalContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultSubagentContent"
+        }
+      ],
+      "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output, and\n`ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions)."
+    },
+    "ToolCallConfirmationReason": {
+      "enum": [
+        "not-needed",
+        "user-action",
+        "setting"
+      ],
+      "type": "string",
+      "description": "How a tool call was confirmed for execution.\n\n- `NotNeeded` — No confirmation required (auto-approved)\n- `UserAction` — User explicitly approved\n- `Setting` — Approved by a persistent user setting"
+    },
+    "ToolCallCancellationReason": {
+      "enum": [
+        "denied",
+        "skipped",
+        "result-denied"
+      ],
+      "type": "string",
+      "description": "Why a tool call was cancelled."
+    },
+    "TerminalClaim": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalClientClaim"
+        },
+        {
+          "$ref": "#/$defs/TerminalSessionClaim"
+        }
+      ],
+      "description": "Describes who currently holds a terminal. A terminal may be claimed by\neither a connected client or a session (e.g. during a tool call)."
+    },
+    "TerminalContentPart": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalUnclassifiedPart"
+        },
+        {
+          "$ref": "#/$defs/TerminalCommandPart"
+        }
+      ],
+      "description": "A content part within terminal output."
+    },
+    "ChangesetStatus": {
+      "enum": [
+        "computing",
+        "ready",
+        "error"
+      ],
+      "type": "string",
+      "description": "Computation lifecycle of a {@link ChangesetState}."
+    },
+    "ChangesetOperationScope": {
+      "enum": [
+        "changeset",
+        "resource",
+        "range"
+      ],
+      "type": "string",
+      "description": "Where a {@link ChangesetOperation} can be invoked."
+    },
+    "ChangesetOperationStatus": {
+      "enum": [
+        "idle",
+        "running",
+        "error",
+        "disabled"
+      ],
+      "type": "string",
+      "description": "Execution lifecycle of a {@link ChangesetOperation}.\n\nAn operation is invoked imperatively via `invokeChangesetOperation`, but\nits progress and outcome are reflected back into changeset state so that\nevery subscriber observes a consistent view (e.g. a spinner on a \"Create\nPull Request\" button, or an inline error after a failed \"revert\")."
+    },
+    "ResourceChangeType": {
+      "enum": [
+        "added",
+        "updated",
+        "deleted"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link ResourceChange.type}."
     }
   }
 }

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -848,7 +848,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ChatInput"
+          "const": "chatInput"
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
@@ -875,7 +875,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolConfirmation"
+          "const": "toolConfirmation"
         },
         "turnId": {
           "type": "string",
@@ -907,7 +907,7 @@
           "description": "The chat the underlying request lives in. This is the channel a client\ndispatches its response to — it does not need to have subscribed to that\nchat first."
         },
         "kind": {
-          "$ref": "#/$defs/SessionInputRequestKind.ToolClientExecution"
+          "const": "toolClientExecution"
         },
         "turnId": {
           "type": "string",
@@ -1311,7 +1311,7 @@
       "description": "Container is being loaded by the host.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loading"
+          "const": "loading"
         }
       },
       "required": [
@@ -1323,7 +1323,7 @@
       "description": "Container loaded successfully.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Loaded"
+          "const": "loaded"
         }
       },
       "required": [
@@ -1335,7 +1335,7 @@
       "description": "Container partially loaded but has warnings.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Degraded"
+          "const": "degraded"
         },
         "message": {
           "type": "string",
@@ -1352,7 +1352,7 @@
       "description": "Container failed to load.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/CustomizationLoadStatus.Error"
+          "const": "error"
         },
         "message": {
           "type": "string",
@@ -1465,7 +1465,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         }
       },
       "required": [
@@ -1523,7 +1523,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Plugin"
+          "const": "plugin"
         },
         "nonce": {
           "type": "string",
@@ -1585,7 +1585,7 @@
           "description": "Children discovered inside this container.\n\nAbsent means the host has not parsed this container yet. An empty\narray means the host parsed the container and it contributes\nnothing."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Directory"
+          "const": "directory"
         },
         "contents": {
           "$ref": "#/$defs/ChildCustomizationType",
@@ -1676,7 +1676,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Agent"
+          "const": "agent"
         },
         "description": {
           "type": "string",
@@ -1746,7 +1746,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Skill"
+          "const": "skill"
         },
         "description": {
           "type": "string",
@@ -1800,7 +1800,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Prompt"
+          "const": "prompt"
         },
         "description": {
           "type": "string",
@@ -1846,7 +1846,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Rule"
+          "const": "rule"
         },
         "description": {
           "type": "string",
@@ -1903,7 +1903,7 @@
           "description": "Whether this child is individually enabled. Absent means enabled, so a\nproducer only needs to set it to surface a child that exists but is\nturned off on its own.\n\nThis flag is independent of the parent container's: the **effective**\nenabled state of a child is\n`container.enabled && (child.enabled ?? true)`, so a disabled container\ndisables every child regardless of each child's own flag.\n\nA child is turned on or off by id with\n{@link SessionCustomizationToggledAction | `session/customizationToggled`}."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.Hook"
+          "const": "hook"
         }
       },
       "required": [
@@ -1941,7 +1941,7 @@
           "description": "Optional span within {@link CustomizationBase.uri | `uri`} when this\ncustomization is a subset of a larger file (for example, one entry\nin an inline `mcpServers` block of a `plugins.json` manifest).\nAbsent when the customization covers the whole resource."
         },
         "type": {
-          "$ref": "#/$defs/CustomizationType.McpServer"
+          "const": "mcpServer"
         },
         "enabled": {
           "type": "boolean",
@@ -2025,7 +2025,7 @@
       "description": "Server is registered with the host but has not yet started.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Starting"
+          "const": "starting"
         }
       },
       "required": [
@@ -2037,7 +2037,7 @@
       "description": "Server is running and serving requests.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Ready"
+          "const": "ready"
         }
       },
       "required": [
@@ -2049,7 +2049,7 @@
       "description": "Server is reachable but cannot serve requests until the client\nauthenticates. Mirrors the discovery flow defined by\n[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)\n(Protected Resource Metadata) and the OAuth 2.1 / RFC 6750 challenge\nsemantics required by the MCP authorization spec.\n\nClients react to this state by calling the existing `authenticate`\ncommand with the {@link ProtectedResourceMetadata.resource | resource}\ncarried here. There is **no** `notify/authRequired` notification for\nMCP servers — the action stream is the single source of truth.\n\nWhen the transition is triggered by a request issued during a turn\n— most commonly\n{@link McpAuthRequiredReason.InsufficientScope | `InsufficientScope`}\nsurfacing mid-tool-call — the host SHOULD also raise\n{@link SessionStatus.InputNeeded} on the session so the block is\nvisible at the summary level. Clients SHOULD watch this status on\nany MCP server backing a running tool call and surface an explicit\naffordance (e.g. a \"grant additional access\" prompt) tied to that\ntool call, rather than relying on the user to notice the\ncustomization’s status badge.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.AuthRequired"
+          "const": "authRequired"
         },
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -2082,7 +2082,7 @@
       "description": "Server failed to start, crashed, or otherwise transitioned to a\nnon-recoverable error. Use {@link McpServerStatus.AuthRequired}\nfor authentication failures.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Error"
+          "const": "error"
         },
         "error": {
           "$ref": "#/$defs/ErrorInfo",
@@ -2099,7 +2099,7 @@
       "description": "Server has been shut down. The host MAY remove the server from the\nsession entirely shortly after this state.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/McpServerStatus.Stopped"
+          "const": "stopped"
         }
       },
       "required": [
@@ -2327,7 +2327,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Text"
+          "const": "text"
         },
         "format": {
           "type": "string",
@@ -2375,10 +2375,10 @@
         "kind": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Number"
+              "const": "number"
             },
             {
-              "$ref": "#/$defs/ChatInputQuestionKind.Integer"
+              "const": "integer"
             }
           ]
         },
@@ -2422,7 +2422,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.Boolean"
+          "const": "boolean"
         },
         "defaultValue": {
           "type": "boolean",
@@ -2456,7 +2456,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.SingleSelect"
+          "const": "single-select"
         },
         "options": {
           "type": "array",
@@ -2498,7 +2498,7 @@
           "description": "Whether the user must answer this question to accept the request"
         },
         "kind": {
-          "$ref": "#/$defs/ChatInputQuestionKind.MultiSelect"
+          "const": "multi-select"
         },
         "options": {
           "type": "array",
@@ -2567,7 +2567,7 @@
       "description": "Value captured for one answer.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Text"
+          "const": "text"
         },
         "value": {
           "type": "string"
@@ -2582,7 +2582,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Number"
+          "const": "number"
         },
         "value": {
           "type": "number"
@@ -2597,7 +2597,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Boolean"
+          "const": "boolean"
         },
         "value": {
           "type": "boolean"
@@ -2612,7 +2612,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.Selected"
+          "const": "selected"
         },
         "value": {
           "type": "string"
@@ -2634,7 +2634,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ChatInputAnswerValueKind.SelectedMany"
+          "const": "selected-many"
         },
         "value": {
           "type": "array",
@@ -2661,10 +2661,10 @@
         "state": {
           "oneOf": [
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Draft"
+              "const": "draft"
             },
             {
-              "$ref": "#/$defs/ChatInputAnswerState.Submitted"
+              "const": "submitted"
             }
           ],
           "description": "Answer state"
@@ -2683,7 +2683,7 @@
       "type": "object",
       "properties": {
         "state": {
-          "$ref": "#/$defs/ChatInputAnswerState.Skipped",
+          "const": "skipped",
           "description": "Answer state"
         },
         "freeformValues": {
@@ -2868,7 +2868,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Simple",
+          "const": "simple",
           "description": "Discriminant"
         },
         "modelRepresentation": {
@@ -2903,7 +2903,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.EmbeddedResource",
+          "const": "embeddedResource",
           "description": "Discriminant"
         },
         "data": {
@@ -2964,7 +2964,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Resource",
+          "const": "resource",
           "description": "Discriminant"
         },
         "selection": {
@@ -3000,7 +3000,7 @@
           "description": "Additional implementation-defined metadata for the attachment.\n\nIf the attachment was produced by the `completions` command, the client\nMUST preserve every property of `_meta` originally returned by the agent\nhost when sending the user message containing the accepted completion."
         },
         "type": {
-          "$ref": "#/$defs/MessageAttachmentKind.Annotations",
+          "const": "annotations",
           "description": "Discriminant"
         },
         "resource": {
@@ -3025,7 +3025,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Markdown",
+          "const": "markdown",
           "description": "Discriminant"
         },
         "id": {
@@ -3064,7 +3064,7 @@
           "description": "Content nonce"
         },
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ContentRef",
+          "const": "contentRef",
           "description": "Discriminant"
         }
       },
@@ -3078,7 +3078,7 @@
       "description": "A tool call represented as a response part.\n\nTool calls are part of the response stream, interleaved with text and\nreasoning. The `toolCall.toolCallId` serves as the part identifier for\nactions that target this part.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.ToolCall",
+          "const": "toolCall",
           "description": "Discriminant"
         },
         "toolCall": {
@@ -3096,7 +3096,7 @@
       "description": "Reasoning/thinking content from the model.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.Reasoning",
+          "const": "reasoning",
           "description": "Discriminant"
         },
         "id": {
@@ -3119,7 +3119,7 @@
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ResponsePartKind.SystemNotification",
+          "const": "systemNotification",
           "description": "Discriminant"
         },
         "content": {
@@ -3163,7 +3163,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.Client"
+          "const": "client"
         },
         "clientId": {
           "type": "string",
@@ -3179,7 +3179,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/ToolCallContributorKind.MCP"
+          "const": "mcp"
         },
         "customizationId": {
           "type": "string",
@@ -3319,7 +3319,7 @@
           "description": "Additional provider-specific metadata for this tool call.\n\nThis MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)\n`McpUiToolMeta` found in MCP tool calls, which may be used in combination\nwith the {@link contributor} to serve MCP Apps."
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Streaming"
+          "const": "streaming"
         },
         "partialInput": {
           "type": "string",
@@ -3375,7 +3375,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingConfirmation"
+          "const": "pending-confirmation"
         },
         "confirmationTitle": {
           "$ref": "#/$defs/StringOrMarkdown",
@@ -3451,7 +3451,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Running"
+          "const": "running"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3551,7 +3551,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.PendingResultConfirmation"
+          "const": "pending-result-confirmation"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3646,7 +3646,7 @@
           "description": "Error details if the tool failed"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Completed"
+          "const": "completed"
         },
         "confirmed": {
           "$ref": "#/$defs/ToolCallConfirmationReason",
@@ -3706,7 +3706,7 @@
           "description": "Raw tool input"
         },
         "status": {
-          "$ref": "#/$defs/ToolCallStatus.Cancelled"
+          "const": "cancelled"
         },
         "reason": {
           "$ref": "#/$defs/ToolCallCancellationReason",
@@ -3739,7 +3739,7 @@
       "description": "Text content in a tool result.\n\nMirrors MCP `TextContent`.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Text"
+          "const": "text"
         },
         "text": {
           "type": "string",
@@ -3756,7 +3756,7 @@
       "description": "Base64-encoded binary content embedded in a tool result.\n\nMirrors MCP `EmbeddedResource` for inline binary data.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.EmbeddedResource"
+          "const": "embeddedResource"
         },
         "data": {
           "type": "string",
@@ -3794,7 +3794,7 @@
           "description": "Content nonce"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Resource"
+          "const": "resource"
         }
       },
       "required": [
@@ -3851,7 +3851,7 @@
           "description": "Optional diff display metadata"
         },
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.FileEdit"
+          "const": "fileEdit"
         }
       },
       "required": [
@@ -3863,7 +3863,7 @@
       "description": "A reference to a terminal whose output is relevant to this tool result.\n\nClients can subscribe to the terminal's URI to stream its output in real\ntime, providing live feedback while a tool is executing.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Terminal"
+          "const": "terminal"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -3885,7 +3885,7 @@
       "description": "A reference, embedded in a tool result, to a worker chat spawned by the tool\ncall (a sub-agent delegation), referenced by a chat URI (`ahp-chat:/...`).\n\nThis is the spawning tool call's forward view of the worker. The worker chat\nrecords the same edge in reverse via its {@link ChatOrigin} (`kind: 'tool'`),\nwhose `toolCallId` identifies the tool call that emitted this content.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ToolResultContentType.Subagent"
+          "const": "subagent"
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -3942,7 +3942,7 @@
       "description": "A terminal claimed by a connected client.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Client",
+          "const": "client",
           "description": "Discriminant"
         },
         "clientId": {
@@ -3960,7 +3960,7 @@
       "description": "A terminal claimed by a session, optionally scoped to a specific turn or tool call.",
       "properties": {
         "kind": {
-          "$ref": "#/$defs/TerminalClaimKind.Session",
+          "const": "session",
           "description": "Discriminant"
         },
         "session": {
@@ -4443,13 +4443,14 @@
         {
           "type": "boolean"
         },
-        {}
+        {
+          "type": "null"
+        }
       ],
       "description": "A primitive JSON value: a string, number, boolean, or `null`."
     },
     "SessionInputRequest": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/SessionChatInputRequest"
         },
@@ -4464,31 +4465,29 @@
     },
     "ChildCustomizationType": {
       "oneOf": [
-        {},
         {
-          "$ref": "#/$defs/CustomizationType.Agent"
+          "const": "agent"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Skill"
+          "const": "skill"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Prompt"
+          "const": "prompt"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Rule"
+          "const": "rule"
         },
         {
-          "$ref": "#/$defs/CustomizationType.Hook"
+          "const": "hook"
         },
         {
-          "$ref": "#/$defs/CustomizationType.McpServer"
+          "const": "mcpServer"
         }
       ],
       "description": "Customization types that appear as children of a\n{@link PluginCustomization} or {@link DirectoryCustomization}."
     },
     "CustomizationLoadState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/CustomizationLoadingState"
         },
@@ -4506,7 +4505,6 @@
     },
     "ChildCustomization": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/AgentCustomization"
         },
@@ -4530,7 +4528,6 @@
     },
     "Customization": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/PluginCustomization"
         },
@@ -4545,7 +4542,6 @@
     },
     "McpServerState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/McpServerStartingState"
         },
@@ -4566,7 +4562,6 @@
     },
     "ChatOrigin": {
       "oneOf": [
-        {},
         {
           "type": "object",
           "properties": {
@@ -4671,7 +4666,6 @@
     },
     "MessageAttachment": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/SimpleMessageAttachment"
         },
@@ -4689,7 +4683,6 @@
     },
     "ResponsePart": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/MarkdownResponsePart"
         },
@@ -4719,7 +4712,6 @@
     },
     "ToolCallState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ToolCallStreamingState"
         },
@@ -4743,7 +4735,6 @@
     },
     "ToolCallConfirmationState": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ToolCallPendingConfirmationState"
         },
@@ -4755,7 +4746,6 @@
     },
     "ToolResultContent": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/ToolResultTextContent"
         },
@@ -4790,7 +4780,6 @@
     },
     "TerminalContentPart": {
       "oneOf": [
-        {},
         {
           "$ref": "#/$defs/TerminalUnclassifiedPart"
         },
@@ -4799,6 +4788,140 @@
         }
       ],
       "description": "A content part within terminal output."
+    },
+    "URI": {
+      "type": "string",
+      "description": "A URI string (e.g. `ahp-root://`, `ahp-session:/<uuid>`, or `ahp-chat:/<uuid>`)."
+    },
+    "PolicyState": {
+      "enum": [
+        "enabled",
+        "disabled",
+        "unconfigured"
+      ],
+      "type": "string",
+      "description": "Policy configuration state for a model."
+    },
+    "SessionStatus": {
+      "enum": [
+        1,
+        2,
+        8,
+        24,
+        32,
+        64
+      ],
+      "type": "number",
+      "description": "Bitset of summary-level session status flags.\n\nUse bitwise checks instead of equality for non-terminal activity. For example,\n`status & SessionStatus.InProgress` matches both ordinary in-progress turns\nand turns that are paused waiting for input."
+    },
+    "SessionLifecycle": {
+      "enum": [
+        "creating",
+        "ready",
+        "creationFailed"
+      ],
+      "type": "string",
+      "description": "Session initialization state."
+    },
+    "McpAuthRequiredReason": {
+      "enum": [
+        "required",
+        "expired",
+        "insufficientScope"
+      ],
+      "type": "string",
+      "description": "Why an MCP server is currently in the {@link McpServerStatus.AuthRequired}\nstate. Mirrors the three failure modes defined by the\n[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md)."
+    },
+    "ChatInteractivity": {
+      "enum": [
+        "full",
+        "read-only",
+        "hidden"
+      ],
+      "type": "string",
+      "description": "How a user can interact with a chat.\n\n- `Full` — user can send messages and watch (default when absent)\n- `ReadOnly` — user can watch but not send messages (e.g. agent team workers)\n- `Hidden` — internal worker not shown in UI at all\n\nSupports the agent-team pattern where a lead chat is fully interactive and\nworker chats are read-only (visible for observability) or hidden (internal\nimplementation detail). The harness sets this based on the chat's role;\nthe UI uses it to show appropriate controls."
+    },
+    "TurnState": {
+      "enum": [
+        "complete",
+        "cancelled",
+        "error"
+      ],
+      "type": "string",
+      "description": "How a turn ended."
+    },
+    "MessageKind": {
+      "enum": [
+        "user",
+        "agent",
+        "tool",
+        "systemNotification"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "ConfirmationOptionKind": {
+      "enum": [
+        "approve",
+        "deny"
+      ],
+      "type": "string",
+      "description": "Whether a confirmation option represents an approval or denial action."
+    },
+    "ToolCallConfirmationReason": {
+      "enum": [
+        "not-needed",
+        "user-action",
+        "setting"
+      ],
+      "type": "string",
+      "description": "How a tool call was confirmed for execution.\n\n- `NotNeeded` — No confirmation required (auto-approved)\n- `UserAction` — User explicitly approved\n- `Setting` — Approved by a persistent user setting"
+    },
+    "ToolCallCancellationReason": {
+      "enum": [
+        "denied",
+        "skipped",
+        "result-denied"
+      ],
+      "type": "string",
+      "description": "Why a tool call was cancelled."
+    },
+    "ChangesetStatus": {
+      "enum": [
+        "computing",
+        "ready",
+        "error"
+      ],
+      "type": "string",
+      "description": "Computation lifecycle of a {@link ChangesetState}."
+    },
+    "ChangesetOperationScope": {
+      "enum": [
+        "changeset",
+        "resource",
+        "range"
+      ],
+      "type": "string",
+      "description": "Where a {@link ChangesetOperation} can be invoked."
+    },
+    "ChangesetOperationStatus": {
+      "enum": [
+        "idle",
+        "running",
+        "error",
+        "disabled"
+      ],
+      "type": "string",
+      "description": "Execution lifecycle of a {@link ChangesetOperation}.\n\nAn operation is invoked imperatively via `invokeChangesetOperation`, but\nits progress and outcome are reflected back into changeset state so that\nevery subscriber observes a consistent view (e.g. a spinner on a \"Create\nPull Request\" button, or an inline error after a failed \"revert\")."
+    },
+    "ResourceChangeType": {
+      "enum": [
+        "added",
+        "updated",
+        "deleted"
+      ],
+      "type": "string",
+      "description": "Discriminant for {@link ResourceChange.type}."
     }
   }
 }

--- a/scripts/generate-json-schema.test.ts
+++ b/scripts/generate-json-schema.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Validates the generated JSON Schema files (schema/*.json) are self-contained
+ * and strict-oneOf-safe. Guards the two correctness bugs fixed for
+ * microsoft/agent-host-protocol#302:
+ *   1. no `oneOf` branch is an empty `{}` schema (which matches any value and
+ *      breaks strict `oneOf` validation for every union type alias), and
+ *   2. no `$ref` is dangling (every `#/$defs/<name>` reference resolves to a
+ *      defined `$def`, so each schema is self-contained).
+ *
+ * Run: npx tsx --test scripts/generate-json-schema.test.ts
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SCHEMA_FILES = [
+  'state.schema.json',
+  'actions.schema.json',
+  'commands.schema.json',
+  'notifications.schema.json',
+  'errors.schema.json',
+];
+
+type JsonNode = Record<string, unknown> | unknown[] | string | number | boolean | null;
+
+function loadSchema(file: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(resolve(root, 'schema', file), 'utf-8'));
+}
+
+// Every `#/$defs/<name>` reference target reachable in the schema.
+function collectRefTargets(node: JsonNode, acc: Set<string>): void {
+  if (Array.isArray(node)) {
+    for (const child of node) collectRefTargets(child as JsonNode, acc);
+    return;
+  }
+  if (node && typeof node === 'object') {
+    const ref = (node as Record<string, unknown>).$ref;
+    if (typeof ref === 'string') {
+      const m = ref.match(/^#\/\$defs\/(.+)$/);
+      if (m) acc.add(m[1]);
+    }
+    for (const value of Object.values(node)) collectRefTargets(value as JsonNode, acc);
+  }
+}
+
+// Count `oneOf` branches that are an empty `{}` (matches any value).
+function countEmptyOneOfBranches(node: JsonNode): number {
+  let count = 0;
+  if (Array.isArray(node)) {
+    for (const child of node) count += countEmptyOneOfBranches(child as JsonNode);
+    return count;
+  }
+  if (node && typeof node === 'object') {
+    const oneOf = (node as Record<string, unknown>).oneOf;
+    if (Array.isArray(oneOf)) {
+      count += oneOf.filter(
+        (branch) => branch && typeof branch === 'object' && Object.keys(branch).length === 0,
+      ).length;
+    }
+    for (const value of Object.values(node)) count += countEmptyOneOfBranches(value as JsonNode);
+  }
+  return count;
+}
+
+describe('generated JSON schemas', () => {
+  for (const file of SCHEMA_FILES) {
+    describe(file, () => {
+      const schema = loadSchema(file);
+
+      it('has no empty `{}` oneOf branch', () => {
+        assert.equal(
+          countEmptyOneOfBranches(schema as JsonNode),
+          0,
+          `${file} contains an empty {} oneOf branch (bug #302.1) — it matches any value and defeats strict oneOf validation`,
+        );
+      });
+
+      it('has no dangling $ref (every referenced $def is defined)', () => {
+        const targets = new Set<string>();
+        collectRefTargets(schema as JsonNode, targets);
+        const defs = new Set(Object.keys((schema.$defs as Record<string, unknown>) ?? {}));
+        const dangling = [...targets].filter((name) => !defs.has(name)).sort();
+        assert.deepEqual(
+          dangling,
+          [],
+          `${file} references ${dangling.length} undefined $def(s) (bug #302.2): ${dangling.slice(0, 10).join(', ')}`,
+        );
+      });
+    });
+  }
+});

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -7,6 +7,7 @@ import {
   Project,
   InterfaceDeclaration,
   TypeAliasDeclaration,
+  EnumDeclaration,
   PropertySignature,
   Node,
   Type,
@@ -72,6 +73,37 @@ function findInterface(project: Project, name: string): InterfaceDeclaration | u
   return undefined;
 }
 
+function findTypeAlias(project: Project, name: string): TypeAliasDeclaration | undefined {
+  for (const sf of project.getSourceFiles()) {
+    const ta = sf.getTypeAlias(name);
+    if (ta) return ta;
+  }
+  return undefined;
+}
+
+function findEnum(project: Project, name: string): EnumDeclaration | undefined {
+  for (const sf of project.getSourceFiles()) {
+    const en = sf.getEnum(name);
+    if (en) return en;
+  }
+  return undefined;
+}
+
+// A whole `const enum` → a JSON Schema `enum` of its members' evaluated values.
+// ts-morph evaluates const-enum initializers (including bitwise expressions like
+// `(1 << 3) | (1 << 4)`), so numeric flag enums resolve to concrete numbers.
+function enumToSchema(en: EnumDeclaration): JsonSchema {
+  const values = en.getMembers().map(m => m.getValue());
+  const defined = values.filter((v): v is string | number => v !== undefined);
+  const schema: JsonSchema = { enum: defined };
+  if (defined.every(v => typeof v === 'string')) schema.type = 'string';
+  else if (defined.every(v => typeof v === 'number')) schema.type = 'number';
+  const rawDesc = en.getJsDocs()[0]?.getDescription();
+  const desc = rawDesc ? normalizeDescription(rawDesc) : '';
+  if (desc) schema.description = desc;
+  return schema;
+}
+
 function getAllInterfaceProperties(iface: InterfaceDeclaration, project: Project): PropertySignature[] {
   const props: PropertySignature[] = [];
 
@@ -94,7 +126,13 @@ function getAllInterfaceProperties(iface: InterfaceDeclaration, project: Project
 
 // ─── Type → JSON Schema Conversion ──────────────────────────────────────────
 
-function typeTextToSchema(typeText: string, project: Project): JsonSchema {
+function typeTextToSchema(typeText: string, project: Project, _depth = 0): JsonSchema {
+  // Real protocol types nest only a handful of levels deep; a runaway depth
+  // means a type text is re-expanding to itself (e.g. a nested `|` mis-routed
+  // as a top-level union). Fail loudly rather than overflowing the stack.
+  if (_depth > 100) {
+    throw new Error(`typeTextToSchema: recursion limit exceeded on type text: ${typeText}`);
+  }
   let cleaned = typeText
     .replace(/import\([^)]+\)\./g, '')
     .trim();
@@ -114,13 +152,14 @@ function typeTextToSchema(typeText: string, project: Project): JsonSchema {
   if (cleaned === 'string') return { type: 'string' };
   if (cleaned === 'number') return { type: 'number' };
   if (cleaned === 'boolean') return { type: 'boolean' };
+  if (cleaned === 'null') return { type: 'null' };
   if (cleaned === 'unknown') return {};
   if (cleaned === 'object') return { type: 'object' };
 
   // Array types
   const arrayMatch = cleaned.match(/^(.+)\[\]$/);
   if (arrayMatch) {
-    return { type: 'array', items: typeTextToSchema(arrayMatch[1], project) };
+    return { type: 'array', items: typeTextToSchema(arrayMatch[1], project, _depth + 1) };
   }
 
   // Record<string, X>
@@ -128,14 +167,14 @@ function typeTextToSchema(typeText: string, project: Project): JsonSchema {
   if (recordMatch) {
     return {
       type: 'object',
-      additionalProperties: typeTextToSchema(recordMatch[1], project) as any,
+      additionalProperties: typeTextToSchema(recordMatch[1], project, _depth + 1) as any,
     };
   }
 
   // Type | undefined → just the type (handled by optionality)
   const undefinedMatch = cleaned.match(/^(.+?)\s*\|\s*undefined$/);
   if (undefinedMatch) {
-    return typeTextToSchema(undefinedMatch[1], project);
+    return typeTextToSchema(undefinedMatch[1], project, _depth + 1);
   }
 
   // Partial<X> — inline every property of X as optional (no `required`).
@@ -152,14 +191,38 @@ function typeTextToSchema(typeText: string, project: Project): JsonSchema {
     }
   }
 
-  // Union types (not string literals): A | B
-  if (cleaned.includes(' | ') && !cleaned.startsWith("'")) {
-    const parts = splitUnionType(cleaned);
-    const filteredParts = parts.filter(p => p !== 'undefined');
-    if (filteredParts.length === 1) {
-      return typeTextToSchema(filteredParts[0], project);
+  // Union types (not string literals): A | B. Only treat as a union when there
+  // is a genuine TOP-LEVEL `|`. splitUnionType is depth-aware, so a `|` nested
+  // inside `{ … }` or `<…>` (e.g. an inline object with a `side?: 'a' | 'b'`
+  // field) yields a single part equal to the input — it must fall through to the
+  // inline-object / reference handling below rather than re-expanding forever.
+  // A union type-alias's printed text can also carry a leading `|`
+  // (`type X =\n  | A\n  | B`), which makes splitUnionType yield an empty first
+  // element; dropping empties (and `undefined`) keeps us from emitting a
+  // matches-anything `{}` branch that breaks strict `oneOf` validation.
+  if (cleaned.includes('|') && !cleaned.startsWith("'")) {
+    const parts = splitUnionType(cleaned).filter(p => p !== 'undefined' && p !== '');
+    if (parts.length > 1) {
+      return { oneOf: parts.map(p => typeTextToSchema(p, project, _depth + 1)) };
     }
-    return { oneOf: filteredParts.map(p => typeTextToSchema(p, project)) };
+    if (parts.length === 1 && parts[0] !== cleaned) {
+      return typeTextToSchema(parts[0], project, _depth + 1);
+    }
+  }
+
+  // Enum member access: `ActionType.ChatTurnStarted` → the member's literal
+  // value as a `const`. Without this the capitalized-identifier fallback below
+  // emits a `$ref` to `#/$defs/ActionType.ChatTurnStarted` that is never
+  // defined (dangling). Must run before the interface-reference fallback.
+  const enumMemberMatch = cleaned.match(/^([A-Z]\w*)\.(\w+)$/);
+  if (enumMemberMatch) {
+    const [, enumName, memberName] = enumMemberMatch;
+    const en = findEnum(project, enumName);
+    const member = en?.getMember(memberName);
+    const value = member?.getValue();
+    if (value !== undefined) {
+      return { const: value };
+    }
   }
 
   // Inline object: { message: string; code?: string }
@@ -507,6 +570,85 @@ function generateErrorsSchema(project: Project): JsonSchema {
   return schema;
 }
 
+// ─── Transitive $def resolution ──────────────────────────────────────────────
+
+// Collect every `#/$defs/<name>` reference target reachable in a schema node.
+function collectRefTargets(node: JsonSchema | undefined, acc: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (node.$ref) {
+    const m = node.$ref.match(/^#\/\$defs\/(.+)$/);
+    if (m) acc.add(m[1]);
+  }
+  if (node.items) collectRefTargets(node.items, acc);
+  if (node.additionalProperties && typeof node.additionalProperties === 'object') {
+    collectRefTargets(node.additionalProperties as JsonSchema, acc);
+  }
+  if (node.properties) {
+    for (const key of Object.keys(node.properties)) collectRefTargets(node.properties[key], acc);
+  }
+  if (node.$defs) {
+    for (const key of Object.keys(node.$defs)) collectRefTargets(node.$defs[key], acc);
+  }
+  for (const branch of [node.oneOf, node.anyOf]) {
+    if (branch) for (const b of branch) collectRefTargets(b, acc);
+  }
+}
+
+// Resolve a referenced type name to its schema, searching interfaces, type
+// aliases, and enums (in that order). Returns undefined for names that resolve
+// to none of the above (left for the caller to surface).
+function buildDefForName(project: Project, name: string): JsonSchema | undefined {
+  const iface = findInterface(project, name);
+  if (iface) return interfaceToSchema(iface, project);
+
+  const ta = findTypeAlias(project, name);
+  if (ta) {
+    const typeText = ta.getTypeNode()?.getText() || '';
+    const schema = typeTextToSchema(typeText, project);
+    const rawDesc = ta.getJsDocs()[0]?.getDescription();
+    const desc = rawDesc ? normalizeDescription(rawDesc) : '';
+    if (desc && !schema.description) schema.description = desc;
+    return schema;
+  }
+
+  const en = findEnum(project, name);
+  if (en) return enumToSchema(en);
+
+  return undefined;
+}
+
+// Walk a fully-built schema and backfill any `$def` that is referenced but not
+// yet defined — enums, type aliases (including `URI = string`), and interfaces
+// living in source files the per-schema generator did not eagerly inline. Runs
+// to a fixpoint because a newly-added `$def` can itself reference further types.
+// This is what keeps every generated schema self-contained (no dangling `$ref`).
+function resolveMissingDefs(schema: JsonSchema, project: Project): void {
+  schema.$defs = schema.$defs || {};
+  const unresolved = new Set<string>();
+  for (;;) {
+    const refs = new Set<string>();
+    collectRefTargets(schema, refs);
+    let added = false;
+    for (const name of refs) {
+      if (schema.$defs[name] || unresolved.has(name)) continue;
+      const def = buildDefForName(project, name);
+      if (def) {
+        schema.$defs[name] = def;
+        added = true;
+      } else {
+        unresolved.add(name);
+      }
+    }
+    if (!added) break;
+  }
+  if (unresolved.size > 0) {
+    throw new Error(
+      `generate-json-schema: unresolved $ref target(s) with no interface/alias/enum: ` +
+        `${[...unresolved].sort().join(', ')}`,
+    );
+  }
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 export function generateJsonSchemas(project: Project, outDir: string): void {
@@ -522,6 +664,7 @@ export function generateJsonSchemas(project: Project, outDir: string): void {
 
   for (const { filename, generator } of schemas) {
     const schema = generator(project);
+    resolveMissingDefs(schema, project);
     fs.writeFileSync(
       path.join(outDir, filename),
       JSON.stringify(schema, null, 2) + '\n',


### PR DESCRIPTION
Fixes #302.

Both bugs are fixed generator-wide, plus one scope correction and a latent crash surfaced along the way.

## Bug 1: empty `{}` oneOf branch

A union type alias's printed type text carries a leading `|` (`type X =\n  | A\n  | B`), so `splitUnionType` yielded an empty first element that fell through `typeTextToSchema` to `{}`. Every union alias's `oneOf` therefore led with a matches-anything branch, so every instance matched two or more branches and strict `oneOf` validation always failed.

While fixing this I hit a pre-existing infinite recursion the union path could already trigger: an inline object with a nested union field (e.g. `side?: 'before' | 'after'`) contains a `|`, so it entered the union branch; `splitUnionType` correctly kept it as a single part (the `|` is nested inside `{}`), and the single-part early-return re-processed the identical string forever. The union branch now fires only for a genuine top-level union (two or more parts) and otherwise falls through to the inline-object / reference handling.

## Bug 2: dangling `$ref`s (broader than the issue scopes it)

One correction on scope: the dangling-ref problem is not unique to `notifications.schema.json`. Every generated file has them. Counts before this PR:

| file | dangling `$ref`s |
|---|---|
| state.schema.json | 74 |
| actions.schema.json | 154 |
| commands.schema.json | 182 |
| notifications.schema.json | 95 |
| errors.schema.json | 103 |
| **total** | **608** |

And most of those (roughly 60-75% per file) are a second root cause the issue does not mention: the generator never walked enums. Any property typed as a bare `const enum` (`SessionStatus`, `TurnState`, ...) or an enum-member-literal discriminant (`type: ActionType.AnnotationsEntryRemoved`) hit the capitalized-identifier fallback in `typeTextToSchema` and was emitted as a `$ref` to a `$def` that was never defined, in any file. The remaining dangling refs were type aliases (`URI`, `JsonPrimitive`, ...) that only two of the five generators transitively collected.

The fix has three parts:
- Enum-member accesses inline as `{ "const": <member value> }` (so `type: ActionType.Foo` becomes `{ "const": "root/agentsChanged" }` rather than a dangling ref).
- A fixpoint `resolveMissingDefs` pass runs after each schema is built and backfills every referenced `$def` that is not yet present, resolving interfaces, type aliases (including `URI = string`), and whole enums (`SessionStatus` becomes `{ "type": "number", "enum": [1, 2, 8, 24, 32, 64] }`, with its bitwise member values evaluated). It throws loudly if a referenced name resolves to none of those, so a future gap fails the build instead of silently emitting a dangling ref.
- `null` union members now render as `{ "type": "null" }` instead of `{}`.

I chose transitive inline collection (option A from the issue) rather than cross-file `$ref`s (option B), since every existing schema file is already self-contained and I did not want to introduce a new cross-document architecture.

## Result

After this PR, across all five files: **0 dangling `$ref`s** (was 608) and **0 empty `{}` oneOf branches** (was 30).

There was no test coverage for the schema generator and no CI gate that would have caught any of this, so I added `scripts/generate-json-schema.test.ts` (wired into `npm test`) asserting that no generated schema has an empty `{}` oneOf branch or a dangling `$ref`. It is dependency-free (no new packages) and fails if either bug is reintroduced.

`npm test` passes (290 tests, typecheck, lint, changelog + release-metadata gates). All five `schema/*.json` files are regenerated in this PR.
