### PR TITLE
docs: move chat-channel actions off the session channel in the guides

### DIFF
--- a/docs/.vitepress/theme/components/HomeWalkthrough.vue
+++ b/docs/.vitepress/theme/components/HomeWalkthrough.vue
@@ -210,27 +210,27 @@ onBeforeUnmount(() => {
             <div class="wire-rail">
               <div class="wire-line" style="--i:0">
                 <span class="seq">41</span>
-                <span class="evt evt-blue">session/turnStarted</span>
+                <span class="evt evt-blue">chat/turnStarted</span>
                 <span class="payload">"Add retry logic to the API client"</span>
               </div>
               <div class="wire-line" style="--i:1">
                 <span class="seq">42</span>
-                <span class="evt evt-blue">session/delta</span>
+                <span class="evt evt-blue">chat/delta</span>
                 <span class="payload">"Sure — I'll wrap the fetch call…"</span>
               </div>
               <div class="wire-line" style="--i:2">
                 <span class="seq">43</span>
-                <span class="evt evt-orange">session/toolCallStart</span>
+                <span class="evt evt-orange">chat/toolCallStart</span>
                 <span class="payload">Edit file · <span class="mono">src/api.ts</span></span>
               </div>
               <div class="wire-line" style="--i:3">
                 <span class="seq">46</span>
-                <span class="evt evt-orange">session/toolCallComplete</span>
+                <span class="evt evt-orange">chat/toolCallComplete</span>
                 <span class="payload"><span class="wt-green">ok</span> · 1 file changed</span>
               </div>
               <div class="wire-line" style="--i:4">
                 <span class="seq">47</span>
-                <span class="evt evt-green">session/turnComplete</span>
+                <span class="evt evt-green">chat/turnComplete</span>
                 <span class="payload">turn <span class="mono">t_8c1</span> done</span>
               </div>
             </div>

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -32,34 +32,34 @@ These mutate root state and travel on the [Root Channel](/specification/root-cha
 | `root/terminalsChanged` | No | Lightweight terminal catalogue changed (full replacement) |
 | `root/configChanged` | **Yes** | Host-level configuration values changed |
 
-## Session Actions
+## Session & Chat Actions
 
-Session actions travel on the relevant [Session Channel](/specification/session-channel). Some are server-only (produced by the agent backend), others are client-dispatchable.
+Actions travel on the channel named by their prefix: `session/*` actions on the [Session Channel](/specification/session-channel) (`ahp-session:/<uuid>`), and `chat/*` actions on a [Chat Channel](/specification/chat-channel) (`ahp-chat:/<cid>`). A session is a catalog of chats; its per-conversation activity — turns, streaming, tool calls, pending messages, and input requests — lives on the chat channels, while lifecycle, metadata, tool-registry, and customization actions live on the session channel. Some actions are server-only (produced by the agent backend), others are client-dispatchable.
 
-When a client dispatches an action, the server applies it to the state and also reacts to it as a side effect (e.g. `session/turnStarted` triggers agent processing, `session/turnCancelled` aborts it). This avoids a separate command→action translation layer for the common interactive cases.
+When a client dispatches an action, the server applies it to the state and also reacts to it as a side effect (e.g. `chat/turnStarted` triggers agent processing, `chat/turnCancelled` aborts it). This avoids a separate command→action translation layer for the common interactive cases.
 
-### Lifecycle
+### Lifecycle (session channel)
 
 | Type | Client-dispatchable? | When |
 |---|---|---|
 | `session/ready` | No | Session backend initialised successfully |
 | `session/creationFailed` | No | Session backend failed to initialise |
 
-### Turn Lifecycle
+### Turn Lifecycle (chat channel)
 
 | Type | Client-dispatchable? | When |
 |---|---|---|
-| `session/turnStarted` | **Yes** | User sent a message; server starts processing |
-| `session/delta` | No | Streaming text chunk appended to a response part by `partId` |
-| `session/responsePart` | No | New response part created (markdown, reasoning, content ref, tool call) |
-| `session/reasoning` | No | Reasoning/thinking text appended to a reasoning part by `partId` |
-| `session/usage` | No | Token usage report for the active turn |
-| `session/turnComplete` | No | Turn finished (assistant idle) |
-| `session/turnCancelled` | **Yes** | Turn was aborted; server stops processing |
-| `session/error` | No | Error during turn processing |
-| `session/truncated` | **Yes** | Turn history truncated (with optional `turnId` cutoff) |
+| `chat/turnStarted` | **Yes** | User sent a message; server starts processing |
+| `chat/delta` | No | Streaming text chunk appended to a response part by `partId` |
+| `chat/responsePart` | No | New response part created (markdown, reasoning, content ref, tool call) |
+| `chat/reasoning` | No | Reasoning/thinking text appended to a reasoning part by `partId` |
+| `chat/usage` | No | Token usage report for the active turn |
+| `chat/turnComplete` | No | Turn finished (assistant idle) |
+| `chat/turnCancelled` | **Yes** | Turn was aborted; server stops processing |
+| `chat/error` | No | Error during turn processing |
+| `chat/truncated` | **Yes** | Turn history truncated (with optional `turnId` cutoff) |
 
-### Tool Calls
+### Tool Calls (chat channel)
 
 Tool calls follow a discriminated-union state machine — see [State Model — Tool Call Lifecycle](/guide/state-model#tool-call-lifecycle) for the full diagram.
 
@@ -88,7 +88,7 @@ Tool calls follow a discriminated-union state machine — see [State Model — T
 | `session/configChanged` | **Yes** | Mutable session config values changed |
 | `session/metaChanged` | No | The session's `_meta` side-channel was replaced |
 
-### Server & Active-Client Tools
+### Server & Active-Client Tools (session channel)
 
 | Type | Client-dispatchable? | When |
 |---|---|---|
@@ -98,23 +98,23 @@ Tool calls follow a discriminated-union state machine — see [State Model — T
 
 See [Customizations & Client Tools](/guide/customizations) for the full flow.
 
-### Pending Messages
+### Pending Messages (chat channel)
 
 | Type | Client-dispatchable? | When |
 |---|---|---|
-| `session/pendingMessageSet` | **Yes** | A steering or queued message was set (upsert) |
-| `session/pendingMessageRemoved` | **Yes** | A pending message was cancelled (by client) or consumed (by server) |
-| `session/queuedMessagesReordered` | **Yes** | Queued messages were reordered |
+| `chat/pendingMessageSet` | **Yes** | A steering or queued message was set (upsert) |
+| `chat/pendingMessageRemoved` | **Yes** | A pending message was cancelled (by client) or consumed (by server) |
+| `chat/queuedMessagesReordered` | **Yes** | Queued messages were reordered |
 
 The `pendingMessageSet` and `pendingMessageRemoved` actions carry a `kind` discriminant (`'steering'` or `'queued'`). See the [State Model — Pending Messages](/guide/state-model#pending-messages) for semantics.
 
-### Input Requests
+### Input Requests (chat channel)
 
 | Type | Client-dispatchable? | When |
 |---|---|---|
-| `session/inputRequested` | No | Server requested structured input from the user (upsert) |
-| `session/inputAnswerChanged` | **Yes** | Client updated a single draft / submitted / skipped answer |
-| `session/inputCompleted` | **Yes** | Client accepted, declined, or cancelled an input request |
+| `chat/inputRequested` | No | Server requested structured input from the user (upsert) |
+| `chat/inputAnswerChanged` | **Yes** | Client updated a single draft / submitted / skipped answer |
+| `chat/inputCompleted` | **Yes** | Client accepted, declined, or cancelled an input request |
 
 See [Elicitation](/guide/elicitation) for the request lifecycle.
 
@@ -173,9 +173,9 @@ Clients interact with the server by dispatching actions as fire-and-forget notif
   "jsonrpc": "2.0",
   "method": "dispatchAction",
   "params": {
-    "channel": "ahp-session:/<uuid>",
+    "channel": "ahp-chat:/<cid>",
     "clientSeq": 1,
-    "action": { "type": "session/turnStarted", "turnId": "t1", ... }
+    "action": { "type": "chat/turnStarted", "turnId": "t1", ... }
   }
 }
 ```
@@ -184,13 +184,13 @@ The client applies the action **optimistically** to its local state before sendi
 
 | Action | Server-side effect |
 |---|---|
-| `session/turnStarted` | Begins agent processing for the new turn |
+| `chat/turnStarted` | Begins agent processing for the new turn |
 | `chat/toolCallConfirmed` | Approves or denies a pending tool call; unblocks or cancels tool execution |
-| `session/turnCancelled` | Aborts the in-progress turn |
+| `chat/turnCancelled` | Aborts the in-progress turn |
 | `session/titleChanged` | Updates the session title (rename) |
-| `session/pendingMessageSet` | Stores a steering or queued message (upsert); if queued and idle, auto-starts a turn |
-| `session/pendingMessageRemoved` | Cancels a pending message before it is consumed |
-| `session/queuedMessagesReordered` | Reorders queued messages; unknown IDs ignored, unmentioned messages kept at end |
+| `chat/pendingMessageSet` | Stores a steering or queued message (upsert); if queued and idle, auto-starts a turn |
+| `chat/pendingMessageRemoved` | Cancels a pending message before it is consumed |
+| `chat/queuedMessagesReordered` | Reorders queued messages; unknown IDs ignored, unmentioned messages kept at end |
 | `session/customizationToggled` | Toggles a container or child customization on or off by id |
 | `session/isReadChanged` | Marks the session as read or unread |
 | `session/isArchivedChanged` | Archives or unarchives the session |
@@ -203,6 +203,7 @@ State is mutated by pure reducer functions — one per state-bearing channel typ
 ```typescript
 rootReducer(state: RootState, action: RootAction): RootState
 sessionReducer(state: SessionState, action: SessionAction): SessionState
+chatReducer(state: ChatState, action: ChatAction): ChatState
 terminalReducer(state: TerminalState, action: TerminalAction): TerminalState
 ```
 

--- a/docs/guide/ahp-and-acp.md
+++ b/docs/guide/ahp-and-acp.md
@@ -40,17 +40,17 @@ The host is the boundary between these two concerns.
 | **Reconnection / replay** | Built-in — clients reconnect with `lastSeenServerSeq` and replay missed actions | Not specified at the protocol level |
 | **Agent abstraction** | Agent-agnostic by design — clients never see agent-specific details | Agent-specific — defines the agent's interface directly |
 | **Session lifecycle** | Host manages sessions; clients subscribe by URI | Client creates sessions directly with the agent |
-| **Streaming** | Actions (`session/delta`, `session/responsePart`) applied through reducers | `session/update` notifications sent over the wire |
+| **Streaming** | Actions (`chat/delta`, `chat/responsePart`) applied through reducers | `session/update` notifications sent over the wire |
 
 ## How They Compose
 
 An AHP host implementation can use ACP as its agent backend protocol. The internal flow looks like this:
 
-1. **Client dispatches an action** (e.g. `session/turnStarted`) via AHP.
+1. **Client dispatches an action** (e.g. `chat/turnStarted`) via AHP.
 2. **Host sequences it** — assigns a `serverSeq`, applies it to the authoritative state, broadcasts the action envelope to all subscribed clients.
 3. **Host translates to ACP** — sends a `session/prompt` to the ACP agent.
 4. **Agent streams back** — the ACP agent sends `session/update` notifications with content chunks, tool calls, and permission requests.
-5. **Host maps to AHP actions** — the agent event mapper converts ACP-specific events into agent-agnostic AHP actions (`session/delta`, `chat/toolCallStart`, `chat/toolCallReady`, etc.).
+5. **Host maps to AHP actions** — the agent event mapper converts ACP-specific events into agent-agnostic AHP actions (`chat/delta`, `chat/toolCallStart`, `chat/toolCallReady`, etc.).
 6. **Host broadcasts** — each mapped action gets a `serverSeq` and flows to all subscribed clients through the normal state synchronization path.
 
 The host is acting as a bridge: it speaks AHP upstream (to clients) and ACP downstream (to agents). The agent event mapper is the translation layer between the two.
@@ -63,9 +63,9 @@ When multiple clients connect to the same agent session, the host serializes the
 
 Concretely:
 
-- **Turn ownership**: Only one turn runs at a time. When Client A starts a turn, Clients B and C see the `session/turnStarted` action and know the session is busy. AHP's state tree makes this visible to everyone.
+- **Turn ownership**: Only one turn runs at a time per chat. When Client A starts a turn in a chat, Clients B and C see the `chat/turnStarted` action and know that chat is busy. AHP's state tree makes this visible to everyone.
 - **Tool call confirmation**: When the agent needs user approval for a tool call, the host surfaces it as a state action. Any client can resolve it — but only once (the first `chat/toolCallConfirmed` wins; subsequent ones are rejected). The host arbitrates.
-- **Cancellation**: Any client can cancel a running turn. The host sequences the `session/turnCancelled` action and forwards the cancellation to the agent via ACP's `session/cancel`. All clients see the result.
+- **Cancellation**: Any client can cancel a running turn. The host sequences the `chat/turnCancelled` action and forwards the cancellation to the agent via ACP's `session/cancel`. All clients see the result.
 - **Optimistic updates with reconciliation**: Clients apply their own actions immediately (write-ahead) and reconcile when the server echoes them back. This gives responsive UI without sacrificing consistency — something a 1:1 protocol doesn't need to worry about.
 
 ACP doesn't need any of this because it assumes one client. AHP adds exactly this coordination, and nothing more — it doesn't redefine how agents work, what tools they expose, or how they stream content.

--- a/docs/guide/changesets.md
+++ b/docs/guide/changesets.md
@@ -50,7 +50,7 @@ unknown variables.
 | Variables in template                     | Meaning                                                                      |
 | ----------------------------------------- | ---------------------------------------------------------------------------- |
 | _(none)_                                  | A static, session-wide changeset. The template is itself a subscribable URI. |
-| `{turnId}`                                | Per-turn slice. Expand with a `Turn.id` from the session.                    |
+| `{turnId}`                                | Per-turn slice. Expand with a `Turn.id` from one of the session's chats.     |
 | `{originalTurnId}` and `{modifiedTurnId}` | Diff between two turns. Both must be present.                                |
 
 ### Changeset State

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -315,7 +315,7 @@ If the client receives a tool call for a tool it does not recognize (e.g. after 
 ```typescript
 dispatch({
   type: 'chat/toolCallConfirmed',
-  session: sessionUri,
+  channel: chatUri,
   turnId,
   toolCallId,
   approved: false,

--- a/docs/guide/elicitation.md
+++ b/docs/guide/elicitation.md
@@ -1,23 +1,23 @@
 # Elicitation
 
-Sessions can request structured input from the user by storing live input requests in top-level session state. These requests are useful for MCP elicitation, URL-based review flows, and agent clarification questions.
+The agent can request structured input from the user by storing live input requests in per-chat state (`ChatState.inputRequests`) on the [chat channel](/specification/chat-channel). These requests are useful for MCP elicitation, URL-based review flows, and agent clarification questions.
 
-Input requests are live state, not one-shot RPC prompts: every subscriber sees open requests and synchronized answer drafts.
+Input requests are live state, not one-shot RPC prompts: every subscriber to the chat sees open requests and synchronized answer drafts.
 
 ## State Shape
 
 ```typescript
-SessionState {
+ChatState {
   // ...existing fields...
-  inputRequests?: SessionInputRequest[]
+  inputRequests?: ChatInputRequest[]
 }
 
-SessionInputRequest {
+ChatInputRequest {
   id: string
-  message: string
+  message?: string
   url?: URI
-  questions?: SessionInputQuestion[]
-  answers?: Record<string, SessionInputAnswer>
+  questions?: ChatInputQuestion[]
+  answers?: Record<string, ChatInputAnswer>
 }
 ```
 
@@ -28,16 +28,16 @@ Each request has a stable `id`. Each question has a stable `id` used as the key 
 The server SHOULD use this sequence when it needs user input to continue a turn:
 
 1. Keep the turn active.
-2. Dispatch `session/inputRequested` with a stable request `id` and stable question IDs.
-3. Observe zero or more client-dispatched `session/inputAnswerChanged` actions. Each action updates one question's draft, submitted, or skipped answer.
-4. Observe `session/inputCompleted` with `response: 'accept'`, `'decline'`, or `'cancel'`.
+2. Dispatch `chat/inputRequested` with a stable request `id` and stable question IDs.
+3. Observe zero or more client-dispatched `chat/inputAnswerChanged` actions. Each action updates one question's draft, submitted, or skipped answer.
+4. Observe `chat/inputCompleted` with `response: 'accept'`, `'decline'`, or `'cancel'`.
 5. Resume the blocked operation, such as completing an MCP `elicitation/create` request or returning a result for an ask-questions tool call.
 
-Because drafts live in session state, a user can answer one question on client A and another on client B; every subscriber observes the merged `answers` map.
+Because drafts live in chat state, a user can answer one question on client A and another on client B; every subscriber to the chat observes the merged `answers` map.
 
 ## Status And Cleanup
 
-While any input request is open, `status` is `SessionStatus.InputNeeded`. When the last request is completed and the turn is still active, status returns to `SessionStatus.InProgress`.
+While a chat has any open input request, that chat's `status` carries `SessionStatus.InputNeeded`, and the session's aggregated `status` is promoted to `InputNeeded` because a chat needs input. When the last request is completed and the turn is still active, the chat's status returns to `SessionStatus.InProgress`.
 
 If the active turn completes, is cancelled, errors, or is truncated before input completes, the server SHOULD consider outstanding input requests abandoned. The reducer removes outstanding requests.
 
@@ -53,11 +53,11 @@ Each question is a discriminated union by `kind`:
 | `single-select` | `{ kind: 'selected', value: optionId, freeformValues?: string[] }` |
 | `multi-select` | `{ kind: 'selected-many', value: optionIds[], freeformValues?: string[] }` |
 
-`SessionInputAnswer.state` distinguishes draft/submitted answers from skipped answers. Draft answers are for multi-client synchronization; submitted answers are ready for the server to consume when the request completes.
+`ChatInputAnswer.state` distinguishes draft/submitted answers (`ChatInputAnswered`) from skipped answers (`ChatInputSkipped`). Draft answers are for multi-client synchronization; submitted answers are ready for the server to consume when the request completes.
 
 ## URL Requests
 
-An input request may include `url` instead of, or in addition to, structured questions. Clients can open the URL or present it for review, then complete the request with `session/inputCompleted`.
+An input request may include `url` instead of, or in addition to, structured questions. Clients can open the URL or present it for review, then complete the request with `chat/inputCompleted`.
 
 ## Validation
 
@@ -65,12 +65,12 @@ Servers SHOULD reject client-dispatched input actions when:
 
 | Action | Condition |
 |---|---|
-| `session/inputAnswerChanged` | No input request has the matching `requestId`. |
-| `session/inputAnswerChanged` | `answer.state` requires a value but `answer.value` is absent, or the value kind does not match the answer payload. |
-| `session/inputCompleted` | No input request has the matching `requestId`. |
-| `session/inputCompleted` | `response` is `'accept'` but required questions do not have submitted answers. |
+| `chat/inputAnswerChanged` | No input request has the matching `requestId`. |
+| `chat/inputAnswerChanged` | `answer.state` requires a value but `answer.value` is absent, or the value kind does not match the answer payload. |
+| `chat/inputCompleted` | No input request has the matching `requestId`. |
+| `chat/inputCompleted` | `response` is `'accept'` but required questions do not have submitted answers. |
 
 ## Related Reference
 
-- [Session Channel Reference](/reference/session) — `SessionInputRequest`, `SessionInputQuestion`, answer value types, and the `session/input*` action variants.
-- [Session Channel](/specification/session-channel) — Session creation, active turns, and client-action validation.
+- [Chat Channel Reference](/reference/chat) — `ChatInputRequest`, `ChatInputQuestion`, answer value types, and the `chat/input*` action variants.
+- [Chat Channel](/specification/chat-channel) — Per-chat turns, active turn, tool calls, and client-action validation.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -84,11 +84,23 @@ Session creation uses an imperative RPC command:
 }
 ```
 
-The initial snapshot has `lifecycle: 'creating'`. The server asynchronously initializes the agent backend, then dispatches either a `session/ready` or `session/creationFailed` action.
+The initial snapshot has `lifecycle: 'creating'`. The server asynchronously initializes the agent backend, then dispatches either a `session/ready` or `session/creationFailed` action. A ready session starts with a default chat: its `ahp-chat:/<cid>` URI is carried in `SessionState.defaultChat` and listed in the session's `chats` catalog. Per-conversation state — turns, streaming responses, and tool calls — lives on that chat's own channel, not the session channel. See the [Chat Channel specification](/specification/chat-channel) for the full per-chat model.
 
 ## Sending a Message
 
-To start a turn, the client dispatches a `session/turnStarted` action. This is a **write-ahead** action — the client applies it optimistically to its local state:
+Turns happen on a **chat channel**. Subscribe to the session's default chat the same way you subscribed to the session:
+
+```jsonc
+// Client → Server (request): subscribe to the session's default chat
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "subscribe",
+  "params": { "channel": "ahp-chat:/<cid>" }
+}
+```
+
+To start a turn, dispatch a `chat/turnStarted` action on the chat channel. This is a **write-ahead** action — the client applies it optimistically to its local chat state:
 
 ```jsonc
 // Client → Server (notification, fire-and-forget)
@@ -96,10 +108,10 @@ To start a turn, the client dispatches a `session/turnStarted` action. This is a
   "jsonrpc": "2.0",
   "method": "dispatchAction",
   "params": {
-    "channel": "ahp-session:/<uuid>",
+    "channel": "ahp-chat:/<cid>",
     "clientSeq": 1,
     "action": {
-      "type": "session/turnStarted",
+      "type": "chat/turnStarted",
       "turnId": "turn-1",
       "message": { "text": "Explain this code", "origin": { "kind": "user" } }
     }
@@ -107,34 +119,34 @@ To start a turn, the client dispatches a `session/turnStarted` action. This is a
 }
 ```
 
-The server begins agent processing and streams back actions:
+The server begins agent processing and streams back actions on the same chat channel:
 
 ```jsonc
 // Server → Client: streaming text delta
 { "method": "action", "params": {
-  "channel": "ahp-session:/<uuid>",
-  "action": { "type": "session/delta", "turnId": "turn-1", "partId": "p1", "content": "This code " },
+  "channel": "ahp-chat:/<cid>",
+  "action": { "type": "chat/delta", "turnId": "turn-1", "partId": "p1", "content": "This code " },
   "serverSeq": 6
 }}
 
 // Server → Client: more streaming text
 { "method": "action", "params": {
-  "channel": "ahp-session:/<uuid>",
-  "action": { "type": "session/delta", "turnId": "turn-1", "partId": "p1", "content": "defines a function..." },
+  "channel": "ahp-chat:/<cid>",
+  "action": { "type": "chat/delta", "turnId": "turn-1", "partId": "p1", "content": "defines a function..." },
   "serverSeq": 7
 }}
 
 // Server → Client: turn complete
 { "method": "action", "params": {
-  "channel": "ahp-session:/<uuid>",
-  "action": { "type": "session/turnComplete", "turnId": "turn-1" },
+  "channel": "ahp-chat:/<cid>",
+  "action": { "type": "chat/turnComplete", "turnId": "turn-1" },
   "serverSeq": 8
 }}
 ```
 
 ## Handling Tool Calls
 
-When the agent invokes a tool, the server emits a sequence of actions modelling the tool call's lifecycle (see [State Model — Tool Call Lifecycle](/guide/state-model#tool-call-lifecycle) for the full state machine):
+When the agent invokes a tool, the server emits a sequence of actions on the chat channel modelling the tool call's lifecycle (see [State Model — Tool Call Lifecycle](/guide/state-model#tool-call-lifecycle) for the full state machine):
 
 1. `chat/toolCallStart` — a new tool call begins.
 2. `chat/toolCallDelta` — partial parameters stream in.
@@ -149,7 +161,7 @@ The client resolves a `pending-confirmation` tool call by dispatching `chat/tool
   "jsonrpc": "2.0",
   "method": "dispatchAction",
   "params": {
-    "channel": "ahp-session:/<uuid>",
+    "channel": "ahp-chat:/<cid>",
     "clientSeq": 2,
     "action": {
       "type": "chat/toolCallConfirmed",

--- a/docs/guide/reconciliation.md
+++ b/docs/guide/reconciliation.md
@@ -52,7 +52,7 @@ Time  Server                          Client A                        Client B
 
 ## Why Rebasing Is Simple
 
-Most session actions are **append-only**:
+Most chat actions are **append-only**:
 - Add turn, append delta, add tool call, append response part.
 
 Pending actions still apply cleanly to an updated confirmed state because they operate on independent data — the turn the client created still exists; the content it appended is additive.

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -137,6 +137,33 @@ Bits 0–4 encode mutually-exclusive **activity** status (exactly one is set at 
 
 For example, `(status & SessionStatus.InProgress) !== 0` is true for both `InProgress` and `InputNeeded`. A session that is idle, read, and archived has status `1 | 32 | 64 = 97`.
 
+## Chat State
+
+Subscribable on a [Chat Channel](/specification/chat-channel) at `ahp-chat:/<cid>`. A session is a catalog of chats (`SessionState.chats`); each chat carries the per-conversation state — the turn history, the active turn and its streaming response parts, tool calls, steering/queued messages, outstanding input requests, and the user's in-progress draft. A session starts with a default chat (`SessionState.defaultChat`); hosts advertising the `multipleChats` capability let clients open more via `createChat`.
+
+```typescript
+ChatState {
+  // Chat summary fields, inlined directly (mirrored into SessionState.chats)
+  resource: URI
+  title: string
+  status: number          // SessionStatus bitset
+  activity?: string
+  modifiedAt: string
+  origin?: ChatOrigin      // how the chat came to exist (user / fork / tool)
+  workingDirectory?: URI
+
+  turns: Turn[]                       // completed turns
+  turnsNextCursor?: string            // page older turns via fetchTurns
+  activeTurn?: ActiveTurn             // the in-progress turn, if any
+  steeringMessage?: PendingMessage
+  queuedMessages?: PendingMessage[]
+  inputRequests?: ChatInputRequest[]
+  draft?: Message                     // user's in-progress input
+}
+```
+
+The sections below — turns, response parts, tool calls, pending messages, and input requests — describe the contents of `ChatState`.
+
 ## Turns
 
 A turn represents one request/response cycle between user and agent.
@@ -266,14 +293,14 @@ All response content — text, tool calls, reasoning, and content references —
 // Inline markdown content
 MarkdownResponsePart {
   kind: 'markdown'
-  id: string               // targeted by session/delta for text appends
+  id: string               // targeted by chat/delta for text appends
   content: string
 }
 
 // Reasoning/thinking content from the model
 ReasoningResponsePart {
   kind: 'reasoning'
-  id: string               // targeted by session/reasoning for text appends
+  id: string               // targeted by chat/reasoning for text appends
   content: string
 }
 
@@ -292,7 +319,7 @@ ContentRef {
 }
 ```
 
-Text content uses a **create-then-append** pattern: the server first emits a `session/responsePart` action to create a new markdown (or reasoning) part with an `id`, then streams text into it via `session/delta` (or `session/reasoning`) actions targeting that `partId`. This pattern is extensible to future streaming content types.
+Text content uses a **create-then-append** pattern: the server first emits a `chat/responsePart` action to create a new markdown (or reasoning) part with an `id`, then streams text into it via `chat/delta` (or `chat/reasoning`) actions targeting that `partId`. This pattern is extensible to future streaming content types.
 
 Clients fetch `ContentRef` content separately via the `resourceRead(uri)` command. This keeps the state tree small and serializable.
 
@@ -357,22 +384,22 @@ By default, clients render a binary approve/deny UI for `pending-confirmation` t
 
 For example, a server might offer `"Approve"`, `"Approve in this Session"`, `"Deny"`, and `"Deny with reason"`. When the user picks an option, the client dispatches `chat/toolCallConfirmed` with `selectedOptionId` set to the chosen option's `id`. The reducer resolves the full `ConfirmationOption` object and stores it as `selectedOption` on the resulting `running` or `cancelled` state, and it carries through to `completed`.
 
-## Session Input Requests
+## Input Requests
 
-Sessions can request structured input from the user by storing live requests in top-level session state:
+A chat can request structured input from the user by storing live requests in its chat state (on the chat channel):
 
 ```typescript
-SessionState {
+ChatState {
   // ...existing fields...
-  inputRequests?: SessionInputRequest[]
+  inputRequests?: ChatInputRequest[]
 }
 
-SessionInputRequest {
+ChatInputRequest {
   id: string
-  message: string
+  message?: string
   url?: URI
-  questions?: SessionInputQuestion[]
-  answers?: Record<string, SessionInputAnswer>
+  questions?: ChatInputQuestion[]
+  answers?: Record<string, ChatInputAnswer>
 }
 ```
 
@@ -407,10 +434,10 @@ Notifications are ephemeral — not processed by reducers, not stored in state, 
 
 ## Pending Messages
 
-Sessions maintain two optional arrays of **pending messages** — instructions queued for future delivery to the agent:
+Each chat maintains two optional **pending messages** — instructions queued for future delivery to the agent:
 
 ```typescript
-SessionState {
+ChatState {
   // ...existing fields...
   steeringMessage?: PendingMessage      // inject into current turn
   queuedMessages?: PendingMessage[]     // start as new turns
@@ -426,7 +453,7 @@ PendingMessage {
 
 The steering message is injected into the **current turn** at a convenient point. Clients set a steering message to guide the agent mid-flight — for example, telling it to focus on a specific file or change approach. Only one steering message exists at a time; adding a new one replaces any existing one.
 
-- When the session has an active turn, the server consumes the steering message at its discretion, dispatching `session/pendingMessageRemoved` when it does.
+- When the chat has an active turn, the server consumes the steering message at its discretion, dispatching `chat/pendingMessageRemoved` when it does.
 - When set while idle, the steering message is silently stored until a turn starts.
 
 ### Queued Messages
@@ -434,8 +461,8 @@ The steering message is injected into the **current turn** at a convenient point
 Queued messages are automatically started as **new turns** after the current turn finishes. The server processes them FIFO (by arrival order).
 
 - When a turn completes and queued messages exist, the server removes the first queued message and starts a new turn from it.
-- When a queued message is added while the session is idle, the server SHOULD immediately consume it and start a turn.
-- The resulting `session/turnStarted` action includes a `queuedMessageId` field linking back to the source queued message.
+- When a queued message is added while the chat is idle, the server SHOULD immediately consume it and start a turn.
+- The resulting `chat/turnStarted` action includes a `queuedMessageId` field linking back to the source queued message.
 
 ```mermaid
 sequenceDiagram
@@ -459,14 +486,14 @@ sequenceDiagram
 
 ### Management
 
-Clients can **set** or **remove** both steering and queued messages at any time using the `session/pendingMessageSet` (upsert) and `session/pendingMessageRemoved` actions with a `kind` discriminant (`'steering'` or `'queued'`).
+Clients can **set** or **remove** both steering and queued messages at any time using the `chat/pendingMessageSet` (upsert) and `chat/pendingMessageRemoved` actions with a `kind` discriminant (`'steering'` or `'queued'`).
 
-## Session Truncation
+## Chat Truncation
 
-The `session/truncated` action removes turn history from a session. It is **client-dispatchable** — either side can truncate. If the session has an active turn it is silently dropped and the session status returns to `idle`.
+The `chat/truncated` action removes turn history from a chat. It is **client-dispatchable** — either side can truncate. If the chat has an active turn it is silently dropped and the chat's status returns to `idle`.
 
 - **With `turnId`** — keeps all turns up to and including the specified turn; removes everything after it.
-- **Without `turnId`** — removes all turns (empties the session).
+- **Without `turnId`** — removes all turns (empties the chat).
 
 A common pattern is to truncate and then immediately start a new turn with an edited message:
 
@@ -477,13 +504,13 @@ sequenceDiagram
 
     Note over Client: User edits message from turn t-2
 
-    Client->>Server: action (session/truncated, turnId: t-1)
+    Client->>Server: action (chat/truncated, turnId: t-1)
     Note over Server: Drops turns after t-1, drops active turn
 
-    Server->>Client: action (session/truncated)
+    Server->>Client: action (chat/truncated)
 
-    Client->>Server: action (session/turnStarted, edited message)
-    Server->>Client: action (session/turnStarted)
+    Client->>Server: action (chat/turnStarted, edited message)
+    Server->>Client: action (chat/turnStarted)
     Note over Server: New turn begins with edited message
 ```
 

--- a/docs/guide/what-is-ahp.md
+++ b/docs/guide/what-is-ahp.md
@@ -10,7 +10,7 @@ AHP stays agent-agnostic: it describes client-facing session state and display-r
 
 ## Channels: the core abstraction
 
-Every push-style interaction in AHP lives on a **channel** — a URI-identified subscribable resource. The root catalogue (`ahp-root://`), each session (`ahp-session:/<uuid>`), each terminal (`ahp-terminal:/<id>`), and each changeset (`ahp-changeset:/<id>`) is its own channel. A channel MAY hold an immutable state tree, or it MAY be a stateless pub/sub topic (planned: logging, MCP relay, LSP relay).
+Every push-style interaction in AHP lives on a **channel** — a URI-identified subscribable resource. The root catalogue (`ahp-root://`), each session (`ahp-session:/<uuid>`), each chat (`ahp-chat:/<uuid>`), each terminal (`ahp-terminal:/<id>`), and each changeset (`ahp-changeset:/<id>`) is its own channel. A channel MAY hold an immutable state tree, or it MAY be a stateless pub/sub topic (planned: logging, MCP relay, LSP relay).
 
 Channels are also the routing key for the wire protocol. **Every command's params and every notification's params carry a top-level `channel: URI`** — so a server, a client, or an intermediate proxy can dispatch any incoming message just by inspecting `(method, params.channel)`, without per-method deserialisation. Connection-level commands (`initialize`, `ping`, `listSessions`, the `resource*` filesystem commands, `authenticate`) use the literal `'ahp-root://'`.
 
@@ -57,8 +57,8 @@ Because updates arrive as ordered actions against shared snapshots, clients can 
 
 | Concept | Description |
 |---|---|
-| **Channels** | URI-identified subscribable resources. State channels (root, sessions, terminals, changesets) hold an immutable state tree; stateless channels exist for streaming data. Every message carries `channel: URI` for routing. |
-| **State** | Immutable tree per state channel — root state, per-session state, per-terminal state, per-changeset state. |
+| **Channels** | URI-identified subscribable resources. State channels (root, sessions, chats, terminals, changesets) hold an immutable state tree; stateless channels exist for streaming data. Every message carries `channel: URI` for routing. |
+| **State** | Immutable tree per state channel — root state, per-session state, per-chat state, per-terminal state, per-changeset state. |
 | **Actions** | Discriminated union of typed mutations. The sole mechanism for state change. Delivered inside `ActionEnvelope`s whose `channel` field identifies the target channel. |
 | **Reducers** | Pure functions: `(state, action) → newState`. Run identically on server and client. |
 | **Subscriptions** | Clients subscribe to channels to receive snapshots and action streams. |

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -110,8 +110,8 @@ The server MUST include all replayed data in the response before returning. If t
   "result": {
     "type": "replay",
     "actions": [
-      { "channel": "ahp-session:/<uuid>", "action": { "type": "session/delta", ... }, "serverSeq": 43 },
-      { "channel": "ahp-session:/<uuid>", "action": { "type": "session/delta", ... }, "serverSeq": 44 }
+      { "channel": "ahp-chat:/<cid>", "action": { "type": "chat/delta", ... }, "serverSeq": 43 },
+      { "channel": "ahp-chat:/<cid>", "action": { "type": "chat/delta", ... }, "serverSeq": 44 }
     ],
     "missing": ["ahp-session:/<disposed-uuid>"]
   }

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -85,13 +85,15 @@ The specification is organised around the **channels** that AHP exposes — each
 - **[Channels & Subscriptions](/specification/subscriptions)** — The channel model, the universal `channel: URI` routing key, and the subscription mechanism shared by every channel type.
 - **[Authentication](/specification/authentication)** — RFC 9728 / RFC 6750 authentication flow.
 - **[Root Channel](/specification/root-channel)** — `ahp-root://` — agents, terminals catalogue, host config, session catalogue events.
-- **[Session Channel](/specification/session-channel)** — `ahp-session:/<uuid>` — per-session state, turns, tool calls, pending messages.
+- **[Session Channel](/specification/session-channel)** — `ahp-session:/<uuid>` — per-session state: the `chats` catalog, default chat, active clients, customizations, changesets, and aggregated status.
+- **[Chat Channel](/specification/chat-channel)** — `ahp-chat:/<cid>` — per-chat conversation state: turns, streaming, tool calls, pending messages, and input requests.
 - **[Terminal Channel](/specification/terminal-channel)** — per-terminal pty state, data flow, claims, command detection.
 - **[Telemetry Channel](/specification/telemetry-channel)** — `ahp-otlp:` — OpenTelemetry logs, traces, and metrics emitted by the agent host.
 - **[Versioning](/specification/versioning)** — Protocol version negotiation and compatibility.
 - **[Common Types](/reference/common)** — Cross-cutting types, base command/notification shapes, and JSON-RPC wire types.
 - **[Root Channel Reference](/reference/root)** — `RootState`, root actions, root commands, and root notifications.
 - **[Session Channel Reference](/reference/session)** — `SessionState`, session actions, and session commands.
+- **[Chat Channel Reference](/reference/chat)** — `ChatState`, chat actions, and chat commands.
 - **[Terminal Channel Reference](/reference/terminal)** — `TerminalState`, terminal actions, and terminal commands.
 - **[Changeset Channel Reference](/reference/changeset)** — `ChangesetState`, changeset actions, and changeset commands.
 - **[Messages](/reference/messages)** — Index of every JSON-RPC method with links to the channel page that documents it.

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -24,7 +24,8 @@ The rest of this page details the URI scheme and the lifecycle of a subscription
 | URI | State type | Description |
 |---|---|---|
 | `ahp-root://` | `RootState` | Global state (agents, terminals, host config). Always present. |
-| `ahp-session:/<uuid>` | `SessionState` | Per-session state. The session's provider is carried on `SessionSummary.provider`, not in the URI scheme. |
+| `ahp-session:/<uuid>` | `SessionState` | Per-session state (metadata plus the `chats` catalog). The session's provider is carried on `SessionSummary.provider`, not in the URI scheme. |
+| `ahp-chat:/<cid>` | `ChatState` | Per-chat conversation state (turns, streaming, tool calls, pending messages, input requests). A session starts with a default chat; multi-chat hosts add more via `createChat`. See [Chat Channel](/specification/chat-channel). |
 | `ahp-terminal:/<id>` | `TerminalState` | Per-terminal state. Server-defined id. |
 | `ahp-changeset:/<id>` | `ChangesetState` | Per-changeset state. URI is obtained by expanding a `Changeset.uriTemplate` advertised on a session; the id is server-defined. |
 | `ahp-otlp:` _(authority/path host-defined)_ | _stateless_ | OpenTelemetry signal channels (logs, traces, metrics). Concrete URIs are advertised on `InitializeResult.telemetry`; clients MUST treat them as opaque. See [Telemetry Channel](/specification/telemetry-channel). |
@@ -44,8 +45,7 @@ Future channel types (LSP relay, MCP relay, …) introduce their own URI schemes
   "method": "subscribe",
   "params": {
     "channel": "ahp-session:/<uuid>",
-    "delivery": { "maxLatencyMs": 100 },
-    "view": { "turns": 30 }
+    "delivery": { "maxLatencyMs": 100 }
   }
 }
 
@@ -57,10 +57,12 @@ Future channel types (LSP relay, MCP relay, …) introduce their own URI schemes
     "snapshot": {
       "resource": "ahp-session:/<uuid>",
       "state": {
-        "summary": { "resource": "ahp-session:/<uuid>", "title": "New Session", ... },
+        "provider": "copilot",
+        "title": "New Session",
+        "status": 1,
         "lifecycle": "creating",
-        "turns": [],
-        "activeTurn": null
+        "chats": [],
+        "activeClients": []
       },
       "fromSeq": 5
     }
@@ -124,8 +126,8 @@ State channels deliver mutations via the `action` server notification. The param
   "jsonrpc": "2.0",
   "method": "action",
   "params": {
-    "channel": "ahp-session:/<uuid>",
-    "action": { "type": "session/delta", "turnId": "t1", "partId": "p1", "content": "Hello" },
+    "channel": "ahp-chat:/<cid>",
+    "action": { "type": "chat/delta", "turnId": "t1", "partId": "p1", "content": "Hello" },
     "serverSeq": 6,
     "origin": { "clientId": "client-1", "clientSeq": 1 }
   }
@@ -134,6 +136,7 @@ State channels deliver mutations via the `action` server notification. The param
 
 - Root actions go to all clients subscribed to `ahp-root://`.
 - Session actions go to all clients subscribed to that session's URI.
+- Chat actions go to all clients subscribed to that chat's URI.
 - Terminal actions go to all clients subscribed to that terminal's URI.
 
 Action payloads (the inner `action` object) carry only fields intrinsic to the action — the channel comes from the envelope. Individual actions do NOT carry a `session: URI` or `terminal: URI` field of their own.
@@ -145,9 +148,9 @@ The client → server dispatch path uses a different method, `dispatchAction`, w
   "jsonrpc": "2.0",
   "method": "dispatchAction",
   "params": {
-    "channel": "ahp-session:/<uuid>",
+    "channel": "ahp-chat:/<cid>",
     "clientSeq": 1,
-    "action": { "type": "session/turnStarted", "turnId": "t1", "message": { "text": "Hi", "origin": { "kind": "user" } } }
+    "action": { "type": "chat/turnStarted", "turnId": "t1", "message": { "text": "Hi", "origin": { "kind": "user" } } }
   }
 }
 ```


### PR DESCRIPTION
## What

The multi-chat change (#213) moved turn, streaming, tool-call, pending-message,
and input-request actions from the session channel onto a per-chat channel
(`ahp-chat:/<cid>`), renaming `session/*` to `chat/*`. The guide and spec docs
were left describing the pre-multi-chat model: stale action names and, in the
operational examples, chat actions dispatched on `ahp-session:/<uuid>`.

This rewrites the core surfaces (getting-started, subscriptions, actions,
state-model, elicitation, ahp-and-acp, lifecycle, and the homepage walkthrough)
to place `chat/*` actions on `ahp-chat:/<cid>`, adds a Chat State section and the
`ahp-chat` channel-table row, and frames per-conversation state as `ChatState`.
It also fixes residual session-channel references in changesets, customizations,
reconciliation, what-is-ahp, and the specification overview.

ACP's own `session/update` and `session/cancel` are preserved.

## Scope

Docs only — no wire or type changes. Verified against `types/channels-chat/*`
and `types/common/actions.ts` on `main` (the `ahp-chat:` channel scheme and the
`chat/*` action types are the source of truth).

13 files, +164/−119.

> Sibling PR (general doc-vs-types drift, independent of this channel move):
> #312. The two touch a few of the same files, so whichever merges second I'll
> rebase.
