### PR TITLE
clients: add protocol-level ping to Rust, Go, Swift, and Kotlin

### DIFF
--- a/clients/go/ahp/client.go
+++ b/clients/go/ahp/client.go
@@ -793,6 +793,19 @@ func (c *Client) Reconnect(ctx context.Context, clientID string, lastSeenServerS
 	return &out, nil
 }
 
+// Ping sends a protocol-level `ping` request to verify the connection is
+// still alive and keep it from being closed by idle-timeout intermediaries
+// (proxies, load balancers, etc.). It is a connection-level command scoped to
+// the root channel and carries no payload in either direction — the response
+// itself is the signal. The server responds regardless of whether Initialize
+// has completed or any subscriptions are held.
+func (c *Client) Ping(ctx context.Context) error {
+	params := struct {
+		Channel ahptypes.URI `json:"channel"`
+	}{Channel: ahptypes.RootResourceURI}
+	return c.Request(ctx, "ping", params, nil)
+}
+
 // Subscribe sends a `subscribe` request and returns the initial snapshot
 // together with a per-URI [Subscription] handle.
 func (c *Client) Subscribe(ctx context.Context, uri string) (*ahptypes.SubscribeResult, *Subscription, error) {

--- a/clients/go/ahp/client_test.go
+++ b/clients/go/ahp/client_test.go
@@ -123,6 +123,71 @@ func TestClientRequestRoundTrip(t *testing.T) {
 	}
 }
 
+// TestPingTargetsRootChannel drives a fake server that answers a single
+// `ping` request with a null result and verifies the request shape.
+func TestPingTargetsRootChannel(t *testing.T) {
+	clientSide, serverSide := newMemTransportPair()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		msg, err := serverSide.Recv(ctx)
+		if err != nil {
+			t.Errorf("server recv: %v", err)
+			return
+		}
+		parsed, err := msg.IntoParsed()
+		if err != nil {
+			t.Errorf("server parse: %v", err)
+			return
+		}
+		if parsed.Request == nil {
+			t.Errorf("expected request, got %+v", parsed)
+			return
+		}
+		if parsed.Request.Method != "ping" {
+			t.Errorf("method = %q, want %q", parsed.Request.Method, "ping")
+		}
+		var params struct {
+			Channel string `json:"channel"`
+		}
+		if err := json.Unmarshal(parsed.Request.Params, &params); err != nil {
+			t.Errorf("server decode params: %v", err)
+			return
+		}
+		if params.Channel != string(ahptypes.RootResourceURI) {
+			t.Errorf("channel = %q, want %q", params.Channel, ahptypes.RootResourceURI)
+		}
+		// The server responds with a null result — the response is the signal.
+		resp := ahptypes.JsonRpcMessage{SuccessResponse: &ahptypes.JsonRpcSuccessResponse{
+			JsonRpc: ahptypes.JsonRpcV2,
+			ID:      parsed.Request.ID,
+			Result:  json.RawMessage("null"),
+		}}
+		out, err := EncodeMessage(resp)
+		if err != nil {
+			t.Errorf("server encode: %v", err)
+			return
+		}
+		if err := serverSide.Send(ctx, out); err != nil {
+			t.Errorf("server send: %v", err)
+			return
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	client, err := Connect(ctx, clientSide, DefaultConfig())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer client.Shutdown(context.Background())
+
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+}
+
 func TestResourceReadSendWrapperTargetsRootChannel(t *testing.T) {
 	clientSide, serverSide := newMemTransportPair()
 	serverErr := make(chan error, 1)

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Messages.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Messages.generated.kt
@@ -86,6 +86,11 @@ object AhpCommands {
     fun initialize(id: Long, params: InitializeParams): JsonRpcRequest<InitializeParams> =
         JsonRpcRequest(id = id, method = "initialize", params = params)
 
+    // `ping` carries no payload beyond the root channel discriminant, so there is
+    // no dedicated `PingParams` type. The helper hardcodes the channel object.
+    fun ping(id: Long): JsonRpcRequest<JsonObject> =
+        JsonRpcRequest(id = id, method = "ping", params = JsonObject(mapOf("channel" to JsonPrimitive("ahp-root://"))))
+
     fun reconnect(id: Long, params: ReconnectParams): JsonRpcRequest<ReconnectParams> =
         JsonRpcRequest(id = id, method = "reconnect", params = params)
 

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/GeneratedStructsTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/GeneratedStructsTest.kt
@@ -1,16 +1,20 @@
 package com.microsoft.agenthostprotocol
 
 import com.microsoft.agenthostprotocol.generated.AgentInfo
+import com.microsoft.agenthostprotocol.generated.AhpCommands
 import com.microsoft.agenthostprotocol.generated.AuthRequiredParams
+import com.microsoft.agenthostprotocol.generated.JsonRpcRequest
 import com.microsoft.agenthostprotocol.generated.PolicyState
 import com.microsoft.agenthostprotocol.generated.ProtectedResourceMetadata
 import com.microsoft.agenthostprotocol.generated.SessionAddedParams
 import com.microsoft.agenthostprotocol.generated.SessionModelInfo
 import com.microsoft.agenthostprotocol.generated.SessionStatus
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -171,5 +175,20 @@ class GeneratedStructsTest {
         val auth = json.decodeFromString(AuthRequiredParams.serializer(), authWire)
         assertEquals("ahp-root://", auth.channel)
         assertEquals("https://api.github.com", auth.resource)
+    }
+
+    @Test
+    fun `AhpCommands ping builds a root-scoped ping request`() {
+        // `ping` has no dedicated params type; the factory hardcodes the root
+        // channel object. Verify the emitted request shape matches the wire.
+        val request = AhpCommands.ping(7L)
+        assertEquals("ping", request.method)
+
+        val encoded = json.encodeToString(JsonRpcRequest.serializer(JsonObject.serializer()), request)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+        assertEquals("2.0", obj["jsonrpc"]?.jsonPrimitive?.content)
+        assertEquals(7L, obj["id"]?.jsonPrimitive?.long)
+        assertEquals("ping", obj["method"]?.jsonPrimitive?.content)
+        assertEquals("ahp-root://", obj["params"]?.jsonObject?.get("channel")?.jsonPrimitive?.content)
     }
 }

--- a/clients/rust/crates/ahp/src/client.rs
+++ b/clients/rust/crates/ahp/src/client.rs
@@ -527,6 +527,28 @@ impl Client {
         self.request("reconnect", params).await
     }
 
+    /// Protocol-level liveness `ping`.
+    ///
+    /// Verifies the connection is still alive and keeps it from being closed
+    /// by idle-timeout intermediaries (proxies, load balancers, etc.). `ping`
+    /// is a connection-level command scoped to the root channel and carries no
+    /// payload in either direction — the response itself is the signal. The
+    /// server responds regardless of whether `initialize` has completed or any
+    /// subscriptions are held.
+    pub async fn ping(&self) -> Result<(), ClientError> {
+        #[derive(Serialize)]
+        struct PingParams {
+            channel: &'static str,
+        }
+        self.request(
+            "ping",
+            PingParams {
+                channel: ROOT_RESOURCE_URI,
+            },
+        )
+        .await
+    }
+
     /// Subscribe to a URI and obtain a handle that streams
     /// [`SubscriptionEvent`]s for that channel.
     pub async fn subscribe(

--- a/clients/rust/crates/ahp/tests/client_roundtrip.rs
+++ b/clients/rust/crates/ahp/tests/client_roundtrip.rs
@@ -204,6 +204,40 @@ async fn resource_read_send_wrapper_targets_root_channel() {
 }
 
 #[tokio::test]
+async fn ping_targets_root_channel_and_resolves_on_null_result() {
+    let (client_side, mut server_side) = pair();
+    let client = Client::connect(client_side, ClientConfig::default())
+        .await
+        .expect("connect");
+
+    let server = tokio::spawn(async move {
+        let msg = server_side.recv().await.unwrap().unwrap();
+        let JsonRpcMessage::Request(req) = msg.into_parsed().unwrap() else {
+            panic!("expected Request")
+        };
+        assert_eq!(req.method, "ping");
+        // `ping` is a connection-level command scoped to the root channel.
+        assert_eq!(req.params.unwrap()["channel"], "ahp-root://");
+
+        // The server responds with a `null` result — the response is the signal.
+        let resp = JsonRpcMessage::SuccessResponse(JsonRpcSuccessResponse {
+            jsonrpc: JsonRpcVersion::V2,
+            id: req.id,
+            result: ahp_types::common::AnyValue::from(serde_json::Value::Null),
+        });
+        server_side
+            .send(TransportMessage::encode(&resp).unwrap())
+            .await
+            .unwrap();
+    });
+
+    client.ping().await.expect("ping");
+
+    client.shutdown().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
 async fn inbound_resource_request_routes_to_typed_handler() {
     use ahp::ResourceRequestHandlers;
     use ahp_types::commands::{ContentEncoding, ResourceReadResult};

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Messages.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Messages.generated.swift
@@ -72,6 +72,12 @@ public enum AHPCommands {
         JsonRpcRequest(id: id, method: "initialize", params: params)
     }
 
+    // `ping` carries no payload beyond the root channel discriminant, so there is
+    // no dedicated `PingParams` type. The helper hardcodes the channel object.
+    public static func ping(id: Int) -> JsonRpcRequest<[String: String]> {
+        JsonRpcRequest(id: id, method: "ping", params: ["channel": "ahp-root://"])
+    }
+
     public static func reconnect(id: Int, params: ReconnectParams) -> JsonRpcRequest<ReconnectParams> {
         JsonRpcRequest(id: id, method: "reconnect", params: params)
     }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocolClient/AHPClient.swift
@@ -305,6 +305,23 @@ public actor AHPClient {
         return result
     }
 
+    /// Protocol-level liveness `ping`.
+    ///
+    /// Verifies the connection is still alive and keeps it from being closed
+    /// by idle-timeout intermediaries (proxies, load balancers, etc.). `ping`
+    /// is a connection-level command scoped to the root channel and carries no
+    /// payload in either direction — the response itself is the signal. The
+    /// server responds regardless of whether `initialize` has completed or any
+    /// subscriptions are held.
+    ///
+    /// This is the protocol-level ping (usable over any transport); it is
+    /// distinct from transport-level WebSocket ping frames exposed via
+    /// ``AHPKeepAliveTransport``.
+    public func ping() async throws {
+        let paramsData = try encoder.encode([ "channel": RootResourceURI ])
+        _ = try await requestRaw(method: "ping", paramsData: paramsData)
+    }
+
     /// Subscribe to a channel URI. Returns the subscribe result (whose
     /// `snapshot` is `nil` for stateless channels) and a fresh stream of
     /// subsequent events.

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolClientTests/AHPClientTests.swift
@@ -37,6 +37,34 @@ final class AHPClientTests: XCTestCase {
         await client.shutdown()
     }
 
+    // MARK: - ping
+
+    func testPingTargetsRootChannelAndResolvesOnNullResult() async throws {
+        let (clientSide, serverSide) = InMemoryTransport.pair()
+        let client = AHPClient(transport: clientSide)
+        try await client.connect()
+
+        // Server task: answer a single `ping` with a null result.
+        let serverTask = Task {
+            let request = try await readRequest(from: serverSide, expectedMethod: "ping")
+            // `ping` is a connection-level command scoped to the root channel.
+            let params = try XCTUnwrap(request.params)
+            let paramsData = try JSONEncoder().encode(params)
+            let obj = try JSONSerialization.jsonObject(with: paramsData) as? [String: Any]
+            XCTAssertEqual(obj?["channel"] as? String, RootResourceURI)
+
+            // The response itself is the signal; `ping` carries a null result.
+            let dict: [String: Any] = ["jsonrpc": "2.0", "id": request.id, "result": NSNull()]
+            let wireBytes = try JSONSerialization.data(withJSONObject: dict)
+            try await serverSide.send(.text(String(data: wireBytes, encoding: .utf8)!))
+        }
+
+        try await client.ping()
+
+        try await serverTask.value
+        await client.shutdown()
+    }
+
     // MARK: - subscribe_streams_actions
 
     func testSubscribeStreamsActions() async throws {

--- a/docs/.changes/20260717-go-client-ping.json
+++ b/docs/.changes/20260717-go-client-ping.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "`Client.Ping()` for protocol-level connection liveness, mirroring the TypeScript client's `AhpClient.ping()`.",
+  "targets": ["go"]
+}

--- a/docs/.changes/20260717-kotlin-command-ping.json
+++ b/docs/.changes/20260717-kotlin-command-ping.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "`AhpCommands.ping(id)` request factory for protocol-level connection liveness, mirroring the TypeScript client's `AhpClient.ping()`.",
+  "targets": ["kotlin"]
+}

--- a/docs/.changes/20260717-rust-client-ping.json
+++ b/docs/.changes/20260717-rust-client-ping.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "`Client::ping()` for protocol-level connection liveness, mirroring the TypeScript client's `AhpClient.ping()`.",
+  "targets": ["rust"]
+}

--- a/docs/.changes/20260717-swift-client-ping.json
+++ b/docs/.changes/20260717-swift-client-ping.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "`AHPClient.ping()` for protocol-level connection liveness and an `AHPCommands.ping(id:)` request factory, mirroring the TypeScript client's `AhpClient.ping()`.",
+  "targets": ["swift"]
+}

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1778,6 +1778,11 @@ object AhpCommands {
     fun initialize(id: Long, params: InitializeParams): JsonRpcRequest<InitializeParams> =
         JsonRpcRequest(id = id, method = "initialize", params = params)
 
+    // \`ping\` carries no payload beyond the root channel discriminant, so there is
+    // no dedicated \`PingParams\` type. The helper hardcodes the channel object.
+    fun ping(id: Long): JsonRpcRequest<JsonObject> =
+        JsonRpcRequest(id = id, method = "ping", params = JsonObject(mapOf("channel" to JsonPrimitive("ahp-root://"))))
+
     fun reconnect(id: Long, params: ReconnectParams): JsonRpcRequest<ReconnectParams> =
         JsonRpcRequest(id = id, method = "reconnect", params = params)
 
@@ -1906,8 +1911,8 @@ function checkExhaustiveness(project: Project): void {
     // PingParams shape is `interface PingParams extends BaseParams { channel: 'ahp-root://' }`
     // (i.e. a `BaseParams` with `channel` narrowed to a string literal). We don't
     // emit a dedicated data class because the only useful payload is the
-    // hard-coded channel value and a typed `AhpCommands.ping(...)` helper can
-    // construct the request without forcing consumers through a wrapper.
+    // hard-coded channel value; the typed `AhpCommands.ping(...)` helper
+    // constructs the request without forcing consumers through a wrapper.
     // Matches the Swift generator's handling.
     'PingParams',
     'ActionType',                   // emitted directly by generateActionsFile(), not via STATE_ENUMS

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1691,6 +1691,12 @@ public enum AHPCommands {
         JsonRpcRequest(id: id, method: "initialize", params: params)
     }
 
+    // \`ping\` carries no payload beyond the root channel discriminant, so there is
+    // no dedicated \`PingParams\` type. The helper hardcodes the channel object.
+    public static func ping(id: Int) -> JsonRpcRequest<[String: String]> {
+        JsonRpcRequest(id: id, method: "ping", params: ["channel": "ahp-root://"])
+    }
+
     public static func reconnect(id: Int, params: ReconnectParams) -> JsonRpcRequest<ReconnectParams> {
         JsonRpcRequest(id: id, method: "reconnect", params: params)
     }
@@ -1941,7 +1947,7 @@ function checkExhaustiveness(project: Project): void {
     'SessionToolCallApprovedAction', // merged into SessionToolCallConfirmedAction
     'SessionToolCallDeniedAction',   // merged into SessionToolCallConfirmedAction
     'SessionToolCallConfirmedAction', // emitted as merged variant
-    'PingParams',                    // empty interface; no Swift type emitted
+    'PingParams',                    // empty interface; no Swift type emitted (AHPCommands.ping hardcodes the channel)
     'TerminalClaim',                // TERMINAL_CLAIM_UNION discriminated union
     'TerminalContentPart',           // TERMINAL_CONTENT_PART_UNION discriminated union
     'ChatInputQuestion',         // SESSION_INPUT_QUESTION_UNION discriminated union


### PR DESCRIPTION
## Summary

Only the **TypeScript** client exposed a `ping()` helper. The protocol defines `ping` as a root-scoped liveness command (`params: { channel }`, `result: null`), but Rust, Go, Swift, and Kotlin never got the helper — a parity gap, not an intentional omission. PR #119 added `ping` to the spec/types only; when the clients were built later, just TS got the method. The Swift and Kotlin generators even carried comments referencing an intended `AhpCommands.ping(...)` helper that was never actually emitted.

This PR closes the gap, mirroring TS's `AhpClient.ping()`:

| Client | Change |
| --- | --- |
| **Rust** | `Client::ping()` |
| **Go** | `Client.Ping(ctx)` |
| **Swift** | `AHPClient.ping()` + generated `AHPCommands.ping(id:)` factory |
| **Kotlin** | generated `AhpCommands.ping(id)` factory (Kotlin ships no async client, so its request-builder surface is the analog) |

Each hardcodes the `ahp-root://` channel, honoring the generators' existing "no `PingParams` wrapper" convention (the params carry no payload beyond the root-channel discriminant). The Swift/Kotlin generated outputs were regenerated and the now-accurate generator comments refreshed.

## Testing

- **Rust**: `cargo fmt --check` + clippy clean; new `ping_targets_root_channel_and_resolves_on_null_result` roundtrip test passes.
- **Go**: gofmt clean; new `TestPingTargetsRootChannel` passes.
- **Swift**: new `testPingTargetsRootChannelAndResolvesOnNullResult` passes.
- **Kotlin**: new `AhpCommands ping builds a root-scoped ping request` test passes.
- Repo `lint` + `typecheck` + change-fragment verify pass; no generation drift.

Changelog fragments added under `docs/.changes/` scoped to each affected client.