### PR TITLE
Add per-chat config overrides

### DIFF
--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -731,6 +731,20 @@ func ApplyActionToChat(state *ahptypes.ChatState, action ahptypes.StateAction) R
 	case *ahptypes.ChatDraftChangedAction:
 		state.Draft = a.Draft
 		return ReduceOutcomeApplied
+	case *ahptypes.ChatConfigChangedAction:
+		if state.Config == nil {
+			return ReduceOutcomeNoOp
+		}
+		replace := a.Replace != nil && *a.Replace
+		if replace {
+			state.Config.Values = make(map[string]json.RawMessage, len(a.Config))
+		} else if state.Config.Values == nil {
+			state.Config.Values = make(map[string]json.RawMessage, len(a.Config))
+		}
+		for k, v := range a.Config {
+			state.Config.Values[k] = v
+		}
+		return ReduceOutcomeApplied
 	}
 	return ReduceOutcomeOutOfScope
 }

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -55,6 +55,7 @@ const (
 	ActionTypeChatPendingMessageRemoved         ActionType = "chat/pendingMessageRemoved"
 	ActionTypeChatQueuedMessagesReordered       ActionType = "chat/queuedMessagesReordered"
 	ActionTypeChatDraftChanged                  ActionType = "chat/draftChanged"
+	ActionTypeChatConfigChanged                 ActionType = "chat/configChanged"
 	ActionTypeChatInputRequested                ActionType = "chat/inputRequested"
 	ActionTypeChatInputAnswerChanged            ActionType = "chat/inputAnswerChanged"
 	ActionTypeChatInputCompleted                ActionType = "chat/inputCompleted"
@@ -713,6 +714,22 @@ type ChatDraftChangedAction struct {
 	Draft *Message `json:"draft,omitempty"`
 }
 
+// Client changed mutable, chat-scoped config values.
+//
+// Only properties with both `chatScoped: true` and `sessionMutable: true` in
+// the config schema may be changed. The server validates and broadcasts the
+// action; the reducer merges the new overrides into `state.config.values`.
+// Properties without a chat override inherit their current value from
+// `SessionState.config`.
+type ChatConfigChangedAction struct {
+	Type ActionType `json:"type"`
+	// Updated chat-scoped config overrides
+	Config map[string]json.RawMessage `json:"config"`
+	// When `true`, replaces all chat config overrides instead of merging.
+	// Omitted properties resume inheriting from the session.
+	Replace *bool `json:"replace,omitempty"`
+}
+
 // A session requested input from the user.
 //
 // Creates an unresolved {@link InputRequestResponsePart} in the active turn,
@@ -1035,8 +1052,10 @@ type SessionMcpServerStopRequestedAction struct {
 // Client changed a mutable config value mid-session.
 //
 // Only properties with `sessionMutable: true` in the config schema may be
-// changed. The server validates and broadcasts the action; the reducer merges
-// the new values into `state.config.values`.
+// changed. For a property with `chatScoped: true`, this changes the inherited
+// default for chats that do not have their own override. The server validates
+// and broadcasts the action; the reducer merges the new values into
+// `state.config.values`.
 type SessionConfigChangedAction struct {
 	Type ActionType `json:"type"`
 	// Updated config values
@@ -1458,6 +1477,7 @@ func (*ChatPendingMessageSetAction) isStateAction()             {}
 func (*ChatPendingMessageRemovedAction) isStateAction()         {}
 func (*ChatQueuedMessagesReorderedAction) isStateAction()       {}
 func (*ChatDraftChangedAction) isStateAction()                  {}
+func (*ChatConfigChangedAction) isStateAction()                 {}
 func (*ChatInputRequestedAction) isStateAction()                {}
 func (*ChatInputAnswerChangedAction) isStateAction()            {}
 func (*ChatInputCompletedAction) isStateAction()                {}
@@ -1710,6 +1730,12 @@ func (u *StateAction) UnmarshalJSON(data []byte) error {
 		u.Value = &value
 	case "chat/draftChanged":
 		var value ChatDraftChangedAction
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "chat/configChanged":
+		var value ChatConfigChangedAction
 		if err := json.Unmarshal(data, &value); err != nil {
 			return err
 		}

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -1054,6 +1054,13 @@ type ChatState struct {
 	// subordinate chat its own git worktree so multiple chats in a session can
 	// make independent edits that the orchestrator later merges back.
 	WorkingDirectory *URI `json:"workingDirectory,omitempty"`
+	// Configuration overrides owned by this chat.
+	//
+	// Only properties whose schema declares `chatScoped: true` may appear in
+	// `values`. A property absent from `values` inherits the current value from
+	// `SessionState.config`. Presence of this state advertises support for
+	// per-chat config overrides.
+	Config *SessionConfigState `json:"config,omitempty"`
 	// Completed turns
 	Turns []Turn `json:"turns"`
 	// Cursor for loading older completed turns into this chat state.
@@ -1171,6 +1178,10 @@ type SessionConfigPropertySchema struct {
 	EnumDynamic *bool `json:"enumDynamic,omitempty"`
 	// When `true`, the user may change this property after session creation
 	SessionMutable *bool `json:"sessionMutable,omitempty"`
+	// When `true`, each chat may override this property in `ChatState.config`.
+	// A chat without an override inherits the current value from
+	// `SessionState.config`.
+	ChatScoped *bool `json:"chatScoped,omitempty"`
 }
 
 // A JSON Schema object describing available session configuration metadata.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -1379,6 +1379,15 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
 
     is StateActionChatDraftChanged -> state.copy(draft = action.value.draft)
 
+    is StateActionChatConfigChanged -> {
+        val a = action.value
+        val config = state.config
+        if (config == null) state else {
+            val newValues = if (a.replace == true) a.config else config.values + a.config
+            state.copy(config = config.copy(values = newValues))
+        }
+    }
+
     else -> state
 
 }

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -98,6 +98,8 @@ enum class ActionType {
     CHAT_QUEUED_MESSAGES_REORDERED,
     @SerialName("chat/draftChanged")
     CHAT_DRAFT_CHANGED,
+    @SerialName("chat/configChanged")
+    CHAT_CONFIG_CHANGED,
     @SerialName("chat/inputRequested")
     CHAT_INPUT_REQUESTED,
     @SerialName("chat/inputAnswerChanged")
@@ -949,6 +951,20 @@ data class ChatDraftChangedAction(
 )
 
 @Serializable
+data class ChatConfigChangedAction(
+    val type: ActionType,
+    /**
+     * Updated chat-scoped config overrides
+     */
+    val config: Map<String, JsonElement>,
+    /**
+     * When `true`, replaces all chat config overrides instead of merging.
+     * Omitted properties resume inheriting from the session.
+     */
+    val replace: Boolean? = null
+)
+
+@Serializable
 data class ChatInputRequestedAction(
     val type: ActionType,
     /**
@@ -1526,6 +1542,7 @@ sealed interface StateAction
 @JvmInline value class StateActionChatPendingMessageRemoved(val value: ChatPendingMessageRemovedAction) : StateAction
 @JvmInline value class StateActionChatQueuedMessagesReordered(val value: ChatQueuedMessagesReorderedAction) : StateAction
 @JvmInline value class StateActionChatDraftChanged(val value: ChatDraftChangedAction) : StateAction
+@JvmInline value class StateActionChatConfigChanged(val value: ChatConfigChangedAction) : StateAction
 @JvmInline value class StateActionChatInputRequested(val value: ChatInputRequestedAction) : StateAction
 @JvmInline value class StateActionChatInputAnswerChanged(val value: ChatInputAnswerChangedAction) : StateAction
 @JvmInline value class StateActionChatInputCompleted(val value: ChatInputCompletedAction) : StateAction
@@ -1622,6 +1639,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             "chat/pendingMessageRemoved" -> StateActionChatPendingMessageRemoved(input.json.decodeFromJsonElement(ChatPendingMessageRemovedAction.serializer(), element))
             "chat/queuedMessagesReordered" -> StateActionChatQueuedMessagesReordered(input.json.decodeFromJsonElement(ChatQueuedMessagesReorderedAction.serializer(), element))
             "chat/draftChanged" -> StateActionChatDraftChanged(input.json.decodeFromJsonElement(ChatDraftChangedAction.serializer(), element))
+            "chat/configChanged" -> StateActionChatConfigChanged(input.json.decodeFromJsonElement(ChatConfigChangedAction.serializer(), element))
             "chat/inputRequested" -> StateActionChatInputRequested(input.json.decodeFromJsonElement(ChatInputRequestedAction.serializer(), element))
             "chat/inputAnswerChanged" -> StateActionChatInputAnswerChanged(input.json.decodeFromJsonElement(ChatInputAnswerChangedAction.serializer(), element))
             "chat/inputCompleted" -> StateActionChatInputCompleted(input.json.decodeFromJsonElement(ChatInputCompletedAction.serializer(), element))
@@ -1711,6 +1729,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             is StateActionChatPendingMessageRemoved -> output.json.encodeToJsonElement(ChatPendingMessageRemovedAction.serializer(), value.value)
             is StateActionChatQueuedMessagesReordered -> output.json.encodeToJsonElement(ChatQueuedMessagesReorderedAction.serializer(), value.value)
             is StateActionChatDraftChanged -> output.json.encodeToJsonElement(ChatDraftChangedAction.serializer(), value.value)
+            is StateActionChatConfigChanged -> output.json.encodeToJsonElement(ChatConfigChangedAction.serializer(), value.value)
             is StateActionChatInputRequested -> output.json.encodeToJsonElement(ChatInputRequestedAction.serializer(), value.value)
             is StateActionChatInputAnswerChanged -> output.json.encodeToJsonElement(ChatInputAnswerChangedAction.serializer(), value.value)
             is StateActionChatInputCompleted -> output.json.encodeToJsonElement(ChatInputCompletedAction.serializer(), value.value)

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -1012,7 +1012,13 @@ data class SessionConfigPropertySchema(
     /**
      * When `true`, the user may change this property after session creation
      */
-    val sessionMutable: Boolean? = null
+    val sessionMutable: Boolean? = null,
+    /**
+     * When `true`, each chat may override this property in `ChatState.config`.
+     * A chat without an override inherits the current value from
+     * `SessionState.config`.
+     */
+    val chatScoped: Boolean? = null
 )
 
 @Serializable

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -1162,6 +1162,15 @@ data class ChatState(
      */
     val workingDirectory: String? = null,
     /**
+     * Configuration overrides owned by this chat.
+     *
+     * Only properties whose schema declares `chatScoped: true` may appear in
+     * `values`. A property absent from `values` inherits the current value from
+     * `SessionState.config`. Presence of this state advertises support for
+     * per-chat config overrides.
+     */
+    val config: SessionConfigState? = null,
+    /**
      * Completed turns
      */
     val turns: List<Turn>,

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -100,6 +100,8 @@ pub enum ActionType {
     ChatQueuedMessagesReordered,
     #[serde(rename = "chat/draftChanged")]
     ChatDraftChanged,
+    #[serde(rename = "chat/configChanged")]
+    ChatConfigChanged,
     #[serde(rename = "chat/inputRequested")]
     ChatInputRequested,
     #[serde(rename = "chat/inputAnswerChanged")]
@@ -1027,6 +1029,24 @@ pub struct ChatDraftChangedAction {
     pub draft: Option<Message>,
 }
 
+/// Client changed mutable, chat-scoped config values.
+///
+/// Only properties with both `chatScoped: true` and `sessionMutable: true` in
+/// the config schema may be changed. The server validates and broadcasts the
+/// action; the reducer merges the new overrides into `state.config.values`.
+/// Properties without a chat override inherit their current value from
+/// `SessionState.config`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatConfigChangedAction {
+    /// Updated chat-scoped config overrides
+    pub config: JsonObject,
+    /// When `true`, replaces all chat config overrides instead of merging.
+    /// Omitted properties resume inheriting from the session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replace: Option<bool>,
+}
+
 /// A session requested input from the user.
 ///
 /// Creates an unresolved {@link InputRequestResponsePart} in the active turn,
@@ -1241,8 +1261,10 @@ pub struct ChatTurnsLoadedAction {
 /// Client changed a mutable config value mid-session.
 ///
 /// Only properties with `sessionMutable: true` in the config schema may be
-/// changed. The server validates and broadcasts the action; the reducer merges
-/// the new values into `state.config.values`.
+/// changed. For a property with `chatScoped: true`, this changes the inherited
+/// default for chats that do not have their own override. The server validates
+/// and broadcasts the action; the reducer merges the new values into
+/// `state.config.values`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionConfigChangedAction {
@@ -1788,6 +1810,8 @@ pub enum StateAction {
     ChatQueuedMessagesReordered(ChatQueuedMessagesReorderedAction),
     #[serde(rename = "chat/draftChanged")]
     ChatDraftChanged(ChatDraftChangedAction),
+    #[serde(rename = "chat/configChanged")]
+    ChatConfigChanged(ChatConfigChangedAction),
     #[serde(rename = "chat/inputRequested")]
     ChatInputRequested(ChatInputRequestedAction),
     #[serde(rename = "chat/inputAnswerChanged")]

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -1005,6 +1005,14 @@ pub struct ChatState {
     /// make independent edits that the orchestrator later merges back.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<Uri>,
+    /// Configuration overrides owned by this chat.
+    ///
+    /// Only properties whose schema declares `chatScoped: true` may appear in
+    /// `values`. A property absent from `values` inherits the current value from
+    /// `SessionState.config`. Presence of this state advertises support for
+    /// per-chat config overrides.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<SessionConfigState>,
     /// Completed turns
     pub turns: Vec<Turn>,
     /// Cursor for loading older completed turns into this chat state.
@@ -1493,6 +1501,11 @@ pub struct SessionConfigPropertySchema {
     /// When `true`, the user may change this property after session creation
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_mutable: Option<bool>,
+    /// When `true`, each chat may override this property in `ChatState.config`.
+    /// A chat without an override inherits the current value from
+    /// `SessionState.config`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_scoped: Option<bool>,
 }
 
 /// A JSON Schema object describing available session configuration metadata.

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -1149,6 +1149,19 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
             state.draft = a.draft.clone();
             ReduceOutcome::Applied
         }
+        StateAction::ChatConfigChanged(a) => {
+            let Some(config) = state.config.as_mut() else {
+                return ReduceOutcome::NoOp;
+            };
+            if a.replace.unwrap_or(false) {
+                config.values = a.config.clone();
+            } else {
+                for (k, v) in &a.config {
+                    config.values.insert(k.clone(), v.clone());
+                }
+            }
+            ReduceOutcome::Applied
+        }
         _ => ReduceOutcome::OutOfScope,
     }
 }
@@ -1938,6 +1951,7 @@ mod tests {
             origin: None,
             interactivity: None,
             working_directory: None,
+            config: None,
             turns: Vec::new(),
             turns_next_cursor: None,
             active_turn: None,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -42,6 +42,7 @@ public enum ActionType: String, Codable, Sendable {
     case chatPendingMessageRemoved = "chat/pendingMessageRemoved"
     case chatQueuedMessagesReordered = "chat/queuedMessagesReordered"
     case chatDraftChanged = "chat/draftChanged"
+    case chatConfigChanged = "chat/configChanged"
     case chatInputRequested = "chat/inputRequested"
     case chatInputAnswerChanged = "chat/inputAnswerChanged"
     case chatInputCompleted = "chat/inputCompleted"
@@ -1208,6 +1209,25 @@ public struct ChatDraftChangedAction: Codable, Sendable {
     }
 }
 
+public struct ChatConfigChangedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Updated chat-scoped config overrides
+    public var config: [String: AnyCodable]
+    /// When `true`, replaces all chat config overrides instead of merging.
+    /// Omitted properties resume inheriting from the session.
+    public var replace: Bool?
+
+    public init(
+        type: ActionType,
+        config: [String: AnyCodable],
+        replace: Bool? = nil
+    ) {
+        self.type = type
+        self.config = config
+        self.replace = replace
+    }
+}
+
 public struct ChatInputRequestedAction: Codable, Sendable {
     public var type: ActionType
     /// Input request to create or replace
@@ -1988,6 +2008,7 @@ public enum StateAction: Codable, Sendable {
     case chatPendingMessageRemoved(ChatPendingMessageRemovedAction)
     case chatQueuedMessagesReordered(ChatQueuedMessagesReorderedAction)
     case chatDraftChanged(ChatDraftChangedAction)
+    case chatConfigChanged(ChatConfigChangedAction)
     case chatInputRequested(ChatInputRequestedAction)
     case chatInputAnswerChanged(ChatInputAnswerChangedAction)
     case chatInputCompleted(ChatInputCompletedAction)
@@ -2121,6 +2142,8 @@ public enum StateAction: Codable, Sendable {
             self = .chatQueuedMessagesReordered(try ChatQueuedMessagesReorderedAction(from: decoder))
         case "chat/draftChanged":
             self = .chatDraftChanged(try ChatDraftChangedAction(from: decoder))
+        case "chat/configChanged":
+            self = .chatConfigChanged(try ChatConfigChangedAction(from: decoder))
         case "chat/inputRequested":
             self = .chatInputRequested(try ChatInputRequestedAction(from: decoder))
         case "chat/inputAnswerChanged":
@@ -2250,6 +2273,7 @@ public enum StateAction: Codable, Sendable {
         case .chatPendingMessageRemoved(let v): try v.encode(to: encoder)
         case .chatQueuedMessagesReordered(let v): try v.encode(to: encoder)
         case .chatDraftChanged(let v): try v.encode(to: encoder)
+        case .chatConfigChanged(let v): try v.encode(to: encoder)
         case .chatInputRequested(let v): try v.encode(to: encoder)
         case .chatInputAnswerChanged(let v): try v.encode(to: encoder)
         case .chatInputCompleted(let v): try v.encode(to: encoder)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -1105,6 +1105,10 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
     public var enumDynamic: Bool?
     /// When `true`, the user may change this property after session creation
     public var sessionMutable: Bool?
+    /// When `true`, each chat may override this property in `ChatState.config`.
+    /// A chat without an override inherits the current value from
+    /// `SessionState.config`.
+    public var chatScoped: Bool?
 
     enum CodingKeys: String, CodingKey {
         case type
@@ -1121,6 +1125,7 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
         case additionalProperties
         case enumDynamic
         case sessionMutable
+        case chatScoped
     }
 
     public init(
@@ -1137,7 +1142,8 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
         required: [String]? = nil,
         additionalProperties: ConfigPropertySchema? = nil,
         enumDynamic: Bool? = nil,
-        sessionMutable: Bool? = nil
+        sessionMutable: Bool? = nil,
+        chatScoped: Bool? = nil
     ) {
         self.type = type
         self.title = title
@@ -1153,6 +1159,7 @@ public struct SessionConfigPropertySchema: Codable, Sendable {
         self.additionalProperties = additionalProperties
         self.enumDynamic = enumDynamic
         self.sessionMutable = sessionMutable
+        self.chatScoped = chatScoped
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -877,6 +877,13 @@ public struct ChatState: Codable, Sendable {
     /// subordinate chat its own git worktree so multiple chats in a session can
     /// make independent edits that the orchestrator later merges back.
     public var workingDirectory: String?
+    /// Configuration overrides owned by this chat.
+    ///
+    /// Only properties whose schema declares `chatScoped: true` may appear in
+    /// `values`. A property absent from `values` inherits the current value from
+    /// `SessionState.config`. Presence of this state advertises support for
+    /// per-chat config overrides.
+    public var config: SessionConfigState?
     /// Completed turns
     public var turns: [Turn]
     /// Cursor for loading older completed turns into this chat state.
@@ -916,6 +923,7 @@ public struct ChatState: Codable, Sendable {
         case origin
         case interactivity
         case workingDirectory
+        case config
         case turns
         case turnsNextCursor
         case activeTurn
@@ -934,6 +942,7 @@ public struct ChatState: Codable, Sendable {
         origin: ChatOrigin? = nil,
         interactivity: ChatInteractivity? = nil,
         workingDirectory: String? = nil,
+        config: SessionConfigState? = nil,
         turns: [Turn],
         turnsNextCursor: String? = nil,
         activeTurn: ActiveTurn? = nil,
@@ -950,6 +959,7 @@ public struct ChatState: Codable, Sendable {
         self.origin = origin
         self.interactivity = interactivity
         self.workingDirectory = workingDirectory
+        self.config = config
         self.turns = turns
         self.turnsNextCursor = turnsNextCursor
         self.activeTurn = activeTurn

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -607,6 +607,13 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
         next.draft = a.draft
         return next
 
+    case .chatConfigChanged(let a):
+        guard var config = state.config else { return state }
+        config.values = a.replace == true ? a.config : config.values.merging(a.config) { _, new in new }
+        var next = state
+        next.config = config
+        return next
+
     default:
         return state
     }
@@ -830,6 +837,7 @@ public let clientDispatchableActions: Set<String> = [
     "chat/pendingMessageSet",
     "chat/pendingMessageRemoved",
     "chat/queuedMessagesReordered",
+    "chat/configChanged",
     "chat/inputAnswerChanged",
     "chat/inputCompleted",
     "session/customizationToggled",
@@ -848,6 +856,7 @@ public func isClientDispatchable(_ action: StateAction) -> Bool {
          .sessionActiveClientRemoved,
          .chatPendingMessageSet,
          .chatPendingMessageRemoved, .chatQueuedMessagesReordered,
+         .chatConfigChanged,
          .chatInputAnswerChanged, .chatInputCompleted,
          .sessionCustomizationToggled,
          .sessionMcpServerStartRequested, .sessionMcpServerStopRequested,

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/ReducersTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/ReducersTests.swift
@@ -88,11 +88,12 @@ final class ReducersTests: XCTestCase {
     // MARK: - Dispatch Validation
 
     func testClientDispatchableReturnsTrue() {
-        let action: StateAction = .chatTurnStarted(ChatTurnStartedAction(
-            type: .chatTurnStarted, turnId: T, startedAt: "2026-07-09T20:00:00.000Z",
-            message: Message(text: "Hello", origin: MessageOrigin(kind: .user))
+        let action: StateAction = .chatConfigChanged(ChatConfigChangedAction(
+            type: .chatConfigChanged,
+            config: [:]
         ))
         XCTAssertTrue(isClientDispatchable(action))
+        XCTAssertTrue(clientDispatchableActions.contains("chat/configChanged"))
     }
 
     func testClientDispatchableReturnsFalse() {

--- a/docs/.changes/20260716-chat-config.json
+++ b/docs/.changes/20260716-chat-config.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "Per-chat configuration state and `chat/configChanged` for overriding inherited mutable config values.",
+  "issues": [335]
+}

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -87,7 +87,8 @@ Tool calls follow a discriminated-union state machine — see [State Model — T
 | `session/changesetsChanged` | No | The catalog of changesets the host advertises for this session changed (full replacement) |
 | `session/isReadChanged` | **Yes** | Client marked session as read or unread |
 | `session/isArchivedChanged` | **Yes** | Client archived or unarchived session |
-| `session/configChanged` | **Yes** | Mutable session config values changed |
+| `session/configChanged` | **Yes** | Mutable session config values or inherited chat defaults changed |
+| `chat/configChanged` | **Yes** | Mutable per-chat config overrides changed |
 | `session/metaChanged` | No | The session's `_meta` side-channel was replaced |
 
 ### Server & Active-Client Tools (session channel)

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -151,6 +151,7 @@ ChatState {
   modifiedAt: string
   origin?: ChatOrigin      // how the chat came to exist (user / fork / tool)
   workingDirectory?: URI
+  config?: SessionConfigState
 
   turns: Turn[]                       // completed turns
   turnsNextCursor?: string            // page older turns via fetchTurns
@@ -160,6 +161,18 @@ ChatState {
   draft?: Message                     // user's in-progress input
 }
 ```
+
+`ChatState.config` contains values for properties whose
+`SessionConfigPropertySchema.chatScoped` flag is `true`. Hosts seed each chat's
+`config.values` with only the properties that chat overrides. An absent
+chat-scoped value inherits dynamically from `SessionState.config.values`, so a
+later `session/configChanged` updates every chat that has not overridden that
+property. Properties without `chatScoped: true` always resolve from
+`SessionState.config`. Clients dispatch `chat/configChanged` on the chat channel
+to set per-chat overrides and `session/configChanged` on the session channel to
+change session values, including the inherited defaults of chat-scoped
+properties. With `replace: true`, properties omitted from `chat/configChanged`
+resume inheriting from the session.
 
 The sections below — turns, response parts, tool calls, pending messages, and input requests — describe the contents of `ChatState`.
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -577,7 +577,7 @@
     },
     "SessionConfigChangedAction": {
       "type": "object",
-      "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
+      "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. For a property with `chatScoped: true`, this changes the inherited\ndefault for chats that do not have their own override. The server validates\nand broadcasts the action; the reducer merges the new values into\n`state.config.values`.",
       "properties": {
         "type": {
           "const": "session/configChanged"
@@ -1432,6 +1432,28 @@
         "type"
       ]
     },
+    "ChatConfigChangedAction": {
+      "type": "object",
+      "description": "Client changed mutable, chat-scoped config values.\n\nOnly properties with both `chatScoped: true` and `sessionMutable: true` in\nthe config schema may be changed. The server validates and broadcasts the\naction; the reducer merges the new overrides into `state.config.values`.\nProperties without a chat override inherit their current value from\n`SessionState.config`.",
+      "properties": {
+        "type": {
+          "const": "chat/configChanged"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Updated chat-scoped config overrides"
+        },
+        "replace": {
+          "type": "boolean",
+          "description": "When `true`, replaces all chat config overrides instead of merging.\nOmitted properties resume inheriting from the session."
+        }
+      },
+      "required": [
+        "type",
+        "config"
+      ]
+    },
     "ChatInputRequestedAction": {
       "type": "object",
       "description": "A session requested input from the user.\n\nCreates an unresolved {@link InputRequestResponsePart} in the active turn,\nor replaces the unresolved part with the same request `id`. Answer drafts\nare preserved unless `request.answers` is provided.",
@@ -2092,6 +2114,9 @@
         },
         {
           "$ref": "#/$defs/ChatDraftChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatConfigChangedAction"
         },
         {
           "$ref": "#/$defs/ChatInputRequestedAction"
@@ -3254,6 +3279,10 @@
         "sessionMutable": {
           "type": "boolean",
           "description": "When `true`, the user may change this property after session creation"
+        },
+        "chatScoped": {
+          "type": "boolean",
+          "description": "When `true`, each chat may override this property in `ChatState.config`.\nA chat without an override inherits the current value from\n`SessionState.config`."
         }
       },
       "required": [
@@ -4364,6 +4393,10 @@
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Optional per-chat working directory.\n\nIf absent, the chat inherits\n{@link SessionState.workingDirectory | the session's working directory}.\nHosts MAY override this for individual chats — for example, to give a\nsubordinate chat its own git worktree so multiple chats in a session can\nmake independent edits that the orchestrator later merges back."
+        },
+        "config": {
+          "$ref": "#/$defs/SessionConfigState",
+          "description": "Configuration overrides owned by this chat.\n\nOnly properties whose schema declares `chatScoped: true` may appear in\n`values`. A property absent from `values` inherits the current value from\n`SessionState.config`. Presence of this state advertises support for\nper-chat config overrides."
         },
         "turns": {
           "type": "array",
@@ -7420,6 +7453,9 @@
         },
         {
           "$ref": "#/$defs/ChatDraftChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatConfigChangedAction"
         },
         {
           "$ref": "#/$defs/ChatInputRequestedAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2460,6 +2460,10 @@
         "sessionMutable": {
           "type": "boolean",
           "description": "When `true`, the user may change this property after session creation"
+        },
+        "chatScoped": {
+          "type": "boolean",
+          "description": "When `true`, each chat may override this property in `ChatState.config`.\nA chat without an override inherits the current value from\n`SessionState.config`."
         }
       },
       "required": [
@@ -3570,6 +3574,10 @@
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Optional per-chat working directory.\n\nIf absent, the chat inherits\n{@link SessionState.workingDirectory | the session's working directory}.\nHosts MAY override this for individual chats — for example, to give a\nsubordinate chat its own git worktree so multiple chats in a session can\nmake independent edits that the orchestrator later merges back."
+        },
+        "config": {
+          "$ref": "#/$defs/SessionConfigState",
+          "description": "Configuration overrides owned by this chat.\n\nOnly properties whose schema declares `chatScoped: true` may appear in\n`values`. A property absent from `values` inherits the current value from\n`SessionState.config`. Presence of this state advertises support for\nper-chat config overrides."
         },
         "turns": {
           "type": "array",
@@ -6642,7 +6650,7 @@
     },
     "SessionConfigChangedAction": {
       "type": "object",
-      "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
+      "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. For a property with `chatScoped: true`, this changes the inherited\ndefault for chats that do not have their own override. The server validates\nand broadcasts the action; the reducer merges the new values into\n`state.config.values`.",
       "properties": {
         "type": {
           "const": "session/configChanged"
@@ -7497,6 +7505,28 @@
         "type"
       ]
     },
+    "ChatConfigChangedAction": {
+      "type": "object",
+      "description": "Client changed mutable, chat-scoped config values.\n\nOnly properties with both `chatScoped: true` and `sessionMutable: true` in\nthe config schema may be changed. The server validates and broadcasts the\naction; the reducer merges the new overrides into `state.config.values`.\nProperties without a chat override inherit their current value from\n`SessionState.config`.",
+      "properties": {
+        "type": {
+          "const": "chat/configChanged"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Updated chat-scoped config overrides"
+        },
+        "replace": {
+          "type": "boolean",
+          "description": "When `true`, replaces all chat config overrides instead of merging.\nOmitted properties resume inheriting from the session."
+        }
+      },
+      "required": [
+        "type",
+        "config"
+      ]
+    },
     "ChatInputRequestedAction": {
       "type": "object",
       "description": "A session requested input from the user.\n\nCreates an unresolved {@link InputRequestResponsePart} in the active turn,\nor replaces the unresolved part with the same request `id`. Answer drafts\nare preserved unless `request.answers` is provided.",
@@ -8231,6 +8261,9 @@
         },
         {
           "$ref": "#/$defs/ChatDraftChangedAction"
+        },
+        {
+          "$ref": "#/$defs/ChatConfigChangedAction"
         },
         {
           "$ref": "#/$defs/ChatInputRequestedAction"

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -1244,6 +1244,10 @@
         "sessionMutable": {
           "type": "boolean",
           "description": "When `true`, the user may change this property after session creation"
+        },
+        "chatScoped": {
+          "type": "boolean",
+          "description": "When `true`, each chat may override this property in `ChatState.config`.\nA chat without an override inherits the current value from\n`SessionState.config`."
         }
       },
       "required": [
@@ -2354,6 +2358,10 @@
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Optional per-chat working directory.\n\nIf absent, the chat inherits\n{@link SessionState.workingDirectory | the session's working directory}.\nHosts MAY override this for individual chats — for example, to give a\nsubordinate chat its own git worktree so multiple chats in a session can\nmake independent edits that the orchestrator later merges back."
+        },
+        "config": {
+          "$ref": "#/$defs/SessionConfigState",
+          "description": "Configuration overrides owned by this chat.\n\nOnly properties whose schema declares `chatScoped: true` may appear in\n`values`. A property absent from `values` inherits the current value from\n`SessionState.config`. Presence of this state advertises support for\nper-chat config overrides."
         },
         "turns": {
           "type": "array",
@@ -6891,6 +6899,9 @@
           "$ref": "#/$defs/ChatDraftChangedAction"
         },
         {
+          "$ref": "#/$defs/ChatConfigChangedAction"
+        },
+        {
           "$ref": "#/$defs/ChatInputRequestedAction"
         },
         {
@@ -7605,7 +7616,7 @@
     },
     "SessionConfigChangedAction": {
       "type": "object",
-      "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. The server validates and broadcasts the action; the reducer merges\nthe new values into `state.config.values`.",
+      "description": "Client changed a mutable config value mid-session.\n\nOnly properties with `sessionMutable: true` in the config schema may be\nchanged. For a property with `chatScoped: true`, this changes the inherited\ndefault for chats that do not have their own override. The server validates\nand broadcasts the action; the reducer merges the new values into\n`state.config.values`.",
       "properties": {
         "type": {
           "const": "session/configChanged"
@@ -8307,6 +8318,28 @@
       },
       "required": [
         "type"
+      ]
+    },
+    "ChatConfigChangedAction": {
+      "type": "object",
+      "description": "Client changed mutable, chat-scoped config values.\n\nOnly properties with both `chatScoped: true` and `sessionMutable: true` in\nthe config schema may be changed. The server validates and broadcasts the\naction; the reducer merges the new overrides into `state.config.values`.\nProperties without a chat override inherit their current value from\n`SessionState.config`.",
+      "properties": {
+        "type": {
+          "const": "chat/configChanged"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Updated chat-scoped config overrides"
+        },
+        "replace": {
+          "type": "boolean",
+          "description": "When `true`, replaces all chat config overrides instead of merging.\nOmitted properties resume inheriting from the session."
+        }
+      },
+      "required": [
+        "type",
+        "config"
       ]
     },
     "ChatInputRequestedAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1404,6 +1404,10 @@
         "sessionMutable": {
           "type": "boolean",
           "description": "When `true`, the user may change this property after session creation"
+        },
+        "chatScoped": {
+          "type": "boolean",
+          "description": "When `true`, each chat may override this property in `ChatState.config`.\nA chat without an override inherits the current value from\n`SessionState.config`."
         }
       },
       "required": [
@@ -2514,6 +2518,10 @@
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Optional per-chat working directory.\n\nIf absent, the chat inherits\n{@link SessionState.workingDirectory | the session's working directory}.\nHosts MAY override this for individual chats — for example, to give a\nsubordinate chat its own git worktree so multiple chats in a session can\nmake independent edits that the orchestrator later merges back."
+        },
+        "config": {
+          "$ref": "#/$defs/SessionConfigState",
+          "description": "Configuration overrides owned by this chat.\n\nOnly properties whose schema declares `chatScoped: true` may appear in\n`values`. A property absent from `values` inherits the current value from\n`SessionState.config`. Presence of this state advertises support for\nper-chat config overrides."
         },
         "turns": {
           "type": "array",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1155,6 +1155,10 @@
         "sessionMutable": {
           "type": "boolean",
           "description": "When `true`, the user may change this property after session creation"
+        },
+        "chatScoped": {
+          "type": "boolean",
+          "description": "When `true`, each chat may override this property in `ChatState.config`.\nA chat without an override inherits the current value from\n`SessionState.config`."
         }
       },
       "required": [
@@ -2265,6 +2269,10 @@
         "workingDirectory": {
           "$ref": "#/$defs/URI",
           "description": "Optional per-chat working directory.\n\nIf absent, the chat inherits\n{@link SessionState.workingDirectory | the session's working directory}.\nHosts MAY override this for individual chats — for example, to give a\nsubordinate chat its own git worktree so multiple chats in a session can\nmake independent edits that the orchestrator later merges back."
+        },
+        "config": {
+          "$ref": "#/$defs/SessionConfigState",
+          "description": "Configuration overrides owned by this chat.\n\nOnly properties whose schema declares `chatScoped: true` may appear in\n`values`. A property absent from `values` inherits the current value from\n`SessionState.config`. Presence of this state advertises support for\nper-chat config overrides."
         },
         "turns": {
           "type": "array",

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1298,6 +1298,7 @@ const ACTION_VARIANTS: {
   { type: 'chat/pendingMessageRemoved', variantName: 'ChatPendingMessageRemoved', tsInterface: 'ChatPendingMessageRemovedAction' },
   { type: 'chat/queuedMessagesReordered', variantName: 'ChatQueuedMessagesReordered', tsInterface: 'ChatQueuedMessagesReorderedAction' },
   { type: 'chat/draftChanged', variantName: 'ChatDraftChanged', tsInterface: 'ChatDraftChangedAction' },
+  { type: 'chat/configChanged', variantName: 'ChatConfigChanged', tsInterface: 'ChatConfigChangedAction' },
   { type: 'chat/inputRequested', variantName: 'ChatInputRequested', tsInterface: 'ChatInputRequestedAction' },
   { type: 'chat/inputAnswerChanged', variantName: 'ChatInputAnswerChanged', tsInterface: 'ChatInputAnswerChangedAction' },
   { type: 'chat/inputCompleted', variantName: 'ChatInputCompleted', tsInterface: 'ChatInputCompletedAction' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1225,6 +1225,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'chat/pendingMessageRemoved', caseName: 'ChatPendingMessageRemoved', tsInterface: 'ChatPendingMessageRemovedAction' },
   { type: 'chat/queuedMessagesReordered', caseName: 'ChatQueuedMessagesReordered', tsInterface: 'ChatQueuedMessagesReorderedAction' },
   { type: 'chat/draftChanged', caseName: 'ChatDraftChanged', tsInterface: 'ChatDraftChangedAction' },
+  { type: 'chat/configChanged', caseName: 'ChatConfigChanged', tsInterface: 'ChatConfigChangedAction' },
   { type: 'chat/inputRequested', caseName: 'ChatInputRequested', tsInterface: 'ChatInputRequestedAction' },
   { type: 'chat/inputAnswerChanged', caseName: 'ChatInputAnswerChanged', tsInterface: 'ChatInputAnswerChangedAction' },
   { type: 'chat/inputCompleted', caseName: 'ChatInputCompleted', tsInterface: 'ChatInputCompletedAction' },

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1220,6 +1220,7 @@ const ACTION_VARIANTS: {
   { type: 'chat/pendingMessageRemoved', variantName: 'ChatPendingMessageRemoved', tsInterface: 'ChatPendingMessageRemovedAction' },
   { type: 'chat/queuedMessagesReordered', variantName: 'ChatQueuedMessagesReordered', tsInterface: 'ChatQueuedMessagesReorderedAction' },
   { type: 'chat/draftChanged', variantName: 'ChatDraftChanged', tsInterface: 'ChatDraftChangedAction' },
+  { type: 'chat/configChanged', variantName: 'ChatConfigChanged', tsInterface: 'ChatConfigChangedAction' },
   { type: 'chat/inputRequested', variantName: 'ChatInputRequested', tsInterface: 'ChatInputRequestedAction' },
   { type: 'chat/inputAnswerChanged', variantName: 'ChatInputAnswerChanged', tsInterface: 'ChatInputAnswerChangedAction' },
   { type: 'chat/inputCompleted', variantName: 'ChatInputCompleted', tsInterface: 'ChatInputCompletedAction' },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1134,6 +1134,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'chat/pendingMessageRemoved', caseName: 'chatPendingMessageRemoved', tsInterface: 'ChatPendingMessageRemovedAction' },
   { type: 'chat/queuedMessagesReordered', caseName: 'chatQueuedMessagesReordered', tsInterface: 'ChatQueuedMessagesReorderedAction' },
   { type: 'chat/draftChanged', caseName: 'chatDraftChanged', tsInterface: 'ChatDraftChangedAction' },
+  { type: 'chat/configChanged', caseName: 'chatConfigChanged', tsInterface: 'ChatConfigChangedAction' },
   { type: 'chat/inputRequested', caseName: 'chatInputRequested', tsInterface: 'ChatInputRequestedAction' },
   { type: 'chat/inputAnswerChanged', caseName: 'chatInputAnswerChanged', tsInterface: 'ChatInputAnswerChangedAction' },
   { type: 'chat/inputCompleted', caseName: 'chatInputCompleted', tsInterface: 'ChatInputCompletedAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -54,6 +54,7 @@ import type {
   ChatPendingMessageRemovedAction,
   ChatQueuedMessagesReorderedAction,
   ChatDraftChangedAction,
+  ChatConfigChangedAction,
   ChatInputRequestedAction,
   ChatInputAnswerChangedAction,
   ChatInputCompletedAction,
@@ -196,6 +197,7 @@ export type ChatAction =
   | ChatPendingMessageRemovedAction
   | ChatQueuedMessagesReorderedAction
   | ChatDraftChangedAction
+  | ChatConfigChangedAction
   | ChatInputRequestedAction
   | ChatInputAnswerChangedAction
   | ChatInputCompletedAction
@@ -215,6 +217,7 @@ export type ClientChatAction =
   | ChatPendingMessageRemovedAction
   | ChatQueuedMessagesReorderedAction
   | ChatDraftChangedAction
+  | ChatConfigChangedAction
   | ChatInputAnswerChangedAction
   | ChatInputCompletedAction
   | ChatTruncatedAction
@@ -396,6 +399,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.ChatPendingMessageRemoved]: true,
   [ActionType.ChatQueuedMessagesReordered]: true,
   [ActionType.ChatDraftChanged]: true,
+  [ActionType.ChatConfigChanged]: true,
   [ActionType.ChatInputRequested]: false,
   [ActionType.ChatInputAnswerChanged]: true,
   [ActionType.ChatInputCompleted]: true,

--- a/types/channels-chat/actions.ts
+++ b/types/channels-chat/actions.ts
@@ -690,6 +690,32 @@ export interface ChatDraftChangedAction {
   draft?: Message;
 }
 
+// ─── Config Actions ──────────────────────────────────────────────────────────
+
+/**
+ * Client changed mutable, chat-scoped config values.
+ *
+ * Only properties with both `chatScoped: true` and `sessionMutable: true` in
+ * the config schema may be changed. The server validates and broadcasts the
+ * action; the reducer merges the new overrides into `state.config.values`.
+ * Properties without a chat override inherit their current value from
+ * `SessionState.config`.
+ *
+ * @category Chat Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface ChatConfigChangedAction {
+  type: ActionType.ChatConfigChanged;
+  /** Updated chat-scoped config overrides */
+  config: Record<string, unknown>;
+  /**
+   * When `true`, replaces all chat config overrides instead of merging.
+   * Omitted properties resume inheriting from the session.
+   */
+  replace?: boolean;
+}
+
 // ─── Session Input Actions ──────────────────────────────────────────────────
 
 /**
@@ -774,6 +800,7 @@ export type ChatAction =
   | ChatPendingMessageRemovedAction
   | ChatQueuedMessagesReorderedAction
   | ChatDraftChangedAction
+  | ChatConfigChangedAction
   | ChatInputRequestedAction
   | ChatInputAnswerChangedAction
   | ChatInputCompletedAction

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -819,6 +819,20 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
     case ActionType.ChatDraftChanged:
       return { ...state, draft: action.draft };
 
+    // ── Config ────────────────────────────────────────────────────────────
+
+    case ActionType.ChatConfigChanged:
+      if (!state.config) {
+        return state;
+      }
+      return {
+        ...state,
+        config: {
+          ...state.config,
+          values: action.replace ? { ...action.config } : { ...state.config.values, ...action.config },
+        },
+      };
+
     default:
       softAssertNever(action, log);
       return state;

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -6,7 +6,12 @@
  */
 
 import type { ModelSelection } from '../channels-root/state.js';
-import type { AgentSelection, McpAuthRequirement, SessionStatus } from '../channels-session/state.js';
+import type {
+  AgentSelection,
+  McpAuthRequirement,
+  SessionConfigState,
+  SessionStatus,
+} from '../channels-session/state.js';
 import type {
   ContentRef,
   ErrorInfo,
@@ -67,6 +72,15 @@ export interface ChatState {
    * make independent edits that the orchestrator later merges back.
    */
   workingDirectory?: URI;
+  /**
+   * Configuration overrides owned by this chat.
+   *
+   * Only properties whose schema declares `chatScoped: true` may appear in
+   * `values`. A property absent from `values` inherits the current value from
+   * `SessionState.config`. Presence of this state advertises support for
+   * per-chat config overrides.
+   */
+  config?: SessionConfigState;
 
   // ── Conversation contents ──────────────────────────────────────────
   /** Completed turns */

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -472,8 +472,10 @@ export interface SessionMcpServerStopRequestedAction {
  * Client changed a mutable config value mid-session.
  *
  * Only properties with `sessionMutable: true` in the config schema may be
- * changed. The server validates and broadcasts the action; the reducer merges
- * the new values into `state.config.values`.
+ * changed. For a property with `chatScoped: true`, this changes the inherited
+ * default for chats that do not have their own override. The server validates
+ * and broadcasts the action; the reducer merges the new values into
+ * `state.config.values`.
  *
  * @category Session Actions
  * @version 1

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -509,6 +509,12 @@ export interface SessionConfigPropertySchema extends ConfigPropertySchema {
   enumDynamic?: boolean;
   /** When `true`, the user may change this property after session creation */
   sessionMutable?: boolean;
+  /**
+   * When `true`, each chat may override this property in `ChatState.config`.
+   * A chat without an override inherits the current value from
+   * `SessionState.config`.
+   */
+  chatScoped?: boolean;
 }
 
 /**

--- a/types/common/actions.ts
+++ b/types/common/actions.ts
@@ -66,6 +66,7 @@ import type {
   ChatPendingMessageRemovedAction,
   ChatQueuedMessagesReorderedAction,
   ChatDraftChangedAction,
+  ChatConfigChangedAction,
   ChatInputRequestedAction,
   ChatInputAnswerChangedAction,
   ChatInputCompletedAction,
@@ -154,6 +155,7 @@ export const enum ActionType {
   ChatPendingMessageRemoved = 'chat/pendingMessageRemoved',
   ChatQueuedMessagesReordered = 'chat/queuedMessagesReordered',
   ChatDraftChanged = 'chat/draftChanged',
+  ChatConfigChanged = 'chat/configChanged',
   ChatInputRequested = 'chat/inputRequested',
   ChatInputAnswerChanged = 'chat/inputAnswerChanged',
   ChatInputCompleted = 'chat/inputCompleted',
@@ -286,6 +288,7 @@ export type StateAction =
   | ChatPendingMessageRemovedAction
   | ChatQueuedMessagesReorderedAction
   | ChatDraftChangedAction
+  | ChatConfigChangedAction
   | ChatInputRequestedAction
   | ChatInputAnswerChangedAction
   | ChatInputCompletedAction

--- a/types/common/reducer-helpers.ts
+++ b/types/common/reducer-helpers.ts
@@ -10,6 +10,8 @@ import type {
   ClientRootAction,
   SessionAction,
   ClientSessionAction,
+  ChatAction,
+  ClientChatAction,
   TerminalAction,
   ClientTerminalAction,
   ChangesetAction,
@@ -40,6 +42,6 @@ export function softAssertNever(value: never, log?: (msg: string) => void): void
  * Servers SHOULD call this to validate incoming `dispatchAction` requests
  * and reject any action the client is not allowed to originate.
  */
-export function isClientDispatchable(action: RootAction | SessionAction | TerminalAction | ChangesetAction | AnnotationsAction): action is ClientRootAction | ClientSessionAction | ClientTerminalAction | ClientChangesetAction | ClientAnnotationsAction {
+export function isClientDispatchable(action: RootAction | SessionAction | ChatAction | TerminalAction | ChangesetAction | AnnotationsAction): action is ClientRootAction | ClientSessionAction | ClientChatAction | ClientTerminalAction | ClientChangesetAction | ClientAnnotationsAction {
   return IS_CLIENT_DISPATCHABLE[action.type];
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -190,6 +190,7 @@ export type {
   ChatPendingMessageRemovedAction,
   ChatQueuedMessagesReorderedAction,
   ChatDraftChangedAction,
+  ChatConfigChangedAction,
   ChatInputAnswerChangedAction,
   ChatInputCompletedAction,
   ChatInputRequestedAction,

--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -211,7 +211,7 @@ describe('IS_CLIENT_DISPATCHABLE', () => {
 
 describe('isClientDispatchable', () => {
   it('returns true for client-dispatchable actions', () => {
-    const action = { type: ActionType.ChatTurnStarted, turnId: 't', startedAt: '2026-07-10T00:00:00.000Z', message: { text: 'Hello', origin: { kind: MessageKind.User } } } as const;
+    const action = { type: ActionType.ChatConfigChanged, config: { permissionMode: 'default' } } as const;
     assert.equal(isClientDispatchable(action), true);
   });
 

--- a/types/test-cases/reducers/256-chat-configchanged-merges-into-config-values.json
+++ b/types/test-cases/reducers/256-chat-configchanged-merges-into-config-values.json
@@ -1,0 +1,72 @@
+{
+  "description": "chat/configChanged merges new overrides into config.values",
+  "reducer": "chat",
+  "initial": {
+    "resource": "ahp-chat:/one",
+    "title": "Chat one",
+    "status": 1,
+    "modifiedAt": "2026-07-16T00:00:00.000Z",
+    "config": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "permissionMode": {
+            "type": "string",
+            "title": "Permission mode",
+            "chatScoped": true,
+            "sessionMutable": true
+          },
+          "autoApprove": {
+            "type": "boolean",
+            "title": "Auto approve",
+            "chatScoped": true,
+            "sessionMutable": true
+          }
+        }
+      },
+      "values": {
+        "permissionMode": "default",
+        "autoApprove": false
+      }
+    },
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "chat/configChanged",
+      "config": {
+        "permissionMode": "bypassPermissions"
+      }
+    }
+  ],
+  "expected": {
+    "resource": "ahp-chat:/one",
+    "title": "Chat one",
+    "status": 1,
+    "modifiedAt": "2026-07-16T00:00:00.000Z",
+    "config": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "permissionMode": {
+            "type": "string",
+            "title": "Permission mode",
+            "chatScoped": true,
+            "sessionMutable": true
+          },
+          "autoApprove": {
+            "type": "boolean",
+            "title": "Auto approve",
+            "chatScoped": true,
+            "sessionMutable": true
+          }
+        }
+      },
+      "values": {
+        "permissionMode": "bypassPermissions",
+        "autoApprove": false
+      }
+    },
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/257-chat-configchanged-noops-when-config-undefined.json
+++ b/types/test-cases/reducers/257-chat-configchanged-noops-when-config-undefined.json
@@ -1,0 +1,26 @@
+{
+  "description": "chat/configChanged is a no-op when config is undefined",
+  "reducer": "chat",
+  "initial": {
+    "resource": "ahp-chat:/one",
+    "title": "Chat one",
+    "status": 1,
+    "modifiedAt": "2026-07-16T00:00:00.000Z",
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "chat/configChanged",
+      "config": {
+        "permissionMode": "bypassPermissions"
+      }
+    }
+  ],
+  "expected": {
+    "resource": "ahp-chat:/one",
+    "title": "Chat one",
+    "status": 1,
+    "modifiedAt": "2026-07-16T00:00:00.000Z",
+    "turns": []
+  }
+}

--- a/types/test-cases/reducers/258-chat-configchanged-replace-replaces-all-values.json
+++ b/types/test-cases/reducers/258-chat-configchanged-replace-replaces-all-values.json
@@ -1,0 +1,72 @@
+{
+  "description": "chat/configChanged with replace replaces all chat config overrides",
+  "reducer": "chat",
+  "initial": {
+    "resource": "ahp-chat:/one",
+    "title": "Chat one",
+    "status": 1,
+    "modifiedAt": "2026-07-16T00:00:00.000Z",
+    "config": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "permissionMode": {
+            "type": "string",
+            "title": "Permission mode",
+            "chatScoped": true,
+            "sessionMutable": true
+          },
+          "autoApprove": {
+            "type": "boolean",
+            "title": "Auto approve",
+            "chatScoped": true,
+            "sessionMutable": true
+          }
+        }
+      },
+      "values": {
+        "permissionMode": "default",
+        "autoApprove": false
+      }
+    },
+    "turns": []
+  },
+  "actions": [
+    {
+      "type": "chat/configChanged",
+      "config": {
+        "autoApprove": true
+      },
+      "replace": true
+    }
+  ],
+  "expected": {
+    "resource": "ahp-chat:/one",
+    "title": "Chat one",
+    "status": 1,
+    "modifiedAt": "2026-07-16T00:00:00.000Z",
+    "config": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "permissionMode": {
+            "type": "string",
+            "title": "Permission mode",
+            "chatScoped": true,
+            "sessionMutable": true
+          },
+          "autoApprove": {
+            "type": "boolean",
+            "title": "Auto approve",
+            "chatScoped": true,
+            "sessionMutable": true
+          }
+        }
+      },
+      "values": {
+        "autoApprove": true
+      }
+    },
+    "turns": []
+  }
+}

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -126,6 +126,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string
   [ActionType.ChatPendingMessageRemoved]: '0.4.0',
   [ActionType.ChatQueuedMessagesReordered]: '0.4.0',
   [ActionType.ChatDraftChanged]: '0.5.0',
+  [ActionType.ChatConfigChanged]: '0.6.0',
   [ActionType.ChatInputRequested]: '0.4.0',
   [ActionType.ChatInputAnswerChanged]: '0.4.0',
   [ActionType.ChatInputCompleted]: '0.4.0',


### PR DESCRIPTION
Add live session fallback inheritance for chat-scoped config values and mirror the state, actions, reducers, schemas, fixtures, and generated clients across all supported languages.

Closes #335