### PR TITLE
chat: allow transcript attachments without an end turn

### DIFF
--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -1720,10 +1720,19 @@ type MessageAnnotationsAttachment struct {
 // An attachment that references a chat transcript through a fixed completed
 // turn.
 //
-// The referenced chat MUST belong to the same session as the message's chat.
-// The host resolves the transcript from its first retained turn through
-// `endTurn`, inclusive, when accepting the message. Later turns do not
-// change the context represented by an already-sent attachment.
+// The referenced chat MAY belong to a different session than the message's
+// chat. The attachment's model representation identifies the chat in a way
+// that hosts can resolve regardless of the session that owns it.
+//
+// When `endTurn` is omitted, the host MUST resolve and pin the referenced
+// chat's latest completed turn when accepting the message. This lets clients
+// attach a chat without knowing its turn identifiers. When provided, `endTurn`
+// MUST reference a completed, retained turn. The host resolves the transcript
+// from its first retained turn through the pinned turn, inclusive. Later turns
+// do not change the context represented by an already-sent attachment.
+//
+// Hosts MUST reject an attachment that omits `endTurn` when the referenced chat
+// has no completed retained turns.
 //
 // Hosts MUST NOT recursively expand chat attachments found inside the
 // referenced transcript. Clients SHOULD keep rendering `label` if the
@@ -1757,8 +1766,9 @@ type MessageChatAttachment struct {
 	Type MessageAttachmentKind `json:"type"`
 	// URI of the referenced chat.
 	Resource URI `json:"resource"`
-	// Last completed turn included in the referenced transcript.
-	EndTurn string `json:"endTurn"`
+	// Last completed turn included in the referenced transcript. When omitted,
+	// the host pins the latest completed turn when accepting the message.
+	EndTurn *string `json:"endTurn,omitempty"`
 }
 
 type MarkdownResponsePart struct {

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -2403,9 +2403,10 @@ data class MessageChatAttachment(
      */
     val resource: String,
     /**
-     * Last completed turn included in the referenced transcript.
+     * Last completed turn included in the referenced transcript. When omitted,
+     * the host pins the latest completed turn when accepting the message.
      */
-    val endTurn: String
+    val endTurn: String? = null
 )
 
 @Serializable

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -2145,10 +2145,19 @@ pub struct MessageAnnotationsAttachment {
 /// An attachment that references a chat transcript through a fixed completed
 /// turn.
 ///
-/// The referenced chat MUST belong to the same session as the message's chat.
-/// The host resolves the transcript from its first retained turn through
-/// `endTurn`, inclusive, when accepting the message. Later turns do not
-/// change the context represented by an already-sent attachment.
+/// The referenced chat MAY belong to a different session than the message's
+/// chat. The attachment's model representation identifies the chat in a way
+/// that hosts can resolve regardless of the session that owns it.
+///
+/// When `endTurn` is omitted, the host MUST resolve and pin the referenced
+/// chat's latest completed turn when accepting the message. This lets clients
+/// attach a chat without knowing its turn identifiers. When provided, `endTurn`
+/// MUST reference a completed, retained turn. The host resolves the transcript
+/// from its first retained turn through the pinned turn, inclusive. Later turns
+/// do not change the context represented by an already-sent attachment.
+///
+/// Hosts MUST reject an attachment that omits `endTurn` when the referenced chat
+/// has no completed retained turns.
 ///
 /// Hosts MUST NOT recursively expand chat attachments found inside the
 /// referenced transcript. Clients SHOULD keep rendering `label` if the
@@ -2185,8 +2194,10 @@ pub struct MessageChatAttachment {
     pub meta: Option<JsonObject>,
     /// URI of the referenced chat.
     pub resource: Uri,
-    /// Last completed turn included in the referenced transcript.
-    pub end_turn: String,
+    /// Last completed turn included in the referenced transcript. When omitted,
+    /// the host pins the latest completed turn when accepting the message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_turn: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -2370,8 +2370,9 @@ public struct MessageChatAttachment: Codable, Sendable {
     public var type: MessageAttachmentKind
     /// URI of the referenced chat.
     public var resource: String
-    /// Last completed turn included in the referenced transcript.
-    public var endTurn: String
+    /// Last completed turn included in the referenced transcript. When omitted,
+    /// the host pins the latest completed turn when accepting the message.
+    public var endTurn: String?
 
     enum CodingKeys: String, CodingKey {
         case label
@@ -2390,7 +2391,7 @@ public struct MessageChatAttachment: Codable, Sendable {
         meta: [String: AnyCodable]? = nil,
         type: MessageAttachmentKind,
         resource: String,
-        endTurn: String
+        endTurn: String? = nil
     ) {
         self.label = label
         self.range = range

--- a/docs/.changes/20260727-chat-attachment-optional-endturn.json
+++ b/docs/.changes/20260727-chat-attachment-optional-endturn.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "`MessageChatAttachment.endTurn` is optional; hosts pin the latest completed turn when it is omitted, and chat attachments may reference chats in other sessions."
+}

--- a/docs/specification/chat-channel.md
+++ b/docs/specification/chat-channel.md
@@ -135,21 +135,28 @@ A `fork`, `sideChat`, or `tool` origin names only the chat's **immediate** sourc
 
 A message can attach a bounded transcript using a
 [`MessageChatAttachment`](/reference/chat#messagechatattachment). Its `resource`
-identifies another chat in the same session and `endTurn` identifies the last
-completed turn included in the transcript. The bound is required: later
-turns in the referenced chat MUST NOT retroactively change the context of an
-already-sent message.
+identifies another chat, which MAY belong to a different session. The model
+representation of the attachment identifies the chat in a way that hosts can
+resolve regardless of which session owns it. When supplied, `endTurn` identifies
+the last completed turn included in the transcript. When it is omitted, the host
+pins the referenced chat's latest completed turn when accepting the message. This
+lets clients attach chats whose turn identifiers they do not know. In either
+case, the bound prevents later turns in the referenced chat from retroactively
+changing the context of an already-sent message.
 
 This is the standard way to pull a side-chat result back into its originating
 chat. It is not limited to that UX: any chat may attach another chat from the
-same session. No merge or chat-to-chat messaging action occurs; the attachment
-travels on the ordinary message in `chat/turnStarted`.
+same or a different session. No merge or chat-to-chat messaging action occurs;
+the attachment travels on the ordinary message in `chat/turnStarted`.
 
 When accepting the message, the host MUST resolve the referenced chat's retained
-transcript from its first turn through `endTurn`, inclusive, and supply it
-as model context. The host MUST reject an unknown chat, a cross-session chat, an
-unknown turn, or an active rather than completed turn. Chat attachments inside
-the referenced transcript MUST remain references and MUST NOT be recursively
+transcript from its first turn through the supplied `endTurn`, or through the
+latest completed turn when `endTurn` is omitted, and supply it as model context.
+When provided, `endTurn` MUST reference a completed, retained turn. The host
+MUST reject an attachment that references an unknown chat, specifies an
+unknown, active, or non-retained `endTurn`, or omits `endTurn` when the
+referenced chat has no completed retained turns. Chat attachments inside the
+referenced transcript MUST remain references and MUST NOT be recursively
 expanded, preventing cycles and unbounded context growth.
 
 The attachment itself remains durable turn state. If the referenced chat is

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -5441,7 +5441,7 @@
     },
     "MessageChatAttachment": {
       "type": "object",
-      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MUST belong to the same session as the message's chat.\nThe host resolves the transcript from its first retained turn through\n`endTurn`, inclusive, when accepting the message. Later turns do not\nchange the context represented by an already-sent attachment.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
+      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MAY belong to a different session than the message's\nchat. The attachment's model representation identifies the chat in a way\nthat hosts can resolve regardless of the session that owns it.\n\nWhen `endTurn` is omitted, the host MUST resolve and pin the referenced\nchat's latest completed turn when accepting the message. This lets clients\nattach a chat without knowing its turn identifiers. When provided, `endTurn`\nMUST reference a completed, retained turn. The host resolves the transcript\nfrom its first retained turn through the pinned turn, inclusive. Later turns\ndo not change the context represented by an already-sent attachment.\n\nHosts MUST reject an attachment that omits `endTurn` when the referenced chat\nhas no completed retained turns.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
       "properties": {
         "label": {
           "type": "string",
@@ -5470,14 +5470,13 @@
         },
         "endTurn": {
           "type": "string",
-          "description": "Last completed turn included in the referenced transcript."
+          "description": "Last completed turn included in the referenced transcript. When omitted,\nthe host pins the latest completed turn when accepting the message."
         }
       },
       "required": [
         "label",
         "type",
-        "resource",
-        "endTurn"
+        "resource"
       ]
     },
     "MarkdownResponsePart": {

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -4616,7 +4616,7 @@
     },
     "MessageChatAttachment": {
       "type": "object",
-      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MUST belong to the same session as the message's chat.\nThe host resolves the transcript from its first retained turn through\n`endTurn`, inclusive, when accepting the message. Later turns do not\nchange the context represented by an already-sent attachment.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
+      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MAY belong to a different session than the message's\nchat. The attachment's model representation identifies the chat in a way\nthat hosts can resolve regardless of the session that owns it.\n\nWhen `endTurn` is omitted, the host MUST resolve and pin the referenced\nchat's latest completed turn when accepting the message. This lets clients\nattach a chat without knowing its turn identifiers. When provided, `endTurn`\nMUST reference a completed, retained turn. The host resolves the transcript\nfrom its first retained turn through the pinned turn, inclusive. Later turns\ndo not change the context represented by an already-sent attachment.\n\nHosts MUST reject an attachment that omits `endTurn` when the referenced chat\nhas no completed retained turns.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
       "properties": {
         "label": {
           "type": "string",
@@ -4645,14 +4645,13 @@
         },
         "endTurn": {
           "type": "string",
-          "description": "Last completed turn included in the referenced transcript."
+          "description": "Last completed turn included in the referenced transcript. When omitted,\nthe host pins the latest completed turn when accepting the message."
         }
       },
       "required": [
         "label",
         "type",
-        "resource",
-        "endTurn"
+        "resource"
       ]
     },
     "MarkdownResponsePart": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -3344,7 +3344,7 @@
     },
     "MessageChatAttachment": {
       "type": "object",
-      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MUST belong to the same session as the message's chat.\nThe host resolves the transcript from its first retained turn through\n`endTurn`, inclusive, when accepting the message. Later turns do not\nchange the context represented by an already-sent attachment.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
+      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MAY belong to a different session than the message's\nchat. The attachment's model representation identifies the chat in a way\nthat hosts can resolve regardless of the session that owns it.\n\nWhen `endTurn` is omitted, the host MUST resolve and pin the referenced\nchat's latest completed turn when accepting the message. This lets clients\nattach a chat without knowing its turn identifiers. When provided, `endTurn`\nMUST reference a completed, retained turn. The host resolves the transcript\nfrom its first retained turn through the pinned turn, inclusive. Later turns\ndo not change the context represented by an already-sent attachment.\n\nHosts MUST reject an attachment that omits `endTurn` when the referenced chat\nhas no completed retained turns.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
       "properties": {
         "label": {
           "type": "string",
@@ -3373,14 +3373,13 @@
         },
         "endTurn": {
           "type": "string",
-          "description": "Last completed turn included in the referenced transcript."
+          "description": "Last completed turn included in the referenced transcript. When omitted,\nthe host pins the latest completed turn when accepting the message."
         }
       },
       "required": [
         "label",
         "type",
-        "resource",
-        "endTurn"
+        "resource"
       ]
     },
     "MarkdownResponsePart": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -3507,7 +3507,7 @@
     },
     "MessageChatAttachment": {
       "type": "object",
-      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MUST belong to the same session as the message's chat.\nThe host resolves the transcript from its first retained turn through\n`endTurn`, inclusive, when accepting the message. Later turns do not\nchange the context represented by an already-sent attachment.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
+      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MAY belong to a different session than the message's\nchat. The attachment's model representation identifies the chat in a way\nthat hosts can resolve regardless of the session that owns it.\n\nWhen `endTurn` is omitted, the host MUST resolve and pin the referenced\nchat's latest completed turn when accepting the message. This lets clients\nattach a chat without knowing its turn identifiers. When provided, `endTurn`\nMUST reference a completed, retained turn. The host resolves the transcript\nfrom its first retained turn through the pinned turn, inclusive. Later turns\ndo not change the context represented by an already-sent attachment.\n\nHosts MUST reject an attachment that omits `endTurn` when the referenced chat\nhas no completed retained turns.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
       "properties": {
         "label": {
           "type": "string",
@@ -3536,14 +3536,13 @@
         },
         "endTurn": {
           "type": "string",
-          "description": "Last completed turn included in the referenced transcript."
+          "description": "Last completed turn included in the referenced transcript. When omitted,\nthe host pins the latest completed turn when accepting the message."
         }
       },
       "required": [
         "label",
         "type",
-        "resource",
-        "endTurn"
+        "resource"
       ]
     },
     "MarkdownResponsePart": {

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -3255,7 +3255,7 @@
     },
     "MessageChatAttachment": {
       "type": "object",
-      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MUST belong to the same session as the message's chat.\nThe host resolves the transcript from its first retained turn through\n`endTurn`, inclusive, when accepting the message. Later turns do not\nchange the context represented by an already-sent attachment.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
+      "description": "An attachment that references a chat transcript through a fixed completed\nturn.\n\nThe referenced chat MAY belong to a different session than the message's\nchat. The attachment's model representation identifies the chat in a way\nthat hosts can resolve regardless of the session that owns it.\n\nWhen `endTurn` is omitted, the host MUST resolve and pin the referenced\nchat's latest completed turn when accepting the message. This lets clients\nattach a chat without knowing its turn identifiers. When provided, `endTurn`\nMUST reference a completed, retained turn. The host resolves the transcript\nfrom its first retained turn through the pinned turn, inclusive. Later turns\ndo not change the context represented by an already-sent attachment.\n\nHosts MUST reject an attachment that omits `endTurn` when the referenced chat\nhas no completed retained turns.\n\nHosts MUST NOT recursively expand chat attachments found inside the\nreferenced transcript. Clients SHOULD keep rendering `label` if the\nreferenced chat is later pruned, and treat opening `resource` as best-effort.",
       "properties": {
         "label": {
           "type": "string",
@@ -3284,14 +3284,13 @@
         },
         "endTurn": {
           "type": "string",
-          "description": "Last completed turn included in the referenced transcript."
+          "description": "Last completed turn included in the referenced transcript. When omitted,\nthe host pins the latest completed turn when accepting the message."
         }
       },
       "required": [
         "label",
         "type",
-        "resource",
-        "endTurn"
+        "resource"
       ]
     },
     "MarkdownResponsePart": {

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -824,10 +824,19 @@ export interface MessageAnnotationsAttachment extends MessageAttachmentBase {
  * An attachment that references a chat transcript through a fixed completed
  * turn.
  *
- * The referenced chat MUST belong to the same session as the message's chat.
- * The host resolves the transcript from its first retained turn through
- * `endTurn`, inclusive, when accepting the message. Later turns do not
- * change the context represented by an already-sent attachment.
+ * The referenced chat MAY belong to a different session than the message's
+ * chat. The attachment's model representation identifies the chat in a way
+ * that hosts can resolve regardless of the session that owns it.
+ *
+ * When `endTurn` is omitted, the host MUST resolve and pin the referenced
+ * chat's latest completed turn when accepting the message. This lets clients
+ * attach a chat without knowing its turn identifiers. When provided, `endTurn`
+ * MUST reference a completed, retained turn. The host resolves the transcript
+ * from its first retained turn through the pinned turn, inclusive. Later turns
+ * do not change the context represented by an already-sent attachment.
+ *
+ * Hosts MUST reject an attachment that omits `endTurn` when the referenced chat
+ * has no completed retained turns.
  *
  * Hosts MUST NOT recursively expand chat attachments found inside the
  * referenced transcript. Clients SHOULD keep rendering `label` if the
@@ -840,8 +849,11 @@ export interface MessageChatAttachment extends MessageAttachmentBase {
   type: MessageAttachmentKind.Chat;
   /** URI of the referenced chat. */
   resource: URI;
-  /** Last completed turn included in the referenced transcript. */
-  endTurn: string;
+  /**
+   * Last completed turn included in the referenced transcript. When omitted,
+   * the host pins the latest completed turn when accepting the message.
+   */
+  endTurn?: string;
 }
 
 /**

--- a/types/test-cases/round-trips/040-chat-transcript-attachment-latest-turn.json
+++ b/types/test-cases/round-trips/040-chat-transcript-attachment-latest-turn.json
@@ -1,0 +1,44 @@
+{
+  "name": "chat-transcript-attachment-latest-turn",
+  "group": "A",
+  "description": "A chat/turnStarted action preserves a chat transcript attachment whose end turn the host pins on acceptance.",
+  "type": "StateAction",
+  "input": {
+    "type": "chat/turnStarted",
+    "turnId": "turn-14",
+    "startedAt": "2026-07-27T19:01:00.000Z",
+    "message": {
+      "text": "Use the latest completed investigation.",
+      "origin": {
+        "kind": "user"
+      },
+      "attachments": [
+        {
+          "type": "chat",
+          "label": "Unloaded investigation",
+          "resource": "ahp-chat:/other-session-chat"
+        }
+      ]
+    }
+  },
+  "acceptableOutputs": [
+    {
+      "type": "chat/turnStarted",
+      "turnId": "turn-14",
+      "startedAt": "2026-07-27T19:01:00.000Z",
+      "message": {
+        "text": "Use the latest completed investigation.",
+        "origin": {
+          "kind": "user"
+        },
+        "attachments": [
+          {
+            "type": "chat",
+            "label": "Unloaded investigation",
+            "resource": "ahp-chat:/other-session-chat"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- make `MessageChatAttachment.endTurn` optional; when omitted, the host resolves and pins the referenced chat's latest completed turn as it accepts the message
- allow chat transcript attachments to reference chats owned by a different session, using host-neutral resolution language
- regenerate schemas and all client types, add an omitted-`endTurn` round-trip fixture, and add a changelog fragment

This synchronizes the upstream protocol with the chat-reference behavior already implemented in `microsoft/vscode`.

## Validation

- `npm run generate`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run verify:change-fragments`
- `npm run verify:changelog`
- TypeScript client: `npm test && npm run build`
- Rust client: `cargo test --workspace`
- Go client: `go test ./...`
- Swift client: `swift build && swift test`
- Kotlin client: `./gradlew test --no-daemon --console=plain` (pinned JDK 17 container)