### PR TITLE
Add terminal command prefix initialize marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 - `ToolResultTerminalCompleteContent` for terminal-style completion metadata in tool
   results.
-- Optional `terminalCommandPrefix` marker on `InitializeResult` for hosts that
-  support interpreting `!`-prefixed user messages as terminal commands.
 - Optional `reviewed` field on `ChangesetFile`. Omitting it (or setting it to
   `undefined`) signals that the server does not support the file "review"
   functionality.
@@ -68,6 +66,8 @@ Spec version: `0.5.2`
   optional `title`), so either side of the handshake can identify its
   implementation and build. Informational only — mirrors LSP/MCP and MUST NOT
   be used for feature detection.
+- Optional `terminalCommandPrefix` marker on `InitializeResult` for hosts that
+  support interpreting `!`-prefixed user messages as terminal commands.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ changes accumulate. Track in-flight protocol changes via PRs touching
 
 - `ToolResultTerminalCompleteContent` for terminal-style completion metadata in tool
   results.
+- Optional `terminalCommandPrefix` marker on `InitializeResult` for hosts that
+  support interpreting `!`-prefixed user messages as terminal commands.
 - Optional `reviewed` field on `ChangesetFile`. Omitting it (or setting it to
   `undefined`) signals that the server does not support the file "review"
   functionality.

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -16,8 +16,6 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
-- Optional `TerminalCommandPrefix` on `InitializeResult` for hosts that support
-  interpreting `!`-prefixed user messages as terminal commands.
 - Typed `resource*` convenience methods on `ahp.Client`: send wrappers (`ResourceRead`, `ResourceWrite`, `ResourceList`, `ResourceCopy`, `ResourceDelete`, `ResourceMove`, `ResourceResolve`, `ResourceMkdir`, `ResourceRequest`, `CreateResourceWatch`) and inbound server-request handling via `SetServerRequestHandler` / `SetResourceRequestHandlers` (new `ServerRequestHandler` and `ResourceRequestHandlers` types). Inbound server-initiated requests are now answered (previously dropped) — via the installed handler, or `MethodNotFound` when none is set.
 
 ## [0.5.2] — Unreleased
@@ -48,6 +46,8 @@ Implements AHP 0.5.2.
   `Version`, optional `Title`), identifying the implementation and build behind
   either side of the handshake. Informational only — MUST NOT be used for
   feature detection.
+- Optional `TerminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
 - Optional `Version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -14,6 +14,11 @@ tag whose matching `## [X.Y.Z]` heading is missing from this file.
 
 ## [Unreleased]
 
+### Added
+
+- Optional `TerminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
+
 ## [0.5.2] — Unreleased
 
 Implements AHP 0.5.2.

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -143,6 +143,12 @@ type InitializeResult struct {
 	// {@link CompletionItemKind.UserMessage}. Typically includes characters like
 	// `'@'` or `'/'`.
 	CompletionTriggerCharacters []string `json:"completionTriggerCharacters,omitempty"`
+	// Prefix that the host recognizes at the start of a user {@link Message.text}
+	// as a shorthand for executing the remainder as a terminal command. Currently
+	// the standardized convention is `"!"`; absence means the host does not
+	// advertise support and clients SHOULD treat `!`-prefixed input as an
+	// ordinary user message.
+	TerminalCommandPrefix *string `json:"terminalCommandPrefix,omitempty"`
 	// OTLP telemetry channels the host emits, if any. Each populated field is
 	// either a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a
 	// client expands before subscribing (currently only the `logs` channel

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -146,8 +146,7 @@ type InitializeResult struct {
 	// Prefix that the host recognizes at the start of a user {@link Message.text}
 	// as a shorthand for executing the remainder as a terminal command. Currently
 	// the standardized convention is `"!"`; absence means the host does not
-	// advertise support and clients SHOULD treat `!`-prefixed input as an
-	// ordinary user message.
+	// support command prefixes.
 	TerminalCommandPrefix *string `json:"terminalCommandPrefix,omitempty"`
 	// OTLP telemetry channels the host emits, if any. Each populated field is
 	// either a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a

--- a/clients/go/ahptypes/roundtrip_fixture_test.go
+++ b/clients/go/ahptypes/roundtrip_fixture_test.go
@@ -238,6 +238,10 @@ func decodeAndReencode(t *testing.T, name, typ, inputJSON string) string {
 		var v Implementation
 		dec(&v)
 		return enc(&v)
+	case "InitializeResult":
+		var v InitializeResult
+		dec(&v)
+		return enc(&v)
 	default:
 		t.Fatalf("%s: round-trip fixture: unknown wire type %q. Add a decode entry to decodeAndReencode.", name, typ)
 		return ""

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -15,11 +15,6 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ## [Unreleased]
 
-### Added
-
-- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
-  interpreting `!`-prefixed user messages as terminal commands.
-
 ## [0.5.2] — Unreleased
 
 Implements AHP 0.5.2.
@@ -47,6 +42,8 @@ Implements AHP 0.5.2.
   `InitializeParams`, each an `Implementation` (`name`, optional `version`,
   optional `title`), identifying the implementation and build behind either side
   of the handshake. Informational only — MUST NOT be used for feature detection.
+- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -15,6 +15,11 @@ versions (`*-SNAPSHOT`) are explicitly rejected by the publish pipeline; bump
 
 ## [Unreleased]
 
+### Added
+
+- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
+
 ## [0.5.2] — Unreleased
 
 Implements AHP 0.5.2.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -190,8 +190,7 @@ data class InitializeResult(
      * Prefix that the host recognizes at the start of a user {@link Message.text}
      * as a shorthand for executing the remainder as a terminal command. Currently
      * the standardized convention is `"!"`; absence means the host does not
-     * advertise support and clients SHOULD treat `!`-prefixed input as an
-     * ordinary user message.
+     * support command prefixes.
      */
     val terminalCommandPrefix: String? = null,
     /**

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -187,6 +187,14 @@ data class InitializeResult(
      */
     val completionTriggerCharacters: List<String>? = null,
     /**
+     * Prefix that the host recognizes at the start of a user {@link Message.text}
+     * as a shorthand for executing the remainder as a terminal command. Currently
+     * the standardized convention is `"!"`; absence means the host does not
+     * advertise support and clients SHOULD treat `!`-prefixed input as an
+     * ordinary user message.
+     */
+    val terminalCommandPrefix: String? = null,
+    /**
      * OTLP telemetry channels the host emits, if any. Each populated field is
      * either a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a
      * client expands before subscribing (currently only the `logs` channel

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/RoundTripCorpusTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/RoundTripCorpusTest.kt
@@ -32,6 +32,7 @@ import com.microsoft.agenthostprotocol.generated.ActionEnvelope
 import com.microsoft.agenthostprotocol.generated.ChangesetOperationTarget
 import com.microsoft.agenthostprotocol.generated.Customization
 import com.microsoft.agenthostprotocol.generated.Implementation
+import com.microsoft.agenthostprotocol.generated.InitializeResult
 import com.microsoft.agenthostprotocol.generated.JsonRpcErrorResponse
 import com.microsoft.agenthostprotocol.generated.JsonRpcNotification
 import com.microsoft.agenthostprotocol.generated.JsonRpcRequest
@@ -249,6 +250,7 @@ class RoundTripCorpusTest {
             "SessionAddedParams" -> rt(SessionAddedParams.serializer())
             "PartialSessionSummary" -> rt(PartialSessionSummary.serializer())
             "Implementation" -> rt(Implementation.serializer())
+            "InitializeResult" -> rt(InitializeResult.serializer())
             else -> fail(
                 "$file: unknown wire type \"$typeName\". " +
                     "Add a decode entry to decodeAndReencode.",

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -15,6 +15,11 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ## [Unreleased]
 
+### Added
+
+- Optional `terminal_command_prefix` on `InitializeResult` for hosts that
+  support interpreting `!`-prefixed user messages as terminal commands.
+
 ## [0.5.2] — Unreleased
 
 Implements AHP 0.5.2.

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -17,8 +17,6 @@ matching `## [X.Y.Z]` heading is missing from this file.
 
 ### Added
 
-- Optional `terminal_command_prefix` on `InitializeResult` for hosts that
-  support interpreting `!`-prefixed user messages as terminal commands.
 - Typed `resource*` convenience methods on `ahp::Client`: send wrappers (`resource_read`, `resource_write`, `resource_list`, `resource_copy`, `resource_delete`, `resource_move`, `resource_resolve`, `resource_mkdir`, `resource_request`, `create_resource_watch`) and inbound server-request handling via `set_server_request_handler` / `set_resource_request_handlers` (new `ServerRequestHandler`, `ServerRequestFuture`, and `ResourceRequestHandlers` types). Inbound server-initiated requests are now answered (previously dropped) — via the installed handler, or `MethodNotFound` when none is set.
 
 ## [0.5.2] — Unreleased
@@ -50,6 +48,8 @@ Implements AHP 0.5.2.
   `version`, optional `title`), identifying the implementation and build behind
   either side of the handshake. Informational only — MUST NOT be used for
   feature detection.
+- Optional `terminal_command_prefix` on `InitializeResult` for hosts that
+  support interpreting `!`-prefixed user messages as terminal commands.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -170,8 +170,7 @@ pub struct InitializeResult {
     /// Prefix that the host recognizes at the start of a user {@link Message.text}
     /// as a shorthand for executing the remainder as a terminal command. Currently
     /// the standardized convention is `"!"`; absence means the host does not
-    /// advertise support and clients SHOULD treat `!`-prefixed input as an
-    /// ordinary user message.
+    /// support command prefixes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terminal_command_prefix: Option<String>,
     /// OTLP telemetry channels the host emits, if any. Each populated field is

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -167,6 +167,13 @@ pub struct InitializeResult {
     /// `'@'` or `'/'`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion_trigger_characters: Option<Vec<String>>,
+    /// Prefix that the host recognizes at the start of a user {@link Message.text}
+    /// as a shorthand for executing the remainder as a terminal command. Currently
+    /// the standardized convention is `"!"`; absence means the host does not
+    /// advertise support and clients SHOULD treat `!`-prefixed input as an
+    /// ordinary user message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_command_prefix: Option<String>,
     /// OTLP telemetry channels the host emits, if any. Each populated field is
     /// either a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a
     /// client expands before subscribing (currently only the `logs` channel

--- a/clients/rust/crates/ahp-types/tests/roundtrip_corpus.rs
+++ b/clients/rust/crates/ahp-types/tests/roundtrip_corpus.rs
@@ -26,7 +26,7 @@
 
 use ahp_types::{
     actions::{ActionEnvelope, StateAction},
-    commands::{ChangesetOperationTarget, Implementation},
+    commands::{ChangesetOperationTarget, Implementation, InitializeResult},
     common::StringOrMarkdown,
     messages::JsonRpcMessage,
     notifications::{PartialSessionSummary, SessionAddedParams},
@@ -220,6 +220,7 @@ fn decode_and_reencode(file: &str, type_name: &str, input_json: &str) -> Result<
         "SessionAddedParams" => round_trip!(SessionAddedParams),
         "PartialSessionSummary" => round_trip!(PartialSessionSummary),
         "Implementation" => round_trip!(Implementation),
+        "InitializeResult" => round_trip!(InitializeResult),
         other => Err(format!(
             "{}: unknown wire type {:?}. Add a decode entry to decode_and_reencode.",
             file, other

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -131,6 +131,12 @@ public struct InitializeResult: Codable, Sendable {
     /// {@link CompletionItemKind.UserMessage}. Typically includes characters like
     /// `'@'` or `'/'`.
     public var completionTriggerCharacters: [String]?
+    /// Prefix that the host recognizes at the start of a user {@link Message.text}
+    /// as a shorthand for executing the remainder as a terminal command. Currently
+    /// the standardized convention is `"!"`; absence means the host does not
+    /// advertise support and clients SHOULD treat `!`-prefixed input as an
+    /// ordinary user message.
+    public var terminalCommandPrefix: String?
     /// OTLP telemetry channels the host emits, if any. Each populated field is
     /// either a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a
     /// client expands before subscribing (currently only the `logs` channel
@@ -145,6 +151,7 @@ public struct InitializeResult: Codable, Sendable {
         snapshots: [Snapshot],
         defaultDirectory: String? = nil,
         completionTriggerCharacters: [String]? = nil,
+        terminalCommandPrefix: String? = nil,
         telemetry: TelemetryCapabilities? = nil
     ) {
         self.protocolVersion = protocolVersion
@@ -153,6 +160,7 @@ public struct InitializeResult: Codable, Sendable {
         self.snapshots = snapshots
         self.defaultDirectory = defaultDirectory
         self.completionTriggerCharacters = completionTriggerCharacters
+        self.terminalCommandPrefix = terminalCommandPrefix
         self.telemetry = telemetry
     }
 }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -134,8 +134,7 @@ public struct InitializeResult: Codable, Sendable {
     /// Prefix that the host recognizes at the start of a user {@link Message.text}
     /// as a shorthand for executing the remainder as a terminal command. Currently
     /// the standardized convention is `"!"`; absence means the host does not
-    /// advertise support and clients SHOULD treat `!`-prefixed input as an
-    /// ordinary user message.
+    /// support command prefixes.
     public var terminalCommandPrefix: String?
     /// OTLP telemetry channels the host emits, if any. Each populated field is
     /// either a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/TypesRoundTripFixtureTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/TypesRoundTripFixtureTests.swift
@@ -186,6 +186,8 @@ final class TypesRoundTripFixtureTests: XCTestCase {
             return try reencode(dec.decode(PartialSessionSummary.self, from: inputData))
         case "Implementation":
             return try reencode(dec.decode(Implementation.self, from: inputData))
+        case "InitializeResult":
+            return try reencode(dec.decode(InitializeResult.self, from: inputData))
         default:
             throw FixtureError.message(
                 "round-trip fixture: unknown wire type \"\(type)\". Add a decode entry to decodeAndReencode.")

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -17,6 +17,11 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ## [Unreleased]
 
+### Added
+
+- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
+
 ## [0.5.2] — Unreleased
 
 Implements AHP 0.5.2.

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -19,8 +19,6 @@ the tag matches the version pinned in [`VERSION`](VERSION).
 
 ### Added
 
-- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
-  interpreting `!`-prefixed user messages as terminal commands.
 - Typed `resource*` convenience methods on `AHPClient`: send wrappers (`resourceRead`, `resourceWrite`, `resourceList`, `resourceCopy`, `resourceDelete`, `resourceMove`, `resourceResolve`, `resourceMkdir`, `resourceRequest`, `createResourceWatch`) and inbound server-request handling via `setServerRequestHandler(_:)` / `setResourceRequestHandlers(_:)` (new `ServerRequestHandler` typealias and `ResourceRequestHandlers` type). Inbound server-initiated requests are answered by the installed handler (still `MethodNotFound` when none is set).
 
 ## [0.5.2] — Unreleased
@@ -50,6 +48,8 @@ Implements AHP 0.5.2.
   `InitializeParams`, each an `Implementation` (`name`, optional `version`,
   optional `title`), identifying the implementation and build behind either side
   of the handshake. Informational only — MUST NOT be used for feature detection.
+- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -20,6 +20,11 @@ hotfix escape hatch.
 
 ## [Unreleased]
 
+### Added
+
+- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
+
 ## [0.5.2] — Unreleased
 
 Implements AHP 0.5.2.

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -22,8 +22,6 @@ hotfix escape hatch.
 
 ### Added
 
-- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
-  interpreting `!`-prefixed user messages as terminal commands.
 - Typed `resource*` convenience methods on `AhpClient`: send wrappers (`resourceRead`, `resourceWrite`, `resourceList`, `resourceCopy`, `resourceDelete`, `resourceMove`, `resourceResolve`, `resourceMkdir`, `resourceRequest`, `createResourceWatch`) and typed inbound handling via `setResourceRequestHandlers` (new `ResourceRequestHandlers` type and `createResourceRequestHandler` helper).
 
 ## [0.5.2] — Unreleased
@@ -53,6 +51,8 @@ Implements AHP 0.5.2.
   `InitializeParams`, each an `Implementation` (`name`, optional `version`,
   optional `title`), identifying the implementation and build behind either side
   of the handshake. Informational only — MUST NOT be used for feature detection.
+- Optional `terminalCommandPrefix` on `InitializeResult` for hosts that support
+  interpreting `!`-prefixed user messages as terminal commands.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.

--- a/clients/typescript/test/types-round-trip.test.ts
+++ b/clients/typescript/test/types-round-trip.test.ts
@@ -59,7 +59,7 @@ import type {
   SessionSummary,
 } from '../src/types/channels-session/state.js';
 import type { SessionAddedParams } from '../src/types/channels-root/notifications.js';
-import type { Implementation } from '../src/types/common/commands.js';
+import type { Implementation, InitializeResult } from '../src/types/common/commands.js';
 
 // ─── Fixture directory ───────────────────────────────────────────────────────
 
@@ -241,6 +241,7 @@ function bindToType(file: string, type: string, parsed: unknown): void {
     case 'SessionAddedParams': void (parsed as SessionAddedParams); break;
     case 'PartialSessionSummary': void (parsed as Partial<SessionSummary>); break;
     case 'Implementation':     void (parsed as Implementation); break;
+    case 'InitializeResult':    void (parsed as InitializeResult); break;
     default:
       throw new Error(
         `${file}: unknown wire type "${type}". Add a decode entry to bindToType.`,

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -285,6 +285,8 @@ CompletionItem {
 
 Servers advertise the characters that should auto-trigger this request via `InitializeResult.completionTriggerCharacters` (e.g. `['@', '#']`). Clients MAY also issue `completions` calls in response to explicit user actions (such as a keyboard shortcut). When the user accepts an item, the client replaces `[rangeStart, rangeEnd)` in the input with `insertText` and associates the item's `attachment` with the resulting `Message`.
 
+Hosts that support the common terminal-command shorthand advertise `InitializeResult.terminalCommandPrefix` as `"!"`. Clients can use that marker to explain that messages beginning with `!` will be interpreted by the host as terminal commands; when the marker is absent, clients should treat `!`-prefixed text as an ordinary user message.
+
 ## Response Parts
 
 All response content — text, tool calls, reasoning, and content references — lives in a single `responseParts` array in stream order. This mirrors how LLM APIs (e.g. OpenAI) represent responses as a unified list of typed items.

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -155,6 +155,10 @@
           },
           "description": "Characters that, when typed in a {@link Message} input, SHOULD cause\nthe client to issue a `completions` request with\n{@link CompletionItemKind.UserMessage}. Typically includes characters like\n`'@'` or `'/'`."
         },
+        "terminalCommandPrefix": {
+          "type": "string",
+          "description": "Prefix that the host recognizes at the start of a user {@link Message.text}\nas a shorthand for executing the remainder as a terminal command. Currently\nthe standardized convention is `\"!\"`; absence means the host does not\nadvertise support and clients SHOULD treat `!`-prefixed input as an\nordinary user message."
+        },
         "telemetry": {
           "$ref": "#/$defs/TelemetryCapabilities",
           "description": "OTLP telemetry channels the host emits, if any. Each populated field is\neither a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a\nclient expands before subscribing (currently only the `logs` channel\ndefines a template variable, `{level}`, for subscriber-side severity\nfiltering). Clients MAY ignore signals they cannot process."

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -157,7 +157,7 @@
         },
         "terminalCommandPrefix": {
           "type": "string",
-          "description": "Prefix that the host recognizes at the start of a user {@link Message.text}\nas a shorthand for executing the remainder as a terminal command. Currently\nthe standardized convention is `\"!\"`; absence means the host does not\nadvertise support and clients SHOULD treat `!`-prefixed input as an\nordinary user message."
+          "description": "Prefix that the host recognizes at the start of a user {@link Message.text}\nas a shorthand for executing the remainder as a terminal command. Currently\nthe standardized convention is `\"!\"`; absence means the host does not\nsupport command prefixes."
         },
         "telemetry": {
           "$ref": "#/$defs/TelemetryCapabilities",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -4696,6 +4696,10 @@
           },
           "description": "Characters that, when typed in a {@link Message} input, SHOULD cause\nthe client to issue a `completions` request with\n{@link CompletionItemKind.UserMessage}. Typically includes characters like\n`'@'` or `'/'`."
         },
+        "terminalCommandPrefix": {
+          "type": "string",
+          "description": "Prefix that the host recognizes at the start of a user {@link Message.text}\nas a shorthand for executing the remainder as a terminal command. Currently\nthe standardized convention is `\"!\"`; absence means the host does not\nadvertise support and clients SHOULD treat `!`-prefixed input as an\nordinary user message."
+        },
         "telemetry": {
           "$ref": "#/$defs/TelemetryCapabilities",
           "description": "OTLP telemetry channels the host emits, if any. Each populated field is\neither a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a\nclient expands before subscribing (currently only the `logs` channel\ndefines a template variable, `{level}`, for subscriber-side severity\nfiltering). Clients MAY ignore signals they cannot process."

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -4698,7 +4698,7 @@
         },
         "terminalCommandPrefix": {
           "type": "string",
-          "description": "Prefix that the host recognizes at the start of a user {@link Message.text}\nas a shorthand for executing the remainder as a terminal command. Currently\nthe standardized convention is `\"!\"`; absence means the host does not\nadvertise support and clients SHOULD treat `!`-prefixed input as an\nordinary user message."
+          "description": "Prefix that the host recognizes at the start of a user {@link Message.text}\nas a shorthand for executing the remainder as a terminal command. Currently\nthe standardized convention is `\"!\"`; absence means the host does not\nsupport command prefixes."
         },
         "telemetry": {
           "$ref": "#/$defs/TelemetryCapabilities",

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -245,6 +245,13 @@ export interface InitializeResult {
    */
   completionTriggerCharacters?: string[];
   /**
+   * Prefix that the host recognizes at the start of a user {@link Message.text}
+   * as a shorthand for executing the remainder as a terminal command. Currently
+   * the standardized convention is `"!"`; absence means the host does not
+   * support command prefixes.
+   */
+  terminalCommandPrefix?: string;
+  /**
    * OTLP telemetry channels the host emits, if any. Each populated field is
    * either a literal `ahp-otlp:` channel URI or an RFC 6570 URI template a
    * client expands before subscribing (currently only the `logs` channel

--- a/types/test-cases/round-trips/029-initialize-terminal-command-prefix.json
+++ b/types/test-cases/round-trips/029-initialize-terminal-command-prefix.json
@@ -1,0 +1,36 @@
+{
+  "name": "initialize-terminal-command-prefix",
+  "group": "A",
+  "description": "InitializeResult carries the optional terminalCommandPrefix marker so hosts can advertise support for !-prefixed terminal-command messages.",
+  "type": "InitializeResult",
+  "input": {
+    "protocolVersion": "0.5.2",
+    "serverSeq": 7,
+    "snapshots": [
+      {
+        "resource": "ahp-root://",
+        "state": {
+          "agents": []
+        },
+        "fromSeq": 7
+      }
+    ],
+    "terminalCommandPrefix": "!"
+  },
+  "acceptableOutputs": [
+    {
+      "protocolVersion": "0.5.2",
+      "serverSeq": 7,
+      "snapshots": [
+        {
+          "resource": "ahp-root://",
+          "state": {
+            "agents": []
+          },
+          "fromSeq": 7
+        }
+      ],
+      "terminalCommandPrefix": "!"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add optional `InitializeResult.terminalCommandPrefix` to advertise `!` terminal-command shorthand support.
- Regenerate schema and client wire types across Go, Kotlin, Rust, Swift, and TypeScript.
- Add shared round-trip fixture coverage and update docs/changelogs.

## Validation
- `npm test`
- `clients/typescript`: `npm test`
- `clients/rust`: `cargo test`; after review fix also `cargo test -p ahp-types`
- `clients/go`: `go test ./...` in a Go container; after review fix also `go test ./ahptypes`
- `clients/kotlin`: `./gradlew.bat test --no-daemon --console=plain`
- `git diff --check`

## Notes
- `swift test` was attempted and failed before reaching this change due to an existing Windows/toolchain issue in `AnyCodable.swift` (`CFGetTypeID` / `CFBooleanGetTypeID` unavailable).
- Council review flagged an extra public `HostHandle` propagation as source-breaking; that was removed, keeping the new marker scoped to `InitializeResult`.
