### PR TITLE
Make input requests live response parts

### DIFF
--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -163,12 +163,25 @@ func hasBlockingToolCall(state *ahptypes.ChatState) bool {
 	return false
 }
 
+func hasOpenInputRequest(state *ahptypes.ChatState) bool {
+	if state.ActiveTurn == nil {
+		return false
+	}
+	for _, part := range state.ActiveTurn.ResponseParts {
+		input, ok := part.Value.(*ahptypes.InputRequestResponsePart)
+		if ok && input.Response == nil {
+			return true
+		}
+	}
+	return false
+}
+
 func summaryStatus(state *ahptypes.ChatState, terminal *ahptypes.SessionStatus) ahptypes.SessionStatus {
 	var activity ahptypes.SessionStatus
 	switch {
 	case terminal != nil:
 		activity = *terminal
-	case len(state.InputRequests) > 0 || hasBlockingToolCall(state):
+	case hasOpenInputRequest(state) || hasBlockingToolCall(state):
 		activity = ahptypes.SessionStatusInputNeeded
 	case state.ActiveTurn != nil:
 		activity = ahptypes.SessionStatusInProgress
@@ -245,33 +258,43 @@ func endTurn(state *ahptypes.ChatState, turnID string, duration int64, turnState
 	}
 
 	state.Turns = append(state.Turns, turn)
-	state.InputRequests = nil
 	state.ModifiedAt = nowISOString()
 	state.Status = summaryStatus(state, terminalStatus)
 	return ReduceOutcomeApplied
 }
 
-func upsertInputRequest(state *ahptypes.ChatState, req ahptypes.ChatInputRequest) {
-	existing := state.InputRequests
-	found := -1
-	for i := range existing {
-		if existing[i].Id == req.Id {
-			found = i
-			break
+func upsertInputRequest(state *ahptypes.ChatState, req ahptypes.ChatInputRequest) ReduceOutcome {
+	if state.ActiveTurn == nil {
+		return ReduceOutcomeNoOp
+	}
+	parts := state.ActiveTurn.ResponseParts
+	for i := range parts {
+		input, ok := parts[i].Value.(*ahptypes.InputRequestResponsePart)
+		if ok && input.Response == nil && input.Request.Id == req.Id {
+			if req.Answers == nil {
+				req.Answers = input.Request.Answers
+			}
+			parts[i].Value = &ahptypes.InputRequestResponsePart{
+				Kind:    ahptypes.ResponsePartKindInputRequest,
+				Request: req,
+			}
+			state.ActiveTurn.ResponseParts = parts
+			state.Status = summaryStatus(state, nil)
+			touchChatModified(state)
+			state.Status = withStatusFlag(state.Status, ahptypes.SessionStatusIsRead, false)
+			return ReduceOutcomeApplied
 		}
 	}
-	if found >= 0 {
-		if req.Answers == nil {
-			req.Answers = existing[found].Answers
-		}
-		existing[found] = req
-	} else {
-		existing = append(existing, req)
-	}
-	state.InputRequests = existing
+	state.ActiveTurn.ResponseParts = append(parts, ahptypes.ResponsePart{
+		Value: &ahptypes.InputRequestResponsePart{
+			Kind:    ahptypes.ResponsePartKindInputRequest,
+			Request: req,
+		},
+	})
 	state.Status = summaryStatus(state, nil)
 	touchChatModified(state)
 	state.Status = withStatusFlag(state.Status, ahptypes.SessionStatusIsRead, false)
+	return ReduceOutcomeApplied
 }
 
 // ─── Customization helpers ─────────────────────────────────────────────
@@ -586,61 +609,42 @@ func ApplyActionToChat(state *ahptypes.ChatState, action ahptypes.StateAction) R
 		state.TurnsNextCursor = a.TurnsNextCursor
 		return ReduceOutcomeApplied
 	case *ahptypes.ChatInputRequestedAction:
-		upsertInputRequest(state, a.Request)
-		return ReduceOutcomeApplied
+		return upsertInputRequest(state, a.Request)
 	case *ahptypes.ChatInputAnswerChangedAction:
 		return applyInputAnswerChanged(state, a)
 	case *ahptypes.ChatInputCompletedAction:
-		list := state.InputRequests
-		if list == nil {
+		if state.ActiveTurn == nil {
 			return ReduceOutcomeNoOp
 		}
-		var completed *ahptypes.ChatInputRequest
-		next := list[:0]
-		for i := range list {
-			if list[i].Id == a.RequestId {
-				c := list[i]
-				completed = &c
+		for i := range state.ActiveTurn.ResponseParts {
+			input, ok := state.ActiveTurn.ResponseParts[i].Value.(*ahptypes.InputRequestResponsePart)
+			if !ok || input.Response != nil || input.Request.Id != a.RequestId {
 				continue
 			}
-			next = append(next, list[i])
-		}
-		if completed == nil {
-			return ReduceOutcomeNoOp
-		}
-		if len(next) == 0 {
-			state.InputRequests = nil
-		} else {
-			state.InputRequests = next
-		}
-		// Project the resolved request into the active turn's transcript so the
-		// decision survives after the live request is gone. Abandoned requests
-		// (turn end/truncate) are removed without a part.
-		if state.ActiveTurn != nil {
 			finalAnswers := map[string]ahptypes.ChatInputAnswer{}
-			for k, v := range completed.Answers {
+			for k, v := range input.Request.Answers {
 				finalAnswers[k] = v
 			}
 			for k, v := range a.Answers {
 				finalAnswers[k] = v
 			}
-			request := *completed
+			request := input.Request
 			if len(finalAnswers) == 0 {
 				request.Answers = nil
 			} else {
 				request.Answers = finalAnswers
 			}
-			state.ActiveTurn.ResponseParts = append(state.ActiveTurn.ResponseParts, ahptypes.ResponsePart{
-				Value: &ahptypes.InputRequestResponsePart{
-					Kind:     ahptypes.ResponsePartKindInputRequest,
-					Request:  request,
-					Response: a.Response,
-				},
-			})
+			response := a.Response
+			state.ActiveTurn.ResponseParts[i].Value = &ahptypes.InputRequestResponsePart{
+				Kind:     ahptypes.ResponsePartKindInputRequest,
+				Request:  request,
+				Response: &response,
+			}
+			refreshSummaryStatus(state)
+			touchChatModified(state)
+			return ReduceOutcomeApplied
 		}
-		refreshSummaryStatus(state)
-		touchChatModified(state)
-		return ReduceOutcomeApplied
+		return ReduceOutcomeNoOp
 	case *ahptypes.ChatPendingMessageSetAction:
 		entry := ahptypes.PendingMessage{Id: a.Id, Message: a.Message}
 		switch a.Kind {
@@ -1411,38 +1415,36 @@ func applyTruncated(state *ahptypes.ChatState, turnID *string) ReduceOutcome {
 		state.Turns = state.Turns[:idx+1]
 	}
 	state.ActiveTurn = nil
-	state.InputRequests = nil
 	touchChatModified(state)
 	state.Status = summaryStatus(state, nil)
 	return ReduceOutcomeApplied
 }
 
 func applyInputAnswerChanged(state *ahptypes.ChatState, a *ahptypes.ChatInputAnswerChangedAction) ReduceOutcome {
-	list := state.InputRequests
-	idx := -1
-	for i := range list {
-		if list[i].Id == a.RequestId {
-			idx = i
-			break
-		}
-	}
-	if idx < 0 {
+	if state.ActiveTurn == nil {
 		return ReduceOutcomeNoOp
 	}
-	req := &list[idx]
-	if req.Answers == nil {
-		req.Answers = make(map[string]ahptypes.ChatInputAnswer)
+	for i := range state.ActiveTurn.ResponseParts {
+		input, ok := state.ActiveTurn.ResponseParts[i].Value.(*ahptypes.InputRequestResponsePart)
+		if !ok || input.Response != nil || input.Request.Id != a.RequestId {
+			continue
+		}
+		req := &input.Request
+		if req.Answers == nil {
+			req.Answers = make(map[string]ahptypes.ChatInputAnswer)
+		}
+		if a.Answer == nil {
+			delete(req.Answers, a.QuestionId)
+		} else {
+			req.Answers[a.QuestionId] = *a.Answer
+		}
+		if len(req.Answers) == 0 {
+			req.Answers = nil
+		}
+		touchChatModified(state)
+		return ReduceOutcomeApplied
 	}
-	if a.Answer == nil {
-		delete(req.Answers, a.QuestionId)
-	} else {
-		req.Answers[a.QuestionId] = *a.Answer
-	}
-	if len(req.Answers) == 0 {
-		req.Answers = nil
-	}
-	touchChatModified(state)
-	return ReduceOutcomeApplied
+	return ReduceOutcomeNoOp
 }
 
 // ─── Terminal Reducer ──────────────────────────────────────────────────

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -715,9 +715,9 @@ type ChatDraftChangedAction struct {
 
 // A session requested input from the user.
 //
-// Full-request upsert semantics: the `request` replaces any existing request
-// with the same `id`, or is appended if it is new. Answer drafts are preserved
-// unless `request.answers` is provided.
+// Creates an unresolved {@link InputRequestResponsePart} in the active turn,
+// or replaces the unresolved part with the same request `id`. Answer drafts
+// are preserved unless `request.answers` is provided.
 type ChatInputRequestedAction struct {
 	Type ActionType `json:"type"`
 	// Input request to create or replace
@@ -737,10 +737,11 @@ type ChatInputAnswerChangedAction struct {
 	Answer *ChatInputAnswer `json:"answer,omitempty"`
 }
 
-// A client accepted, declined, or cancelled a session input request.
+// A client submitted an accept, decline, or cancel response to an input request.
 //
 // If accepted, the server uses `answers` (when provided) plus the request's
-// synced answer state to resume the blocked operation.
+// synced answer state to resume the blocked operation. The reducer records the
+// response and final answers on the existing {@link InputRequestResponsePart}.
 type ChatInputCompletedAction struct {
 	Type ActionType `json:"type"`
 	// Input request identifier

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -153,7 +153,7 @@ const (
 type SessionInputRequestKind string
 
 const (
-	// A user-facing elicitation mirrored from a chat's `inputRequests`.
+	// A user-facing elicitation mirrored from an unresolved chat response part.
 	SessionInputRequestKindChatInput SessionInputRequestKind = "chatInput"
 	// A tool call awaiting parameter- or result-confirmation.
 	SessionInputRequestKindToolConfirmation SessionInputRequestKind = "toolConfirmation"
@@ -819,8 +819,8 @@ type SessionActiveClient struct {
 	Customizations []ClientPluginCustomization `json:"customizations,omitempty"`
 }
 
-// A user-input elicitation surfaced at the session level, mirroring one entry
-// of the owning chat's {@link ChatState.inputRequests}.
+// A user-input elicitation surfaced at the session level, mirroring the request
+// from an unresolved {@link InputRequestResponsePart} in the owning chat.
 //
 // Respond by dispatching `chat/inputCompleted` (or syncing drafts with
 // `chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},
@@ -1069,8 +1069,6 @@ type ChatState struct {
 	SteeringMessage *PendingMessage `json:"steeringMessage,omitempty"`
 	// Messages to send automatically as new turns after the current turn finishes
 	QueuedMessages []PendingMessage `json:"queuedMessages,omitempty"`
-	// Requests for user input that are currently blocking or informing chat progress
-	InputRequests []ChatInputRequest `json:"inputRequests,omitempty"`
 	// The user's in-progress draft input for this chat — the message they are
 	// composing but have not sent yet, including its
 	// {@link Message.model | model} / {@link Message.agent | agent} selection
@@ -1428,11 +1426,11 @@ type ChatInputMultiSelectQuestion struct {
 	Max *int64 `json:"max,omitempty"`
 }
 
-// A live request for user input.
+// The request payload carried by an {@link InputRequestResponsePart}.
 //
-// The server creates or replaces requests with `chat/inputRequested`.
-// Clients sync drafts with `chat/inputAnswerChanged` and complete requests
-// with `chat/inputCompleted`.
+// The server creates or replaces the containing response part with
+// `chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`
+// and submit responses with `chat/inputCompleted`.
 type ChatInputRequest struct {
 	// Stable request identifier
 	Id string `json:"id"`
@@ -1713,27 +1711,25 @@ type SystemNotificationResponsePart struct {
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
-// A resolved input request (elicitation) recorded in the turn transcript.
+// A live or resolved input request (elicitation) in the turn response stream.
 //
-// While an input request is open it lives in {@link ChatState.inputRequests}
-// as live, interactive state (see {@link ChatInputRequest}). When the request
-// completes via `chat/inputCompleted`, the reducer removes it from
-// `inputRequests` and appends this part to the active turn so the decision
-// survives in history. This mirrors how a tool-call confirmation persists in
-// its {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the
-// terminal {@link ToolCallState}): the live surface drives in-flight UX, the
-// terminal outcome is durable and backfillable via `fetchTurns`.
+// The server inserts the part with `chat/inputRequested`. While
+// {@link response} is absent, clients can update answer drafts with
+// `chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.
+// Completion updates this part in place so its stream position is stable and
+// the full interaction remains durable and backfillable via `fetchTurns`.
 //
-// No part is recorded when an outstanding request is *abandoned* (the turn
-// completes, is cancelled, errors, or is truncated) rather than *completed*.
+// If the turn ends without a submitted response, the unresolved part remains
+// in the completed turn transcript with {@link response} absent.
 type InputRequestResponsePart struct {
 	// Discriminant
 	Kind ResponsePartKind `json:"kind"`
-	// The resolved request, carrying its `id`, `message`, `url`, `questions`,
-	// and the final `answers` synced/submitted at completion.
+	// The request, carrying its `id`, `message`, `url`, `questions`, and current
+	// draft or submitted `answers`.
 	Request ChatInputRequest `json:"request"`
-	// How the request was resolved: `accept`, `decline`, or `cancel`.
-	Response ChatInputResponseKind `json:"response"`
+	// How the request was resolved. Absent until a client submits `accept`,
+	// `decline`, or `cancel` with `chat/inputCompleted`.
+	Response *ChatInputResponseKind `json:"response,omitempty"`
 }
 
 // Tool execution result details, available after execution completes.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -115,7 +115,7 @@ private fun withInputNeededStatus(status: SessionStatus, inputNeeded: List<Sessi
 private fun chatSummaryStatus(state: ChatState, terminalStatus: SessionStatus? = null): SessionStatus {
     val activity: SessionStatus = when {
         terminalStatus != null -> terminalStatus
-        (state.inputRequests?.size ?: 0) > 0 || hasBlockingToolCall(state) ->
+        hasOpenInputRequest(state) || hasBlockingToolCall(state) ->
             SessionStatus.INPUT_NEEDED
         state.activeTurn != null -> SessionStatus.IN_PROGRESS
         else -> SessionStatus.IDLE
@@ -123,6 +123,11 @@ private fun chatSummaryStatus(state: ChatState, terminalStatus: SessionStatus? =
     val preserved = state.status.rawValue and STATUS_ACTIVITY_MASK.inv()
     return SessionStatus(preserved or activity.rawValue)
 }
+
+private fun hasOpenInputRequest(state: ChatState): Boolean =
+    state.activeTurn?.responseParts?.any { part ->
+        part is ResponsePartInputRequest && part.value.response == null
+    } == true
 
 /**
  * Returns a state with chat [ChatState.status] recomputed. Use after reducers that
@@ -414,22 +419,36 @@ private fun endTurn(
     val withoutTurn = state.copy(
         turns = state.turns + turn,
         activeTurn = null,
-        inputRequests = null,
         modifiedAt = nowIsoString(),
     )
     return withoutTurn.copy(status = chatSummaryStatus(withoutTurn, terminalStatus))
 }
 
 private fun upsertInputRequest(state: ChatState, request: ChatInputRequest): ChatState {
-    val existing = state.inputRequests ?: emptyList()
-    val idx = existing.indexOfFirst { it.id == request.id }
-    val updated: List<ChatInputRequest> = if (idx >= 0) {
-        val priorAnswers = existing[idx].answers
-        existing.toMutableList().also { it[idx] = request.copy(answers = request.answers ?: priorAnswers) }
-    } else {
-        existing + request
+    val activeTurn = state.activeTurn ?: return state
+    val idx = activeTurn.responseParts.indexOfFirst { part ->
+        part is ResponsePartInputRequest
+            && part.value.response == null
+            && part.value.request.id == request.id
     }
-    val next = state.copy(inputRequests = updated)
+    val updated = activeTurn.responseParts.toMutableList()
+    if (idx >= 0) {
+        val existing = (updated[idx] as ResponsePartInputRequest).value
+        updated[idx] = ResponsePartInputRequest(
+            InputRequestResponsePart(
+                kind = ResponsePartKind.INPUT_REQUEST,
+                request = request.copy(answers = request.answers ?: existing.request.answers),
+            ),
+        )
+    } else {
+        updated += ResponsePartInputRequest(
+            InputRequestResponsePart(
+                kind = ResponsePartKind.INPUT_REQUEST,
+                request = request,
+            ),
+        )
+    }
+    val next = state.copy(activeTurn = activeTurn.copy(responseParts = updated))
     return next.copy(
         status = withStatusFlag(chatSummaryStatus(next), SessionStatus.IS_READ, false),
         modifiedAt = nowIsoString(),
@@ -1220,7 +1239,6 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
             turns = turns,
             turnsNextCursor = if (a.turnId == null) null else state.turnsNextCursor,
             activeTurn = null,
-            inputRequests = null,
             modifiedAt = nowIsoString(),
         )
         next.copy(status = chatSummaryStatus(next))
@@ -1243,12 +1261,17 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
 
     is StateActionChatInputAnswerChanged -> {
         val a = action.value
-        val existing = state.inputRequests
-        val idx = existing?.indexOfFirst { it.id == a.requestId } ?: -1
-        if (existing == null || idx < 0) {
+        val activeTurn = state.activeTurn
+        val idx = activeTurn?.responseParts?.indexOfFirst { part ->
+            part is ResponsePartInputRequest
+                && part.value.response == null
+                && part.value.request.id == a.requestId
+        } ?: -1
+        if (activeTurn == null || idx < 0) {
             state
         } else {
-            val request = existing[idx]
+            val part = (activeTurn.responseParts[idx] as ResponsePartInputRequest).value
+            val request = part.request
             val answers = (request.answers ?: emptyMap()).toMutableMap()
             if (a.answer == null) {
                 answers.remove(a.questionId)
@@ -1256,9 +1279,11 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
                 answers[a.questionId] = a.answer
             }
             val newRequest = request.copy(answers = if (answers.isEmpty()) null else answers)
-            val updated = existing.toMutableList().also { it[idx] = newRequest }
+            val updated = activeTurn.responseParts.toMutableList().also {
+                it[idx] = ResponsePartInputRequest(part.copy(request = newRequest))
+            }
             state.copy(
-                inputRequests = updated,
+                activeTurn = activeTurn.copy(responseParts = updated),
                 modifiedAt = nowIsoString(),
             )
         }
@@ -1266,31 +1291,26 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
 
     is StateActionChatInputCompleted -> {
         val a = action.value
-        val existing = state.inputRequests
-        val completed = existing?.firstOrNull { it.id == a.requestId }
-        if (existing == null || completed == null) {
+        val activeTurn = state.activeTurn
+        val idx = activeTurn?.responseParts?.indexOfFirst { part ->
+            part is ResponsePartInputRequest
+                && part.value.response == null
+                && part.value.request.id == a.requestId
+        } ?: -1
+        if (activeTurn == null || idx < 0) {
             state
         } else {
-            val remaining = existing.filter { it.id != a.requestId }
-            var next = state.copy(inputRequests = remaining.ifEmpty { null })
-            // Project the resolved request into the active turn's transcript so
-            // the decision survives after the live request is gone. Abandoned
-            // requests (turn end/truncate) are removed without a part.
-            val activeTurn = next.activeTurn
-            if (activeTurn != null) {
-                val finalAnswers = (completed.answers ?: emptyMap()) + (a.answers ?: emptyMap())
-                val request = completed.copy(answers = finalAnswers.ifEmpty { null })
-                val newPart = ResponsePartInputRequest(
-                    InputRequestResponsePart(
-                        kind = ResponsePartKind.INPUT_REQUEST,
-                        request = request,
+            val part = (activeTurn.responseParts[idx] as ResponsePartInputRequest).value
+            val finalAnswers = (part.request.answers ?: emptyMap()) + (a.answers ?: emptyMap())
+            val updated = activeTurn.responseParts.toMutableList().also {
+                it[idx] = ResponsePartInputRequest(
+                    part.copy(
+                        request = part.request.copy(answers = finalAnswers.ifEmpty { null }),
                         response = a.response,
                     ),
                 )
-                next = next.copy(
-                    activeTurn = activeTurn.copy(responseParts = activeTurn.responseParts + newPart),
-                )
             }
+            val next = state.copy(activeTurn = activeTurn.copy(responseParts = updated))
             next.copy(
                 status = chatSummaryStatus(next),
                 modifiedAt = nowIsoString(),

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -293,7 +293,7 @@ enum class ChatInputResponseKind {
 @Serializable
 enum class SessionInputRequestKind {
     /**
-     * A user-facing elicitation mirrored from a chat's `inputRequests`.
+     * A user-facing elicitation mirrored from an unresolved chat response part.
      */
     @SerialName("chatInput")
     CHAT_INPUT,
@@ -1186,10 +1186,6 @@ data class ChatState(
      * Messages to send automatically as new turns after the current turn finishes
      */
     val queuedMessages: List<PendingMessage>? = null,
-    /**
-     * Requests for user input that are currently blocking or informing chat progress
-     */
-    val inputRequests: List<ChatInputRequest>? = null,
     /**
      * The user's in-progress draft input for this chat — the message they are
      * composing but have not sent yet, including its
@@ -2381,14 +2377,15 @@ data class InputRequestResponsePart(
      */
     val kind: ResponsePartKind,
     /**
-     * The resolved request, carrying its `id`, `message`, `url`, `questions`,
-     * and the final `answers` synced/submitted at completion.
+     * The request, carrying its `id`, `message`, `url`, `questions`, and current
+     * draft or submitted `answers`.
      */
     val request: ChatInputRequest,
     /**
-     * How the request was resolved: `accept`, `decline`, or `cancel`.
+     * How the request was resolved. Absent until a client submits `accept`,
+     * `decline`, or `cancel` with `chat/inputCompleted`.
      */
-    val response: ChatInputResponseKind
+    val response: ChatInputResponseKind? = null
 )
 
 @Serializable

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -1029,9 +1029,9 @@ pub struct ChatDraftChangedAction {
 
 /// A session requested input from the user.
 ///
-/// Full-request upsert semantics: the `request` replaces any existing request
-/// with the same `id`, or is appended if it is new. Answer drafts are preserved
-/// unless `request.answers` is provided.
+/// Creates an unresolved {@link InputRequestResponsePart} in the active turn,
+/// or replaces the unresolved part with the same request `id`. Answer drafts
+/// are preserved unless `request.answers` is provided.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatInputRequestedAction {
@@ -1054,10 +1054,11 @@ pub struct ChatInputAnswerChangedAction {
     pub answer: Option<ChatInputAnswer>,
 }
 
-/// A client accepted, declined, or cancelled a session input request.
+/// A client submitted an accept, decline, or cancel response to an input request.
 ///
 /// If accepted, the server uses `answers` (when provided) plus the request's
-/// synced answer state to resume the blocked operation.
+/// synced answer state to resume the blocked operation. The reducer records the
+/// response and final answers on the existing {@link InputRequestResponsePart}.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatInputCompletedAction {

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -235,7 +235,7 @@ pub enum ChatInputResponseKind {
 /// a `*Kind`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SessionInputRequestKind {
-    /// A user-facing elicitation mirrored from a chat's `inputRequests`.
+    /// A user-facing elicitation mirrored from an unresolved chat response part.
     #[serde(rename = "chatInput")]
     ChatInput,
     /// A tool call awaiting parameter- or result-confirmation.
@@ -1024,9 +1024,6 @@ pub struct ChatState {
     /// Messages to send automatically as new turns after the current turn finishes
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub queued_messages: Option<Vec<PendingMessage>>,
-    /// Requests for user input that are currently blocking or informing chat progress
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub input_requests: Option<Vec<ChatInputRequest>>,
     /// The user's in-progress draft input for this chat — the message they are
     /// composing but have not sent yet, including its
     /// {@link Message.model | model} / {@link Message.agent | agent} selection
@@ -1222,8 +1219,8 @@ pub struct SessionActiveClient {
     pub customizations: Option<Vec<ClientPluginCustomization>>,
 }
 
-/// A user-input elicitation surfaced at the session level, mirroring one entry
-/// of the owning chat's {@link ChatState.inputRequests}.
+/// A user-input elicitation surfaced at the session level, mirroring the request
+/// from an unresolved {@link InputRequestResponsePart} in the owning chat.
 ///
 /// Respond by dispatching `chat/inputCompleted` (or syncing drafts with
 /// `chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},
@@ -1812,11 +1809,11 @@ pub struct ChatInputMultiSelectQuestion {
     pub max: Option<i64>,
 }
 
-/// A live request for user input.
+/// The request payload carried by an {@link InputRequestResponsePart}.
 ///
-/// The server creates or replaces requests with `chat/inputRequested`.
-/// Clients sync drafts with `chat/inputAnswerChanged` and complete requests
-/// with `chat/inputCompleted`.
+/// The server creates or replaces the containing response part with
+/// `chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`
+/// and submit responses with `chat/inputCompleted`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatInputRequest {
@@ -2137,27 +2134,26 @@ pub struct SystemNotificationResponsePart {
     pub meta: Option<JsonObject>,
 }
 
-/// A resolved input request (elicitation) recorded in the turn transcript.
+/// A live or resolved input request (elicitation) in the turn response stream.
 ///
-/// While an input request is open it lives in {@link ChatState.inputRequests}
-/// as live, interactive state (see {@link ChatInputRequest}). When the request
-/// completes via `chat/inputCompleted`, the reducer removes it from
-/// `inputRequests` and appends this part to the active turn so the decision
-/// survives in history. This mirrors how a tool-call confirmation persists in
-/// its {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the
-/// terminal {@link ToolCallState}): the live surface drives in-flight UX, the
-/// terminal outcome is durable and backfillable via `fetchTurns`.
+/// The server inserts the part with `chat/inputRequested`. While
+/// {@link response} is absent, clients can update answer drafts with
+/// `chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.
+/// Completion updates this part in place so its stream position is stable and
+/// the full interaction remains durable and backfillable via `fetchTurns`.
 ///
-/// No part is recorded when an outstanding request is *abandoned* (the turn
-/// completes, is cancelled, errors, or is truncated) rather than *completed*.
+/// If the turn ends without a submitted response, the unresolved part remains
+/// in the completed turn transcript with {@link response} absent.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InputRequestResponsePart {
-    /// The resolved request, carrying its `id`, `message`, `url`, `questions`,
-    /// and the final `answers` synced/submitted at completion.
+    /// The request, carrying its `id`, `message`, `url`, `questions`, and current
+    /// draft or submitted `answers`.
     pub request: ChatInputRequest,
-    /// How the request was resolved: `accept`, `decline`, or `cancel`.
-    pub response: ChatInputResponseKind,
+    /// How the request was resolved. Absent until a client submits `accept`,
+    /// `decline`, or `cancel` with `chat/inputCompleted`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response: Option<ChatInputResponseKind>,
 }
 
 /// Tool execution result details, available after execution completes.

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -263,12 +263,7 @@ fn with_input_needed_status(status: u32, input_needed: &[SessionInputRequest]) -
 fn summary_status(state: &ChatState, terminal: Option<SessionStatus>) -> u32 {
     let activity: u32 = if let Some(t) = terminal {
         t.bits()
-    } else if state
-        .input_requests
-        .as_ref()
-        .map(|r| !r.is_empty())
-        .unwrap_or(false)
-        || has_blocking_tool_call(state)
+    } else if has_open_input_request(state) || has_blocking_tool_call(state)
     {
         SessionStatus::InputNeeded.bits()
     } else if state.active_turn.is_some() {
@@ -277,6 +272,18 @@ fn summary_status(state: &ChatState, terminal: Option<SessionStatus>) -> u32 {
         SessionStatus::Idle.bits()
     };
     (state.status & !STATUS_ACTIVITY_MASK) | activity
+}
+
+fn has_open_input_request(state: &ChatState) -> bool {
+    state
+        .active_turn
+        .as_ref()
+        .map(|turn| {
+            turn.response_parts.iter().any(|part| {
+                matches!(part, ResponsePart::InputRequest(input) if input.response.is_none())
+            })
+        })
+        .unwrap_or(false)
 }
 
 fn refresh_summary_status(state: &mut ChatState) {
@@ -373,28 +380,43 @@ fn end_turn(
     };
 
     state.turns.push(turn);
-    state.input_requests = None;
     state.modified_at = now_iso();
     state.status = summary_status(state, terminal_status);
     ReduceOutcome::Applied
 }
 
-fn upsert_input_request(state: &mut ChatState, request: ChatInputRequest) {
-    let existing = state.input_requests.get_or_insert_with(Vec::new);
-    if let Some(idx) = existing.iter().position(|r| r.id == request.id) {
+fn upsert_input_request(state: &mut ChatState, request: ChatInputRequest) -> ReduceOutcome {
+    let Some(active) = state.active_turn.as_mut() else {
+        return ReduceOutcome::NoOp;
+    };
+    if let Some(existing) = active.response_parts.iter_mut().find_map(|part| match part {
+        ResponsePart::InputRequest(input)
+            if input.response.is_none() && input.request.id == request.id =>
+        {
+            Some(input)
+        }
+        _ => None,
+    }) {
         let answers = request
             .answers
             .clone()
-            .or_else(|| existing[idx].answers.clone());
+            .or_else(|| existing.request.answers.clone());
         let mut next = request;
         next.answers = answers;
-        existing[idx] = next;
+        existing.request = next;
+        existing.response = None;
     } else {
-        existing.push(request);
+        active
+            .response_parts
+            .push(ResponsePart::InputRequest(InputRequestResponsePart {
+                request,
+                response: None,
+            }));
     }
     state.status = summary_status(state, None);
     touch_chat_modified(state);
     state.status = with_status_flag(state.status, SessionStatus::IsRead, false);
+    ReduceOutcome::Applied
 }
 
 // ─── Customization Helpers ───────────────────────────────────────────────────
@@ -1020,48 +1042,35 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
             ReduceOutcome::Applied
         }
         StateAction::ChatInputRequested(a) => {
-            upsert_input_request(state, a.request.clone());
-            ReduceOutcome::Applied
+            upsert_input_request(state, a.request.clone())
         }
         StateAction::ChatInputAnswerChanged(a) => apply_input_answer_changed(state, a),
         StateAction::ChatInputCompleted(a) => {
-            let Some(list) = state.input_requests.as_ref() else {
+            let Some(active) = state.active_turn.as_mut() else {
                 return ReduceOutcome::NoOp;
             };
-            let Some(completed) = list.iter().find(|r| r.id == a.request_id).cloned() else {
+            let Some(part) = active.response_parts.iter_mut().find_map(|part| match part {
+                ResponsePart::InputRequest(input)
+                    if input.response.is_none() && input.request.id == a.request_id =>
+                {
+                    Some(input)
+                }
+                _ => None,
+            }) else {
                 return ReduceOutcome::NoOp;
             };
-            if let Some(list) = state.input_requests.as_mut() {
-                list.retain(|r| r.id != a.request_id);
-                if list.is_empty() {
-                    state.input_requests = None;
+            let mut final_answers = part.request.answers.clone().unwrap_or_default();
+            if let Some(answers) = &a.answers {
+                for (k, v) in answers {
+                    final_answers.insert(k.clone(), v.clone());
                 }
             }
-            // Project the resolved request into the active turn's transcript so
-            // the decision survives after the live request is gone. Abandoned
-            // requests (turn end/truncate) are removed without a part.
-            if let Some(active) = state.active_turn.as_mut() {
-                let mut final_answers = completed.answers.clone().unwrap_or_default();
-                if let Some(answers) = &a.answers {
-                    for (k, v) in answers {
-                        final_answers.insert(k.clone(), v.clone());
-                    }
-                }
-                let request = ChatInputRequest {
-                    answers: if final_answers.is_empty() {
-                        None
-                    } else {
-                        Some(final_answers)
-                    },
-                    ..completed
-                };
-                active
-                    .response_parts
-                    .push(ResponsePart::InputRequest(InputRequestResponsePart {
-                        request,
-                        response: a.response,
-                    }));
-            }
+            part.request.answers = if final_answers.is_empty() {
+                None
+            } else {
+                Some(final_answers)
+            };
+            part.response = Some(a.response);
             refresh_summary_status(state);
             touch_chat_modified(state);
             ReduceOutcome::Applied
@@ -1538,7 +1547,6 @@ fn apply_truncated(state: &mut ChatState, turn_id: Option<&str>) -> ReduceOutcom
         }
     }
     state.active_turn = None;
-    state.input_requests = None;
     touch_chat_modified(state);
     state.status = summary_status(state, None);
     ReduceOutcome::Applied
@@ -1548,13 +1556,20 @@ fn apply_input_answer_changed(
     state: &mut ChatState,
     a: &ChatInputAnswerChangedAction,
 ) -> ReduceOutcome {
-    let Some(list) = state.input_requests.as_mut() else {
+    let Some(active) = state.active_turn.as_mut() else {
         return ReduceOutcome::NoOp;
     };
-    let Some(idx) = list.iter().position(|r| r.id == a.request_id) else {
+    let Some(part) = active.response_parts.iter_mut().find_map(|part| match part {
+        ResponsePart::InputRequest(input)
+            if input.response.is_none() && input.request.id == a.request_id =>
+        {
+            Some(input)
+        }
+        _ => None,
+    }) else {
         return ReduceOutcome::NoOp;
     };
-    let req = &mut list[idx];
+    let req = &mut part.request;
     let answers = req.answers.get_or_insert_with(HashMap::new);
     match &a.answer {
         None => {
@@ -1919,7 +1934,6 @@ mod tests {
             active_turn: None,
             steering_message: None,
             queued_messages: None,
-            input_requests: None,
             draft: None,
             meta: None,
         }

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -263,8 +263,7 @@ fn with_input_needed_status(status: u32, input_needed: &[SessionInputRequest]) -
 fn summary_status(state: &ChatState, terminal: Option<SessionStatus>) -> u32 {
     let activity: u32 = if let Some(t) = terminal {
         t.bits()
-    } else if has_open_input_request(state) || has_blocking_tool_call(state)
-    {
+    } else if has_open_input_request(state) || has_blocking_tool_call(state) {
         SessionStatus::InputNeeded.bits()
     } else if state.active_turn.is_some() {
         SessionStatus::InProgress.bits()
@@ -389,14 +388,18 @@ fn upsert_input_request(state: &mut ChatState, request: ChatInputRequest) -> Red
     let Some(active) = state.active_turn.as_mut() else {
         return ReduceOutcome::NoOp;
     };
-    if let Some(existing) = active.response_parts.iter_mut().find_map(|part| match part {
-        ResponsePart::InputRequest(input)
-            if input.response.is_none() && input.request.id == request.id =>
-        {
-            Some(input)
-        }
-        _ => None,
-    }) {
+    if let Some(existing) = active
+        .response_parts
+        .iter_mut()
+        .find_map(|part| match part {
+            ResponsePart::InputRequest(input)
+                if input.response.is_none() && input.request.id == request.id =>
+            {
+                Some(input)
+            }
+            _ => None,
+        })
+    {
         let answers = request
             .answers
             .clone()
@@ -1041,22 +1044,24 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
             state.turns_next_cursor = a.turns_next_cursor.clone();
             ReduceOutcome::Applied
         }
-        StateAction::ChatInputRequested(a) => {
-            upsert_input_request(state, a.request.clone())
-        }
+        StateAction::ChatInputRequested(a) => upsert_input_request(state, a.request.clone()),
         StateAction::ChatInputAnswerChanged(a) => apply_input_answer_changed(state, a),
         StateAction::ChatInputCompleted(a) => {
             let Some(active) = state.active_turn.as_mut() else {
                 return ReduceOutcome::NoOp;
             };
-            let Some(part) = active.response_parts.iter_mut().find_map(|part| match part {
-                ResponsePart::InputRequest(input)
-                    if input.response.is_none() && input.request.id == a.request_id =>
-                {
-                    Some(input)
-                }
-                _ => None,
-            }) else {
+            let Some(part) = active
+                .response_parts
+                .iter_mut()
+                .find_map(|part| match part {
+                    ResponsePart::InputRequest(input)
+                        if input.response.is_none() && input.request.id == a.request_id =>
+                    {
+                        Some(input)
+                    }
+                    _ => None,
+                })
+            else {
                 return ReduceOutcome::NoOp;
             };
             let mut final_answers = part.request.answers.clone().unwrap_or_default();
@@ -1559,14 +1564,18 @@ fn apply_input_answer_changed(
     let Some(active) = state.active_turn.as_mut() else {
         return ReduceOutcome::NoOp;
     };
-    let Some(part) = active.response_parts.iter_mut().find_map(|part| match part {
-        ResponsePart::InputRequest(input)
-            if input.response.is_none() && input.request.id == a.request_id =>
-        {
-            Some(input)
-        }
-        _ => None,
-    }) else {
+    let Some(part) = active
+        .response_parts
+        .iter_mut()
+        .find_map(|part| match part {
+            ResponsePart::InputRequest(input)
+                if input.response.is_none() && input.request.id == a.request_id =>
+            {
+                Some(input)
+            }
+            _ => None,
+        })
+    else {
         return ReduceOutcome::NoOp;
     };
     let req = &mut part.request;

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -153,7 +153,7 @@ public enum ChatInputResponseKind: String, Codable, Sendable {
 /// This is a general/typological union (not a lifecycle), so the discriminant is
 /// a `*Kind`.
 public enum SessionInputRequestKind: String, Codable, Sendable {
-    /// A user-facing elicitation mirrored from a chat's `inputRequests`.
+    /// A user-facing elicitation mirrored from an unresolved chat response part.
     case chatInput = "chatInput"
     /// A tool call awaiting parameter- or result-confirmation.
     case toolConfirmation = "toolConfirmation"
@@ -892,8 +892,6 @@ public struct ChatState: Codable, Sendable {
     public var steeringMessage: PendingMessage?
     /// Messages to send automatically as new turns after the current turn finishes
     public var queuedMessages: [PendingMessage]?
-    /// Requests for user input that are currently blocking or informing chat progress
-    public var inputRequests: [ChatInputRequest]?
     /// The user's in-progress draft input for this chat — the message they are
     /// composing but have not sent yet, including its
     /// {@link Message.model | model} / {@link Message.agent | agent} selection
@@ -923,7 +921,6 @@ public struct ChatState: Codable, Sendable {
         case activeTurn
         case steeringMessage
         case queuedMessages
-        case inputRequests
         case draft
         case meta = "_meta"
     }
@@ -942,7 +939,6 @@ public struct ChatState: Codable, Sendable {
         activeTurn: ActiveTurn? = nil,
         steeringMessage: PendingMessage? = nil,
         queuedMessages: [PendingMessage]? = nil,
-        inputRequests: [ChatInputRequest]? = nil,
         draft: Message? = nil,
         meta: [String: AnyCodable]? = nil
     ) {
@@ -959,7 +955,6 @@ public struct ChatState: Codable, Sendable {
         self.activeTurn = activeTurn
         self.steeringMessage = steeringMessage
         self.queuedMessages = queuedMessages
-        self.inputRequests = inputRequests
         self.draft = draft
         self.meta = meta
     }
@@ -2381,16 +2376,17 @@ public struct SystemNotificationResponsePart: Codable, Sendable {
 public struct InputRequestResponsePart: Codable, Sendable {
     /// Discriminant
     public var kind: ResponsePartKind
-    /// The resolved request, carrying its `id`, `message`, `url`, `questions`,
-    /// and the final `answers` synced/submitted at completion.
+    /// The request, carrying its `id`, `message`, `url`, `questions`, and current
+    /// draft or submitted `answers`.
     public var request: ChatInputRequest
-    /// How the request was resolved: `accept`, `decline`, or `cancel`.
-    public var response: ChatInputResponseKind
+    /// How the request was resolved. Absent until a client submits `accept`,
+    /// `decline`, or `cancel` with `chat/inputCompleted`.
+    public var response: ChatInputResponseKind?
 
     public init(
         kind: ResponsePartKind,
         request: ChatInputRequest,
-        response: ChatInputResponseKind
+        response: ChatInputResponseKind? = nil
     ) {
         self.kind = kind
         self.request = request

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -489,7 +489,6 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
             next.turnsNextCursor = nil
         }
         next.activeTurn = nil
-        next.inputRequests = nil
         next.status = chatSummaryStatus(next)
         next.modifiedAt = currentTimestamp()
         return next
@@ -508,11 +507,15 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
         return upsertInputRequest(state: state, request: a.request)
 
     case .chatInputAnswerChanged(let a):
-        guard var existing = state.inputRequests,
-              let idx = existing.firstIndex(where: { $0.id == a.requestId }) else {
+        guard var activeTurn = state.activeTurn,
+              let idx = activeTurn.responseParts.firstIndex(where: { part in
+                  guard case .inputRequest(let input) = part else { return false }
+                  return input.response == nil && input.request.id == a.requestId
+              }),
+              case .inputRequest(var part) = activeTurn.responseParts[idx] else {
             return state
         }
-        var request = existing[idx]
+        var request = part.request
         var answers = request.answers ?? [:]
         if let answer = a.answer {
             answers[a.questionId] = answer
@@ -520,39 +523,33 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
             answers.removeValue(forKey: a.questionId)
         }
         request.answers = answers.isEmpty ? nil : answers
-        existing[idx] = request
+        part.request = request
+        activeTurn.responseParts[idx] = .inputRequest(part)
         var next = state
-        next.inputRequests = existing
+        next.activeTurn = activeTurn
         next.modifiedAt = currentTimestamp()
         return next
 
     case .chatInputCompleted(let a):
-        guard var existing = state.inputRequests,
-              let completed = existing.first(where: { $0.id == a.requestId }) else {
+        guard var activeTurn = state.activeTurn,
+              let idx = activeTurn.responseParts.firstIndex(where: { part in
+                  guard case .inputRequest(let input) = part else { return false }
+                  return input.response == nil && input.request.id == a.requestId
+              }),
+              case .inputRequest(var part) = activeTurn.responseParts[idx] else {
             return state
         }
-        existing.removeAll { $0.id == a.requestId }
-        var next = state
-        next.inputRequests = existing.isEmpty ? nil : existing
-        // Project the resolved request into the active turn's transcript so the
-        // decision survives after the live request is gone. Abandoned requests
-        // (turn end/truncate) are removed without a part.
-        if var activeTurn = next.activeTurn {
-            var finalAnswers = completed.answers ?? [:]
-            if let answers = a.answers {
-                for (k, v) in answers {
-                    finalAnswers[k] = v
-                }
+        var finalAnswers = part.request.answers ?? [:]
+        if let answers = a.answers {
+            for (k, v) in answers {
+                finalAnswers[k] = v
             }
-            var request = completed
-            request.answers = finalAnswers.isEmpty ? nil : finalAnswers
-            activeTurn.responseParts.append(.inputRequest(InputRequestResponsePart(
-                kind: .inputRequest,
-                request: request,
-                response: a.response
-            )))
-            next.activeTurn = activeTurn
         }
+        part.request.answers = finalAnswers.isEmpty ? nil : finalAnswers
+        part.response = a.response
+        activeTurn.responseParts[idx] = .inputRequest(part)
+        var next = state
+        next.activeTurn = activeTurn
         next.status = chatSummaryStatus(next)
         next.modifiedAt = currentTimestamp()
         return next
@@ -915,7 +912,7 @@ private func chatSummaryStatus(_ state: ChatState, terminalStatus: SessionStatus
     let activity: SessionStatus
     if let terminalStatus {
         activity = terminalStatus
-    } else if state.inputRequests?.isEmpty == false || hasBlockingToolCall(state) {
+    } else if hasOpenInputRequest(state) || hasBlockingToolCall(state) {
         activity = .inputNeeded
     } else if state.activeTurn != nil {
         activity = .inProgress
@@ -923,6 +920,14 @@ private func chatSummaryStatus(_ state: ChatState, terminalStatus: SessionStatus
         activity = .idle
     }
     return state.status.subtracting(statusActivityMask).union(activity)
+}
+
+private func hasOpenInputRequest(_ state: ChatState) -> Bool {
+    guard let activeTurn = state.activeTurn else { return false }
+    return activeTurn.responseParts.contains { part in
+        guard case .inputRequest(let input) = part else { return false }
+        return input.response == nil
+    }
 }
 
 /// Returns `true` if the active turn has any tool call blocked on external input.
@@ -949,16 +954,25 @@ private func refreshChatSummaryStatus(_ state: ChatState) -> ChatState {
 }
 
 private func upsertInputRequest(state: ChatState, request: ChatInputRequest) -> ChatState {
-    var next = state
-    var existing = next.inputRequests ?? []
-    if let idx = existing.firstIndex(where: { $0.id == request.id }) {
+    guard var activeTurn = state.activeTurn else { return state }
+    if let idx = activeTurn.responseParts.firstIndex(where: { part in
+        guard case .inputRequest(let input) = part else { return false }
+        return input.response == nil && input.request.id == request.id
+    }), case .inputRequest(let existing) = activeTurn.responseParts[idx] {
         var replacement = request
-        replacement.answers = request.answers ?? existing[idx].answers
-        existing[idx] = replacement
+        replacement.answers = request.answers ?? existing.request.answers
+        activeTurn.responseParts[idx] = .inputRequest(InputRequestResponsePart(
+            kind: .inputRequest,
+            request: replacement
+        ))
     } else {
-        existing.append(request)
+        activeTurn.responseParts.append(.inputRequest(InputRequestResponsePart(
+            kind: .inputRequest,
+            request: request
+        )))
     }
-    next.inputRequests = existing
+    var next = state
+    next.activeTurn = activeTurn
     next.status = withStatusFlag(chatSummaryStatus(next), .isRead, false)
     next.modifiedAt = currentTimestamp()
     return next
@@ -1042,7 +1056,6 @@ private func endTurn(
     var next = state
     next.turns.append(turn)
     next.activeTurn = nil
-    next.inputRequests = nil
     next.status = chatSummaryStatus(next, terminalStatus: terminalStatus)
     next.modifiedAt = currentTimestamp()
     return next

--- a/docs/.changes/20260716-live-input-response-parts.json
+++ b/docs/.changes/20260716-live-input-response-parts.json
@@ -1,0 +1,5 @@
+{
+  "type": "changed",
+  "message": "Input requests now live in turn `responseParts`, with an optional `response` until `chat/inputCompleted` submits the result.",
+  "issues": [327]
+}

--- a/docs/guide/elicitation.md
+++ b/docs/guide/elicitation.md
@@ -1,53 +1,50 @@
 # Elicitation
 
-The agent can request structured input from the user by storing live input requests in per-chat state (`ChatState.inputRequests`) on the [chat channel](/specification/chat-channel). These requests are useful for MCP elicitation, URL-based review flows, and agent clarification questions.
+The agent can request structured input from the user by inserting an `InputRequestResponsePart` into the active turn on the [chat channel](/specification/chat-channel). These requests are useful for MCP elicitation, URL-based review flows, and agent clarification questions.
 
-Input requests are live state, not one-shot RPC prompts: every subscriber to the chat sees open requests and synchronized answer drafts.
+Input requests are live response parts, not one-shot RPC prompts: every subscriber to the chat sees open requests and synchronized answer drafts in their original response-stream position.
 
 ## State Shape
 
 ```typescript
-ChatState {
-  // ...existing fields...
-  inputRequests?: ChatInputRequest[]
-}
-
-ChatInputRequest {
-  id: string
-  message?: string
-  url?: URI
-  questions?: ChatInputQuestion[]
-  answers?: Record<string, ChatInputAnswer>
+InputRequestResponsePart {
+  kind: 'inputRequest'
+  request: {
+    id: string
+    message?: string
+    url?: URI
+    questions?: ChatInputQuestion[]
+    answers?: Record<string, ChatInputAnswer>
+  }
+  response?: 'accept' | 'decline' | 'cancel'
 }
 ```
 
-Each request has a stable `id`. Each question has a stable `id` used as the key in `answers`.
+The part lives in `ChatState.activeTurn.responseParts` while the turn is active, then moves unchanged into the completed turn. Each request has a stable `id`. Each question has a stable `id` used as the key in `answers`. An absent `response` means the request is still awaiting submission.
 
 ## Request Lifecycle
 
 The server SHOULD use this sequence when it needs user input to continue a turn:
 
 1. Keep the turn active.
-2. Dispatch `chat/inputRequested` with a stable request `id` and stable question IDs.
+2. Dispatch `chat/inputRequested` with a stable request `id` and stable question IDs. The reducer inserts an unresolved input-request part at the current end of the response stream.
 3. Observe zero or more client-dispatched `chat/inputAnswerChanged` actions. Each action updates one question's draft, submitted, or skipped answer.
-4. Observe `chat/inputCompleted` with `response: 'accept'`, `'decline'`, or `'cancel'`.
+4. Observe `chat/inputCompleted` with `response: 'accept'`, `'decline'`, or `'cancel'`. The reducer sets `response` and any final answers on that same part.
 5. Resume the blocked operation, such as completing an MCP `elicitation/create` request or returning a result for an ask-questions tool call.
 
-Because drafts live in chat state, a user can answer one question on client A and another on client B; every subscriber to the chat observes the merged `answers` map.
+Because drafts live in the response part, a user can answer one question on client A and another on client B; every subscriber to the chat observes the merged `answers` map.
 
 ## Status And Cleanup
 
-While a chat has any open input request, that chat's `status` carries `SessionStatus.InputNeeded`, and the session's aggregated `status` is promoted to `InputNeeded` because a chat needs input. When the last request is completed and the turn is still active, the chat's status returns to `SessionStatus.InProgress`.
+While the active turn has any input-request part without a `response`, that chat's `status` carries `SessionStatus.InputNeeded`, and the session's aggregated `status` is promoted to `InputNeeded` because a chat needs input. When the last request receives a response and the turn is still active, the chat's status returns to `SessionStatus.InProgress`.
 
-If the active turn completes, is cancelled, errors, or is truncated before input completes, the server SHOULD consider outstanding input requests abandoned. The reducer removes outstanding requests.
+If the active turn completes, is cancelled, or errors before input is submitted, the unresolved part remains in the completed transcript with `response` absent. Truncating the active turn removes it along with every other response part in that turn.
 
 ## Durable Record
 
-When `chat/inputCompleted` resolves a request while a turn is active, the reducer removes the live request from `inputRequests` and appends an `InputRequestResponsePart` (`kind: 'inputRequest'`) to the active turn's `responseParts`. This mirrors how a resolved tool-call confirmation persists on its terminal `ToolCallState`: the decision becomes part of the durable, replayable transcript instead of vanishing with the ephemeral request.
+`InputRequestResponsePart` is both the live interaction and its durable record. `chat/inputRequested` inserts it into the active turn, answer changes update it in place, and `chat/inputCompleted` sets its final `response` and answers without moving it. This mirrors how a tool-call confirmation remains on its `ToolCallResponsePart` throughout the lifecycle.
 
-The recorded part embeds the resolved `request` — carrying its `id`, `message`, `url`, `questions`, and the final `answers` (synced drafts overlaid by any `answers` supplied on `chat/inputCompleted`) — alongside the `response` (`accept`, `decline`, or `cancel`). All three outcomes are recorded, so a declined or cancelled prompt still leaves a trace a client can render after the fact.
-
-Abandonment is the one case that records nothing: when a turn ends, is cancelled, errors, or is truncated, outstanding requests are dropped without a transcript part, because no user decision was reached.
+The part embeds the request's `id`, `message`, `url`, `questions`, and current `answers`. On completion, any `answers` supplied by `chat/inputCompleted` overlay synchronized drafts. All three submitted outcomes are recorded, while an unanswered prompt remains distinguishable by its absent `response`.
 
 ## Questions And Answers
 
@@ -73,12 +70,12 @@ Servers SHOULD reject client-dispatched input actions when:
 
 | Action | Condition |
 |---|---|
-| `chat/inputAnswerChanged` | No input request has the matching `requestId`. |
+| `chat/inputAnswerChanged` | No unresolved input-request part has the matching `requestId` in the active turn. |
 | `chat/inputAnswerChanged` | `answer.state` requires a value but `answer.value` is absent, or the value kind does not match the answer payload. |
-| `chat/inputCompleted` | No input request has the matching `requestId`. |
+| `chat/inputCompleted` | No unresolved input-request part has the matching `requestId` in the active turn. |
 | `chat/inputCompleted` | `response` is `'accept'` but required questions do not have submitted answers. |
 
 ## Related Reference
 
-- [Chat Channel Reference](/reference/chat) — `ChatInputRequest`, `ChatInputQuestion`, answer value types, and the `chat/input*` action variants.
+- [Chat Channel Reference](/reference/chat) — `InputRequestResponsePart`, `ChatInputRequest`, question and answer value types, and the `chat/input*` action variants.
 - [Chat Channel](/specification/chat-channel) — Per-chat turns, active turn, tool calls, and client-action validation.

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -139,7 +139,7 @@ For example, `(status & SessionStatus.InProgress) !== 0` is true for both `InPro
 
 ## Chat State
 
-Subscribable on a [Chat Channel](/specification/chat-channel) at `ahp-chat:/<cid>`. A session is a catalog of chats (`SessionState.chats`); each chat carries the per-conversation state — the turn history, the active turn and its streaming response parts, tool calls, steering/queued messages, outstanding input requests, and the user's in-progress draft. A session starts with a default chat (`SessionState.defaultChat`); hosts advertising the `multipleChats` capability let clients open more via `createChat`.
+Subscribable on a [Chat Channel](/specification/chat-channel) at `ahp-chat:/<cid>`. A session is a catalog of chats (`SessionState.chats`); each chat carries the per-conversation state — the turn history, the active turn and its streaming response parts (including live input requests), tool calls, steering/queued messages, and the user's in-progress draft. A session starts with a default chat (`SessionState.defaultChat`); hosts advertising the `multipleChats` capability let clients open more via `createChat`.
 
 ```typescript
 ChatState {
@@ -157,7 +157,6 @@ ChatState {
   activeTurn?: ActiveTurn             // the in-progress turn, if any
   steeringMessage?: PendingMessage
   queuedMessages?: PendingMessage[]
-  inputRequests?: ChatInputRequest[]
   draft?: Message                     // user's in-progress input
 }
 ```
@@ -423,24 +422,17 @@ For example, a server might offer `"Approve"`, `"Approve in this Session"`, `"De
 
 ## Input Requests
 
-A chat can request structured input from the user by storing live requests in its chat state (on the chat channel):
+A chat can request structured input from the user with a live response part in its active turn:
 
 ```typescript
-ChatState {
-  // ...existing fields...
-  inputRequests?: ChatInputRequest[]
-}
-
-ChatInputRequest {
-  id: string
-  message?: string
-  url?: URI
-  questions?: ChatInputQuestion[]
-  answers?: Record<string, ChatInputAnswer>
+InputRequestResponsePart {
+  kind: 'inputRequest'
+  request: ChatInputRequest
+  response?: 'accept' | 'decline' | 'cancel'
 }
 ```
 
-See [Elicitation](/guide/elicitation) for the request lifecycle, question and answer shapes, URL requests, multi-client draft synchronization, and validation rules.
+An absent `response` marks a live request. `chat/inputCompleted` sets the response on the same part, preserving its response-stream position and transcript history. See [Elicitation](/guide/elicitation) for the request lifecycle, question and answer shapes, URL requests, multi-client draft synchronization, and validation rules.
 
 ## Usage Info
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1434,7 +1434,7 @@
     },
     "ChatInputRequestedAction": {
       "type": "object",
-      "description": "A session requested input from the user.\n\nFull-request upsert semantics: the `request` replaces any existing request\nwith the same `id`, or is appended if it is new. Answer drafts are preserved\nunless `request.answers` is provided.",
+      "description": "A session requested input from the user.\n\nCreates an unresolved {@link InputRequestResponsePart} in the active turn,\nor replaces the unresolved part with the same request `id`. Answer drafts\nare preserved unless `request.answers` is provided.",
       "properties": {
         "type": {
           "const": "chat/inputRequested"
@@ -1477,7 +1477,7 @@
     },
     "ChatInputCompletedAction": {
       "type": "object",
-      "description": "A client accepted, declined, or cancelled a session input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation.",
+      "description": "A client submitted an accept, decline, or cancel response to an input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation. The reducer records the\nresponse and final answers on the existing {@link InputRequestResponsePart}.",
       "properties": {
         "type": {
           "const": "chat/inputCompleted"
@@ -2936,7 +2936,7 @@
     },
     "SessionChatInputRequest": {
       "type": "object",
-      "description": "A user-input elicitation surfaced at the session level, mirroring one entry\nof the owning chat's {@link ChatState.inputRequests}.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
+      "description": "A user-input elicitation surfaced at the session level, mirroring the request\nfrom an unresolved {@link InputRequestResponsePart} in the owning chat.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
       "properties": {
         "id": {
           "type": "string",
@@ -4391,13 +4391,6 @@
           },
           "description": "Messages to send automatically as new turns after the current turn finishes"
         },
-        "inputRequests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChatInputRequest"
-          },
-          "description": "Requests for user input that are currently blocking or informing chat progress"
-        },
         "draft": {
           "$ref": "#/$defs/Message",
           "description": "The user's in-progress draft input for this chat — the message they are\ncomposing but have not sent yet, including its\n{@link Message.model | model} / {@link Message.agent | agent} selection\nand attachments.\n\nClients MAY periodically sync their local input state into this field so\na draft survives reloads and is visible to other clients viewing the same\nchat. Eager syncing is **not** required — clients SHOULD debounce and MAY\nsync only at convenient points. When presenting input UI for an existing\nchat, clients SHOULD use any `draft` to initialize their input state.\nCleared (set to `undefined`) once the message is sent."
@@ -4752,7 +4745,7 @@
     },
     "ChatInputRequest": {
       "type": "object",
-      "description": "A live request for user input.\n\nThe server creates or replaces requests with `chat/inputRequested`.\nClients sync drafts with `chat/inputAnswerChanged` and complete requests\nwith `chat/inputCompleted`.",
+      "description": "The request payload carried by an {@link InputRequestResponsePart}.\n\nThe server creates or replaces the containing response part with\n`chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`\nand submit responses with `chat/inputCompleted`.",
       "properties": {
         "id": {
           "type": "string",
@@ -5352,7 +5345,7 @@
     },
     "InputRequestResponsePart": {
       "type": "object",
-      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "description": "A live or resolved input request (elicitation) in the turn response stream.\n\nThe server inserts the part with `chat/inputRequested`. While\n{@link response} is absent, clients can update answer drafts with\n`chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.\nCompletion updates this part in place so its stream position is stable and\nthe full interaction remains durable and backfillable via `fetchTurns`.\n\nIf the turn ends without a submitted response, the unresolved part remains\nin the completed turn transcript with {@link response} absent.",
       "properties": {
         "kind": {
           "const": "inputRequest",
@@ -5360,17 +5353,16 @@
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
-          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+          "description": "The request, carrying its `id`, `message`, `url`, `questions`, and current\ndraft or submitted `answers`."
         },
         "response": {
           "$ref": "#/$defs/ChatInputResponseKind",
-          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+          "description": "How the request was resolved. Absent until a client submits `accept`,\n`decline`, or `cancel` with `chat/inputCompleted`."
         }
       },
       "required": [
         "kind",
-        "request",
-        "response"
+        "request"
       ]
     },
     "SystemNotificationResponsePart": {

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2142,7 +2142,7 @@
     },
     "SessionChatInputRequest": {
       "type": "object",
-      "description": "A user-input elicitation surfaced at the session level, mirroring one entry\nof the owning chat's {@link ChatState.inputRequests}.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
+      "description": "A user-input elicitation surfaced at the session level, mirroring the request\nfrom an unresolved {@link InputRequestResponsePart} in the owning chat.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
       "properties": {
         "id": {
           "type": "string",
@@ -3597,13 +3597,6 @@
           },
           "description": "Messages to send automatically as new turns after the current turn finishes"
         },
-        "inputRequests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChatInputRequest"
-          },
-          "description": "Requests for user input that are currently blocking or informing chat progress"
-        },
         "draft": {
           "$ref": "#/$defs/Message",
           "description": "The user's in-progress draft input for this chat — the message they are\ncomposing but have not sent yet, including its\n{@link Message.model | model} / {@link Message.agent | agent} selection\nand attachments.\n\nClients MAY periodically sync their local input state into this field so\na draft survives reloads and is visible to other clients viewing the same\nchat. Eager syncing is **not** required — clients SHOULD debounce and MAY\nsync only at convenient points. When presenting input UI for an existing\nchat, clients SHOULD use any `draft` to initialize their input state.\nCleared (set to `undefined`) once the message is sent."
@@ -3958,7 +3951,7 @@
     },
     "ChatInputRequest": {
       "type": "object",
-      "description": "A live request for user input.\n\nThe server creates or replaces requests with `chat/inputRequested`.\nClients sync drafts with `chat/inputAnswerChanged` and complete requests\nwith `chat/inputCompleted`.",
+      "description": "The request payload carried by an {@link InputRequestResponsePart}.\n\nThe server creates or replaces the containing response part with\n`chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`\nand submit responses with `chat/inputCompleted`.",
       "properties": {
         "id": {
           "type": "string",
@@ -4558,7 +4551,7 @@
     },
     "InputRequestResponsePart": {
       "type": "object",
-      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "description": "A live or resolved input request (elicitation) in the turn response stream.\n\nThe server inserts the part with `chat/inputRequested`. While\n{@link response} is absent, clients can update answer drafts with\n`chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.\nCompletion updates this part in place so its stream position is stable and\nthe full interaction remains durable and backfillable via `fetchTurns`.\n\nIf the turn ends without a submitted response, the unresolved part remains\nin the completed turn transcript with {@link response} absent.",
       "properties": {
         "kind": {
           "const": "inputRequest",
@@ -4566,17 +4559,16 @@
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
-          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+          "description": "The request, carrying its `id`, `message`, `url`, `questions`, and current\ndraft or submitted `answers`."
         },
         "response": {
           "$ref": "#/$defs/ChatInputResponseKind",
-          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+          "description": "How the request was resolved. Absent until a client submits `accept`,\n`decline`, or `cancel` with `chat/inputCompleted`."
         }
       },
       "required": [
         "kind",
-        "request",
-        "response"
+        "request"
       ]
     },
     "SystemNotificationResponsePart": {
@@ -7507,7 +7499,7 @@
     },
     "ChatInputRequestedAction": {
       "type": "object",
-      "description": "A session requested input from the user.\n\nFull-request upsert semantics: the `request` replaces any existing request\nwith the same `id`, or is appended if it is new. Answer drafts are preserved\nunless `request.answers` is provided.",
+      "description": "A session requested input from the user.\n\nCreates an unresolved {@link InputRequestResponsePart} in the active turn,\nor replaces the unresolved part with the same request `id`. Answer drafts\nare preserved unless `request.answers` is provided.",
       "properties": {
         "type": {
           "const": "chat/inputRequested"
@@ -7550,7 +7542,7 @@
     },
     "ChatInputCompletedAction": {
       "type": "object",
-      "description": "A client accepted, declined, or cancelled a session input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation.",
+      "description": "A client submitted an accept, decline, or cancel response to an input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation. The reducer records the\nresponse and final answers on the existing {@link InputRequestResponsePart}.",
       "properties": {
         "type": {
           "const": "chat/inputCompleted"

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -926,7 +926,7 @@
     },
     "SessionChatInputRequest": {
       "type": "object",
-      "description": "A user-input elicitation surfaced at the session level, mirroring one entry\nof the owning chat's {@link ChatState.inputRequests}.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
+      "description": "A user-input elicitation surfaced at the session level, mirroring the request\nfrom an unresolved {@link InputRequestResponsePart} in the owning chat.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
       "properties": {
         "id": {
           "type": "string",
@@ -2381,13 +2381,6 @@
           },
           "description": "Messages to send automatically as new turns after the current turn finishes"
         },
-        "inputRequests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChatInputRequest"
-          },
-          "description": "Requests for user input that are currently blocking or informing chat progress"
-        },
         "draft": {
           "$ref": "#/$defs/Message",
           "description": "The user's in-progress draft input for this chat — the message they are\ncomposing but have not sent yet, including its\n{@link Message.model | model} / {@link Message.agent | agent} selection\nand attachments.\n\nClients MAY periodically sync their local input state into this field so\na draft survives reloads and is visible to other clients viewing the same\nchat. Eager syncing is **not** required — clients SHOULD debounce and MAY\nsync only at convenient points. When presenting input UI for an existing\nchat, clients SHOULD use any `draft` to initialize their input state.\nCleared (set to `undefined`) once the message is sent."
@@ -2742,7 +2735,7 @@
     },
     "ChatInputRequest": {
       "type": "object",
-      "description": "A live request for user input.\n\nThe server creates or replaces requests with `chat/inputRequested`.\nClients sync drafts with `chat/inputAnswerChanged` and complete requests\nwith `chat/inputCompleted`.",
+      "description": "The request payload carried by an {@link InputRequestResponsePart}.\n\nThe server creates or replaces the containing response part with\n`chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`\nand submit responses with `chat/inputCompleted`.",
       "properties": {
         "id": {
           "type": "string",
@@ -3342,7 +3335,7 @@
     },
     "InputRequestResponsePart": {
       "type": "object",
-      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "description": "A live or resolved input request (elicitation) in the turn response stream.\n\nThe server inserts the part with `chat/inputRequested`. While\n{@link response} is absent, clients can update answer drafts with\n`chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.\nCompletion updates this part in place so its stream position is stable and\nthe full interaction remains durable and backfillable via `fetchTurns`.\n\nIf the turn ends without a submitted response, the unresolved part remains\nin the completed turn transcript with {@link response} absent.",
       "properties": {
         "kind": {
           "const": "inputRequest",
@@ -3350,17 +3343,16 @@
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
-          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+          "description": "The request, carrying its `id`, `message`, `url`, `questions`, and current\ndraft or submitted `answers`."
         },
         "response": {
           "$ref": "#/$defs/ChatInputResponseKind",
-          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+          "description": "How the request was resolved. Absent until a client submits `accept`,\n`decline`, or `cancel` with `chat/inputCompleted`."
         }
       },
       "required": [
         "kind",
-        "request",
-        "response"
+        "request"
       ]
     },
     "SystemNotificationResponsePart": {
@@ -8319,7 +8311,7 @@
     },
     "ChatInputRequestedAction": {
       "type": "object",
-      "description": "A session requested input from the user.\n\nFull-request upsert semantics: the `request` replaces any existing request\nwith the same `id`, or is appended if it is new. Answer drafts are preserved\nunless `request.answers` is provided.",
+      "description": "A session requested input from the user.\n\nCreates an unresolved {@link InputRequestResponsePart} in the active turn,\nor replaces the unresolved part with the same request `id`. Answer drafts\nare preserved unless `request.answers` is provided.",
       "properties": {
         "type": {
           "const": "chat/inputRequested"
@@ -8362,7 +8354,7 @@
     },
     "ChatInputCompletedAction": {
       "type": "object",
-      "description": "A client accepted, declined, or cancelled a session input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation.",
+      "description": "A client submitted an accept, decline, or cancel response to an input request.\n\nIf accepted, the server uses `answers` (when provided) plus the request's\nsynced answer state to resume the blocked operation. The reducer records the\nresponse and final answers on the existing {@link InputRequestResponsePart}.",
       "properties": {
         "type": {
           "const": "chat/inputCompleted"

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1086,7 +1086,7 @@
     },
     "SessionChatInputRequest": {
       "type": "object",
-      "description": "A user-input elicitation surfaced at the session level, mirroring one entry\nof the owning chat's {@link ChatState.inputRequests}.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
+      "description": "A user-input elicitation surfaced at the session level, mirroring the request\nfrom an unresolved {@link InputRequestResponsePart} in the owning chat.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
       "properties": {
         "id": {
           "type": "string",
@@ -2541,13 +2541,6 @@
           },
           "description": "Messages to send automatically as new turns after the current turn finishes"
         },
-        "inputRequests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChatInputRequest"
-          },
-          "description": "Requests for user input that are currently blocking or informing chat progress"
-        },
         "draft": {
           "$ref": "#/$defs/Message",
           "description": "The user's in-progress draft input for this chat — the message they are\ncomposing but have not sent yet, including its\n{@link Message.model | model} / {@link Message.agent | agent} selection\nand attachments.\n\nClients MAY periodically sync their local input state into this field so\na draft survives reloads and is visible to other clients viewing the same\nchat. Eager syncing is **not** required — clients SHOULD debounce and MAY\nsync only at convenient points. When presenting input UI for an existing\nchat, clients SHOULD use any `draft` to initialize their input state.\nCleared (set to `undefined`) once the message is sent."
@@ -2902,7 +2895,7 @@
     },
     "ChatInputRequest": {
       "type": "object",
-      "description": "A live request for user input.\n\nThe server creates or replaces requests with `chat/inputRequested`.\nClients sync drafts with `chat/inputAnswerChanged` and complete requests\nwith `chat/inputCompleted`.",
+      "description": "The request payload carried by an {@link InputRequestResponsePart}.\n\nThe server creates or replaces the containing response part with\n`chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`\nand submit responses with `chat/inputCompleted`.",
       "properties": {
         "id": {
           "type": "string",
@@ -3502,7 +3495,7 @@
     },
     "InputRequestResponsePart": {
       "type": "object",
-      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "description": "A live or resolved input request (elicitation) in the turn response stream.\n\nThe server inserts the part with `chat/inputRequested`. While\n{@link response} is absent, clients can update answer drafts with\n`chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.\nCompletion updates this part in place so its stream position is stable and\nthe full interaction remains durable and backfillable via `fetchTurns`.\n\nIf the turn ends without a submitted response, the unresolved part remains\nin the completed turn transcript with {@link response} absent.",
       "properties": {
         "kind": {
           "const": "inputRequest",
@@ -3510,17 +3503,16 @@
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
-          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+          "description": "The request, carrying its `id`, `message`, `url`, `questions`, and current\ndraft or submitted `answers`."
         },
         "response": {
           "$ref": "#/$defs/ChatInputResponseKind",
-          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+          "description": "How the request was resolved. Absent until a client submits `accept`,\n`decline`, or `cancel` with `chat/inputCompleted`."
         }
       },
       "required": [
         "kind",
-        "request",
-        "response"
+        "request"
       ]
     },
     "SystemNotificationResponsePart": {

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -837,7 +837,7 @@
     },
     "SessionChatInputRequest": {
       "type": "object",
-      "description": "A user-input elicitation surfaced at the session level, mirroring one entry\nof the owning chat's {@link ChatState.inputRequests}.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
+      "description": "A user-input elicitation surfaced at the session level, mirroring the request\nfrom an unresolved {@link InputRequestResponsePart} in the owning chat.\n\nRespond by dispatching `chat/inputCompleted` (or syncing drafts with\n`chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},\nkeyed by {@link ChatInputRequest.id | `request.id`}.",
       "properties": {
         "id": {
           "type": "string",
@@ -2292,13 +2292,6 @@
           },
           "description": "Messages to send automatically as new turns after the current turn finishes"
         },
-        "inputRequests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChatInputRequest"
-          },
-          "description": "Requests for user input that are currently blocking or informing chat progress"
-        },
         "draft": {
           "$ref": "#/$defs/Message",
           "description": "The user's in-progress draft input for this chat — the message they are\ncomposing but have not sent yet, including its\n{@link Message.model | model} / {@link Message.agent | agent} selection\nand attachments.\n\nClients MAY periodically sync their local input state into this field so\na draft survives reloads and is visible to other clients viewing the same\nchat. Eager syncing is **not** required — clients SHOULD debounce and MAY\nsync only at convenient points. When presenting input UI for an existing\nchat, clients SHOULD use any `draft` to initialize their input state.\nCleared (set to `undefined`) once the message is sent."
@@ -2653,7 +2646,7 @@
     },
     "ChatInputRequest": {
       "type": "object",
-      "description": "A live request for user input.\n\nThe server creates or replaces requests with `chat/inputRequested`.\nClients sync drafts with `chat/inputAnswerChanged` and complete requests\nwith `chat/inputCompleted`.",
+      "description": "The request payload carried by an {@link InputRequestResponsePart}.\n\nThe server creates or replaces the containing response part with\n`chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`\nand submit responses with `chat/inputCompleted`.",
       "properties": {
         "id": {
           "type": "string",
@@ -3253,7 +3246,7 @@
     },
     "InputRequestResponsePart": {
       "type": "object",
-      "description": "A resolved input request (elicitation) recorded in the turn transcript.\n\nWhile an input request is open it lives in {@link ChatState.inputRequests}\nas live, interactive state (see {@link ChatInputRequest}). When the request\ncompletes via `chat/inputCompleted`, the reducer removes it from\n`inputRequests` and appends this part to the active turn so the decision\nsurvives in history. This mirrors how a tool-call confirmation persists in\nits {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the\nterminal {@link ToolCallState}): the live surface drives in-flight UX, the\nterminal outcome is durable and backfillable via `fetchTurns`.\n\nNo part is recorded when an outstanding request is *abandoned* (the turn\ncompletes, is cancelled, errors, or is truncated) rather than *completed*.",
+      "description": "A live or resolved input request (elicitation) in the turn response stream.\n\nThe server inserts the part with `chat/inputRequested`. While\n{@link response} is absent, clients can update answer drafts with\n`chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.\nCompletion updates this part in place so its stream position is stable and\nthe full interaction remains durable and backfillable via `fetchTurns`.\n\nIf the turn ends without a submitted response, the unresolved part remains\nin the completed turn transcript with {@link response} absent.",
       "properties": {
         "kind": {
           "const": "inputRequest",
@@ -3261,17 +3254,16 @@
         },
         "request": {
           "$ref": "#/$defs/ChatInputRequest",
-          "description": "The resolved request, carrying its `id`, `message`, `url`, `questions`,\nand the final `answers` synced/submitted at completion."
+          "description": "The request, carrying its `id`, `message`, `url`, `questions`, and current\ndraft or submitted `answers`."
         },
         "response": {
           "$ref": "#/$defs/ChatInputResponseKind",
-          "description": "How the request was resolved: `accept`, `decline`, or `cancel`."
+          "description": "How the request was resolved. Absent until a client submits `accept`,\n`decline`, or `cancel` with `chat/inputCompleted`."
         }
       },
       "required": [
         "kind",
-        "request",
-        "response"
+        "request"
       ]
     },
     "SystemNotificationResponsePart": {

--- a/types/channels-chat/actions.ts
+++ b/types/channels-chat/actions.ts
@@ -695,9 +695,9 @@ export interface ChatDraftChangedAction {
 /**
  * A session requested input from the user.
  *
- * Full-request upsert semantics: the `request` replaces any existing request
- * with the same `id`, or is appended if it is new. Answer drafts are preserved
- * unless `request.answers` is provided.
+ * Creates an unresolved {@link InputRequestResponsePart} in the active turn,
+ * or replaces the unresolved part with the same request `id`. Answer drafts
+ * are preserved unless `request.answers` is provided.
  *
  * @category Chat Actions
  * @version 1
@@ -728,10 +728,11 @@ export interface ChatInputAnswerChangedAction {
 }
 
 /**
- * A client accepted, declined, or cancelled a session input request.
+ * A client submitted an accept, decline, or cancel response to an input request.
  *
  * If accepted, the server uses `answers` (when provided) plus the request's
- * synced answer state to resume the blocked operation.
+ * synced answer state to resume the blocked operation. The reducer records the
+ * response and final answers on the existing {@link InputRequestResponsePart}.
  *
  * @category Chat Actions
  * @version 1

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -7,7 +7,6 @@
 
 import { ActionType } from '../common/actions.js';
 import type {
-  ChatInputRequest,
   ChatState,
   ToolCallState,
   ResponsePart,
@@ -76,6 +75,29 @@ function hasBlockingToolCall(state: ChatState): boolean {
   );
 }
 
+/** Returns whether the active turn contains an input request awaiting submission. */
+function hasOpenInputRequest(state: ChatState): boolean {
+  return state.activeTurn?.responseParts.some(part =>
+    part.kind === ResponsePartKind.InputRequest && part.response === undefined,
+  ) ?? false;
+}
+
+function findOpenInputRequestPart(
+  responseParts: readonly ResponsePart[],
+  requestId: string,
+): { index: number; part: InputRequestResponsePart } | undefined {
+  const index = responseParts.findIndex(part =>
+    part.kind === ResponsePartKind.InputRequest
+    && part.response === undefined
+    && part.request.id === requestId,
+  );
+  if (index < 0) {
+    return undefined;
+  }
+  const part = responseParts[index];
+  return part.kind === ResponsePartKind.InputRequest ? { index, part } : undefined;
+}
+
 /** Bitmask covering the mutually-exclusive activity bits (bits 0–4). */
 const STATUS_ACTIVITY_MASK = (1 << 5) - 1;
 
@@ -89,7 +111,7 @@ function summaryStatus(state: ChatState, terminalStatus?: SessionStatus.Error): 
   let activity: SessionStatus;
   if (terminalStatus) {
     activity = terminalStatus;
-  } else if ((state.inputRequests?.length ?? 0) > 0 || hasBlockingToolCall(state)) {
+  } else if (hasOpenInputRequest(state) || hasBlockingToolCall(state)) {
     activity = SessionStatus.InputNeeded;
   } else if (state.activeTurn) {
     activity = SessionStatus.InProgress;
@@ -172,24 +194,39 @@ function endTurn(
     activeTurn: undefined,
     modifiedAt: new Date(Date.now()).toISOString(),
   };
-  delete next.inputRequests;
   return {
     ...next,
     status: summaryStatus(next, terminalStatus),
   };
 }
 
-function upsertInputRequest(state: ChatState, request: ChatInputRequest): ChatState {
-  const existing = state.inputRequests ?? [];
-  const idx = existing.findIndex(r => r.id === request.id);
-  const inputRequests = [...existing];
-  if (idx >= 0) {
-    const answers = request.answers ?? inputRequests[idx].answers;
-    inputRequests[idx] = { ...request, answers };
-  } else {
-    inputRequests.push(request);
+function upsertInputRequestPart(state: ChatState, request: InputRequestResponsePart['request']): ChatState {
+  const activeTurn = state.activeTurn;
+  if (!activeTurn) {
+    return state;
   }
-  const next = { ...state, inputRequests };
+  const existing = findOpenInputRequestPart(activeTurn.responseParts, request.id);
+  const responseParts = [...activeTurn.responseParts];
+  const part: InputRequestResponsePart = {
+    kind: ResponsePartKind.InputRequest,
+    request,
+  };
+  if (existing) {
+    part.request = {
+      ...request,
+      answers: request.answers ?? existing.part.request.answers,
+    };
+    responseParts[existing.index] = part;
+  } else {
+    responseParts.push(part);
+  }
+  const next: ChatState = {
+    ...state,
+    activeTurn: {
+      ...activeTurn,
+      responseParts,
+    },
+  };
   return { ...next, status: withStatusFlag(summaryStatus(next), SessionStatus.IsRead, false), modifiedAt: new Date(Date.now()).toISOString() };
 }
 
@@ -627,7 +664,6 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
         activeTurn: undefined,
         modifiedAt: new Date(Date.now()).toISOString(),
       };
-      delete next.inputRequests;
       if (action.turnId === undefined) {
         delete next.turnsNextCursor;
       }
@@ -650,67 +686,68 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
     // ── Session Input Requests ─────────────────────────────────────────────
 
     case ActionType.ChatInputRequested:
-      return upsertInputRequest(state, action.request);
+      return upsertInputRequestPart(state, action.request);
 
     case ActionType.ChatInputAnswerChanged: {
-      const existing = state.inputRequests;
-      const idx = existing?.findIndex(request => request.id === action.requestId) ?? -1;
-      if (!existing || idx < 0) {
+      const activeTurn = state.activeTurn;
+      const existing = activeTurn
+        ? findOpenInputRequestPart(activeTurn.responseParts, action.requestId)
+        : undefined;
+      if (!activeTurn || !existing) {
         return state;
       }
-      const request = existing[idx];
+      const { index, part } = existing;
+      const request = part.request;
       const answers = { ...(request.answers ?? {}) };
       if (action.answer === undefined) {
         delete answers[action.questionId];
       } else {
         answers[action.questionId] = action.answer;
       }
-      const updated = [...existing];
-      updated[idx] = {
-        ...request,
-        answers: Object.keys(answers).length > 0 ? answers : undefined,
+      const responseParts = [...activeTurn.responseParts];
+      responseParts[index] = {
+        ...part,
+        request: {
+          ...request,
+          answers: Object.keys(answers).length > 0 ? answers : undefined,
+        },
       };
       return {
         ...state,
-        inputRequests: updated,
+        activeTurn: {
+          ...activeTurn,
+          responseParts,
+        },
         modifiedAt: new Date(Date.now()).toISOString(),
       };
     }
 
     case ActionType.ChatInputCompleted: {
-      const existing = state.inputRequests;
-      const idx = existing?.findIndex(request => request.id === action.requestId) ?? -1;
-      if (!existing || idx < 0) {
+      const activeTurn = state.activeTurn;
+      const existing = activeTurn
+        ? findOpenInputRequestPart(activeTurn.responseParts, action.requestId)
+        : undefined;
+      if (!activeTurn || !existing) {
         return state;
       }
-      const completed = existing[idx];
-      const inputRequests = existing.filter(request => request.id !== action.requestId);
+      const { index, part } = existing;
+      const finalAnswers = { ...(part.request.answers ?? {}), ...(action.answers ?? {}) };
+      const responseParts = [...activeTurn.responseParts];
+      responseParts[index] = {
+        ...part,
+        request: {
+          ...part.request,
+          answers: Object.keys(finalAnswers).length > 0 ? finalAnswers : undefined,
+        },
+        response: action.response,
+      };
       const next: ChatState = {
         ...state,
+        activeTurn: {
+          ...activeTurn,
+          responseParts,
+        },
       };
-      if (inputRequests.length > 0) {
-        next.inputRequests = inputRequests;
-      } else {
-        delete next.inputRequests;
-      }
-      // Project the resolved request into the active turn's transcript so the
-      // "asked X → answered Y" decision survives after the live request is
-      // gone. Abandoned requests (turn end/truncate) are removed without a part.
-      if (next.activeTurn) {
-        const finalAnswers = { ...(completed.answers ?? {}), ...(action.answers ?? {}) };
-        const part: InputRequestResponsePart = {
-          kind: ResponsePartKind.InputRequest,
-          request: {
-            ...completed,
-            answers: Object.keys(finalAnswers).length > 0 ? finalAnswers : undefined,
-          },
-          response: action.response,
-        };
-        next.activeTurn = {
-          ...next.activeTurn,
-          responseParts: [...next.activeTurn.responseParts, part],
-        };
-      }
       return {
         ...next,
         status: summaryStatus(next),

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -86,8 +86,6 @@ export interface ChatState {
   steeringMessage?: PendingMessage;
   /** Messages to send automatically as new turns after the current turn finishes */
   queuedMessages?: PendingMessage[];
-  /** Requests for user input that are currently blocking or informing chat progress */
-  inputRequests?: ChatInputRequest[];
   /**
    * The user's in-progress draft input for this chat — the message they are
    * composing but have not sent yet, including its
@@ -359,11 +357,11 @@ export type ChatInputQuestion = ChatInputTextQuestion
   | ChatInputMultiSelectQuestion;
 
 /**
- * A live request for user input.
+ * The request payload carried by an {@link InputRequestResponsePart}.
  *
- * The server creates or replaces requests with `chat/inputRequested`.
- * Clients sync drafts with `chat/inputAnswerChanged` and complete requests
- * with `chat/inputCompleted`.
+ * The server creates or replaces the containing response part with
+ * `chat/inputRequested`. Clients sync drafts with `chat/inputAnswerChanged`
+ * and submit responses with `chat/inputCompleted`.
  *
  * @category Chat Input Types
  */
@@ -847,19 +845,16 @@ export type ResponsePart =
   | InputRequestResponsePart;
 
 /**
- * A resolved input request (elicitation) recorded in the turn transcript.
+ * A live or resolved input request (elicitation) in the turn response stream.
  *
- * While an input request is open it lives in {@link ChatState.inputRequests}
- * as live, interactive state (see {@link ChatInputRequest}). When the request
- * completes via `chat/inputCompleted`, the reducer removes it from
- * `inputRequests` and appends this part to the active turn so the decision
- * survives in history. This mirrors how a tool-call confirmation persists in
- * its {@link ToolCallResponsePart} (via `confirmed` / `selectedOption` on the
- * terminal {@link ToolCallState}): the live surface drives in-flight UX, the
- * terminal outcome is durable and backfillable via `fetchTurns`.
+ * The server inserts the part with `chat/inputRequested`. While
+ * {@link response} is absent, clients can update answer drafts with
+ * `chat/inputAnswerChanged` and submit a response with `chat/inputCompleted`.
+ * Completion updates this part in place so its stream position is stable and
+ * the full interaction remains durable and backfillable via `fetchTurns`.
  *
- * No part is recorded when an outstanding request is *abandoned* (the turn
- * completes, is cancelled, errors, or is truncated) rather than *completed*.
+ * If the turn ends without a submitted response, the unresolved part remains
+ * in the completed turn transcript with {@link response} absent.
  *
  * @category Response Parts
  */
@@ -867,12 +862,15 @@ export interface InputRequestResponsePart {
   /** Discriminant */
   kind: ResponsePartKind.InputRequest;
   /**
-   * The resolved request, carrying its `id`, `message`, `url`, `questions`,
-   * and the final `answers` synced/submitted at completion.
+   * The request, carrying its `id`, `message`, `url`, `questions`, and current
+   * draft or submitted `answers`.
    */
   request: ChatInputRequest;
-  /** How the request was resolved: `accept`, `decline`, or `cancel`. */
-  response: ChatInputResponseKind;
+  /**
+   * How the request was resolved. Absent until a client submits `accept`,
+   * `decline`, or `cancel` with `chat/inputCompleted`.
+   */
+  response?: ChatInputResponseKind;
 }
 
 /**

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -236,7 +236,7 @@ export interface SessionActiveClient {
  * @category Session Input Types
  */
 export const enum SessionInputRequestKind {
-  /** A user-facing elicitation mirrored from a chat's `inputRequests`. */
+  /** A user-facing elicitation mirrored from an unresolved chat response part. */
   ChatInput = 'chatInput',
   /** A tool call awaiting parameter- or result-confirmation. */
   ToolConfirmation = 'toolConfirmation',
@@ -269,8 +269,8 @@ interface SessionInputRequestBase {
 }
 
 /**
- * A user-input elicitation surfaced at the session level, mirroring one entry
- * of the owning chat's {@link ChatState.inputRequests}.
+ * A user-input elicitation surfaced at the session level, mirroring the request
+ * from an unresolved {@link InputRequestResponsePart} in the owning chat.
  *
  * Respond by dispatching `chat/inputCompleted` (or syncing drafts with
  * `chat/inputAnswerChanged`) to {@link SessionInputRequestBase.chat | `chat`},

--- a/types/test-cases/reducers/106-session-input-requested-with-drafts-status.json
+++ b/types/test-cases/reducers/106-session-input-requested-with-drafts-status.json
@@ -59,31 +59,33 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
-      "usage": null
-    },
-    "inputRequests": [
-      {
-        "id": "input-1",
-        "message": "Clarify requirements",
-        "questions": [
-          {
-            "id": "q1",
-            "kind": "number",
-            "message": "How many?"
-          }
-        ],
-        "answers": {
-          "q1": {
-            "state": "draft",
-            "value": {
-              "kind": "number",
-              "value": 1.5
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "input-1",
+            "message": "Clarify requirements",
+            "questions": [
+              {
+                "id": "q1",
+                "kind": "number",
+                "message": "How many?"
+              }
+            ],
+            "answers": {
+              "q1": {
+                "state": "draft",
+                "value": {
+                  "kind": "number",
+                  "value": 1.5
+                }
+              }
             }
           }
         }
-      }
-    ],
+      ],
+      "usage": null
+    },
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,

--- a/types/test-cases/reducers/107-session-input-turn-end-cleans-turn-scoped-only.json
+++ b/types/test-cases/reducers/107-session-input-turn-end-cleans-turn-scoped-only.json
@@ -1,5 +1,5 @@
 {
-  "description": "turn end clears outstanding session input requests",
+  "description": "turn end preserves unresolved input request parts in the completed transcript",
   "reducer": "chat",
   "initial": {
     "turns": [],
@@ -12,27 +12,32 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "url-input",
+            "message": "Review this URL",
+            "url": "https://example.com/form"
+          }
+        },
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "form-input",
+            "message": "Answer this form",
+            "questions": [
+              {
+                "id": "q1",
+                "kind": "boolean",
+                "message": "Continue?"
+              }
+            ]
+          }
+        }
+      ],
       "usage": null
     },
-    "inputRequests": [
-      {
-        "id": "url-input",
-        "message": "Review this URL",
-        "url": "https://example.com/form"
-      },
-      {
-        "id": "form-input",
-        "message": "Answer this form",
-        "questions": [
-          {
-            "id": "q1",
-            "kind": "boolean",
-            "message": "Continue?"
-          }
-        ]
-      }
-    ],
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,
@@ -57,7 +62,30 @@
             "kind": "user"
           }
         },
-        "responseParts": [],
+        "responseParts": [
+          {
+            "kind": "inputRequest",
+            "request": {
+              "id": "url-input",
+              "message": "Review this URL",
+              "url": "https://example.com/form"
+            }
+          },
+          {
+            "kind": "inputRequest",
+            "request": {
+              "id": "form-input",
+              "message": "Answer this form",
+              "questions": [
+                {
+                  "id": "q1",
+                  "kind": "boolean",
+                  "message": "Continue?"
+                }
+              ]
+            }
+          }
+        ],
         "usage": null,
         "state": "complete",
         "error": null

--- a/types/test-cases/reducers/108-session-input-upsert-and-clear-answer.json
+++ b/types/test-cases/reducers/108-session-input-upsert-and-clear-answer.json
@@ -12,24 +12,26 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
-      "usage": null
-    },
-    "inputRequests": [
-      {
-        "id": "input-1",
-        "message": "Old message",
-        "answers": {
-          "q1": {
-            "state": "draft",
-            "value": {
-              "kind": "text",
-              "value": "draft"
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "input-1",
+            "message": "Old message",
+            "answers": {
+              "q1": {
+                "state": "draft",
+                "value": {
+                  "kind": "text",
+                  "value": "draft"
+                }
+              }
             }
           }
         }
-      }
-    ],
+      ],
+      "usage": null
+    },
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,
@@ -72,16 +74,18 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "input-1",
+            "message": "New message",
+            "answers": null
+          }
+        }
+      ],
       "usage": null
     },
-    "inputRequests": [
-      {
-        "id": "input-1",
-        "message": "New message",
-        "answers": null
-      }
-    ],
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,

--- a/types/test-cases/reducers/110-session-input-completion-and-truncation-filtering.json
+++ b/types/test-cases/reducers/110-session-input-completion-and-truncation-filtering.json
@@ -37,20 +37,25 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "complete-me",
+            "message": "Complete me"
+          }
+        },
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "remaining-input",
+            "message": "Remaining request",
+            "url": "https://example.com/form"
+          }
+        }
+      ],
       "usage": null
     },
-    "inputRequests": [
-      {
-        "id": "complete-me",
-        "message": "Complete me"
-      },
-      {
-        "id": "remaining-input",
-        "message": "Remaining request",
-        "url": "https://example.com/form"
-      }
-    ],
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,

--- a/types/test-cases/reducers/235-session-input-completion-records-declined-request-in-turn.json
+++ b/types/test-cases/reducers/235-session-input-completion-records-declined-request-in-turn.json
@@ -12,33 +12,35 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
-      "usage": null
-    },
-    "inputRequests": [
-      {
-        "id": "review-1",
-        "message": "Review before continuing",
-        "url": "https://example.com/plan",
-        "questions": [
-          {
-            "id": "approve",
-            "kind": "boolean",
-            "message": "Approve the plan?",
-            "required": true
-          }
-        ],
-        "answers": {
-          "approve": {
-            "state": "draft",
-            "value": {
-              "kind": "boolean",
-              "value": true
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "review-1",
+            "message": "Review before continuing",
+            "url": "https://example.com/plan",
+            "questions": [
+              {
+                "id": "approve",
+                "kind": "boolean",
+                "message": "Approve the plan?",
+                "required": true
+              }
+            ],
+            "answers": {
+              "approve": {
+                "state": "draft",
+                "value": {
+                  "kind": "boolean",
+                  "value": true
+                }
+              }
             }
           }
         }
-      }
-    ],
+      ],
+      "usage": null
+    },
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,

--- a/types/test-cases/reducers/236-session-input-completion-without-active-turn-records-nothing.json
+++ b/types/test-cases/reducers/236-session-input-completion-without-active-turn-records-nothing.json
@@ -1,5 +1,5 @@
 {
-  "description": "session input completion without an active turn removes the request and records no transcript part",
+  "description": "session input request and completion without an active turn are no-ops",
   "reducer": "chat",
   "initial": {
     "turns": [
@@ -16,18 +16,19 @@
         "state": "complete"
       }
     ],
-    "inputRequests": [
-      {
-        "id": "orphan-1",
-        "message": "Standalone request"
-      }
-    ],
     "resource": "copilot:/test-session",
     "title": "Test Session",
-    "status": 24,
+    "status": 1,
     "modifiedAt": "1970-01-01T00:00:01.000Z"
   },
   "actions": [
+    {
+      "type": "chat/inputRequested",
+      "request": {
+        "id": "orphan-1",
+        "message": "Standalone request"
+      }
+    },
     {
       "type": "chat/inputCompleted",
       "requestId": "orphan-1",
@@ -52,6 +53,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/237-session-input-completion-no-op-unknown-id-with-open-requests.json
+++ b/types/test-cases/reducers/237-session-input-completion-no-op-unknown-id-with-open-requests.json
@@ -12,15 +12,17 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "present-1",
+            "message": "Still open"
+          }
+        }
+      ],
       "usage": null
     },
-    "inputRequests": [
-      {
-        "id": "present-1",
-        "message": "Still open"
-      }
-    ],
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,
@@ -44,15 +46,17 @@
           "kind": "user"
         }
       },
-      "responseParts": [],
+      "responseParts": [
+        {
+          "kind": "inputRequest",
+          "request": {
+            "id": "present-1",
+            "message": "Still open"
+          }
+        }
+      ],
       "usage": null
     },
-    "inputRequests": [
-      {
-        "id": "present-1",
-        "message": "Still open"
-      }
-    ],
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,


### PR DESCRIPTION
## Summary
- remove `ChatState.inputRequests`
- make unresolved `InputRequestResponsePart` entries the authoritative live input state
- update input actions, reducers, fixtures, schemas, docs, and all client mirrors

## Validation
- `npm test`
- TypeScript client typecheck and tests
- Rust workspace tests
- Go tests
- Swift package tests
- Kotlin tests in JDK 17 container
- two independent council reviews with no blocking findings

Fixes #327