### PR TITLE
Add native `version` field to `PluginCustomization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ changes accumulate. Track in-flight protocol changes via PRs touching
   functionality.
 - `changeset/filesReviewedChanged` action for servers to update the `reviewed`
   flag of one or more changeset files.
+- Optional `version` field on `PluginCustomization` (inherited by
+  `ClientPluginCustomization`), carrying the plugin's semver sourced from the
+  Open Plugins manifest's optional `version`. Provenance / display only; absent
+  when the manifest declares no version or the source has no version concept.
 
 ## [0.5.2] — Unreleased
 

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -35,6 +35,9 @@ Implements AHP 0.5.2.
   `Version`, optional `Title`), identifying the implementation and build behind
   either side of the handshake. Informational only — MUST NOT be used for
   feature detection.
+- Optional `Version` field on `PluginCustomization` (inherited by
+  `ClientPluginCustomization`), carrying the plugin's semver sourced from the
+  Open Plugins manifest. Provenance / display only.
 
 ### Changed
 

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -2076,6 +2076,13 @@ type PluginCustomization struct {
 	// nothing.
 	Children []ChildCustomization `json:"children,omitempty"`
 	Type     CustomizationType    `json:"type"`
+	// Version of the plugin, sourced from the
+	// [Open Plugins](https://open-plugins.com/) manifest's optional
+	// `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+	// declares no version — the field is optional there — or the source
+	// has no version concept. Provenance / display only: the host neither
+	// parses nor enforces it.
+	Version *string `json:"version,omitempty"`
 }
 
 // A {@link PluginCustomization} as published by a client. Extends the
@@ -2124,6 +2131,13 @@ type ClientPluginCustomization struct {
 	// nothing.
 	Children []ChildCustomization `json:"children,omitempty"`
 	Type     CustomizationType    `json:"type"`
+	// Version of the plugin, sourced from the
+	// [Open Plugins](https://open-plugins.com/) manifest's optional
+	// `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+	// declares no version — the field is optional there — or the source
+	// has no version concept. Provenance / display only: the host neither
+	// parses nor enforces it.
+	Version *string `json:"version,omitempty"`
 	// Opaque version token used by the host to detect changes.
 	Nonce *string `json:"nonce,omitempty"`
 }

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -35,6 +35,9 @@ Implements AHP 0.5.2.
   `InitializeParams`, each an `Implementation` (`name`, optional `version`,
   optional `title`), identifying the implementation and build behind either side
   of the handshake. Informational only — MUST NOT be used for feature detection.
+- Optional `version` field on `PluginCustomization` (inherited by
+  `ClientPluginCustomization`), carrying the plugin's semver sourced from the
+  Open Plugins manifest. Provenance / display only.
 
 ### Changed
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -2947,7 +2947,16 @@ data class PluginCustomization(
      * nothing.
      */
     val children: List<ChildCustomization>? = null,
-    val type: CustomizationType
+    val type: CustomizationType,
+    /**
+     * Version of the plugin, sourced from the
+     * [Open Plugins](https://open-plugins.com/) manifest's optional
+     * `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+     * declares no version — the field is optional there — or the source
+     * has no version concept. Provenance / display only: the host neither
+     * parses nor enforces it.
+     */
+    val version: String? = null
 )
 
 @Serializable
@@ -3006,6 +3015,15 @@ data class ClientPluginCustomization(
      */
     val children: List<ChildCustomization>? = null,
     val type: CustomizationType,
+    /**
+     * Version of the plugin, sourced from the
+     * [Open Plugins](https://open-plugins.com/) manifest's optional
+     * `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+     * declares no version — the field is optional there — or the source
+     * has no version concept. Provenance / display only: the host neither
+     * parses nor enforces it.
+     */
+    val version: String? = null,
     /**
      * Opaque version token used by the host to detect changes.
      */

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -37,6 +37,9 @@ Implements AHP 0.5.2.
   `version`, optional `title`), identifying the implementation and build behind
   either side of the handshake. Informational only — MUST NOT be used for
   feature detection.
+- Optional `version` field on `PluginCustomization` (inherited by
+  `ClientPluginCustomization`), carrying the plugin's semver sourced from the
+  Open Plugins manifest. Provenance / display only.
 
 ### Changed
 

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -2584,6 +2584,14 @@ pub struct PluginCustomization {
     /// nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<ChildCustomization>>,
+    /// Version of the plugin, sourced from the
+    /// [Open Plugins](https://open-plugins.com/) manifest's optional
+    /// `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+    /// declares no version — the field is optional there — or the source
+    /// has no version concept. Provenance / display only: the host neither
+    /// parses nor enforces it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
 }
 
 /// A {@link PluginCustomization} as published by a client. Extends the
@@ -2638,6 +2646,14 @@ pub struct ClientPluginCustomization {
     /// nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<ChildCustomization>>,
+    /// Version of the plugin, sourced from the
+    /// [Open Plugins](https://open-plugins.com/) manifest's optional
+    /// `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+    /// declares no version — the field is optional there — or the source
+    /// has no version concept. Provenance / display only: the host neither
+    /// parses nor enforces it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     /// Opaque version token used by the host to detect changes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nonce: Option<String>,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -3132,6 +3132,13 @@ public struct PluginCustomization: Codable, Sendable {
     /// nothing.
     public var children: [ChildCustomization]?
     public var type: CustomizationType
+    /// Version of the plugin, sourced from the
+    /// [Open Plugins](https://open-plugins.com/) manifest's optional
+    /// `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+    /// declares no version — the field is optional there — or the source
+    /// has no version concept. Provenance / display only: the host neither
+    /// parses nor enforces it.
+    public var version: String?
 
     public init(
         id: String,
@@ -3143,7 +3150,8 @@ public struct PluginCustomization: Codable, Sendable {
         clientId: String? = nil,
         load: CustomizationLoadState? = nil,
         children: [ChildCustomization]? = nil,
-        type: CustomizationType
+        type: CustomizationType,
+        version: String? = nil
     ) {
         self.id = id
         self.uri = uri
@@ -3155,6 +3163,7 @@ public struct PluginCustomization: Codable, Sendable {
         self.load = load
         self.children = children
         self.type = type
+        self.version = version
     }
 }
 
@@ -3195,6 +3204,13 @@ public struct ClientPluginCustomization: Codable, Sendable {
     /// nothing.
     public var children: [ChildCustomization]?
     public var type: CustomizationType
+    /// Version of the plugin, sourced from the
+    /// [Open Plugins](https://open-plugins.com/) manifest's optional
+    /// `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+    /// declares no version — the field is optional there — or the source
+    /// has no version concept. Provenance / display only: the host neither
+    /// parses nor enforces it.
+    public var version: String?
     /// Opaque version token used by the host to detect changes.
     public var nonce: String?
 
@@ -3209,6 +3225,7 @@ public struct ClientPluginCustomization: Codable, Sendable {
         load: CustomizationLoadState? = nil,
         children: [ChildCustomization]? = nil,
         type: CustomizationType,
+        version: String? = nil,
         nonce: String? = nil
     ) {
         self.id = id
@@ -3221,6 +3238,7 @@ public struct ClientPluginCustomization: Codable, Sendable {
         self.load = load
         self.children = children
         self.type = type
+        self.version = version
         self.nonce = nonce
     }
 }

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -37,6 +37,9 @@ Implements AHP 0.5.2.
   `InitializeParams`, each an `Implementation` (`name`, optional `version`,
   optional `title`), identifying the implementation and build behind either side
   of the handshake. Informational only — MUST NOT be used for feature detection.
+- Optional `version` field on `PluginCustomization` (inherited by
+  `ClientPluginCustomization`), carrying the plugin's semver sourced from the
+  Open Plugins manifest. Provenance / display only.
 
 ### Changed
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -40,6 +40,9 @@ Implements AHP 0.5.2.
   `InitializeParams`, each an `Implementation` (`name`, optional `version`,
   optional `title`), identifying the implementation and build behind either side
   of the handshake. Informational only — MUST NOT be used for feature detection.
+- Optional `version` field on `PluginCustomization` (inherited by
+  `ClientPluginCustomization`), carrying the plugin's semver sourced from the
+  Open Plugins manifest. Provenance / display only.
 
 ### Changed
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1646,7 +1646,7 @@
       "description": "Update the {@link ChangesetFile.reviewed} flag for one or more files,\nidentified by their {@link ChangesetFile.id}.\n\nDispatched by the server as the user marks files reviewed or unreviewed\n(e.g. toggling a single file, or a \"mark all as reviewed\" affordance).\nOnly servers that support the \"review\" functionality dispatch this; a\nserver that leaves {@link ChangesetFile.reviewed} `undefined` never does.\n\nThe reducer sets `reviewed` on every matching file and ignores any\n`fileIds` entry that does not correspond to a current file.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFilesReviewedChanged"
+          "const": "changeset/filesReviewedChanged"
         },
         "fileIds": {
           "type": "array",
@@ -3442,6 +3442,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         }
       },
       "required": [
@@ -3500,6 +3504,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         },
         "nonce": {
           "type": "string",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2760,6 +2760,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         }
       },
       "required": [
@@ -2818,6 +2822,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         },
         "nonce": {
           "type": "string",
@@ -7352,7 +7360,7 @@
       "description": "Update the {@link ChangesetFile.reviewed} flag for one or more files,\nidentified by their {@link ChangesetFile.id}.\n\nDispatched by the server as the user marks files reviewed or unreviewed\n(e.g. toggling a single file, or a \"mark all as reviewed\" affordance).\nOnly servers that support the \"review\" functionality dispatch this; a\nserver that leaves {@link ChangesetFile.reviewed} `undefined` never does.\n\nThe reducer sets `reviewed` on every matching file and ignores any\n`fileIds` entry that does not correspond to a current file.",
       "properties": {
         "type": {
-          "$ref": "#/$defs/ActionType.ChangesetFilesReviewedChanged"
+          "const": "changeset/filesReviewedChanged"
         },
         "fileIds": {
           "type": "array",
@@ -7767,6 +7775,9 @@
         },
         {
           "$ref": "#/$defs/ChangesetFileRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/ChangesetFilesReviewedChangedAction"
         },
         {
           "$ref": "#/$defs/ChangesetContentChangedAction"

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -1555,6 +1555,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         }
       },
       "required": [
@@ -1613,6 +1617,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         },
         "nonce": {
           "type": "string",
@@ -6506,6 +6514,9 @@
           "$ref": "#/$defs/ChangesetFileRemovedAction"
         },
         {
+          "$ref": "#/$defs/ChangesetFilesReviewedChangedAction"
+        },
+        {
           "$ref": "#/$defs/ChangesetContentChangedAction"
         },
         {
@@ -7945,6 +7956,31 @@
       "required": [
         "type",
         "fileId"
+      ]
+    },
+    "ChangesetFilesReviewedChangedAction": {
+      "type": "object",
+      "description": "Update the {@link ChangesetFile.reviewed} flag for one or more files,\nidentified by their {@link ChangesetFile.id}.\n\nDispatched by the server as the user marks files reviewed or unreviewed\n(e.g. toggling a single file, or a \"mark all as reviewed\" affordance).\nOnly servers that support the \"review\" functionality dispatch this; a\nserver that leaves {@link ChangesetFile.reviewed} `undefined` never does.\n\nThe reducer sets `reviewed` on every matching file and ignores any\n`fileIds` entry that does not correspond to a current file.",
+      "properties": {
+        "type": {
+          "const": "changeset/filesReviewedChanged"
+        },
+        "fileIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The {@link ChangesetFile.id}s whose reviewed state changed."
+        },
+        "reviewed": {
+          "type": "boolean",
+          "description": "The new reviewed state to apply to each listed file."
+        }
+      },
+      "required": [
+        "type",
+        "fileIds",
+        "reviewed"
       ]
     },
     "ChangesetContentChangedAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1715,6 +1715,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         }
       },
       "required": [
@@ -1773,6 +1777,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         },
         "nonce": {
           "type": "string",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1466,6 +1466,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         }
       },
       "required": [
@@ -1524,6 +1528,10 @@
         },
         "type": {
           "const": "plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin, sourced from the\n[Open Plugins](https://open-plugins.com/) manifest's optional\n`version` field (semver, e.g. `\"1.2.0\"`). Absent when the manifest\ndeclares no version — the field is optional there — or the source\nhas no version concept. Provenance / display only: the host neither\nparses nor enforces it."
         },
         "nonce": {
           "type": "string",

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -750,6 +750,15 @@ interface ContainerCustomizationBase extends CustomizationBase {
  */
 export interface PluginCustomization extends ContainerCustomizationBase {
   type: CustomizationType.Plugin;
+  /**
+   * Version of the plugin, sourced from the
+   * [Open Plugins](https://open-plugins.com/) manifest's optional
+   * `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
+   * declares no version — the field is optional there — or the source
+   * has no version concept. Provenance / display only: the host neither
+   * parses nor enforces it.
+   */
+  version?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #315.

## What

Adds an optional, display-only `version?: string` to `PluginCustomization` (inherited by `ClientPluginCustomization`).

```ts
export interface PluginCustomization extends ContainerCustomizationBase {
  type: CustomizationType.Plugin;
  /**
   * Version of the plugin, sourced from the
   * [Open Plugins](https://open-plugins.com/) manifest's optional
   * `version` field (semver, e.g. `"1.2.0"`). Absent when the manifest
   * declares no version — the field is optional there — or the source
   * has no version concept. Provenance / display only: the host neither
   * parses nor enforces it.
   */
  version?: string;
}
```

## Why

`PluginCustomization` mirrors an [Open Plugins](https://open-plugins.com/) package and already carries `name` via `CustomizationBase`, but not `version`. The Open Plugins spec lists `version` as an optional `plugin.json` metadata field — *"Semantic version (e.g., `"2.1.0"`). Used by tools to determine update availability"* — sitting right next to `name`. A host that resolved a plugin's version had nowhere to put it, so the value was dropped on the wire.

This follows the established **native, type-specific field over a generic `_meta` bag** precedent (`RuleCustomization.alwaysApply`/`globs`, `AgentCustomization.model`/`tools`, #303's `argumentHint`), because a plugin version is a first-class attribute of a plugin rather than incidental metadata. It is deliberately independent of #316, which hoists a generic `_meta` slot onto `CustomizationBase` for provider-specific data that lacks a first-class home — the two are complementary.

## Validation

I independently verified every assumption in the issue:

- **Open Plugins manifest** — confirmed against the [Open Plugins Specification v1.0.0](https://open-plugins.com/plugin-builders/specification): `version` is an **optional** metadata field (semver, "used by tools to determine update availability"), and `name` is the only required field. This maps cleanly onto AHP's required `name: string` + optional `version?`.
- **Mirror claim** — `PluginCustomization`'s doc comment already declares it "An Open Plugins plugin," and it carries `name` but no `version`.
- **Doctrine** — passes the design tests in `docs/guide/doctrine.md`: optional/additive (a minimal client can ignore it), durable state (lives in `SessionState.customizations`), host-authoritative, and not an agent implementation detail.
- **Reducers** — customizations are upserted as whole objects (`SessionCustomizationUpdated` / `SessionCustomizationsChanged`), so an optional field needs no reducer logic and no new fixtures; 100% branch coverage is unaffected.

## Ripple / scope

Matches the shape of a prior additive-optional-field change (#299, `contentSha256` on `ContentRef`):

- `types/channels-session/state.ts` — the field (hand-edited).
- Regenerated the five client mirrors (Go, Rust, Kotlin, Swift, TypeScript) and the JSON Schema via `npm run generate`.
- CHANGELOG entries added to the spec and every client, per the repo's changelog rules for a `types/**` change.
- `PROTOCOL_VERSION` intentionally **not** bumped.

## Testing

`npm run generate` and `npm run test` both run clean: typecheck, lint, `verify:release-metadata`, and `verify:changelog` all pass, and the full suite is **292/292**. (The `c8` coverage wrapper crashes locally on Node v26 via a yargs ESM/CJS incompat in its bootstrap — unrelated to this change; CI runs on a pinned Node.)

> [!NOTE]
> #316 is being implemented in parallel and also touches `types/channels-session/state.ts` and the CHANGELOGs. The changes are logically independent (different location in the file, complementary intent); a mechanical merge may be needed depending on land order.