### PR TITLE
Record resolved input request in turn transcript (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ Spec version: `0.5.2`
   optional `title`), so either side of the handshake can identify its
   implementation and build. Informational only — mirrors LSP/MCP and MUST NOT
   be used for feature detection.
+- `InputRequestResponsePart` (`kind: 'inputRequest'`) — a new `ResponsePart`
+  variant that records a resolved input request in a turn's transcript. On
+  `chat/inputCompleted`, the reducer now appends this part (embedding the
+  resolved `ChatInputRequest` with its final `answers` and the `response`:
+  `accept`, `decline`, or `cancel`) to the active turn's `responseParts`, so an
+  elicitation's outcome persists durably, mirroring how a resolved tool-call
+  confirmation is retained. Requests abandoned by turn end, cancel, error, or
+  truncation still record nothing (#324).
 
 ### Changed
 

--- a/clients/go/CHANGELOG.md
+++ b/clients/go/CHANGELOG.md
@@ -48,6 +48,12 @@ Implements AHP 0.5.2.
   actions for clients to ask the host to start or stop MCP servers; stopping
   moves an `authRequired` server to `stopped` so it no longer waits on
   authentication.
+- `InputRequestResponsePart` and the `ResponsePartKindInputRequest` discriminant.
+  The reducer now records a resolved input request in the active turn's
+  `ResponseParts` on `ChatInputCompletedAction` — embedding the resolved
+  `ChatInputRequest` (final `Answers`) and the `Response` (`accept`, `decline`,
+  or `cancel`) — so the outcome persists after the live request is removed.
+  Abandoned requests still record nothing (#324).
 
 ### Changed
 

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -566,22 +566,48 @@ func ApplyActionToChat(state *ahptypes.ChatState, action ahptypes.StateAction) R
 		if list == nil {
 			return ReduceOutcomeNoOp
 		}
-		had := false
+		var completed *ahptypes.ChatInputRequest
 		next := list[:0]
-		for _, r := range list {
-			if r.Id == a.RequestId {
-				had = true
+		for i := range list {
+			if list[i].Id == a.RequestId {
+				c := list[i]
+				completed = &c
 				continue
 			}
-			next = append(next, r)
+			next = append(next, list[i])
 		}
-		if !had {
+		if completed == nil {
 			return ReduceOutcomeNoOp
 		}
 		if len(next) == 0 {
 			state.InputRequests = nil
 		} else {
 			state.InputRequests = next
+		}
+		// Project the resolved request into the active turn's transcript so the
+		// decision survives after the live request is gone. Abandoned requests
+		// (turn end/truncate) are removed without a part.
+		if state.ActiveTurn != nil {
+			finalAnswers := map[string]ahptypes.ChatInputAnswer{}
+			for k, v := range completed.Answers {
+				finalAnswers[k] = v
+			}
+			for k, v := range a.Answers {
+				finalAnswers[k] = v
+			}
+			request := *completed
+			if len(finalAnswers) == 0 {
+				request.Answers = nil
+			} else {
+				request.Answers = finalAnswers
+			}
+			state.ActiveTurn.ResponseParts = append(state.ActiveTurn.ResponseParts, ahptypes.ResponsePart{
+				Value: &ahptypes.InputRequestResponsePart{
+					Kind:     ahptypes.ResponsePartKindInputRequest,
+					Request:  request,
+					Response: a.Response,
+				},
+			})
 		}
 		refreshSummaryStatus(state)
 		touchChatModified(state)

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -209,6 +209,7 @@ const (
 	ResponsePartKindToolCall           ResponsePartKind = "toolCall"
 	ResponsePartKindReasoning          ResponsePartKind = "reasoning"
 	ResponsePartKindSystemNotification ResponsePartKind = "systemNotification"
+	ResponsePartKindInputRequest       ResponsePartKind = "inputRequest"
 )
 
 // Status of a tool call in the lifecycle state machine.
@@ -1644,6 +1645,29 @@ type SystemNotificationResponsePart struct {
 	Kind ResponsePartKind `json:"kind"`
 	// The text of the system notification
 	Content StringOrMarkdown `json:"content"`
+}
+
+// A resolved input request (elicitation) recorded in the turn transcript.
+//
+// While an input request is open it lives in {@link ChatState.inputRequests}
+// as live, interactive state (see {@link ChatInputRequest}). When the request
+// completes via `chat/inputCompleted`, the reducer removes it from
+// `inputRequests` and appends this part to the active turn so the decision
+// survives in history. This mirrors how a tool-call confirmation persists in
+// its {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the
+// terminal {@link ToolCallState}): the live surface drives in-flight UX, the
+// terminal outcome is durable and backfillable via `fetchTurns`.
+//
+// No part is recorded when an outstanding request is *abandoned* (the turn
+// completes, is cancelled, errors, or is truncated) rather than *completed*.
+type InputRequestResponsePart struct {
+	// Discriminant
+	Kind ResponsePartKind `json:"kind"`
+	// The resolved request, carrying its `id`, `message`, `url`, `questions`,
+	// and the final `answers` synced/submitted at completion.
+	Request ChatInputRequest `json:"request"`
+	// How the request was resolved: `accept`, `decline`, or `cancel`.
+	Response ChatInputResponseKind `json:"response"`
 }
 
 // Tool execution result details, available after execution completes.
@@ -3114,6 +3138,7 @@ func (*ResourceResponsePart) isResponsePart()           {}
 func (*ToolCallResponsePart) isResponsePart()           {}
 func (*ReasoningResponsePart) isResponsePart()          {}
 func (*SystemNotificationResponsePart) isResponsePart() {}
+func (*InputRequestResponsePart) isResponsePart()       {}
 
 // ResponsePartUnknown carries an unrecognized ResponsePart variant — typically a discriminator value introduced by a newer protocol version. The original JSON object is preserved verbatim so that re-encoding round-trips faithfully.
 type ResponsePartUnknown struct {
@@ -3155,6 +3180,12 @@ func (u *ResponsePart) UnmarshalJSON(data []byte) error {
 		u.Value = &value
 	case "systemNotification":
 		var value SystemNotificationResponsePart
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "inputRequest":
+		var value InputRequestResponsePart
 		if err := json.Unmarshal(data, &value); err != nil {
 			return err
 		}

--- a/clients/kotlin/CHANGELOG.md
+++ b/clients/kotlin/CHANGELOG.md
@@ -44,6 +44,12 @@ Implements AHP 0.5.2.
   actions for clients to ask the host to start or stop MCP servers; stopping
   moves an `authRequired` server to `stopped` so it no longer waits on
   authentication.
+- `InputRequestResponsePart` and the `ResponsePartInputRequest` variant. The
+  reducer now records a resolved input request in the active turn's
+  `responseParts` on `StateActionChatInputCompleted` — embedding the resolved
+  `ChatInputRequest` (final `answers`) and the `response` (`accept`, `decline`,
+  or `cancel`) — so the outcome persists after the live request is removed.
+  Abandoned requests still record nothing (#324).
 
 ### Changed
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -1154,11 +1154,30 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
     is StateActionChatInputCompleted -> {
         val a = action.value
         val existing = state.inputRequests
-        if (existing == null || existing.none { it.id == a.requestId }) {
+        val completed = existing?.firstOrNull { it.id == a.requestId }
+        if (existing == null || completed == null) {
             state
         } else {
             val remaining = existing.filter { it.id != a.requestId }
-            val next = state.copy(inputRequests = remaining.ifEmpty { null })
+            var next = state.copy(inputRequests = remaining.ifEmpty { null })
+            // Project the resolved request into the active turn's transcript so
+            // the decision survives after the live request is gone. Abandoned
+            // requests (turn end/truncate) are removed without a part.
+            val activeTurn = next.activeTurn
+            if (activeTurn != null) {
+                val finalAnswers = (completed.answers ?: emptyMap()) + (a.answers ?: emptyMap())
+                val request = completed.copy(answers = finalAnswers.ifEmpty { null })
+                val newPart = ResponsePartInputRequest(
+                    InputRequestResponsePart(
+                        kind = ResponsePartKind.INPUT_REQUEST,
+                        request = request,
+                        response = a.response,
+                    ),
+                )
+                next = next.copy(
+                    activeTurn = activeTurn.copy(responseParts = activeTurn.responseParts + newPart),
+                )
+            }
             next.copy(
                 status = chatSummaryStatus(next),
                 modifiedAt = nowIsoString(),

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -392,7 +392,9 @@ enum class ResponsePartKind {
     @SerialName("reasoning")
     REASONING,
     @SerialName("systemNotification")
-    SYSTEM_NOTIFICATION
+    SYSTEM_NOTIFICATION,
+    @SerialName("inputRequest")
+    INPUT_REQUEST
 }
 
 /**
@@ -2288,6 +2290,23 @@ data class SystemNotificationResponsePart(
      * The text of the system notification
      */
     val content: StringOrMarkdown
+)
+
+@Serializable
+data class InputRequestResponsePart(
+    /**
+     * Discriminant
+     */
+    val kind: ResponsePartKind,
+    /**
+     * The resolved request, carrying its `id`, `message`, `url`, `questions`,
+     * and the final `answers` synced/submitted at completion.
+     */
+    val request: ChatInputRequest,
+    /**
+     * How the request was resolved: `accept`, `decline`, or `cancel`.
+     */
+    val response: ChatInputResponseKind
 )
 
 @Serializable
@@ -4233,6 +4252,8 @@ value class ResponsePartToolCall(val value: ToolCallResponsePart) : ResponsePart
 value class ResponsePartReasoning(val value: ReasoningResponsePart) : ResponsePart
 @JvmInline
 value class ResponsePartSystemNotification(val value: SystemNotificationResponsePart) : ResponsePart
+@JvmInline
+value class ResponsePartInputRequest(val value: InputRequestResponsePart) : ResponsePart
 /**
  * Forward-compat catch-all for unknown ResponsePart discriminators.
  *
@@ -4262,6 +4283,7 @@ internal object ResponsePartSerializer : KSerializer<ResponsePart> {
             "toolCall" -> ResponsePartToolCall(input.json.decodeFromJsonElement(ToolCallResponsePart.serializer(), element))
             "reasoning" -> ResponsePartReasoning(input.json.decodeFromJsonElement(ReasoningResponsePart.serializer(), element))
             "systemNotification" -> ResponsePartSystemNotification(input.json.decodeFromJsonElement(SystemNotificationResponsePart.serializer(), element))
+            "inputRequest" -> ResponsePartInputRequest(input.json.decodeFromJsonElement(InputRequestResponsePart.serializer(), element))
             else -> ResponsePartUnknown(obj)
         }
     }
@@ -4275,6 +4297,7 @@ internal object ResponsePartSerializer : KSerializer<ResponsePart> {
             is ResponsePartToolCall -> output.json.encodeToJsonElement(ToolCallResponsePart.serializer(), value.value)
             is ResponsePartReasoning -> output.json.encodeToJsonElement(ReasoningResponsePart.serializer(), value.value)
             is ResponsePartSystemNotification -> output.json.encodeToJsonElement(SystemNotificationResponsePart.serializer(), value.value)
+            is ResponsePartInputRequest -> output.json.encodeToJsonElement(InputRequestResponsePart.serializer(), value.value)
             is ResponsePartUnknown -> value.raw
         }
         output.encodeJsonElement(element)

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -50,6 +50,12 @@ Implements AHP 0.5.2.
   actions for clients to ask the host to start or stop MCP servers; stopping
   moves an `authRequired` server to `stopped` so it no longer waits on
   authentication.
+- `InputRequestResponsePart` and the `ResponsePart::InputRequest` variant. The
+  reducer now records a resolved input request in the active turn's
+  `response_parts` on `chat/inputCompleted` — embedding the resolved
+  `ChatInputRequest` (final `answers`) and the `response` (`accept`, `decline`,
+  or `cancel`) — so the outcome persists after the live request is removed.
+  Abandoned requests still record nothing (#324).
 
 ### Changed
 

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -306,6 +306,8 @@ pub enum ResponsePartKind {
     Reasoning,
     #[serde(rename = "systemNotification")]
     SystemNotification,
+    #[serde(rename = "inputRequest")]
+    InputRequest,
 }
 
 /// Status of a tool call in the lifecycle state machine.
@@ -2062,6 +2064,29 @@ pub struct SystemNotificationResponsePart {
     pub content: StringOrMarkdown,
 }
 
+/// A resolved input request (elicitation) recorded in the turn transcript.
+///
+/// While an input request is open it lives in {@link ChatState.inputRequests}
+/// as live, interactive state (see {@link ChatInputRequest}). When the request
+/// completes via `chat/inputCompleted`, the reducer removes it from
+/// `inputRequests` and appends this part to the active turn so the decision
+/// survives in history. This mirrors how a tool-call confirmation persists in
+/// its {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the
+/// terminal {@link ToolCallState}): the live surface drives in-flight UX, the
+/// terminal outcome is durable and backfillable via `fetchTurns`.
+///
+/// No part is recorded when an outstanding request is *abandoned* (the turn
+/// completes, is cancelled, errors, or is truncated) rather than *completed*.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InputRequestResponsePart {
+    /// The resolved request, carrying its `id`, `message`, `url`, `questions`,
+    /// and the final `answers` synced/submitted at completion.
+    pub request: ChatInputRequest,
+    /// How the request was resolved: `accept`, `decline`, or `cancel`.
+    pub response: ChatInputResponseKind,
+}
+
 /// Tool execution result details, available after execution completes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -3801,6 +3826,8 @@ pub enum ResponsePart {
     Reasoning(ReasoningResponsePart),
     #[serde(rename = "systemNotification")]
     SystemNotification(SystemNotificationResponsePart),
+    #[serde(rename = "inputRequest")]
+    InputRequest(InputRequestResponsePart),
     /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
     /// Reducers treat this as a no-op.
     #[serde(untagged)]

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -59,13 +59,14 @@ use ahp_types::actions::{
 use ahp_types::state::{
     ActiveTurn, AnnotationsState, ChangesetOperationStatus, ChangesetState, ChangesetStatus,
     ChatInputRequest, ChatState, ChildCustomization, ConfirmationOption, Customization, ErrorInfo,
-    McpServerStartingState, McpServerState, McpServerStoppedState, PendingMessage,
-    PendingMessageKind, ResourceWatchState, ResponsePart, RootState, SessionInputRequest,
-    SessionLifecycle, SessionState, SessionStatus, TerminalCommandPart, TerminalContentPart,
-    TerminalState, TerminalUnclassifiedPart, ToolCallCancellationReason, ToolCallCancelledState,
-    ToolCallCompletedState, ToolCallConfirmationReason, ToolCallContributor,
-    ToolCallPendingConfirmationState, ToolCallPendingResultConfirmationState, ToolCallResponsePart,
-    ToolCallRunningState, ToolCallState, ToolCallStreamingState, Turn, TurnState,
+    InputRequestResponsePart, McpServerStartingState, McpServerState, McpServerStoppedState,
+    PendingMessage, PendingMessageKind, ResourceWatchState, ResponsePart, RootState,
+    SessionInputRequest, SessionLifecycle, SessionState, SessionStatus, TerminalCommandPart,
+    TerminalContentPart, TerminalState, TerminalUnclassifiedPart, ToolCallCancellationReason,
+    ToolCallCancelledState, ToolCallCompletedState, ToolCallConfirmationReason,
+    ToolCallContributor, ToolCallPendingConfirmationState, ToolCallPendingResultConfirmationState,
+    ToolCallResponsePart, ToolCallRunningState, ToolCallState, ToolCallStreamingState, Turn,
+    TurnState,
 };
 
 /// What happened when an action was applied.
@@ -519,6 +520,7 @@ where
             ResponsePart::Reasoning(r) => Some(r.id.clone()),
             ResponsePart::ContentRef(_)
             | ResponsePart::SystemNotification(_)
+            | ResponsePart::InputRequest(_)
             | ResponsePart::Unknown(_) => None,
         };
         if id.as_deref() == Some(part_id) {
@@ -978,16 +980,42 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
         }
         StateAction::ChatInputAnswerChanged(a) => apply_input_answer_changed(state, a),
         StateAction::ChatInputCompleted(a) => {
-            let Some(list) = state.input_requests.as_mut() else {
+            let Some(list) = state.input_requests.as_ref() else {
                 return ReduceOutcome::NoOp;
             };
-            let had = list.iter().any(|r| r.id == a.request_id);
-            if !had {
+            let Some(completed) = list.iter().find(|r| r.id == a.request_id).cloned() else {
                 return ReduceOutcome::NoOp;
+            };
+            if let Some(list) = state.input_requests.as_mut() {
+                list.retain(|r| r.id != a.request_id);
+                if list.is_empty() {
+                    state.input_requests = None;
+                }
             }
-            list.retain(|r| r.id != a.request_id);
-            if list.is_empty() {
-                state.input_requests = None;
+            // Project the resolved request into the active turn's transcript so
+            // the decision survives after the live request is gone. Abandoned
+            // requests (turn end/truncate) are removed without a part.
+            if let Some(active) = state.active_turn.as_mut() {
+                let mut final_answers = completed.answers.clone().unwrap_or_default();
+                if let Some(answers) = &a.answers {
+                    for (k, v) in answers {
+                        final_answers.insert(k.clone(), v.clone());
+                    }
+                }
+                let request = ChatInputRequest {
+                    answers: if final_answers.is_empty() {
+                        None
+                    } else {
+                        Some(final_answers)
+                    },
+                    ..completed
+                };
+                active
+                    .response_parts
+                    .push(ResponsePart::InputRequest(InputRequestResponsePart {
+                        request,
+                        response: a.response,
+                    }));
             }
             refresh_summary_status(state);
             touch_chat_modified(state);

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -201,6 +201,7 @@ public enum ResponsePartKind: String, Codable, Sendable {
     case toolCall = "toolCall"
     case reasoning = "reasoning"
     case systemNotification = "systemNotification"
+    case inputRequest = "inputRequest"
 }
 
 /// Status of a tool call in the lifecycle state machine.
@@ -2297,6 +2298,26 @@ public struct SystemNotificationResponsePart: Codable, Sendable {
     ) {
         self.kind = kind
         self.content = content
+    }
+}
+
+public struct InputRequestResponsePart: Codable, Sendable {
+    /// Discriminant
+    public var kind: ResponsePartKind
+    /// The resolved request, carrying its `id`, `message`, `url`, `questions`,
+    /// and the final `answers` synced/submitted at completion.
+    public var request: ChatInputRequest
+    /// How the request was resolved: `accept`, `decline`, or `cancel`.
+    public var response: ChatInputResponseKind
+
+    public init(
+        kind: ResponsePartKind,
+        request: ChatInputRequest,
+        response: ChatInputResponseKind
+    ) {
+        self.kind = kind
+        self.request = request
+        self.response = response
     }
 }
 
@@ -4640,6 +4661,7 @@ public enum ResponsePart: Codable, Sendable {
     case toolCall(ToolCallResponsePart)
     case reasoning(ReasoningResponsePart)
     case systemNotification(SystemNotificationResponsePart)
+    case inputRequest(InputRequestResponsePart)
     /// Unknown or future discriminant; the raw payload is preserved
     /// and re-encoded verbatim for forward-compatibility.
     case unknown(AnyCodable)
@@ -4662,6 +4684,8 @@ public enum ResponsePart: Codable, Sendable {
             self = .reasoning(try ReasoningResponsePart(from: decoder))
         case "systemNotification":
             self = .systemNotification(try SystemNotificationResponsePart(from: decoder))
+        case "inputRequest":
+            self = .inputRequest(try InputRequestResponsePart(from: decoder))
         default:
             self = .unknown(try AnyCodable(from: decoder))
         }
@@ -4674,6 +4698,7 @@ public enum ResponsePart: Codable, Sendable {
         case .toolCall(let value): try value.encode(to: encoder)
         case .reasoning(let value): try value.encode(to: encoder)
         case .systemNotification(let value): try value.encode(to: encoder)
+        case .inputRequest(let value): try value.encode(to: encoder)
         case .unknown(let value): try value.encode(to: encoder)
         }
     }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -446,12 +446,31 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
 
     case .chatInputCompleted(let a):
         guard var existing = state.inputRequests,
-              existing.contains(where: { $0.id == a.requestId }) else {
+              let completed = existing.first(where: { $0.id == a.requestId }) else {
             return state
         }
         existing.removeAll { $0.id == a.requestId }
         var next = state
         next.inputRequests = existing.isEmpty ? nil : existing
+        // Project the resolved request into the active turn's transcript so the
+        // decision survives after the live request is gone. Abandoned requests
+        // (turn end/truncate) are removed without a part.
+        if var activeTurn = next.activeTurn {
+            var finalAnswers = completed.answers ?? [:]
+            if let answers = a.answers {
+                for (k, v) in answers {
+                    finalAnswers[k] = v
+                }
+            }
+            var request = completed
+            request.answers = finalAnswers.isEmpty ? nil : finalAnswers
+            activeTurn.responseParts.append(.inputRequest(InputRequestResponsePart(
+                kind: .inputRequest,
+                request: request,
+                response: a.response
+            )))
+            next.activeTurn = activeTurn
+        }
         next.status = chatSummaryStatus(next)
         next.modifiedAt = currentTimestamp()
         return next

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/ToolCallStateExtensions.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/ToolCallStateExtensions.swift
@@ -84,6 +84,7 @@ extension ResponsePart {
         case .toolCall(let t): return t.toolCall.toolCallId
         case .contentRef: return nil
         case .systemNotification: return nil
+        case .inputRequest: return nil
         case .unknown: return nil
         }
     }

--- a/clients/swift/CHANGELOG.md
+++ b/clients/swift/CHANGELOG.md
@@ -50,6 +50,12 @@ Implements AHP 0.5.2.
   actions for clients to ask the host to start or stop MCP servers; stopping
   moves an `authRequired` server to `stopped` so it no longer waits on
   authentication.
+- `InputRequestResponsePart` and the `ResponsePart.inputRequest` case. The
+  reducer now records a resolved input request in the active turn's
+  `responseParts` on `chatInputCompleted` — embedding the resolved
+  `ChatInputRequest` (final `answers`) and the `response` (`accept`, `decline`,
+  or `cancel`) — so the outcome persists after the live request is removed.
+  Abandoned requests still record nothing (#324).
 
 ### Changed
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -53,6 +53,12 @@ Implements AHP 0.5.2.
   actions for clients to ask the host to start or stop MCP servers; stopping
   moves an `authRequired` server to `stopped` so it no longer waits on
   authentication.
+- `InputRequestResponsePart` (`kind: 'inputRequest'`) response-part variant. The
+  reducer now records a resolved input request in the active turn's
+  `responseParts` on `chat/inputCompleted` — embedding the resolved
+  `ChatInputRequest` (final `answers`) and the `response` (`accept`, `decline`,
+  or `cancel`) — so the outcome persists after the live request is removed.
+  Abandoned requests still record nothing (#324).
 
 ### Changed
 

--- a/docs/guide/elicitation.md
+++ b/docs/guide/elicitation.md
@@ -41,6 +41,14 @@ While a chat has any open input request, that chat's `status` carries `SessionSt
 
 If the active turn completes, is cancelled, errors, or is truncated before input completes, the server SHOULD consider outstanding input requests abandoned. The reducer removes outstanding requests.
 
+## Durable Record
+
+When `chat/inputCompleted` resolves a request while a turn is active, the reducer removes the live request from `inputRequests` and appends an `InputRequestResponsePart` (`kind: 'inputRequest'`) to the active turn's `responseParts`. This mirrors how a resolved tool-call confirmation persists on its terminal `ToolCallState`: the decision becomes part of the durable, replayable transcript instead of vanishing with the ephemeral request.
+
+The recorded part embeds the resolved `request` — carrying its `id`, `message`, `url`, `questions`, and the final `answers` (synced drafts overlaid by any `answers` supplied on `chat/inputCompleted`) — alongside the `response` (`accept`, `decline`, or `cancel`). All three outcomes are recorded, so a declined or cancelled prompt still leaves a trace a client can render after the fact.
+
+Abandonment is the one case that records nothing: when a turn ends, is cancelled, errors, or is truncated, outstanding requests are dropped without a transcript part, because no user decision was reached.
+
 ## Questions And Answers
 
 Each question is a discriminated union by `kind`:

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -318,6 +318,12 @@ ContentRef {
   contentType?: string
 }
 
+// Harness-authored notification surfaced in the stream (e.g. "subagent finished")
+SystemNotificationResponsePart {
+  kind: 'systemNotification'
+  content: StringOrMarkdown
+}
+
 // Durable record of a resolved input request (see Input Requests below)
 InputRequestResponsePart {
   kind: 'inputRequest'

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -317,6 +317,13 @@ ContentRef {
   sizeHint?: number
   contentType?: string
 }
+
+// Durable record of a resolved input request (see Input Requests below)
+InputRequestResponsePart {
+  kind: 'inputRequest'
+  request: ChatInputRequest   // the resolved request, with its final answers
+  response: ChatInputResponseKind  // 'accept' | 'decline' | 'cancel'
+}
 ```
 
 Text content uses a **create-then-append** pattern: the server first emits a `chat/responsePart` action to create a new markdown (or reasoning) part with an `id`, then streams text into it via `chat/delta` (or `chat/reasoning`) actions targeting that `partId`. This pattern is extensible to future streaming content types.

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -5132,6 +5132,29 @@
         "content"
       ]
     },
+    "InputRequestResponsePart": {
+      "type": "object",
+      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "properties": {
+        "kind": {
+          "const": "inputRequest",
+          "description": "Discriminant"
+        },
+        "request": {
+          "$ref": "#/$defs/ChatInputRequest",
+          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+        },
+        "response": {
+          "$ref": "#/$defs/ChatInputResponseKind",
+          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+        }
+      },
+      "required": [
+        "kind",
+        "request",
+        "response"
+      ]
+    },
     "SystemNotificationResponsePart": {
       "type": "object",
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
@@ -6751,6 +6774,9 @@
         },
         {
           "$ref": "#/$defs/SystemNotificationResponsePart"
+        },
+        {
+          "$ref": "#/$defs/InputRequestResponsePart"
         }
       ]
     },

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -4416,6 +4416,29 @@
         "content"
       ]
     },
+    "InputRequestResponsePart": {
+      "type": "object",
+      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "properties": {
+        "kind": {
+          "const": "inputRequest",
+          "description": "Discriminant"
+        },
+        "request": {
+          "$ref": "#/$defs/ChatInputRequest",
+          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+        },
+        "response": {
+          "$ref": "#/$defs/ChatInputResponseKind",
+          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+        }
+      },
+      "required": [
+        "kind",
+        "request",
+        "response"
+      ]
+    },
     "SystemNotificationResponsePart": {
       "type": "object",
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
@@ -8372,6 +8395,9 @@
         },
         {
           "$ref": "#/$defs/SystemNotificationResponsePart"
+        },
+        {
+          "$ref": "#/$defs/InputRequestResponsePart"
         }
       ]
     },
@@ -8393,6 +8419,15 @@
       ],
       "type": "string",
       "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "ChatInputResponseKind": {
+      "enum": [
+        "accept",
+        "decline",
+        "cancel"
+      ],
+      "type": "string",
+      "description": "How a client completed an input request."
     },
     "ConfirmationOptionKind": {
       "enum": [
@@ -8511,15 +8546,6 @@
       ],
       "type": "string",
       "description": "Discriminant for pending message kinds."
-    },
-    "ChatInputResponseKind": {
-      "enum": [
-        "accept",
-        "decline",
-        "cancel"
-      ],
-      "type": "string",
-      "description": "How a client completed an input request."
     },
     "ChatToolCallConfirmedAction": {
       "oneOf": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -3211,6 +3211,29 @@
         "content"
       ]
     },
+    "InputRequestResponsePart": {
+      "type": "object",
+      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "properties": {
+        "kind": {
+          "const": "inputRequest",
+          "description": "Discriminant"
+        },
+        "request": {
+          "$ref": "#/$defs/ChatInputRequest",
+          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+        },
+        "response": {
+          "$ref": "#/$defs/ChatInputResponseKind",
+          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+        }
+      },
+      "required": [
+        "kind",
+        "request",
+        "response"
+      ]
+    },
     "SystemNotificationResponsePart": {
       "type": "object",
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
@@ -6174,6 +6197,9 @@
         },
         {
           "$ref": "#/$defs/SystemNotificationResponsePart"
+        },
+        {
+          "$ref": "#/$defs/InputRequestResponsePart"
         }
       ]
     },
@@ -6212,6 +6238,15 @@
         }
       ],
       "description": "An attachment associated with a {@link Message}."
+    },
+    "ChatInputResponseKind": {
+      "enum": [
+        "accept",
+        "decline",
+        "cancel"
+      ],
+      "type": "string",
+      "description": "How a client completed an input request."
     },
     "StringOrMarkdown": {
       "oneOf": [
@@ -8588,15 +8623,6 @@
       ],
       "type": "string",
       "description": "Discriminant for pending message kinds."
-    },
-    "ChatInputResponseKind": {
-      "enum": [
-        "accept",
-        "decline",
-        "cancel"
-      ],
-      "type": "string",
-      "description": "How a client completed an input request."
     }
   }
 }

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -3371,6 +3371,29 @@
         "content"
       ]
     },
+    "InputRequestResponsePart": {
+      "type": "object",
+      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "properties": {
+        "kind": {
+          "const": "inputRequest",
+          "description": "Discriminant"
+        },
+        "request": {
+          "$ref": "#/$defs/ChatInputRequest",
+          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+        },
+        "response": {
+          "$ref": "#/$defs/ChatInputResponseKind",
+          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+        }
+      },
+      "required": [
+        "kind",
+        "request",
+        "response"
+      ]
+    },
     "SystemNotificationResponsePart": {
       "type": "object",
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
@@ -5048,6 +5071,9 @@
         },
         {
           "$ref": "#/$defs/SystemNotificationResponsePart"
+        },
+        {
+          "$ref": "#/$defs/InputRequestResponsePart"
         }
       ]
     },
@@ -5086,6 +5112,15 @@
         }
       ],
       "description": "An attachment associated with a {@link Message}."
+    },
+    "ChatInputResponseKind": {
+      "enum": [
+        "accept",
+        "decline",
+        "cancel"
+      ],
+      "type": "string",
+      "description": "How a client completed an input request."
     },
     "StringOrMarkdown": {
       "oneOf": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -3122,6 +3122,29 @@
         "content"
       ]
     },
+    "InputRequestResponsePart": {
+      "type": "object",
+      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "properties": {
+        "kind": {
+          "const": "inputRequest",
+          "description": "Discriminant"
+        },
+        "request": {
+          "$ref": "#/$defs/ChatInputRequest",
+          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+        },
+        "response": {
+          "$ref": "#/$defs/ChatInputResponseKind",
+          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+        }
+      },
+      "required": [
+        "kind",
+        "request",
+        "response"
+      ]
+    },
     "SystemNotificationResponsePart": {
       "type": "object",
       "description": "A system notification surfaced as part of the response stream.\n\nSystem notifications are messages authored by the agent harness\nthat need to be visible to both the agent (for situational awareness) and\nthe user (for transcript continuity). Examples include \"background subagent\nX completed\" or \"task Y was cancelled\".",
@@ -4741,6 +4764,9 @@
         },
         {
           "$ref": "#/$defs/SystemNotificationResponsePart"
+        },
+        {
+          "$ref": "#/$defs/InputRequestResponsePart"
         }
       ]
     },
@@ -4906,6 +4932,15 @@
       ],
       "type": "string",
       "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "ChatInputResponseKind": {
+      "enum": [
+        "accept",
+        "decline",
+        "cancel"
+      ],
+      "type": "string",
+      "description": "How a client completed an input request."
     },
     "ConfirmationOptionKind": {
       "enum": [

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -709,6 +709,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: strin
   { name: 'ToolCallResponsePart' },
   { name: 'ReasoningResponsePart' },
   { name: 'SystemNotificationResponsePart' },
+  { name: 'InputRequestResponsePart' },
   { name: 'ToolCallResult' },
   { name: 'ConfirmationOption' },
   { name: 'ToolCallStreamingState' },
@@ -781,6 +782,7 @@ const RESPONSE_PART_UNION: UnionConfig = {
     { variantName: 'ToolCall', innerType: 'ToolCallResponsePart', wireValue: 'toolCall' },
     { variantName: 'Reasoning', innerType: 'ReasoningResponsePart', wireValue: 'reasoning' },
     { variantName: 'SystemNotification', innerType: 'SystemNotificationResponsePart', wireValue: 'systemNotification' },
+    { variantName: 'InputRequest', innerType: 'InputRequestResponsePart', wireValue: 'inputRequest' },
   ],
   unknown: true,
 };

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -821,7 +821,7 @@ const STATE_STRUCTS = [
   'MessageAnnotationsAttachment',
   'MarkdownResponsePart', 'ContentRef',
   'ResourceReponsePart', 'ToolCallResponsePart', 'ReasoningResponsePart',
-  'SystemNotificationResponsePart',
+  'SystemNotificationResponsePart', 'InputRequestResponsePart',
   'ToolCallResult', 'ToolCallStreamingState',
   'ToolCallPendingConfirmationState', 'ToolCallRunningState',
   'ToolCallPendingResultConfirmationState', 'ToolCallCompletedState',
@@ -858,6 +858,7 @@ const RESPONSE_PART_UNION: UnionConfig = {
     { caseName: 'ToolCall', structName: 'ToolCallResponsePart', discriminantValue: 'toolCall' },
     { caseName: 'Reasoning', structName: 'ReasoningResponsePart', discriminantValue: 'reasoning' },
     { caseName: 'SystemNotification', structName: 'SystemNotificationResponsePart', discriminantValue: 'systemNotification' },
+    { caseName: 'InputRequest', structName: 'InputRequestResponsePart', discriminantValue: 'inputRequest' },
   ],
   unknown: true,
 };

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -740,6 +740,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'ToolCallResponsePart', omitDiscriminants: true },
   { name: 'ReasoningResponsePart', omitDiscriminants: true },
   { name: 'SystemNotificationResponsePart', omitDiscriminants: true },
+  { name: 'InputRequestResponsePart', omitDiscriminants: true },
   { name: 'ToolCallResult' },
   { name: 'ConfirmationOption' },
   { name: 'ToolCallStreamingState', omitDiscriminants: true },
@@ -812,6 +813,7 @@ const RESPONSE_PART_UNION: UnionConfig = {
     { variantName: 'ToolCall', innerType: 'ToolCallResponsePart', wireValue: 'toolCall', boxed: true },
     { variantName: 'Reasoning', innerType: 'ReasoningResponsePart', wireValue: 'reasoning' },
     { variantName: 'SystemNotification', innerType: 'SystemNotificationResponsePart', wireValue: 'systemNotification' },
+    { variantName: 'InputRequest', innerType: 'InputRequestResponsePart', wireValue: 'inputRequest' },
   ],
   unknown: true,
 };

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -571,7 +571,7 @@ const STATE_STRUCTS = [
   'MessageAnnotationsAttachment',
   'MarkdownResponsePart', 'ContentRef',
   'ResourceReponsePart', 'ToolCallResponsePart', 'ReasoningResponsePart',
-  'SystemNotificationResponsePart',
+  'SystemNotificationResponsePart', 'InputRequestResponsePart',
   'ToolCallResult', 'ToolCallStreamingState',
   'ToolCallPendingConfirmationState', 'ToolCallRunningState',
   'ToolCallPendingResultConfirmationState', 'ToolCallCompletedState',
@@ -613,6 +613,7 @@ const RESPONSE_PART_UNION: UnionConfig = {
     { caseName: 'toolCall', structName: 'ToolCallResponsePart', discriminantValue: 'toolCall' },
     { caseName: 'reasoning', structName: 'ReasoningResponsePart', discriminantValue: 'reasoning' },
     { caseName: 'systemNotification', structName: 'SystemNotificationResponsePart', discriminantValue: 'systemNotification' },
+    { caseName: 'inputRequest', structName: 'InputRequestResponsePart', discriminantValue: 'inputRequest' },
   ],
 };
 

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -12,6 +12,7 @@ import type {
   ToolCallState,
   ResponsePart,
   ToolCallResponsePart,
+  InputRequestResponsePart,
   Turn,
   PendingMessage,
   ConfirmationOption,
@@ -596,9 +597,11 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
 
     case ActionType.ChatInputCompleted: {
       const existing = state.inputRequests;
-      if (!existing?.some(request => request.id === action.requestId)) {
+      const idx = existing?.findIndex(request => request.id === action.requestId) ?? -1;
+      if (!existing || idx < 0) {
         return state;
       }
+      const completed = existing[idx];
       const inputRequests = existing.filter(request => request.id !== action.requestId);
       const next: ChatState = {
         ...state,
@@ -607,6 +610,24 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
         next.inputRequests = inputRequests;
       } else {
         delete next.inputRequests;
+      }
+      // Project the resolved request into the active turn's transcript so the
+      // "asked X → answered Y" decision survives after the live request is
+      // gone. Abandoned requests (turn end/truncate) are removed without a part.
+      if (next.activeTurn) {
+        const finalAnswers = { ...(completed.answers ?? {}), ...(action.answers ?? {}) };
+        const part: InputRequestResponsePart = {
+          kind: ResponsePartKind.InputRequest,
+          request: {
+            ...completed,
+            answers: Object.keys(finalAnswers).length > 0 ? finalAnswers : undefined,
+          },
+          response: action.response,
+        };
+        next.activeTurn = {
+          ...next.activeTurn,
+          responseParts: [...next.activeTurn.responseParts, part],
+        };
       }
       return {
         ...next,

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -774,6 +774,7 @@ export const enum ResponsePartKind {
   ToolCall = 'toolCall',
   Reasoning = 'reasoning',
   SystemNotification = 'systemNotification',
+  InputRequest = 'inputRequest',
 }
 
 /**
@@ -836,7 +837,37 @@ export type ResponsePart =
   | ResourceReponsePart
   | ToolCallResponsePart
   | ReasoningResponsePart
-  | SystemNotificationResponsePart;
+  | SystemNotificationResponsePart
+  | InputRequestResponsePart;
+
+/**
+ * A resolved input request (elicitation) recorded in the turn transcript.
+ *
+ * While an input request is open it lives in {@link ChatState.inputRequests}
+ * as live, interactive state (see {@link ChatInputRequest}). When the request
+ * completes via `chat/inputCompleted`, the reducer removes it from
+ * `inputRequests` and appends this part to the active turn so the decision
+ * survives in history. This mirrors how a tool-call confirmation persists in
+ * its {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the
+ * terminal {@link ToolCallState}): the live surface drives in-flight UX, the
+ * terminal outcome is durable and backfillable via `fetchTurns`.
+ *
+ * No part is recorded when an outstanding request is *abandoned* (the turn
+ * completes, is cancelled, errors, or is truncated) rather than *completed*.
+ *
+ * @category Response Parts
+ */
+export interface InputRequestResponsePart {
+  /** Discriminant */
+  kind: ResponsePartKind.InputRequest;
+  /**
+   * The resolved request, carrying its `id`, `message`, `url`, `questions`,
+   * and the final `answers` synced/submitted at completion.
+   */
+  request: ChatInputRequest;
+  /** How the request was resolved: `accept`, `decline`, or `cancel`. */
+  response: ChatInputResponseKind;
+}
 
 /**
  * A system notification surfaced as part of the response stream.

--- a/types/test-cases/reducers/105-session-input-full-draft-and-complete-flow.json
+++ b/types/test-cases/reducers/105-session-input-full-draft-and-complete-flow.json
@@ -1,5 +1,5 @@
 {
-  "description": "session input requests sync drafts and restore in-progress status after completion",
+  "description": "session input requests sync drafts, record a resolved inputRequest part in the active turn, and restore in-progress status after completion",
   "reducer": "chat",
   "initial": {
     "turns": [],
@@ -88,7 +88,54 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "input-1",
+            "message": "Clarify requirements",
+            "questions": [
+              {
+                "id": "q1",
+                "kind": "single-select",
+                "message": "Which runtime?",
+                "options": [
+                  {
+                    "id": "node",
+                    "label": "Node.js"
+                  },
+                  {
+                    "id": "deno",
+                    "label": "Deno"
+                  }
+                ]
+              },
+              {
+                "id": "q2",
+                "kind": "text",
+                "message": "Anything else?"
+              }
+            ],
+            "answers": {
+              "q1": {
+                "state": "draft",
+                "value": {
+                  "kind": "selected",
+                  "value": "node"
+                }
+              },
+              "q2": {
+                "state": "draft",
+                "value": {
+                  "kind": "text",
+                  "value": "Keep it small."
+                }
+              }
+            }
+          },
+          "response": "accept"
+        }
+      ],
       "usage": null
     },
     "resource": "copilot:/test-session",

--- a/types/test-cases/reducers/235-session-input-completion-records-declined-request-in-turn.json
+++ b/types/test-cases/reducers/235-session-input-completion-records-declined-request-in-turn.json
@@ -1,0 +1,107 @@
+{
+  "description": "session input completion records a declined URL request in the active turn, merging final answers over synced drafts",
+  "reducer": "chat",
+  "initial": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Review",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [],
+      "usage": null
+    },
+    "inputRequests": [
+      {
+        "id": "review-1",
+        "message": "Review before continuing",
+        "url": "https://example.com/plan",
+        "questions": [
+          {
+            "id": "approve",
+            "kind": "boolean",
+            "message": "Approve the plan?",
+            "required": true
+          }
+        ],
+        "answers": {
+          "approve": {
+            "state": "draft",
+            "value": {
+              "kind": "boolean",
+              "value": true
+            }
+          }
+        }
+      }
+    ],
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 24,
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/inputCompleted",
+      "requestId": "review-1",
+      "response": "decline",
+      "answers": {
+        "approve": {
+          "state": "submitted",
+          "value": {
+            "kind": "boolean",
+            "value": false
+          }
+        }
+      }
+    }
+  ],
+  "expected": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Review",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "review-1",
+            "message": "Review before continuing",
+            "url": "https://example.com/plan",
+            "questions": [
+              {
+                "id": "approve",
+                "kind": "boolean",
+                "message": "Approve the plan?",
+                "required": true
+              }
+            ],
+            "answers": {
+              "approve": {
+                "state": "submitted",
+                "value": {
+                  "kind": "boolean",
+                  "value": false
+                }
+              }
+            }
+          },
+          "response": "decline"
+        }
+      ],
+      "usage": null
+    },
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 8,
+    "modifiedAt": "1970-01-01T00:00:09.999Z"
+  }
+}

--- a/types/test-cases/reducers/236-session-input-completion-without-active-turn-records-nothing.json
+++ b/types/test-cases/reducers/236-session-input-completion-without-active-turn-records-nothing.json
@@ -1,0 +1,57 @@
+{
+  "description": "session input completion without an active turn removes the request and records no transcript part",
+  "reducer": "chat",
+  "initial": {
+    "turns": [
+      {
+        "id": "t1",
+        "message": {
+          "text": "Earlier",
+          "origin": {
+            "kind": "user"
+          }
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "inputRequests": [
+      {
+        "id": "orphan-1",
+        "message": "Standalone request"
+      }
+    ],
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 24,
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/inputCompleted",
+      "requestId": "orphan-1",
+      "response": "accept"
+    }
+  ],
+  "expected": {
+    "turns": [
+      {
+        "id": "t1",
+        "message": {
+          "text": "Earlier",
+          "origin": {
+            "kind": "user"
+          }
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 1,
+    "modifiedAt": "1970-01-01T00:00:09.999Z"
+  }
+}

--- a/types/test-cases/reducers/237-session-input-completion-no-op-unknown-id-with-open-requests.json
+++ b/types/test-cases/reducers/237-session-input-completion-no-op-unknown-id-with-open-requests.json
@@ -1,0 +1,59 @@
+{
+  "description": "session input completion is a no-op for an unknown id while other requests remain open",
+  "reducer": "chat",
+  "initial": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Hi",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [],
+      "usage": null
+    },
+    "inputRequests": [
+      {
+        "id": "present-1",
+        "message": "Still open"
+      }
+    ],
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 24,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/inputCompleted",
+      "requestId": "absent",
+      "response": "cancel"
+    }
+  ],
+  "expected": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "message": {
+        "text": "Hi",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [],
+      "usage": null
+    },
+    "inputRequests": [
+      {
+        "id": "present-1",
+        "message": "Still open"
+      }
+    ],
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 24,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  }
+}


### PR DESCRIPTION
Closes #324.

## Problem

An input request (elicitation) lives in `ChatState.inputRequests` as live, interactive state. On `chat/inputCompleted` the reducer removed the request and the submitted answers were consumed by the server without ever landing in the durable turn transcript.

This is asymmetric with tool-call confirmations, whose outcome persists on the terminal `ToolCallState` inside the turn's `responseParts`. The AHP [doctrine](docs/guide/doctrine.md) design test asks for a *durable, user-visible result represented in state, not only an ephemeral notification* — so the gap is real and the proposal is doctrine-aligned.

## Change

Add a new `ResponsePart` variant `InputRequestResponsePart` (`kind: 'inputRequest'`) that embeds the resolved `ChatInputRequest` (with its final answers) plus the `response` (`accept` / `decline` / `cancel`). The embed shape mirrors `ToolCallResponsePart { toolCall }` — idiomatic, DRY, and forward-compatible — rather than the flattened sketch in the issue.

Reducer semantics on `chat/inputCompleted`:
- still removes the live request from `inputRequests`;
- additionally, **when a turn is active**, appends an `InputRequestResponsePart` to `activeTurn.responseParts`;
- final answers = the request's synced drafts overlaid by any `answers` supplied on the action, normalized to absent when empty;
- **abandonment** (turn end / cancel / error / truncate) still records nothing — only a real completion leaves a trace.

## Scope

- **Spec**: `types/channels-chat/state.ts` (enum + interface + union), `types/channels-chat/reducer.ts`.
- **Fixtures**: updated shared `105`; added `235` (decline + URL + answer merge, active turn), `236` (no active turn → no part), `237` (unknown id no-op) for full branch coverage.
- **Clients**: mirrored the reducer into all four hand-written parity reducers (Rust, Go, Swift, Kotlin); regenerated every client type mirror and the JSON Schemas; the TypeScript client reducer is a generated copy of the spec.
- **Docs**: `docs/guide/elicitation.md` (new *Durable Record* section) and `docs/guide/state-model.md` (response-parts list).
- **CHANGELOGs**: root spec + all five clients (a `types/**` change ripples to every client).

## Verification

- Spec: `npm run test` — typecheck, lint, verify:release-metadata, verify:changelog, 295 tests, 100% reducer branch coverage.
- Rust: `cargo test` + `cargo clippy --all-targets` (clean).
- Go: `go test ./...`.
- Swift: `swift test` (107 tests).
- Kotlin: `./gradlew test` (218 fixture cases, 0 failures — including 105/235/236/237).
- TypeScript client: `npm test` (59 tests).
- `npm run generate` produces no unexpected drift.

No protocol version bump; the new type is additive to the unreleased `0.5.2` surface.