### PR TITLE
Add Swift AHPCommands.createTerminal/disposeTerminal builders

### DIFF
--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Messages.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Messages.generated.swift
@@ -133,6 +133,14 @@ public enum AHPCommands {
     public static func authenticate(id: Int, params: AuthenticateParams) -> JsonRpcRequest<AuthenticateParams> {
         JsonRpcRequest(id: id, method: "authenticate", params: params)
     }
+
+    public static func createTerminal(id: Int, params: CreateTerminalParams) -> JsonRpcRequest<CreateTerminalParams> {
+        JsonRpcRequest(id: id, method: "createTerminal", params: params)
+    }
+
+    public static func disposeTerminal(id: Int, params: DisposeTerminalParams) -> JsonRpcRequest<DisposeTerminalParams> {
+        JsonRpcRequest(id: id, method: "disposeTerminal", params: params)
+    }
 }
 
 /// Typed helper for constructing client → server notifications.

--- a/docs/.changes/20260717-swift-command-terminal.json
+++ b/docs/.changes/20260717-swift-command-terminal.json
@@ -1,0 +1,6 @@
+{
+  "type": "added",
+  "message": "`AHPCommands.createTerminal(id:params:)` and `AHPCommands.disposeTerminal(id:params:)` request factories, so the generated `CreateTerminalParams` / `DisposeTerminalParams` are reachable through the typed command surface for parity with `createSession` / `disposeSession`.",
+  "targets": ["swift"],
+  "issues": [341]
+}

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1752,6 +1752,14 @@ public enum AHPCommands {
     public static func authenticate(id: Int, params: AuthenticateParams) -> JsonRpcRequest<AuthenticateParams> {
         JsonRpcRequest(id: id, method: "authenticate", params: params)
     }
+
+    public static func createTerminal(id: Int, params: CreateTerminalParams) -> JsonRpcRequest<CreateTerminalParams> {
+        JsonRpcRequest(id: id, method: "createTerminal", params: params)
+    }
+
+    public static func disposeTerminal(id: Int, params: DisposeTerminalParams) -> JsonRpcRequest<DisposeTerminalParams> {
+        JsonRpcRequest(id: id, method: "disposeTerminal", params: params)
+    }
 }
 
 /// Typed helper for constructing client → server notifications.


### PR DESCRIPTION
## Summary

Fixes #341.

The Swift `AgentHostProtocol` module could fully **consume** the terminal channel (the `terminalReducer` plus all `terminal/*` state actions) and had the generated `CreateTerminalParams` / `DisposeTerminalParams`, but there was no typed way to **drive** it: `AHPCommands` had `createSession` / `disposeSession` builders but no terminal equivalents. Callers had to fall back to a raw `"createTerminal"` method string.

This adds `AHPCommands.createTerminal(id:params:)` and `AHPCommands.disposeTerminal(id:params:)` request factories, giving the terminal commands parity with the session commands and making the generated param types reachable through the typed surface.

## Changes

- `scripts/generate-swift.ts` — add the two builders to the hardcoded `AHPCommands` list, placed after `authenticate` to match Kotlin's ordering.
- `clients/swift/.../Generated/Messages.generated.swift` — regenerated output.
- `docs/.changes/20260717-swift-command-terminal.json` — changelog fragment (`targets: ["swift"]`).

## Cross-client parity check

I audited the other clients for the same gap:

| Client | Terminal command surface | Action |
| --- | --- | --- |
| Swift | `AHPCommands` builder — **missing** terminal | **Fixed here** |
| Kotlin | `AhpCommands` already has `createTerminal` / `disposeTerminal` | none |
| TypeScript | typed `CommandMap` already includes both | none |
| Rust | fully generic `request(method, params)` — no per-command builders (`createSession` isn't a method either) | none |
| Go | fully generic `Request(...)` — no per-command builders | none |

Only Swift was missing coverage, so this is a Swift-only change.

## Validation

- `npm run generate:swift` — regenerated, only the expected diff.
- `swift build` — compiles.
- `swift test` — 110 tests pass.
- `npm run verify:change-fragments` — passes.

## Note

Swift's `AHPCommands` list is also missing some unrelated commands (`resolveSessionConfig`, `sessionConfigCompletions`, `completions`, `invokeChangesetOperation`) that Kotlin already exposes. That's outside the scope of #341 and left for a separate follow-up.