### PR TITLE
Add optional `_meta` slot to `SystemNotificationResponsePart`

### DIFF
--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -1645,6 +1645,14 @@ type SystemNotificationResponsePart struct {
 	Kind ResponsePartKind `json:"kind"`
 	// The text of the system notification
 	Content StringOrMarkdown `json:"content"`
+	// Additional provider-specific metadata for this notification.
+	//
+	// A host MAY attach a machine-readable descriptor of what triggered the
+	// notification so clients can categorize, icon, group, filter, or localize
+	// it without parsing `content`. Clients MAY look for well-known keys here to
+	// provide enhanced UI, and MUST render coherently from `content` alone when
+	// `_meta` is absent or unrecognized.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // A resolved input request (elicitation) recorded in the turn transcript.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -2289,7 +2289,18 @@ data class SystemNotificationResponsePart(
     /**
      * The text of the system notification
      */
-    val content: StringOrMarkdown
+    val content: StringOrMarkdown,
+    /**
+     * Additional provider-specific metadata for this notification.
+     *
+     * A host MAY attach a machine-readable descriptor of what triggered the
+     * notification so clients can categorize, icon, group, filter, or localize
+     * it without parsing `content`. Clients MAY look for well-known keys here to
+     * provide enhanced UI, and MUST render coherently from `content` alone when
+     * `_meta` is absent or unrecognized.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -2062,6 +2062,15 @@ pub struct ReasoningResponsePart {
 pub struct SystemNotificationResponsePart {
     /// The text of the system notification
     pub content: StringOrMarkdown,
+    /// Additional provider-specific metadata for this notification.
+    ///
+    /// A host MAY attach a machine-readable descriptor of what triggered the
+    /// notification so clients can categorize, icon, group, filter, or localize
+    /// it without parsing `content`. Clients MAY look for well-known keys here to
+    /// provide enhanced UI, and MUST render coherently from `content` alone when
+    /// `_meta` is absent or unrecognized.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// A resolved input request (elicitation) recorded in the turn transcript.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -2291,13 +2291,29 @@ public struct SystemNotificationResponsePart: Codable, Sendable {
     public var kind: ResponsePartKind
     /// The text of the system notification
     public var content: StringOrMarkdown
+    /// Additional provider-specific metadata for this notification.
+    ///
+    /// A host MAY attach a machine-readable descriptor of what triggered the
+    /// notification so clients can categorize, icon, group, filter, or localize
+    /// it without parsing `content`. Clients MAY look for well-known keys here to
+    /// provide enhanced UI, and MUST render coherently from `content` alone when
+    /// `_meta` is absent or unrecognized.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case content
+        case meta = "_meta"
+    }
 
     public init(
         kind: ResponsePartKind,
-        content: StringOrMarkdown
+        content: StringOrMarkdown,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.kind = kind
         self.content = content
+        self.meta = meta
     }
 }
 

--- a/docs/.changes/20260709-system-notification-meta-slot.json
+++ b/docs/.changes/20260709-system-notification-meta-slot.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "Optional `_meta` slot on `SystemNotificationResponsePart`, following the MCP `_meta` convention. A host MAY attach a machine-readable descriptor of what triggered the notification so clients can categorize, icon, group, filter, or localize it without parsing `content`.",
+  "issues": [308]
+}

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -324,6 +324,7 @@ ContentRef {
 SystemNotificationResponsePart {
   kind: 'systemNotification'
   content: StringOrMarkdown
+  _meta?: Record<string, unknown>   // machine-readable trigger metadata; see below
 }
 
 // Durable record of a resolved input request (see Input Requests below)
@@ -333,6 +334,8 @@ InputRequestResponsePart {
   response: ChatInputResponseKind  // 'accept' | 'decline' | 'cancel'
 }
 ```
+
+`SystemNotificationResponsePart._meta` carries provider-specific metadata describing what triggered the notification. A host MAY attach a machine-readable descriptor so clients can categorize, icon, group, filter, or localize the notification without parsing `content`. Clients MAY inspect well-known keys for enhanced UI, and MUST render coherently from `content` alone when `_meta` is absent or unrecognized.
 
 Text content uses a **create-then-append** pattern: the server first emits a `chat/responsePart` action to create a new markdown (or reasoning) part with an `id`, then streams text into it via `chat/delta` (or `chat/reasoning`) actions targeting that `partId`. This pattern is extensible to future streaming content types.
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -5221,6 +5221,11 @@
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "The text of the system notification"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this notification.\n\nA host MAY attach a machine-readable descriptor of what triggered the\nnotification so clients can categorize, icon, group, filter, or localize\nit without parsing `content`. Clients MAY look for well-known keys here to\nprovide enhanced UI, and MUST render coherently from `content` alone when\n`_meta` is absent or unrecognized."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -4509,6 +4509,11 @@
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "The text of the system notification"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this notification.\n\nA host MAY attach a machine-readable descriptor of what triggered the\nnotification so clients can categorize, icon, group, filter, or localize\nit without parsing `content`. Clients MAY look for well-known keys here to\nprovide enhanced UI, and MUST render coherently from `content` alone when\n`_meta` is absent or unrecognized."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -3300,6 +3300,11 @@
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "The text of the system notification"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this notification.\n\nA host MAY attach a machine-readable descriptor of what triggered the\nnotification so clients can categorize, icon, group, filter, or localize\nit without parsing `content`. Clients MAY look for well-known keys here to\nprovide enhanced UI, and MUST render coherently from `content` alone when\n`_meta` is absent or unrecognized."
         }
       },
       "required": [

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -3460,6 +3460,11 @@
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "The text of the system notification"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this notification.\n\nA host MAY attach a machine-readable descriptor of what triggered the\nnotification so clients can categorize, icon, group, filter, or localize\nit without parsing `content`. Clients MAY look for well-known keys here to\nprovide enhanced UI, and MUST render coherently from `content` alone when\n`_meta` is absent or unrecognized."
         }
       },
       "required": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -3211,6 +3211,11 @@
         "content": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "The text of the system notification"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Additional provider-specific metadata for this notification.\n\nA host MAY attach a machine-readable descriptor of what triggered the\nnotification so clients can categorize, icon, group, filter, or localize\nit without parsing `content`. Clients MAY look for well-known keys here to\nprovide enhanced UI, and MUST render coherently from `content` alone when\n`_meta` is absent or unrecognized."
         }
       },
       "required": [

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -884,6 +884,16 @@ export interface SystemNotificationResponsePart {
   kind: ResponsePartKind.SystemNotification;
   /** The text of the system notification */
   content: StringOrMarkdown;
+  /**
+   * Additional provider-specific metadata for this notification.
+   *
+   * A host MAY attach a machine-readable descriptor of what triggered the
+   * notification so clients can categorize, icon, group, filter, or localize
+   * it without parsing `content`. Clients MAY look for well-known keys here to
+   * provide enhanced UI, and MUST render coherently from `content` alone when
+   * `_meta` is absent or unrecognized.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 


### PR DESCRIPTION
## Summary

Closes #307.

`SystemNotificationResponsePart` conveys a harness event as human-readable `content` only. There is no machine-readable indication of *what triggered* it, so a client cannot categorize, icon, group, filter, or localize these parts without string-matching natural-language prose. This adds the standard `_meta` escape hatch to close that gap.

```ts
export interface SystemNotificationResponsePart {
  kind: ResponsePartKind.SystemNotification;
  content: StringOrMarkdown;
  /**
   * Additional provider-specific metadata for this notification.
   *
   * A host MAY attach a machine-readable descriptor of what triggered the
   * notification so clients can categorize, icon, group, filter, or localize
   * it without parsing `content`. Clients MAY look for well-known keys here to
   * provide enhanced UI, and MUST render coherently from `content` alone when
   * `_meta` is absent or unrecognized.
   */
  _meta?: Record<string, unknown>;
}
```

## Why

- `_meta?: Record<string, unknown>` is the established escape hatch across AHP state carriers (`Message`, `ChatState`, `UsageInfo`, `ErrorInfo`, `RootState`, `ToolDefinition`, session types, …), mirroring the MCP `_meta` convention. No response-part type carried one before — and the system notification, whose whole purpose is to surface an out-of-band harness event, is the part that most needs it.
- It fits the doctrine's "escape hatches are explicit" principle: provider-specific metadata is allowed but never required for the baseline experience. A minimal client ignores `_meta` and still renders coherently from `content`; a typed trigger discriminator can graduate out of `_meta` later if a portable subset proves worthwhile.

## Compatibility

Purely additive and optional. Existing clients ignore `_meta`; hosts that omit it stay compliant. No reducer change is required — `SystemNotificationResponsePart` is delivered via the existing `ChatResponsePartAction`, whose reducer appends the part wholesale, so `_meta` rides through unchanged.

## Changes

- **`types/channels-chat/state.ts`** — add the `_meta` slot with a convention-matching doc comment.
- **Generated mirrors** — regenerated the JSON Schema and all five client mirrors (Rust, Kotlin, Swift, TypeScript, Go).
- **`docs/guide/state-model.md`** — document `SystemNotificationResponsePart` in the Response Parts section (it was previously missing) and describe the `_meta` slot.
- **CHANGELOGs** — added an `### Added` entry under `## [0.5.2] — Unreleased` in the spec changelog and every per-client changelog.