### PR TITLE
sessions: add MCP server start and stop actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ changes accumulate. Track in-flight protocol changes via PRs touching
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest's optional `version`. Provenance / display only; absent
   when the manifest declares no version or the source has no version concept.
+- `session/mcpServerStartRequested` and `session/mcpServerStopRequested`
+  actions for clients to ask the host to start or stop MCP servers; stopping
+  moves an `authRequired` server to `stopped` so it no longer waits on
+  authentication.
 
 ## [0.5.2] — Unreleased
 

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -40,6 +40,10 @@ Implements AHP 0.5.2.
 - Optional `Version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.
+- `session/mcpServerStartRequested` and `session/mcpServerStopRequested`
+  actions for clients to ask the host to start or stop MCP servers; stopping
+  moves an `authRequired` server to `stopped` so it no longer waits on
+  authentication.
 
 ### Changed
 

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -882,7 +882,15 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 		}
 		return ReduceOutcomeNoOp
 	case *ahptypes.SessionMcpServerStateChangedAction:
-		return applyMcpServerStatusChanged(state, a)
+		return updateMcpServerCustomizationState(state, a.Id, a.State, a.Channel)
+	case *ahptypes.SessionMcpServerStartRequestedAction:
+		return updateMcpServerCustomizationState(state, a.Id, ahptypes.McpServerState{Value: &ahptypes.McpServerStartingState{
+			Kind: ahptypes.McpServerStatusStarting,
+		}}, nil)
+	case *ahptypes.SessionMcpServerStopRequestedAction:
+		return updateMcpServerCustomizationState(state, a.Id, ahptypes.McpServerState{Value: &ahptypes.McpServerStoppedState{
+			Kind: ahptypes.McpServerStatusStopped,
+		}}, nil)
 	}
 	return ReduceOutcomeOutOfScope
 }
@@ -1174,22 +1182,22 @@ func applyToolCallResultConfirmed(state *ahptypes.ChatState, a *ahptypes.ChatToo
 	})
 }
 
-func applyMcpServerStatusChanged(state *ahptypes.SessionState, a *ahptypes.SessionMcpServerStateChangedAction) ReduceOutcome {
+func updateMcpServerCustomizationState(state *ahptypes.SessionState, id string, nextState ahptypes.McpServerState, channel *ahptypes.URI) ReduceOutcome {
 	list := state.Customizations
 	if list == nil {
 		return ReduceOutcomeNoOp
 	}
 	for i := range list {
 		got, ok := customizationID(list[i])
-		if !ok || got != a.Id {
+		if !ok || got != id {
 			continue
 		}
 		mcp, ok := list[i].Value.(*ahptypes.McpServerCustomization)
 		if !ok {
 			return ReduceOutcomeNoOp
 		}
-		mcp.State = a.State
-		mcp.Channel = a.Channel
+		mcp.State = nextState
+		mcp.Channel = channel
 		return ReduceOutcomeApplied
 	}
 	for i := range list {
@@ -1199,15 +1207,15 @@ func applyMcpServerStatusChanged(state *ahptypes.SessionState, a *ahptypes.Sessi
 		}
 		for j := range *children {
 			got, ok := childCustomizationID((*children)[j])
-			if !ok || got != a.Id {
+			if !ok || got != id {
 				continue
 			}
 			mcp, ok := (*children)[j].Value.(*ahptypes.McpServerCustomization)
 			if !ok {
 				return ReduceOutcomeNoOp
 			}
-			mcp.State = a.State
-			mcp.Channel = a.Channel
+			mcp.State = nextState
+			mcp.Channel = channel
 			return ReduceOutcomeApplied
 		}
 	}

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -61,6 +61,8 @@ const (
 	ActionTypeSessionCustomizationUpdated       ActionType = "session/customizationUpdated"
 	ActionTypeSessionCustomizationRemoved       ActionType = "session/customizationRemoved"
 	ActionTypeSessionMcpServerStateChanged      ActionType = "session/mcpServerStateChanged"
+	ActionTypeSessionMcpServerStartRequested    ActionType = "session/mcpServerStartRequested"
+	ActionTypeSessionMcpServerStopRequested     ActionType = "session/mcpServerStopRequested"
 	ActionTypeChatTruncated                     ActionType = "chat/truncated"
 	ActionTypeChatTurnsLoaded                   ActionType = "chat/turnsLoaded"
 	ActionTypeSessionIsReadChanged              ActionType = "session/isReadChanged"
@@ -900,6 +902,46 @@ type SessionMcpServerStateChangedAction struct {
 	Channel *URI `json:"channel,omitempty"`
 }
 
+// Requests that the host start or restart an existing
+// {@link McpServerCustomization}.
+//
+// Locates the target entry by `id`, searching both the top-level
+// customization list and the `children` array of every container. The
+// reducer optimistically moves the server to
+// {@link McpServerStatus.Starting | `starting`} and clears any previous
+// {@link McpServerCustomization.channel | `channel`}; the host remains
+// authoritative and SHOULD follow with
+// {@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}
+// once the server becomes ready, needs authentication, fails, or is
+// rejected. Is a no-op when no matching `McpServerCustomization` is found.
+type SessionMcpServerStartRequestedAction struct {
+	Type ActionType `json:"type"`
+	// The id of the {@link McpServerCustomization} to start.
+	Id string `json:"id"`
+}
+
+// Requests that the host stop an existing {@link McpServerCustomization}.
+//
+// Locates the target entry by `id`, searching both the top-level
+// customization list and the `children` array of every container. The
+// reducer optimistically moves the server to
+// {@link McpServerStatus.Stopped | `stopped`} and clears any previous
+// {@link McpServerCustomization.channel | `channel`}. Replacing an
+// {@link McpServerStatus.AuthRequired | `authRequired`} lifecycle state with
+// `stopped` unblocks the server from waiting on authentication. If the host
+// also raised session-level input-needed state solely for that MCP server, it
+// SHOULD remove that input-needed entry when accepting the stop.
+//
+// The host remains authoritative and MAY reject the action or follow with
+// {@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}
+// if the final lifecycle state differs. Is a no-op when no matching
+// `McpServerCustomization` is found.
+type SessionMcpServerStopRequestedAction struct {
+	Type ActionType `json:"type"`
+	// The id of the {@link McpServerCustomization} to stop.
+	Id string `json:"id"`
+}
+
 // Client changed a mutable config value mid-session.
 //
 // Only properties with `sessionMutable: true` in the config schema may be
@@ -1332,6 +1374,8 @@ func (*SessionCustomizationToggledAction) isStateAction()       {}
 func (*SessionCustomizationUpdatedAction) isStateAction()       {}
 func (*SessionCustomizationRemovedAction) isStateAction()       {}
 func (*SessionMcpServerStateChangedAction) isStateAction()      {}
+func (*SessionMcpServerStartRequestedAction) isStateAction()    {}
+func (*SessionMcpServerStopRequestedAction) isStateAction()     {}
 func (*SessionConfigChangedAction) isStateAction()              {}
 func (*SessionMetaChangedAction) isStateAction()                {}
 func (*ChangesetStatusChangedAction) isStateAction()            {}
@@ -1665,6 +1709,18 @@ func (u *StateAction) UnmarshalJSON(data []byte) error {
 		u.Value = &value
 	case "session/mcpServerStateChanged":
 		var value SessionMcpServerStateChangedAction
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "session/mcpServerStartRequested":
+		var value SessionMcpServerStartRequestedAction
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "session/mcpServerStopRequested":
+		var value SessionMcpServerStopRequestedAction
 		if err := json.Unmarshal(data, &value); err != nil {
 			return err
 		}

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -40,6 +40,10 @@ Implements AHP 0.5.2.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.
+- `session/mcpServerStartRequested` and `session/mcpServerStopRequested`
+  actions for clients to ask the host to start or stop MCP servers; stopping
+  moves an `authRequired` server to `stopped` so it no longer waits on
+  authentication.
 
 ### Changed
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -671,14 +671,46 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
 
     is StateActionSessionMcpServerStateChanged -> {
         val a = action.value
+        updateMcpServerCustomizationState(state, a.id, a.state, a.channel)
+    }
+
+    is StateActionSessionMcpServerStartRequested -> {
+        val a = action.value
+        updateMcpServerCustomizationState(
+            state,
+            a.id,
+            McpServerStateStarting(McpServerStartingState(McpServerStatus.STARTING)),
+            null
+        )
+    }
+
+    is StateActionSessionMcpServerStopRequested -> {
+        val a = action.value
+        updateMcpServerCustomizationState(
+            state,
+            a.id,
+            McpServerStateStopped(McpServerStoppedState(McpServerStatus.STOPPED)),
+            null
+        )
+    }
+
+    else -> state
+}
+
+private fun updateMcpServerCustomizationState(
+    state: SessionState,
+    id: String,
+    nextState: McpServerState,
+    channel: URI?
+): SessionState {
         val list = state.customizations
-        if (list == null) state else {
-            val topIdx = list.indexOfFirst { customizationId(it) == a.id }
+    return if (list == null) state else {
+            val topIdx = list.indexOfFirst { customizationId(it) == id }
             if (topIdx >= 0) {
                 val entry = list[topIdx]
                 if (entry !is CustomizationMcpServer) state else {
                     val updated = list.toMutableList()
-                    updated[topIdx] = CustomizationMcpServer(entry.value.copy(state = a.state, channel = a.channel))
+                    updated[topIdx] = CustomizationMcpServer(entry.value.copy(state = nextState, channel = channel))
                     state.copy(customizations = updated)
                 }
             } else {
@@ -686,13 +718,13 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
                 val updated = list.map { container ->
                     val children = customizationChildren(container)
                     if (children == null) container else {
-                        val childIdx = children.indexOfFirst { childCustomizationId(it) == a.id }
+                        val childIdx = children.indexOfFirst { childCustomizationId(it) == id }
                         if (childIdx < 0) container else {
                             val child = children[childIdx]
                             if (child !is ChildCustomizationMcpServer) container else {
                                 changed = true
                                 val newChildren = children.toMutableList()
-                                newChildren[childIdx] = ChildCustomizationMcpServer(child.value.copy(state = a.state, channel = a.channel))
+                                newChildren[childIdx] = ChildCustomizationMcpServer(child.value.copy(state = nextState, channel = channel))
                                 withCustomizationChildren(container, newChildren)
                             }
                         }
@@ -701,9 +733,6 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
                 if (!changed) state else state.copy(customizations = updated)
             }
         }
-    }
-
-    else -> state
 }
 
 // ─── Chat Reducer ───────────────────────────────────────────────────────────

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -110,6 +110,10 @@ enum class ActionType {
     SESSION_CUSTOMIZATION_REMOVED,
     @SerialName("session/mcpServerStateChanged")
     SESSION_MCP_SERVER_STATE_CHANGED,
+    @SerialName("session/mcpServerStartRequested")
+    SESSION_MCP_SERVER_START_REQUESTED,
+    @SerialName("session/mcpServerStopRequested")
+    SESSION_MCP_SERVER_STOP_REQUESTED,
     @SerialName("chat/truncated")
     CHAT_TRUNCATED,
     @SerialName("chat/turnsLoaded")
@@ -964,6 +968,24 @@ data class SessionMcpServerStateChangedAction(
 )
 
 @Serializable
+data class SessionMcpServerStartRequestedAction(
+    val type: ActionType,
+    /**
+     * The id of the {@link McpServerCustomization} to start.
+     */
+    val id: String
+)
+
+@Serializable
+data class SessionMcpServerStopRequestedAction(
+    val type: ActionType,
+    /**
+     * The id of the {@link McpServerCustomization} to stop.
+     */
+    val id: String
+)
+
+@Serializable
 data class ChatTruncatedAction(
     val type: ActionType,
     /**
@@ -1427,6 +1449,8 @@ sealed interface StateAction
 @JvmInline value class StateActionSessionCustomizationUpdated(val value: SessionCustomizationUpdatedAction) : StateAction
 @JvmInline value class StateActionSessionCustomizationRemoved(val value: SessionCustomizationRemovedAction) : StateAction
 @JvmInline value class StateActionSessionMcpServerStateChanged(val value: SessionMcpServerStateChangedAction) : StateAction
+@JvmInline value class StateActionSessionMcpServerStartRequested(val value: SessionMcpServerStartRequestedAction) : StateAction
+@JvmInline value class StateActionSessionMcpServerStopRequested(val value: SessionMcpServerStopRequestedAction) : StateAction
 @JvmInline value class StateActionChatTruncated(val value: ChatTruncatedAction) : StateAction
 @JvmInline value class StateActionChatTurnsLoaded(val value: ChatTurnsLoadedAction) : StateAction
 @JvmInline value class StateActionSessionConfigChanged(val value: SessionConfigChangedAction) : StateAction
@@ -1519,6 +1543,8 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             "session/customizationUpdated" -> StateActionSessionCustomizationUpdated(input.json.decodeFromJsonElement(SessionCustomizationUpdatedAction.serializer(), element))
             "session/customizationRemoved" -> StateActionSessionCustomizationRemoved(input.json.decodeFromJsonElement(SessionCustomizationRemovedAction.serializer(), element))
             "session/mcpServerStateChanged" -> StateActionSessionMcpServerStateChanged(input.json.decodeFromJsonElement(SessionMcpServerStateChangedAction.serializer(), element))
+            "session/mcpServerStartRequested" -> StateActionSessionMcpServerStartRequested(input.json.decodeFromJsonElement(SessionMcpServerStartRequestedAction.serializer(), element))
+            "session/mcpServerStopRequested" -> StateActionSessionMcpServerStopRequested(input.json.decodeFromJsonElement(SessionMcpServerStopRequestedAction.serializer(), element))
             "chat/truncated" -> StateActionChatTruncated(input.json.decodeFromJsonElement(ChatTruncatedAction.serializer(), element))
             "chat/turnsLoaded" -> StateActionChatTurnsLoaded(input.json.decodeFromJsonElement(ChatTurnsLoadedAction.serializer(), element))
             "session/configChanged" -> StateActionSessionConfigChanged(input.json.decodeFromJsonElement(SessionConfigChangedAction.serializer(), element))
@@ -1604,6 +1630,8 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             is StateActionSessionCustomizationUpdated -> output.json.encodeToJsonElement(SessionCustomizationUpdatedAction.serializer(), value.value)
             is StateActionSessionCustomizationRemoved -> output.json.encodeToJsonElement(SessionCustomizationRemovedAction.serializer(), value.value)
             is StateActionSessionMcpServerStateChanged -> output.json.encodeToJsonElement(SessionMcpServerStateChangedAction.serializer(), value.value)
+            is StateActionSessionMcpServerStartRequested -> output.json.encodeToJsonElement(SessionMcpServerStartRequestedAction.serializer(), value.value)
+            is StateActionSessionMcpServerStopRequested -> output.json.encodeToJsonElement(SessionMcpServerStopRequestedAction.serializer(), value.value)
             is StateActionChatTruncated -> output.json.encodeToJsonElement(ChatTruncatedAction.serializer(), value.value)
             is StateActionChatTurnsLoaded -> output.json.encodeToJsonElement(ChatTurnsLoadedAction.serializer(), value.value)
             is StateActionSessionConfigChanged -> output.json.encodeToJsonElement(SessionConfigChangedAction.serializer(), value.value)

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -42,6 +42,10 @@ Implements AHP 0.5.2.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.
+- `session/mcpServerStartRequested` and `session/mcpServerStopRequested`
+  actions for clients to ask the host to start or stop MCP servers; stopping
+  moves an `authRequired` server to `stopped` so it no longer waits on
+  authentication.
 
 ### Changed
 

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -111,6 +111,10 @@ pub enum ActionType {
     SessionCustomizationRemoved,
     #[serde(rename = "session/mcpServerStateChanged")]
     SessionMcpServerStateChanged,
+    #[serde(rename = "session/mcpServerStartRequested")]
+    SessionMcpServerStartRequested,
+    #[serde(rename = "session/mcpServerStopRequested")]
+    SessionMcpServerStopRequested,
     #[serde(rename = "chat/truncated")]
     ChatTruncated,
     #[serde(rename = "chat/turnsLoaded")]
@@ -1060,6 +1064,48 @@ pub struct SessionMcpServerStateChangedAction {
     pub channel: Option<Uri>,
 }
 
+/// Requests that the host start or restart an existing
+/// {@link McpServerCustomization}.
+///
+/// Locates the target entry by `id`, searching both the top-level
+/// customization list and the `children` array of every container. The
+/// reducer optimistically moves the server to
+/// {@link McpServerStatus.Starting | `starting`} and clears any previous
+/// {@link McpServerCustomization.channel | `channel`}; the host remains
+/// authoritative and SHOULD follow with
+/// {@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}
+/// once the server becomes ready, needs authentication, fails, or is
+/// rejected. Is a no-op when no matching `McpServerCustomization` is found.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMcpServerStartRequestedAction {
+    /// The id of the {@link McpServerCustomization} to start.
+    pub id: String,
+}
+
+/// Requests that the host stop an existing {@link McpServerCustomization}.
+///
+/// Locates the target entry by `id`, searching both the top-level
+/// customization list and the `children` array of every container. The
+/// reducer optimistically moves the server to
+/// {@link McpServerStatus.Stopped | `stopped`} and clears any previous
+/// {@link McpServerCustomization.channel | `channel`}. Replacing an
+/// {@link McpServerStatus.AuthRequired | `authRequired`} lifecycle state with
+/// `stopped` unblocks the server from waiting on authentication. If the host
+/// also raised session-level input-needed state solely for that MCP server, it
+/// SHOULD remove that input-needed entry when accepting the stop.
+///
+/// The host remains authoritative and MAY reject the action or follow with
+/// {@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}
+/// if the final lifecycle state differs. Is a no-op when no matching
+/// `McpServerCustomization` is found.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMcpServerStopRequestedAction {
+    /// The id of the {@link McpServerCustomization} to stop.
+    pub id: String,
+}
+
 /// Truncates a session's history. If `turnId` is provided, all turns after that
 /// turn are removed and the specified turn is kept. If `turnId` is omitted, all
 /// turns are removed.
@@ -1645,6 +1691,10 @@ pub enum StateAction {
     SessionCustomizationRemoved(SessionCustomizationRemovedAction),
     #[serde(rename = "session/mcpServerStateChanged")]
     SessionMcpServerStateChanged(Box<SessionMcpServerStateChangedAction>),
+    #[serde(rename = "session/mcpServerStartRequested")]
+    SessionMcpServerStartRequested(SessionMcpServerStartRequestedAction),
+    #[serde(rename = "session/mcpServerStopRequested")]
+    SessionMcpServerStopRequested(SessionMcpServerStopRequestedAction),
     #[serde(rename = "chat/truncated")]
     ChatTruncated(ChatTruncatedAction),
     #[serde(rename = "chat/turnsLoaded")]

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -59,13 +59,13 @@ use ahp_types::actions::{
 use ahp_types::state::{
     ActiveTurn, AnnotationsState, ChangesetOperationStatus, ChangesetState, ChangesetStatus,
     ChatInputRequest, ChatState, ChildCustomization, ConfirmationOption, Customization, ErrorInfo,
-    PendingMessage, PendingMessageKind, ResourceWatchState, ResponsePart, RootState,
-    SessionInputRequest, SessionLifecycle, SessionState, SessionStatus, TerminalCommandPart,
-    TerminalContentPart, TerminalState, TerminalUnclassifiedPart, ToolCallCancellationReason,
-    ToolCallCancelledState, ToolCallCompletedState, ToolCallConfirmationReason,
-    ToolCallContributor, ToolCallPendingConfirmationState, ToolCallPendingResultConfirmationState,
-    ToolCallResponsePart, ToolCallRunningState, ToolCallState, ToolCallStreamingState, Turn,
-    TurnState,
+    McpServerStartingState, McpServerState, McpServerStoppedState, PendingMessage,
+    PendingMessageKind, ResourceWatchState, ResponsePart, RootState, SessionInputRequest,
+    SessionLifecycle, SessionState, SessionStatus, TerminalCommandPart, TerminalContentPart,
+    TerminalState, TerminalUnclassifiedPart, ToolCallCancellationReason, ToolCallCancelledState,
+    ToolCallCompletedState, ToolCallConfirmationReason, ToolCallContributor,
+    ToolCallPendingConfirmationState, ToolCallPendingResultConfirmationState, ToolCallResponsePart,
+    ToolCallRunningState, ToolCallState, ToolCallStreamingState, Turn, TurnState,
 };
 
 /// What happened when an action was applied.
@@ -793,43 +793,58 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
             ReduceOutcome::NoOp
         }
         StateAction::SessionMcpServerStateChanged(a) => {
-            let Some(list) = state.customizations.as_mut() else {
-                return ReduceOutcome::NoOp;
-            };
-            if let Some(idx) = list
-                .iter()
-                .position(|c| customization_id(c) == Some(a.id.as_str()))
-            {
-                match &mut list[idx] {
-                    Customization::McpServer(m) => {
-                        m.state = a.state.clone();
-                        m.channel = a.channel.clone();
-                        return ReduceOutcome::Applied;
-                    }
-                    // Top-level entry exists but isn't an MCP server: no-op.
-                    _ => return ReduceOutcome::NoOp,
-                }
-            }
-            for container in list.iter_mut() {
-                let Some(children) = container_children_mut(container) else {
-                    continue;
-                };
-                if let Some(idx) = children
-                    .iter()
-                    .position(|c| child_id_of(c) == Some(a.id.as_str()))
-                {
-                    if let ChildCustomization::McpServer(m) = &mut children[idx] {
-                        m.state = a.state.clone();
-                        m.channel = a.channel.clone();
-                        return ReduceOutcome::Applied;
-                    }
-                    return ReduceOutcome::NoOp;
-                }
-            }
-            ReduceOutcome::NoOp
+            update_mcp_server_customization_state(state, &a.id, a.state.clone(), a.channel.clone())
         }
+        StateAction::SessionMcpServerStartRequested(a) => update_mcp_server_customization_state(
+            state,
+            &a.id,
+            McpServerState::Starting(McpServerStartingState {}),
+            None,
+        ),
+        StateAction::SessionMcpServerStopRequested(a) => update_mcp_server_customization_state(
+            state,
+            &a.id,
+            McpServerState::Stopped(McpServerStoppedState {}),
+            None,
+        ),
         _ => ReduceOutcome::OutOfScope,
     }
+}
+
+fn update_mcp_server_customization_state(
+    state: &mut SessionState,
+    id: &str,
+    next_state: McpServerState,
+    channel: Option<String>,
+) -> ReduceOutcome {
+    let Some(list) = state.customizations.as_mut() else {
+        return ReduceOutcome::NoOp;
+    };
+    if let Some(idx) = list.iter().position(|c| customization_id(c) == Some(id)) {
+        match &mut list[idx] {
+            Customization::McpServer(m) => {
+                m.state = next_state;
+                m.channel = channel;
+                return ReduceOutcome::Applied;
+            }
+            // Top-level entry exists but isn't an MCP server: no-op.
+            _ => return ReduceOutcome::NoOp,
+        }
+    }
+    for container in list.iter_mut() {
+        let Some(children) = container_children_mut(container) else {
+            continue;
+        };
+        if let Some(idx) = children.iter().position(|c| child_id_of(c) == Some(id)) {
+            if let ChildCustomization::McpServer(m) = &mut children[idx] {
+                m.state = next_state;
+                m.channel = channel;
+                return ReduceOutcome::Applied;
+            }
+            return ReduceOutcome::NoOp;
+        }
+    }
+    ReduceOutcome::NoOp
 }
 
 // ─── Chat Reducer ─────────────────────────────────────────────────────

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -48,6 +48,8 @@ public enum ActionType: String, Codable, Sendable {
     case sessionCustomizationUpdated = "session/customizationUpdated"
     case sessionCustomizationRemoved = "session/customizationRemoved"
     case sessionMcpServerStateChanged = "session/mcpServerStateChanged"
+    case sessionMcpServerStartRequested = "session/mcpServerStartRequested"
+    case sessionMcpServerStopRequested = "session/mcpServerStopRequested"
     case chatTruncated = "chat/truncated"
     case chatTurnsLoaded = "chat/turnsLoaded"
     case sessionIsReadChanged = "session/isReadChanged"
@@ -1239,6 +1241,34 @@ public struct SessionMcpServerStateChangedAction: Codable, Sendable {
     }
 }
 
+public struct SessionMcpServerStartRequestedAction: Codable, Sendable {
+    public var type: ActionType
+    /// The id of the {@link McpServerCustomization} to start.
+    public var id: String
+
+    public init(
+        type: ActionType,
+        id: String
+    ) {
+        self.type = type
+        self.id = id
+    }
+}
+
+public struct SessionMcpServerStopRequestedAction: Codable, Sendable {
+    public var type: ActionType
+    /// The id of the {@link McpServerCustomization} to stop.
+    public var id: String
+
+    public init(
+        type: ActionType,
+        id: String
+    ) {
+        self.type = type
+        self.id = id
+    }
+}
+
 public struct ChatTruncatedAction: Codable, Sendable {
     public var type: ActionType
     /// Keep turns up to and including this turn. Omit to clear all turns.
@@ -1855,6 +1885,8 @@ public enum StateAction: Codable, Sendable {
     case sessionCustomizationUpdated(SessionCustomizationUpdatedAction)
     case sessionCustomizationRemoved(SessionCustomizationRemovedAction)
     case sessionMcpServerStateChanged(SessionMcpServerStateChangedAction)
+    case sessionMcpServerStartRequested(SessionMcpServerStartRequestedAction)
+    case sessionMcpServerStopRequested(SessionMcpServerStopRequestedAction)
     case chatTruncated(ChatTruncatedAction)
     case chatTurnsLoaded(ChatTurnsLoadedAction)
     case sessionConfigChanged(SessionConfigChangedAction)
@@ -1990,6 +2022,10 @@ public enum StateAction: Codable, Sendable {
             self = .sessionCustomizationRemoved(try SessionCustomizationRemovedAction(from: decoder))
         case "session/mcpServerStateChanged":
             self = .sessionMcpServerStateChanged(try SessionMcpServerStateChangedAction(from: decoder))
+        case "session/mcpServerStartRequested":
+            self = .sessionMcpServerStartRequested(try SessionMcpServerStartRequestedAction(from: decoder))
+        case "session/mcpServerStopRequested":
+            self = .sessionMcpServerStopRequested(try SessionMcpServerStopRequestedAction(from: decoder))
         case "chat/truncated":
             self = .chatTruncated(try ChatTruncatedAction(from: decoder))
         case "chat/turnsLoaded":
@@ -2105,6 +2141,8 @@ public enum StateAction: Codable, Sendable {
         case .sessionCustomizationUpdated(let v): try v.encode(to: encoder)
         case .sessionCustomizationRemoved(let v): try v.encode(to: encoder)
         case .sessionMcpServerStateChanged(let v): try v.encode(to: encoder)
+        case .sessionMcpServerStartRequested(let v): try v.encode(to: encoder)
+        case .sessionMcpServerStopRequested(let v): try v.encode(to: encoder)
         case .chatTruncated(let v): try v.encode(to: encoder)
         case .chatTurnsLoaded(let v): try v.encode(to: encoder)
         case .sessionConfigChanged(let v): try v.encode(to: encoder)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -695,31 +695,23 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
         return state
 
     case .sessionMcpServerStateChanged(let a):
-        guard var list = state.customizations else { return state }
-        if let topIdx = list.firstIndex(where: { customizationId($0) == a.id }) {
-            guard case .mcpServer(var entry) = list[topIdx] else { return state }
-            entry.state = a.state
-            entry.channel = a.channel
-            list[topIdx] = .mcpServer(entry)
-            var next = state
-            next.customizations = list
-            return next
-        }
-        for containerIdx in list.indices {
-            var container = list[containerIdx]
-            guard var children = customizationChildren(container) else { continue }
-            guard let childIdx = children.firstIndex(where: { childId($0) == a.id }) else { continue }
-            guard case .mcpServer(var child) = children[childIdx] else { continue }
-            child.state = a.state
-            child.channel = a.channel
-            children[childIdx] = .mcpServer(child)
-            setCustomizationChildren(&container, children)
-            list[containerIdx] = container
-            var next = state
-            next.customizations = list
-            return next
-        }
-        return state
+        return updateMcpServerCustomizationState(state, id: a.id, state: a.state, channel: a.channel)
+
+    case .sessionMcpServerStartRequested(let a):
+        return updateMcpServerCustomizationState(
+            state,
+            id: a.id,
+            state: .starting(McpServerStartingState(kind: .starting)),
+            channel: nil
+        )
+
+    case .sessionMcpServerStopRequested(let a):
+        return updateMcpServerCustomizationState(
+            state,
+            id: a.id,
+            state: .stopped(McpServerStoppedState(kind: .stopped)),
+            channel: nil
+        )
 
     default:
         return state
@@ -743,6 +735,8 @@ public let clientDispatchableActions: Set<String> = [
     "chat/inputAnswerChanged",
     "chat/inputCompleted",
     "session/customizationToggled",
+    "session/mcpServerStartRequested",
+    "session/mcpServerStopRequested",
     "session/isReadChanged",
     "session/isArchivedChanged",
 ]
@@ -757,7 +751,9 @@ public func isClientDispatchable(_ action: StateAction) -> Bool {
          .chatPendingMessageSet,
          .chatPendingMessageRemoved, .chatQueuedMessagesReordered,
          .chatInputAnswerChanged, .chatInputCompleted,
-         .sessionCustomizationToggled, .sessionIsReadChanged,
+         .sessionCustomizationToggled,
+         .sessionMcpServerStartRequested, .sessionMcpServerStopRequested,
+         .sessionIsReadChanged,
          .sessionIsArchivedChanged:
         return true
     default:
@@ -770,6 +766,39 @@ public func isClientDispatchable(_ action: StateAction) -> Bool {
 private func currentTimestamp() -> String {
     let date = Date(timeIntervalSince1970: Double(currentTimestampProvider()) / 1000)
     return iso8601TimestampFormatter.string(from: date)
+}
+
+private func updateMcpServerCustomizationState(
+    _ state: SessionState,
+    id: String,
+    state nextState: McpServerState,
+    channel: URI?
+) -> SessionState {
+    guard var list = state.customizations else { return state }
+    if let topIdx = list.firstIndex(where: { customizationId($0) == id }) {
+        guard case .mcpServer(var entry) = list[topIdx] else { return state }
+        entry.state = nextState
+        entry.channel = channel
+        list[topIdx] = .mcpServer(entry)
+        var next = state
+        next.customizations = list
+        return next
+    }
+    for containerIdx in list.indices {
+        var container = list[containerIdx]
+        guard var children = customizationChildren(container) else { continue }
+        guard let childIdx = children.firstIndex(where: { childId($0) == id }) else { continue }
+        guard case .mcpServer(var child) = children[childIdx] else { continue }
+        child.state = nextState
+        child.channel = channel
+        children[childIdx] = .mcpServer(child)
+        setCustomizationChildren(&container, children)
+        list[containerIdx] = container
+        var next = state
+        next.customizations = list
+        return next
+    }
+    return state
 }
 
 private func mergeChatSummaryChanges(_ summary: inout ChatSummary, changes: PartialChatSummary) {

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -42,6 +42,10 @@ Implements AHP 0.5.2.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.
+- `session/mcpServerStartRequested` and `session/mcpServerStopRequested`
+  actions for clients to ask the host to start or stop MCP servers; stopping
+  moves an `authRequired` server to `stopped` so it no longer waits on
+  authentication.
 
 ### Changed
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -45,6 +45,10 @@ Implements AHP 0.5.2.
 - Optional `version` field on `PluginCustomization` (inherited by
   `ClientPluginCustomization`), carrying the plugin's semver sourced from the
   Open Plugins manifest. Provenance / display only.
+- `session/mcpServerStartRequested` and `session/mcpServerStopRequested`
+  actions for clients to ask the host to start or stop MCP servers; stopping
+  moves an `authRequired` server to `stopped` so it no longer waits on
+  authentication.
 
 ### Changed
 

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -42,6 +42,11 @@ McpServerCustomization {
 
 `enabled` follows the same model as any other container — it's toggled with `session/customizationToggled`. Disabling a server signals the host to stop it; the host then transitions the runtime through `stopped` and removes it from the session (or leaves it as `stopped` until removal, host's choice).
 
+Clients can also ask the host to manage the server process without changing the customization's enabled intent:
+
+- [`session/mcpServerStartRequested`](/reference/session#sessionmcpserverstartrequestedaction) asks the host to start or restart an existing MCP server customization. Reducers optimistically move the server to `starting` and clear any stale `channel`; the host remains authoritative and follows with `session/mcpServerStateChanged`.
+- [`session/mcpServerStopRequested`](/reference/session#sessionmcpserverstoprequestedaction) asks the host to stop an existing MCP server customization. Reducers optimistically move the server to `stopped` and clear any stale `channel`. Stopping an `authRequired` server unblocks it from waiting on authentication; if the host raised session-level input solely for that server, it should remove that input-needed entry when accepting the stop.
+
 ## Runtime status
 
 `state` is a [discriminated union on `kind`](/reference/session#mcpserverstatus). It is the host's view of the server's lifecycle, separate from `enabled` (which is the user's intent).
@@ -56,15 +61,16 @@ stateDiagram-v2
 
     ready --> authRequired : token expired / step-up
     ready --> error : crashed
-    ready --> stopped : disabled or removed
+    ready --> stopped : disabled, stop requested, or removed
 
     authRequired --> ready : authenticate succeeded
     authRequired --> error : auth abandoned / fatal
-    authRequired --> stopped : disabled
+    authRequired --> stopped : disabled or stop requested
 
-    error --> starting : retry
+    error --> starting : retry or start requested
     error --> stopped : removed
 
+    stopped --> starting : start requested
     stopped --> [*]
 ```
 
@@ -76,7 +82,7 @@ stateDiagram-v2
 | `error` | Unrecoverable failure. Carries an `ErrorInfo`. Use `authRequired` for auth-specific failures. |
 | `stopped` | Shut down. The host MAY remove the entry shortly after. |
 
-High-frequency lifecycle transitions go through the narrow [`session/mcpServerStateChanged`](/reference/session#sessionmcpserverstatuschangedaction) action, which upserts just `state` (and optionally `channel`) on an existing entry. Use `session/customizationUpdated` for anything else (name, icons, `mcpApp`).
+High-frequency lifecycle transitions go through the narrow [`session/mcpServerStateChanged`](/reference/session#sessionmcpserverstatuschangedaction) action, which upserts just `state` (and optionally `channel`) on an existing entry. Client start/stop intent goes through `session/mcpServerStartRequested` and `session/mcpServerStopRequested`; use `session/customizationUpdated` for anything else (name, icons, `mcpApp`).
 
 ## Authentication
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -541,6 +541,40 @@
         "state"
       ]
     },
+    "SessionMcpServerStartRequestedAction": {
+      "type": "object",
+      "description": "Requests that the host start or restart an existing\n{@link McpServerCustomization}.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container. The\nreducer optimistically moves the server to\n{@link McpServerStatus.Starting | `starting`} and clears any previous\n{@link McpServerCustomization.channel | `channel`}; the host remains\nauthoritative and SHOULD follow with\n{@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}\nonce the server becomes ready, needs authentication, fails, or is\nrejected. Is a no-op when no matching `McpServerCustomization` is found.",
+      "properties": {
+        "type": {
+          "const": "session/mcpServerStartRequested"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the {@link McpServerCustomization} to start."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "SessionMcpServerStopRequestedAction": {
+      "type": "object",
+      "description": "Requests that the host stop an existing {@link McpServerCustomization}.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container. The\nreducer optimistically moves the server to\n{@link McpServerStatus.Stopped | `stopped`} and clears any previous\n{@link McpServerCustomization.channel | `channel`}. Replacing an\n{@link McpServerStatus.AuthRequired | `authRequired`} lifecycle state with\n`stopped` unblocks the server from waiting on authentication. If the host\nalso raised session-level input-needed state solely for that MCP server, it\nSHOULD remove that input-needed entry when accepting the stop.\n\nThe host remains authoritative and MAY reject the action or follow with\n{@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}\nif the final lifecycle state differs. Is a no-op when no matching\n`McpServerCustomization` is found.",
+      "properties": {
+        "type": {
+          "const": "session/mcpServerStopRequested"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the {@link McpServerCustomization} to stop."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
     "SessionConfigChangedAction": {
       "type": "object",
       "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
@@ -6880,6 +6914,12 @@
         },
         {
           "$ref": "#/$defs/SessionMcpServerStateChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMcpServerStartRequestedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMcpServerStopRequestedAction"
         },
         {
           "$ref": "#/$defs/SessionIsReadChangedAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -6287,6 +6287,40 @@
         "state"
       ]
     },
+    "SessionMcpServerStartRequestedAction": {
+      "type": "object",
+      "description": "Requests that the host start or restart an existing\n{@link McpServerCustomization}.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container. The\nreducer optimistically moves the server to\n{@link McpServerStatus.Starting | `starting`} and clears any previous\n{@link McpServerCustomization.channel | `channel`}; the host remains\nauthoritative and SHOULD follow with\n{@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}\nonce the server becomes ready, needs authentication, fails, or is\nrejected. Is a no-op when no matching `McpServerCustomization` is found.",
+      "properties": {
+        "type": {
+          "const": "session/mcpServerStartRequested"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the {@link McpServerCustomization} to start."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "SessionMcpServerStopRequestedAction": {
+      "type": "object",
+      "description": "Requests that the host stop an existing {@link McpServerCustomization}.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container. The\nreducer optimistically moves the server to\n{@link McpServerStatus.Stopped | `stopped`} and clears any previous\n{@link McpServerCustomization.channel | `channel`}. Replacing an\n{@link McpServerStatus.AuthRequired | `authRequired`} lifecycle state with\n`stopped` unblocks the server from waiting on authentication. If the host\nalso raised session-level input-needed state solely for that MCP server, it\nSHOULD remove that input-needed entry when accepting the stop.\n\nThe host remains authoritative and MAY reject the action or follow with\n{@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}\nif the final lifecycle state differs. Is a no-op when no matching\n`McpServerCustomization` is found.",
+      "properties": {
+        "type": {
+          "const": "session/mcpServerStopRequested"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the {@link McpServerCustomization} to stop."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
     "SessionConfigChangedAction": {
       "type": "object",
       "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
@@ -7705,6 +7739,12 @@
         },
         {
           "$ref": "#/$defs/SessionMcpServerStateChangedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMcpServerStartRequestedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMcpServerStopRequestedAction"
         },
         {
           "$ref": "#/$defs/SessionIsReadChangedAction"

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -6447,6 +6447,12 @@
           "$ref": "#/$defs/SessionMcpServerStateChangedAction"
         },
         {
+          "$ref": "#/$defs/SessionMcpServerStartRequestedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionMcpServerStopRequestedAction"
+        },
+        {
           "$ref": "#/$defs/SessionIsReadChangedAction"
         },
         {
@@ -7130,6 +7136,40 @@
         "type",
         "id",
         "state"
+      ]
+    },
+    "SessionMcpServerStartRequestedAction": {
+      "type": "object",
+      "description": "Requests that the host start or restart an existing\n{@link McpServerCustomization}.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container. The\nreducer optimistically moves the server to\n{@link McpServerStatus.Starting | `starting`} and clears any previous\n{@link McpServerCustomization.channel | `channel`}; the host remains\nauthoritative and SHOULD follow with\n{@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}\nonce the server becomes ready, needs authentication, fails, or is\nrejected. Is a no-op when no matching `McpServerCustomization` is found.",
+      "properties": {
+        "type": {
+          "const": "session/mcpServerStartRequested"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the {@link McpServerCustomization} to start."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "SessionMcpServerStopRequestedAction": {
+      "type": "object",
+      "description": "Requests that the host stop an existing {@link McpServerCustomization}.\n\nLocates the target entry by `id`, searching both the top-level\ncustomization list and the `children` array of every container. The\nreducer optimistically moves the server to\n{@link McpServerStatus.Stopped | `stopped`} and clears any previous\n{@link McpServerCustomization.channel | `channel`}. Replacing an\n{@link McpServerStatus.AuthRequired | `authRequired`} lifecycle state with\n`stopped` unblocks the server from waiting on authentication. If the host\nalso raised session-level input-needed state solely for that MCP server, it\nSHOULD remove that input-needed entry when accepting the stop.\n\nThe host remains authoritative and MAY reject the action or follow with\n{@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}\nif the final lifecycle state differs. Is a no-op when no matching\n`McpServerCustomization` is found.",
+      "properties": {
+        "type": {
+          "const": "session/mcpServerStopRequested"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the {@link McpServerCustomization} to stop."
+        }
+      },
+      "required": [
+        "type",
+        "id"
       ]
     },
     "SessionIsReadChangedAction": {

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1290,6 +1290,8 @@ const ACTION_VARIANTS: {
   { type: 'session/customizationUpdated', variantName: 'SessionCustomizationUpdated', tsInterface: 'SessionCustomizationUpdatedAction' },
   { type: 'session/customizationRemoved', variantName: 'SessionCustomizationRemoved', tsInterface: 'SessionCustomizationRemovedAction' },
   { type: 'session/mcpServerStateChanged', variantName: 'SessionMcpServerStateChanged', tsInterface: 'SessionMcpServerStateChangedAction' },
+  { type: 'session/mcpServerStartRequested', variantName: 'SessionMcpServerStartRequested', tsInterface: 'SessionMcpServerStartRequestedAction' },
+  { type: 'session/mcpServerStopRequested', variantName: 'SessionMcpServerStopRequested', tsInterface: 'SessionMcpServerStopRequestedAction' },
   { type: 'session/configChanged', variantName: 'SessionConfigChanged', tsInterface: 'SessionConfigChangedAction' },
   { type: 'session/metaChanged', variantName: 'SessionMetaChanged', tsInterface: 'SessionMetaChangedAction' },
   { type: 'changeset/statusChanged', variantName: 'ChangesetStatusChanged', tsInterface: 'ChangesetStatusChangedAction' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1211,6 +1211,8 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'session/customizationUpdated', caseName: 'SessionCustomizationUpdated', tsInterface: 'SessionCustomizationUpdatedAction' },
   { type: 'session/customizationRemoved', caseName: 'SessionCustomizationRemoved', tsInterface: 'SessionCustomizationRemovedAction' },
   { type: 'session/mcpServerStateChanged', caseName: 'SessionMcpServerStateChanged', tsInterface: 'SessionMcpServerStateChangedAction' },
+  { type: 'session/mcpServerStartRequested', caseName: 'SessionMcpServerStartRequested', tsInterface: 'SessionMcpServerStartRequestedAction' },
+  { type: 'session/mcpServerStopRequested', caseName: 'SessionMcpServerStopRequested', tsInterface: 'SessionMcpServerStopRequestedAction' },
   { type: 'chat/truncated', caseName: 'ChatTruncated', tsInterface: 'ChatTruncatedAction' },
   { type: 'chat/turnsLoaded', caseName: 'ChatTurnsLoaded', tsInterface: 'ChatTurnsLoadedAction' },
   { type: 'session/configChanged', caseName: 'SessionConfigChanged', tsInterface: 'SessionConfigChangedAction' },

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1201,6 +1201,8 @@ const ACTION_VARIANTS: {
   { type: 'session/customizationUpdated', variantName: 'SessionCustomizationUpdated', tsInterface: 'SessionCustomizationUpdatedAction', boxed: true },
   { type: 'session/customizationRemoved', variantName: 'SessionCustomizationRemoved', tsInterface: 'SessionCustomizationRemovedAction' },
   { type: 'session/mcpServerStateChanged', variantName: 'SessionMcpServerStateChanged', tsInterface: 'SessionMcpServerStateChangedAction', boxed: true },
+  { type: 'session/mcpServerStartRequested', variantName: 'SessionMcpServerStartRequested', tsInterface: 'SessionMcpServerStartRequestedAction' },
+  { type: 'session/mcpServerStopRequested', variantName: 'SessionMcpServerStopRequested', tsInterface: 'SessionMcpServerStopRequestedAction' },
   { type: 'chat/truncated', variantName: 'ChatTruncated', tsInterface: 'ChatTruncatedAction' },
   { type: 'chat/turnsLoaded', variantName: 'ChatTurnsLoaded', tsInterface: 'ChatTurnsLoadedAction' },
   { type: 'session/configChanged', variantName: 'SessionConfigChanged', tsInterface: 'SessionConfigChangedAction' },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1120,6 +1120,8 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'session/customizationUpdated', caseName: 'sessionCustomizationUpdated', tsInterface: 'SessionCustomizationUpdatedAction' },
   { type: 'session/customizationRemoved', caseName: 'sessionCustomizationRemoved', tsInterface: 'SessionCustomizationRemovedAction' },
   { type: 'session/mcpServerStateChanged', caseName: 'sessionMcpServerStateChanged', tsInterface: 'SessionMcpServerStateChangedAction' },
+  { type: 'session/mcpServerStartRequested', caseName: 'sessionMcpServerStartRequested', tsInterface: 'SessionMcpServerStartRequestedAction' },
+  { type: 'session/mcpServerStopRequested', caseName: 'sessionMcpServerStopRequested', tsInterface: 'SessionMcpServerStopRequestedAction' },
   { type: 'chat/truncated', caseName: 'chatTruncated', tsInterface: 'ChatTruncatedAction' },
   { type: 'chat/turnsLoaded', caseName: 'chatTurnsLoaded', tsInterface: 'ChatTurnsLoadedAction' },
   { type: 'session/configChanged', caseName: 'sessionConfigChanged', tsInterface: 'SessionConfigChangedAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -24,6 +24,8 @@ import type {
   SessionCustomizationUpdatedAction,
   SessionCustomizationRemovedAction,
   SessionMcpServerStateChangedAction,
+  SessionMcpServerStartRequestedAction,
+  SessionMcpServerStopRequestedAction,
   SessionIsReadChangedAction,
   SessionIsArchivedChangedAction,
   SessionActivityChangedAction,
@@ -125,6 +127,8 @@ export type SessionAction =
   | SessionCustomizationUpdatedAction
   | SessionCustomizationRemovedAction
   | SessionMcpServerStateChangedAction
+  | SessionMcpServerStartRequestedAction
+  | SessionMcpServerStopRequestedAction
   | SessionIsReadChangedAction
   | SessionIsArchivedChangedAction
   | SessionActivityChangedAction
@@ -139,6 +143,8 @@ export type ClientSessionAction =
   | SessionActiveClientSetAction
   | SessionActiveClientRemovedAction
   | SessionCustomizationToggledAction
+  | SessionMcpServerStartRequestedAction
+  | SessionMcpServerStopRequestedAction
   | SessionIsReadChangedAction
   | SessionIsArchivedChangedAction
   | SessionConfigChangedAction
@@ -355,6 +361,8 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.SessionCustomizationUpdated]: false,
   [ActionType.SessionCustomizationRemoved]: false,
   [ActionType.SessionMcpServerStateChanged]: false,
+  [ActionType.SessionMcpServerStartRequested]: true,
+  [ActionType.SessionMcpServerStopRequested]: true,
   [ActionType.SessionIsReadChanged]: true,
   [ActionType.SessionIsArchivedChanged]: true,
   [ActionType.SessionActivityChanged]: false,

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -414,6 +414,58 @@ export interface SessionMcpServerStateChangedAction {
   channel?: URI;
 }
 
+/**
+ * Requests that the host start or restart an existing
+ * {@link McpServerCustomization}.
+ *
+ * Locates the target entry by `id`, searching both the top-level
+ * customization list and the `children` array of every container. The
+ * reducer optimistically moves the server to
+ * {@link McpServerStatus.Starting | `starting`} and clears any previous
+ * {@link McpServerCustomization.channel | `channel`}; the host remains
+ * authoritative and SHOULD follow with
+ * {@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}
+ * once the server becomes ready, needs authentication, fails, or is
+ * rejected. Is a no-op when no matching `McpServerCustomization` is found.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface SessionMcpServerStartRequestedAction {
+  type: ActionType.SessionMcpServerStartRequested;
+  /** The id of the {@link McpServerCustomization} to start. */
+  id: string;
+}
+
+/**
+ * Requests that the host stop an existing {@link McpServerCustomization}.
+ *
+ * Locates the target entry by `id`, searching both the top-level
+ * customization list and the `children` array of every container. The
+ * reducer optimistically moves the server to
+ * {@link McpServerStatus.Stopped | `stopped`} and clears any previous
+ * {@link McpServerCustomization.channel | `channel`}. Replacing an
+ * {@link McpServerStatus.AuthRequired | `authRequired`} lifecycle state with
+ * `stopped` unblocks the server from waiting on authentication. If the host
+ * also raised session-level input-needed state solely for that MCP server, it
+ * SHOULD remove that input-needed entry when accepting the stop.
+ *
+ * The host remains authoritative and MAY reject the action or follow with
+ * {@link SessionMcpServerStateChangedAction | `session/mcpServerStateChanged`}
+ * if the final lifecycle state differs. Is a no-op when no matching
+ * `McpServerCustomization` is found.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface SessionMcpServerStopRequestedAction {
+  type: ActionType.SessionMcpServerStopRequested;
+  /** The id of the {@link McpServerCustomization} to stop. */
+  id: string;
+}
+
 // ─── Config Actions ──────────────────────────────────────────────────────────
 
 /**

--- a/types/channels-session/reducer.ts
+++ b/types/channels-session/reducer.ts
@@ -14,6 +14,7 @@ import {
   SessionLifecycle,
   SessionStatus,
   CustomizationType,
+  McpServerStatus,
 } from './state.js';
 import type { SessionAction } from '../action-origin.generated.js';
 import { softAssertNever } from '../common/reducer-helpers.js';
@@ -42,6 +43,53 @@ function withInputNeededStatus(status: SessionStatus, inputNeeded: readonly Sess
     return (status & ~STATUS_ACTIVITY_MASK) | SessionStatus.InputNeeded;
   }
   return status & ~(SessionStatus.InputNeeded & ~SessionStatus.InProgress);
+}
+
+function updateMcpServerCustomization(
+  state: SessionState,
+  id: string,
+  update: (entry: McpServerCustomization) => McpServerCustomization,
+): SessionState {
+  const list = state.customizations;
+  if (!list) {
+    return state;
+  }
+  const topIdx = list.findIndex(c => c.id === id);
+  if (topIdx >= 0) {
+    const entry = list[topIdx];
+    if (entry.type !== CustomizationType.McpServer) {
+      return state;
+    }
+    const updated = list.slice();
+    updated[topIdx] = update(entry);
+    return { ...state, customizations: updated };
+  }
+  let changed = false;
+  const updated = list.map(container => {
+    if (container.type === CustomizationType.McpServer) {
+      return container;
+    }
+    const children = container.children;
+    if (!children) {
+      return container;
+    }
+    const childIdx = children.findIndex(c => c.id === id);
+    if (childIdx < 0) {
+      return container;
+    }
+    const child = children[childIdx];
+    if (child.type !== CustomizationType.McpServer) {
+      return container;
+    }
+    changed = true;
+    const newChildren = children.slice();
+    newChildren[childIdx] = update(child);
+    return { ...container, children: newChildren };
+  });
+  if (!changed) {
+    return state;
+  }
+  return { ...state, customizations: updated };
 }
 
 // ─── Session Reducer ─────────────────────────────────────────────────────────
@@ -295,56 +343,27 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
     }
 
     case ActionType.SessionMcpServerStateChanged: {
-      const list = state.customizations;
-      if (!list) {
-        return state;
-      }
-      const topIdx = list.findIndex(c => c.id === action.id);
-      if (topIdx >= 0) {
-        const entry = list[topIdx];
-        if (entry.type !== CustomizationType.McpServer) {
-          return state;
-        }
-        const updatedEntry: McpServerCustomization = {
-          ...entry,
-          state: action.state,
-          channel: action.channel,
-        };
-        const updated = list.slice();
-        updated[topIdx] = updatedEntry;
-        return { ...state, customizations: updated };
-      }
-      let changed = false;
-      const updated = list.map(container => {
-        if (container.type === CustomizationType.McpServer) {
-          return container;
-        }
-        const children = container.children;
-        if (!children) {
-          return container;
-        }
-        const childIdx = children.findIndex(c => c.id === action.id);
-        if (childIdx < 0) {
-          return container;
-        }
-        const child = children[childIdx];
-        if (child.type !== CustomizationType.McpServer) {
-          return container;
-        }
-        changed = true;
-        const updatedChild: McpServerCustomization = {
-          ...child,
-          state: action.state,
-          channel: action.channel,
-        };
-        const newChildren = children.slice();
-        newChildren[childIdx] = updatedChild;
-        return { ...container, children: newChildren };
-      });
-      if (!changed) {
-        return state;
-      }
-      return { ...state, customizations: updated };
+      return updateMcpServerCustomization(state, action.id, entry => ({
+        ...entry,
+        state: action.state,
+        channel: action.channel,
+      }));
+    }
+
+    case ActionType.SessionMcpServerStartRequested: {
+      return updateMcpServerCustomization(state, action.id, entry => ({
+        ...entry,
+        state: { kind: McpServerStatus.Starting },
+        channel: undefined,
+      }));
+    }
+
+    case ActionType.SessionMcpServerStopRequested: {
+      return updateMcpServerCustomization(state, action.id, entry => ({
+        ...entry,
+        state: { kind: McpServerStatus.Stopped },
+        channel: undefined,
+      }));
     }
 
     default:

--- a/types/common/actions.ts
+++ b/types/common/actions.ts
@@ -33,6 +33,8 @@ import type {
   SessionCustomizationUpdatedAction,
   SessionCustomizationRemovedAction,
   SessionMcpServerStateChangedAction,
+  SessionMcpServerStartRequestedAction,
+  SessionMcpServerStopRequestedAction,
   SessionIsReadChangedAction,
   SessionIsArchivedChangedAction,
   SessionActivityChangedAction,
@@ -156,6 +158,8 @@ export const enum ActionType {
   SessionCustomizationUpdated = 'session/customizationUpdated',
   SessionCustomizationRemoved = 'session/customizationRemoved',
   SessionMcpServerStateChanged = 'session/mcpServerStateChanged',
+  SessionMcpServerStartRequested = 'session/mcpServerStartRequested',
+  SessionMcpServerStopRequested = 'session/mcpServerStopRequested',
   ChatTruncated = 'chat/truncated',
   ChatTurnsLoaded = 'chat/turnsLoaded',
   SessionIsReadChanged = 'session/isReadChanged',
@@ -248,6 +252,8 @@ export type StateAction =
   | SessionCustomizationUpdatedAction
   | SessionCustomizationRemovedAction
   | SessionMcpServerStateChangedAction
+  | SessionMcpServerStartRequestedAction
+  | SessionMcpServerStopRequestedAction
   | SessionIsReadChangedAction
   | SessionIsArchivedChangedAction
   | SessionActivityChangedAction

--- a/types/test-cases/reducers/235-session-mcpserverstartrequested-starts-top-level-server.json
+++ b/types/test-cases/reducers/235-session-mcpserverstartrequested-starts-top-level-server.json
@@ -1,0 +1,52 @@
+{
+  "description": "session/mcpServerStartRequested moves a top-level McpServer customization to starting and clears its channel",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "mcpServer",
+        "id": "mcp-1",
+        "uri": "file:///workspace/.mcp/servers.json",
+        "name": "Filesystem",
+        "enabled": true,
+        "state": {
+          "kind": "ready"
+        },
+        "channel": "mcp://filesystem"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/mcpServerStartRequested",
+      "id": "mcp-1"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "mcpServer",
+        "id": "mcp-1",
+        "uri": "file:///workspace/.mcp/servers.json",
+        "name": "Filesystem",
+        "enabled": true,
+        "state": {
+          "kind": "starting"
+        },
+        "channel": null
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/236-session-mcpserverstoprequested-stops-auth-required-server.json
+++ b/types/test-cases/reducers/236-session-mcpserverstoprequested-stops-auth-required-server.json
@@ -1,0 +1,58 @@
+{
+  "description": "session/mcpServerStopRequested moves an auth-required top-level McpServer customization to stopped",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "mcpServer",
+        "id": "mcp-1",
+        "uri": "file:///workspace/.mcp/servers.json",
+        "name": "Filesystem",
+        "enabled": true,
+        "state": {
+          "kind": "authRequired",
+          "reason": "required",
+          "resource": {
+            "resource": "https://mcp.example/filesystem",
+            "authorization_servers": [
+              "https://login.example"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/mcpServerStopRequested",
+      "id": "mcp-1"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "mcpServer",
+        "id": "mcp-1",
+        "uri": "file:///workspace/.mcp/servers.json",
+        "name": "Filesystem",
+        "enabled": true,
+        "state": {
+          "kind": "stopped"
+        },
+        "channel": null
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/237-session-mcpserverstoprequested-stops-container-child.json
+++ b/types/test-cases/reducers/237-session-mcpserverstoprequested-stops-container-child.json
@@ -1,0 +1,82 @@
+{
+  "description": "session/mcpServerStopRequested moves a nested McpServer customization to stopped and clears its channel",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "plugin",
+        "id": "plugin-a",
+        "uri": "https://plugins.example/a",
+        "name": "Plugin A",
+        "enabled": true,
+        "children": [
+          {
+            "type": "skill",
+            "id": "skill-1",
+            "uri": "https://plugins.example/a#skills/lint",
+            "name": "lint"
+          },
+          {
+            "type": "mcpServer",
+            "id": "mcp-child",
+            "uri": "https://plugins.example/a#mcp/search",
+            "name": "Search",
+            "enabled": true,
+            "state": {
+              "kind": "ready"
+            },
+            "channel": "mcp://search"
+          }
+        ]
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/mcpServerStopRequested",
+      "id": "mcp-child"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "plugin",
+        "id": "plugin-a",
+        "uri": "https://plugins.example/a",
+        "name": "Plugin A",
+        "enabled": true,
+        "children": [
+          {
+            "type": "skill",
+            "id": "skill-1",
+            "uri": "https://plugins.example/a#skills/lint",
+            "name": "lint"
+          },
+          {
+            "type": "mcpServer",
+            "id": "mcp-child",
+            "uri": "https://plugins.example/a#mcp/search",
+            "name": "Search",
+            "enabled": true,
+            "state": {
+              "kind": "stopped"
+            },
+            "channel": null
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/types/test-cases/reducers/238-session-mcpserverstartrequested-no-op-absent-customizations.json
+++ b/types/test-cases/reducers/238-session-mcpserverstartrequested-no-op-absent-customizations.json
@@ -1,0 +1,26 @@
+{
+  "description": "session/mcpServerStartRequested is a no-op when the session has no customizations",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": []
+  },
+  "actions": [
+    {
+      "type": "session/mcpServerStartRequested",
+      "id": "mcp-1"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": []
+  }
+}

--- a/types/test-cases/reducers/239-session-mcpserverstartrequested-no-op-unknown-id.json
+++ b/types/test-cases/reducers/239-session-mcpserverstartrequested-no-op-unknown-id.json
@@ -1,0 +1,94 @@
+{
+  "description": "session/mcpServerStartRequested is a no-op when no customization carries the targeted id",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "plugin",
+        "id": "plugin-a",
+        "uri": "https://plugins.example/a",
+        "name": "Plugin A",
+        "enabled": true
+      },
+      {
+        "type": "plugin",
+        "id": "plugin-b",
+        "uri": "https://plugins.example/b",
+        "name": "Plugin B",
+        "enabled": true,
+        "children": [
+          {
+            "type": "skill",
+            "id": "skill-1",
+            "uri": "https://plugins.example/b#skills/lint",
+            "name": "lint"
+          }
+        ]
+      },
+      {
+        "type": "mcpServer",
+        "id": "mcp-1",
+        "uri": "file:///workspace/.mcp/servers.json",
+        "name": "Filesystem",
+        "enabled": true,
+        "state": {
+          "kind": "stopped"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/mcpServerStartRequested",
+      "id": "mcp-does-not-exist"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "customizations": [
+      {
+        "type": "plugin",
+        "id": "plugin-a",
+        "uri": "https://plugins.example/a",
+        "name": "Plugin A",
+        "enabled": true
+      },
+      {
+        "type": "plugin",
+        "id": "plugin-b",
+        "uri": "https://plugins.example/b",
+        "name": "Plugin B",
+        "enabled": true,
+        "children": [
+          {
+            "type": "skill",
+            "id": "skill-1",
+            "uri": "https://plugins.example/b#skills/lint",
+            "name": "lint"
+          }
+        ]
+      },
+      {
+        "type": "mcpServer",
+        "id": "mcp-1",
+        "uri": "file:///workspace/.mcp/servers.json",
+        "name": "Filesystem",
+        "enabled": true,
+        "state": {
+          "kind": "stopped"
+        }
+      }
+    ]
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -95,6 +95,8 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string
   [ActionType.SessionCustomizationUpdated]: '0.1.0',
   [ActionType.SessionCustomizationRemoved]: '0.2.0',
   [ActionType.SessionMcpServerStateChanged]: '0.3.0',
+  [ActionType.SessionMcpServerStartRequested]: '0.5.2',
+  [ActionType.SessionMcpServerStopRequested]: '0.5.2',
   [ActionType.SessionIsReadChanged]: '0.1.0',
   [ActionType.SessionIsArchivedChanged]: '0.1.0',
   [ActionType.SessionActivityChanged]: '0.1.0',


### PR DESCRIPTION
## Summary
- add client-dispatchable session actions for requesting MCP server start/stop
- update reducers, fixtures, generated clients, schemas, docs, and changelogs
- document that stopping an auth-required MCP server unblocks it by moving to stopped

## Validation
- npm run generate
- npm run test
- npm run docs:build

## Review
- Council review: no blocking issues found