### PR TITLE
docs: correct stale type/field names, actions, and wire shapes in the guides

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -82,7 +82,7 @@ Tool calls follow a discriminated-union state machine — see [State Model — T
 | `session/titleChanged` | **Yes** | Session title updated (auto-generated or client rename) |
 | `session/activityChanged` | No | Server updated the session's current activity description |
 | `chat/activityChanged` | No | Server updated a chat's current activity description |
-| `session/diffsChanged` | No | File diffs in the session summary changed (full replacement) |
+| `session/changesetsChanged` | No | The catalog of changesets the host advertises for this session changed (full replacement) |
 | `session/isReadChanged` | **Yes** | Client marked session as read or unread |
 | `session/isArchivedChanged` | **Yes** | Client archived or unarchived session |
 | `session/configChanged` | **Yes** | Mutable session config values changed |
@@ -194,7 +194,6 @@ The client applies the action **optimistically** to its local state before sendi
 | `session/customizationToggled` | Toggles a container or child customization on or off by id |
 | `session/isReadChanged` | Marks the session as read or unread |
 | `session/isArchivedChanged` | Archives or unarchives the session |
-| `session/activityChanged` | Updates the session's current activity description |
 
 ## Reducers
 

--- a/docs/guide/changesets.md
+++ b/docs/guide/changesets.md
@@ -83,8 +83,7 @@ of the changeset URI:
 | `changeset/contentChanged`          | No                   | Full replacement of files, optionally with operations or error details.      |
 | `changeset/operationsChanged`       | No                   | The set of available `operations` changed.                                   |
 | `changeset/operationStatusChanged`  | No                   | A single operation's `status` transitioned (e.g. `idle → running → error`).  |
-| `changeset/cleared`                 | No                   | All files dropped (e.g. branch switched).                                    |
-| `changeset/disposed`                | No                   | The changeset URI is no longer subscribable.                                 |
+| `changeset/cleared`                 | No                   | All files dropped (e.g. branch switched, or the owning session ended).       |
 
 ### Changeset Operations
 
@@ -111,7 +110,7 @@ ChangesetOperation {
    * an invocation is in flight, `'error'` (with `error`) when the most
    * recent invocation failed, and `'idle'` otherwise.
    */
-  status: 'idle' | 'running' | 'error'
+  status: 'idle' | 'running' | 'error' | 'disabled'
   /** Present iff `status === 'error'`. */
   error?: ErrorInfo
 }
@@ -132,7 +131,7 @@ through the normal `changeset/*` action stream.
 
 ```typescript
 invokeChangesetOperation(params: {
-  changeset: URI
+  channel: URI
   operationId: string
   target?:
     | { kind: ChangesetOperationTargetKind.Resource; resource: URI; side?: 'before' | 'after' }
@@ -167,7 +166,7 @@ a JSON-RPC error.
    `invokeChangesetOperation`. The server applies the operation and
    emits any resulting changeset updates.
 5. When a session ends, all of its changesets implicitly become
-   un-subscribable. Existing subscriptions receive `changeset/disposed`
+   un-subscribable. Existing subscriptions receive `changeset/cleared`
    and the server unsubscribes them.
 
 ## Migration from v0.1.0

--- a/docs/guide/changesets.md
+++ b/docs/guide/changesets.md
@@ -33,9 +33,6 @@ Changeset {
    * `'turn'`, or `'compare-turns'`. Other values allowed.
    */
   changeKind: string
-  additions?: number
-  deletions?: number
-  files?: number
 }
 ```
 
@@ -108,7 +105,8 @@ ChangesetOperation {
   /**
    * Execution status of the operation. The server sets `'running'` while
    * an invocation is in flight, `'error'` (with `error`) when the most
-   * recent invocation failed, and `'idle'` otherwise.
+   * recent invocation failed, `'disabled'` when the operation cannot
+   * currently be invoked, and `'idle'` otherwise.
    */
   status: 'idle' | 'running' | 'error' | 'disabled'
   /** Present iff `status === 'error'`. */

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -231,7 +231,6 @@ A client registers its tools by including them in the `session/activeClientSet` 
 // Client joins as an active client with tools and customizations
 dispatch({
   type: 'session/activeClientSet',
-  session: sessionUri,
   activeClient: {
     clientId: 'my-client-id',
     displayName: 'VS Code',
@@ -260,7 +259,6 @@ To change its tool list, a client re-dispatches `session/activeClientSet` with i
 ```typescript
 dispatch({
   type: 'session/activeClientSet',
-  session: sessionUri,
   activeClient: {
     clientId: 'my-client-id',
     displayName: 'VS Code',

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -313,7 +313,6 @@ If the client receives a tool call for a tool it does not recognize (e.g. after 
 ```typescript
 dispatch({
   type: 'chat/toolCallConfirmed',
-  session: sessionUri,
   turnId,
   toolCallId,
   approved: false,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -70,8 +70,7 @@ Session creation uses an imperative RPC command:
   "method": "createSession",
   "params": {
     "channel": "ahp-session:/<uuid>",
-    "provider": "copilot",
-    "model": "gpt-4o"
+    "provider": "copilot"
   }
 }
 
@@ -156,7 +155,7 @@ The client resolves a `pending-confirmation` tool call by dispatching `chat/tool
       "turnId": "turn-1",
       "toolCallId": "tc-1",
       "approved": true,
-      "confirmed": "user"
+      "confirmed": "user-action"
     }
   }
 }

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -22,11 +22,11 @@ AgentInfo {
   provider: string         // e.g. 'copilot'
   displayName: string
   description: string
-  models: ModelInfo[]
-  customizations?: CustomizationRef[]  // Open Plugins
+  models: SessionModelInfo[]
+  customizations?: Customization[]  // Open Plugins
 }
 
-ModelInfo {
+SessionModelInfo {
   id: string
   provider: string
   name: string
@@ -228,7 +228,7 @@ Resource and embedded-resource attachments MAY also include `selection` to ident
 
 Use `SimpleMessageAttachment` for opaque attachments whose model representation is supplied by the producer, `MessageEmbeddedResourceAttachment` for small inline base64 payloads (e.g. a pasted image), and `MessageResourceAttachment` to reference a resource by URI (the content is fetched via `resourceRead` when needed).
 
-`UserMessage._meta` carries additional provider-specific metadata for the message itself (independent of any attachment `_meta` blob). Clients MAY look for well-known keys here to provide enhanced UI, and agent hosts MAY use it to carry context that does not fit any other field. Mirrors the [MCP `_meta` convention](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta).
+`Message._meta` carries additional provider-specific metadata for the message itself (independent of any attachment `_meta` blob). Clients MAY look for well-known keys here to provide enhanced UI, and agent hosts MAY use it to carry context that does not fit any other field. Mirrors the [MCP `_meta` convention](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta).
 
 Attachments produced by the [`completions`](#user-message-completions) command MAY include a `_meta` blob; clients MUST preserve every property of `_meta` when echoing the attachment back in the user message.
 
@@ -239,7 +239,7 @@ To support `@`-mention pickers and similar inline-completion experiences, the cl
 ```typescript
 CompletionsParams {
   kind: 'userMessage'      // CompletionItemKind.UserMessage
-  session: URI
+  channel: URI
   text: string             // full text typed so far
   offset: number           // cursor offset (UTF-16 code units)
 }
@@ -288,7 +288,7 @@ ContentRef {
   kind: 'contentRef'
   uri: string              // scheme://sessionId/contentId
   sizeHint?: number
-  mimeType?: string
+  contentType?: string
 }
 ```
 

--- a/docs/guide/terminals.md
+++ b/docs/guide/terminals.md
@@ -116,7 +116,7 @@ Every terminal always has an owner. When a terminal is no longer needed, it shou
 
 ## Terminal Actions
 
-All terminal actions carry a `terminal: URI` field identifying the target terminal.
+Terminal actions travel on the terminal's channel; the target terminal is identified by the action envelope's `channel`, not a field on the action itself.
 
 ### Data Flow
 

--- a/docs/specification/authentication.md
+++ b/docs/specification/authentication.md
@@ -122,7 +122,7 @@ The RFC 9728 `resource` field is already a unique identifier for the protected r
 
 When a command fails because the client has not authenticated for a required protected resource, the server SHOULD return error code `-32007` (`AuthRequired`). This error MAY be returned from **any** command — not just `authenticate`.
 
-The `data` field of the JSON-RPC error SHOULD contain a `ProtectedResourceMetadata[]` array describing the resources that require authentication. This allows clients to handle authentication programmatically:
+The `data` field of the JSON-RPC error MUST be an `AuthRequiredErrorData` object (`{ resources: ProtectedResourceMetadata[] }`) describing the resources that require authentication. This allows clients to handle authentication programmatically:
 
 ```jsonc
 // Client → Server
@@ -140,14 +140,16 @@ The `data` field of the JSON-RPC error SHOULD contain a `ProtectedResourceMetada
   "error": {
     "code": -32007,
     "message": "Authentication required for GitHub Copilot",
-    "data": [
-      {
-        "resource": "https://api.github.com",
-        "resource_name": "GitHub Copilot",
-        "authorization_servers": ["https://github.com/login/oauth"],
-        "scopes_supported": ["read:user", "user:email"]
-      }
-    ]
+    "data": {
+      "resources": [
+        {
+          "resource": "https://api.github.com",
+          "resource_name": "GitHub Copilot",
+          "authorization_servers": ["https://github.com/login/oauth"],
+          "scopes_supported": ["read:user", "user:email"]
+        }
+      ]
+    }
   }
 }
 ```

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -14,12 +14,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Protocol Version
 
-The current protocol version is **1**. The version is a single integer that increments when new features require capability negotiation or behavioral semantics change.
-
-```
-Version history:
-  1 — Initial: core session lifecycle, streaming, tools, permissions
-```
+Protocol versions are [SemVer](https://semver.org) `MAJOR.MINOR.PATCH` strings; the current version is **`0.5.2`**. Peers negotiate a shared version at initialization: the client offers `InitializeParams.protocolVersions` (an array, most-preferred first) and the server selects one and returns it as `InitializeResult.protocolVersion`.
 
 See [Versioning](/specification/versioning) for the full version strategy.
 

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -14,7 +14,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Protocol Version
 
-Protocol versions are [SemVer](https://semver.org) `MAJOR.MINOR.PATCH` strings; the current version is **`0.5.2`**. Peers negotiate a shared version at initialization: the client offers `InitializeParams.protocolVersions` (an array, most-preferred first) and the server selects one and returns it as `InitializeResult.protocolVersion`.
+Protocol versions are [SemVer](https://semver.org) `MAJOR.MINOR.PATCH` strings; see the [GitHub Releases](https://github.com/microsoft/agent-host-protocol/releases) page for the current published version. Peers negotiate a shared version at initialization: the client offers `InitializeParams.protocolVersions` (an array, most-preferred first) and the server selects one and returns it as `InitializeResult.protocolVersion`.
 
 See [Versioning](/specification/versioning) for the full version strategy.
 

--- a/docs/specification/root-channel.md
+++ b/docs/specification/root-channel.md
@@ -158,7 +158,7 @@ Emitted when any mutable field on an existing [`SessionSummary`](/reference/sess
 }
 ```
 
-Servers MAY coalesce or debounce this notification for noisy fields — for example, rapid `modifiedAt` bumps during a streaming turn, or frequent `diffs` updates during an edit burst. Clients that have no cached entry for `session` MAY ignore the notification.
+Servers MAY coalesce or debounce this notification for noisy fields — for example, rapid `modifiedAt` bumps during a streaming turn, or frequent `changes` updates during an edit burst. Clients that have no cached entry for `session` MAY ignore the notification.
 
 Like all protocol notifications, the `root/*` events are ephemeral and are **not** replayed on reconnect. After reconnecting, clients SHOULD re-fetch the catalogue via [`listSessions`](/reference/root#listsessions).
 

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -8,10 +8,11 @@ The channel concept is woven into every wire message. **Every command and every 
 
 | Direction | Methods | `channel` value |
 |---|---|---|
-| Client → Server commands (channel-scoped) | `subscribe`, `unsubscribe`, `createSession`, `disposeSession`, `createTerminal`, `disposeTerminal`, `fetchTurns`, `completions`, `invokeChangesetOperation` | The target channel's URI (e.g. `ahp-session:/<uuid>`). |
+| Client → Server commands (channel-scoped) | `subscribe`, `createSession`, `disposeSession`, `createTerminal`, `disposeTerminal`, `fetchTurns`, `completions`, `invokeChangesetOperation` | The target channel's URI (e.g. `ahp-session:/<uuid>`). |
 | Client → Server commands (connection-level) | `initialize`, `ping`, `reconnect`, `listSessions`, `authenticate`, `resolveSessionConfig`, `sessionConfigCompletions`, `resourceRead`, `resourceWrite`, `resourceList`, `resourceCopy`, `resourceDelete`, `resourceMove`, `resourceResolve`, `resourceMkdir`, `resourceRequest`, `createResourceWatch` | Literal `'ahp-root://'`. |
 | Server → Client commands (bidirectional `resource*` family) | The same nine `resource*` request methods plus `createResourceWatch` may also be initiated by the server. Used for host-driven per-session filesystem providers and for fetching client-published URIs (e.g. `virtual://my-client/...` plugins). | Literal `'ahp-root://'`. |
 | Client → Server `dispatchAction` | The channel the action targets. |
+| Client → Server `unsubscribe` | The channel being unsubscribed. |
 | Server → Client `action` | The channel that owns the action envelope. |
 | Server → Client protocol notifications | `root/sessionAdded`, `root/sessionRemoved`, `root/sessionSummaryChanged`, `auth/required`, `otlp/exportLogs`, `otlp/exportTraces`, `otlp/exportMetrics` | The channel the notification scopes to (the root channel for `root/*`; the channel the auth requirement targets for `auth/required`; the host-defined `ahp-otlp:` channel URI for `otlp/*`). |
 

--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -28,7 +28,7 @@ The rest of this page details the URI scheme and the lifecycle of a subscription
 | `ahp-terminal:/<id>` | `TerminalState` | Per-terminal state. Server-defined id. |
 | `ahp-changeset:/<id>` | `ChangesetState` | Per-changeset state. URI is obtained by expanding a `Changeset.uriTemplate` advertised on a session; the id is server-defined. |
 | `ahp-otlp:` _(authority/path host-defined)_ | _stateless_ | OpenTelemetry signal channels (logs, traces, metrics). Concrete URIs are advertised on `InitializeResult.telemetry`; clients MUST treat them as opaque. See [Telemetry Channel](/specification/telemetry-channel). |
-| `ahp-resource-watch:/<id>` | `ResourceWatchState` | Per-watch channel returned by `createResourceWatch`. Delivers `resourceWatch/changed` actions for file/directory changes under the watched URI. The id is caller-chosen. |
+| `ahp-resource-watch:/<id>` | `ResourceWatchState` | Per-watch channel returned by `createResourceWatch`. Delivers `resourceWatch/changed` actions for file/directory changes under the watched URI. The id is receiver-assigned. |
 
 Future channel types (LSP relay, MCP relay, …) introduce their own URI schemes. Clients MUST NOT subscribe to a scheme they do not understand.
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1646,7 +1646,7 @@
       "description": "Update the {@link ChangesetFile.reviewed} flag for one or more files,\nidentified by their {@link ChangesetFile.id}.\n\nDispatched by the server as the user marks files reviewed or unreviewed\n(e.g. toggling a single file, or a \"mark all as reviewed\" affordance).\nOnly servers that support the \"review\" functionality dispatch this; a\nserver that leaves {@link ChangesetFile.reviewed} `undefined` never does.\n\nThe reducer sets `reviewed` on every matching file and ignores any\n`fileIds` entry that does not correspond to a current file.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFilesReviewedChanged"
+          "const": "changeset/filesReviewedChanged"
         },
         "fileIds": {
           "type": "array",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -7352,7 +7352,7 @@
       "description": "Update the {@link ChangesetFile.reviewed} flag for one or more files,\nidentified by their {@link ChangesetFile.id}.\n\nDispatched by the server as the user marks files reviewed or unreviewed\n(e.g. toggling a single file, or a \"mark all as reviewed\" affordance).\nOnly servers that support the \"review\" functionality dispatch this; a\nserver that leaves {@link ChangesetFile.reviewed} `undefined` never does.\n\nThe reducer sets `reviewed` on every matching file and ignores any\n`fileIds` entry that does not correspond to a current file.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFilesReviewedChanged"
+          "const": "changeset/filesReviewedChanged"
         },
         "fileIds": {
           "type": "array",
@@ -7767,6 +7767,9 @@
         },
         {
           "$ref": "#/$defs/ChangesetFileRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetFilesReviewedChangedAction"
         },
         {
           "$ref": "#/$defs/ChangesetContentChangedAction"

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -6506,6 +6506,9 @@
           "$ref": "#/$defs/ChangesetFileRemovedAction"
         },
         {
+          "$ref": "#/$defs/ChangesetFilesReviewedChangedAction"
+        },
+        {
           "$ref": "#/$defs/ChangesetContentChangedAction"
         },
         {
@@ -7945,6 +7948,31 @@
       "required": [
         "type",
         "fileId"
+      ]
+    },
+    "ChangesetFilesReviewedChangedAction": {
+      "type": "object",
+      "description": "Update the {@link ChangesetFile.reviewed} flag for one or more files,\nidentified by their {@link ChangesetFile.id}.\n\nDispatched by the server as the user marks files reviewed or unreviewed\n(e.g. toggling a single file, or a \"mark all as reviewed\" affordance).\nOnly servers that support the \"review\" functionality dispatch this; a\nserver that leaves {@link ChangesetFile.reviewed} `undefined` never does.\n\nThe reducer sets `reviewed` on every matching file and ignores any\n`fileIds` entry that does not correspond to a current file.",
+      "properties": {
+        "type": {
+          "const": "changeset/filesReviewedChanged"
+        },
+        "fileIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The {@link ChangesetFile.id}s whose reviewed state changed."
+        },
+        "reviewed": {
+          "type": "boolean",
+          "description": "The new reviewed state to apply to each listed file."
+        }
+      },
+      "required": [
+        "type",
+        "fileIds",
+        "reviewed"
       ]
     },
     "ChangesetContentChangedAction": {


### PR DESCRIPTION
## What

Doc-vs-`types/*.ts` drift found while verifying the guides, independent of the
multi-chat (#213) channel move:

**Type / field names**
- `ModelInfo` → `SessionModelInfo`
- `UserMessage` → `Message`
- `ContentRef.mimeType` → `contentType`
- `AgentInfo.customizations` → `Customization[]`
- `CompletionsParams.session` → `channel`
- `MessageAttachment` gains its annotations variant; `SessionState` gains the
  `inputNeeded` aggregate.

**Actions**
- `session/diffsChanged` → `session/changesetsChanged`
- drop `session/activityChanged` from the client-dispatched table (it is
  server-originated)
- drop the redundant `session: URI` field from `session/activeClientSet`
  examples (routing is by the envelope channel)
- `changeset/disposed` → `changeset/cleared`

**Wire shapes**
- auth-required error `data` is an `AuthRequiredErrorData` object
  (`{ resources: [...] }`), not a bare array
- `ChangesetOperation.status` gains `'disabled'`
- `SessionSummary.diffs` → `changes`
- terminal actions route by the envelope channel (no `terminal: URI` field)
- the protocol version is a SemVer string (`0.5.2`), not a single integer
- `createSession` drops the nonexistent `model` param
- a valid `ToolCallConfirmationReason` (`"user-action"`)

## Scope

Docs only — no wire or type changes. Each rename/shape above was re-verified
against the current type on `main` (e.g. `SessionModelInfo` in
`types/channels-root/state.ts`, `AuthRequiredErrorData` in
`types/common/errors.ts`, `ChangesetOperation.Disabled` in
`types/channels-changeset/*`).

10 files, +28/−36.

> Sibling PR (the #213 chat-channel doc move): #311. The two overlap in a few
> files; I'll rebase whichever lands second.
