### PR TITLE
chat: refine tool call metadata at ready

### DIFF
--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -1043,9 +1043,31 @@ func applyToolCallDelta(state *ahptypes.ChatState, a *ahptypes.ChatToolCallDelta
 	})
 }
 
+func refineToolCallContributor(current, next *ahptypes.ToolCallContributor) *ahptypes.ToolCallContributor {
+	if next == nil {
+		return current
+	}
+	if current != nil {
+		if currentClient, ok := current.Value.(*ahptypes.ToolCallClientContributor); ok {
+			if nextClient, ok := next.Value.(*ahptypes.ToolCallClientContributor); ok && nextClient.ClientId == currentClient.ClientId {
+				return next
+			}
+			return current
+		}
+	}
+	if _, ok := next.Value.(*ahptypes.ToolCallClientContributor); ok {
+		return current
+	}
+	return next
+}
+
 func applyToolCallReady(state *ahptypes.ChatState, a *ahptypes.ChatToolCallReadyAction) ReduceOutcome {
 	return updateToolCall(state, a.TurnId, a.ToolCallId, func(tc ahptypes.ToolCallState) ahptypes.ToolCallState {
 		common := toolCallMeta(tc)
+		if a.Intention != nil {
+			common.intention = a.Intention
+		}
+		common.contributor = refineToolCallContributor(common.contributor, a.Contributor)
 		if a.Meta != nil {
 			common.meta = a.Meta
 		}

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -350,6 +350,12 @@ type ChatToolCallReadyAction struct {
 	// contain escape sequences).
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	Type ActionType                 `json:"type"`
+	// Final contributor metadata. MUST NOT change execution ownership established
+	// at `chat/toolCallStart`; a client contributor must keep the same `clientId`.
+	Contributor *ToolCallContributor `json:"contributor,omitempty"`
+	// Final human-readable description of what the tool invocation intends to do.
+	// When present, replaces the provisional intention from `chat/toolCallStart`.
+	Intention *string `json:"intention,omitempty"`
 	// Message describing what the tool will do or what confirmation is needed
 	InvocationMessage StringOrMarkdown `json:"invocationMessage"`
 	// Raw tool input

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -171,6 +171,21 @@ private data class ToolCallBase(
     fun withMeta(meta: Map<String, JsonElement>?): ToolCallBase = copy(meta = meta ?: this.meta)
 }
 
+private fun refineToolCallContributor(
+    current: ToolCallContributor?,
+    next: ToolCallContributor?,
+): ToolCallContributor? {
+    if (next == null) return current
+    if (current is ToolCallContributorClient) {
+        if (next is ToolCallContributorClient && next.value.clientId == current.value.clientId) {
+            return next
+        }
+        return current
+    }
+    if (next is ToolCallContributorClient) return current
+    return next
+}
+
 private fun toolCallBase(tc: ToolCallState): ToolCallBase = when (tc) {
     is ToolCallStateStreaming -> tc.value.let {
         ToolCallBase(it.toolCallId, it.toolName, it.displayName, it.intention, it.contributor, it.meta)
@@ -939,7 +954,11 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
                 ) {
                     tc
                 } else {
-                    val base = toolCallBase(tc).withMeta(a.meta)
+                    val initialBase = toolCallBase(tc)
+                    val base = initialBase.copy(
+                        intention = a.intention ?: initialBase.intention,
+                        contributor = refineToolCallContributor(initialBase.contributor, a.contributor),
+                    ).withMeta(a.meta)
                     val pending = (tc as? ToolCallStatePendingConfirmation)?.value
                     if (a.confirmed != null) {
                         ToolCallStateRunning(

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -472,6 +472,16 @@ data class ChatToolCallReadyAction(
     val meta: Map<String, JsonElement>? = null,
     val type: ActionType,
     /**
+     * Final contributor metadata. MUST NOT change execution ownership established
+     * at `chat/toolCallStart`; a client contributor must keep the same `clientId`.
+     */
+    val contributor: ToolCallContributor? = null,
+    /**
+     * Final human-readable description of what the tool invocation intends to do.
+     * When present, replaces the provisional intention from `chat/toolCallStart`.
+     */
+    val intention: String? = null,
+    /**
      * Message describing what the tool will do or what confirmation is needed
      */
     val invocationMessage: StringOrMarkdown,

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -481,6 +481,14 @@ pub struct ChatToolCallReadyAction {
     /// contain escape sequences).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<JsonObject>,
+    /// Final contributor metadata. MUST NOT change execution ownership established
+    /// at `chat/toolCallStart`; a client contributor must keep the same `clientId`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contributor: Option<ToolCallContributor>,
+    /// Final human-readable description of what the tool invocation intends to do.
+    /// When present, replaces the provisional intention from `chat/toolCallStart`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intention: Option<String>,
     /// Message describing what the tool will do or what confirmation is needed
     pub invocation_message: StringOrMarkdown,
     /// Raw tool input

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -137,6 +137,27 @@ struct ToolCallBase {
     meta: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
+fn refine_tool_call_contributor(
+    current: Option<ToolCallContributor>,
+    next: Option<ToolCallContributor>,
+) -> Option<ToolCallContributor> {
+    let Some(next) = next else {
+        return current;
+    };
+    if let Some(ToolCallContributor::Client(current_client)) = current.as_ref() {
+        if let ToolCallContributor::Client(next_client) = &next {
+            if next_client.client_id == current_client.client_id {
+                return Some(next);
+            }
+        }
+        return current;
+    }
+    if matches!(next, ToolCallContributor::Client(_)) {
+        return current;
+    }
+    Some(next)
+}
+
 fn tool_call_meta(tc: &ToolCallState) -> ToolCallBase {
     match tc {
         ToolCallState::Streaming(s) => ToolCallBase {
@@ -1234,7 +1255,9 @@ fn apply_tool_call_delta(state: &mut ChatState, a: &ChatToolCallDeltaAction) -> 
 
 fn apply_tool_call_ready(state: &mut ChatState, a: &ChatToolCallReadyAction) -> ReduceOutcome {
     update_tool_call(state, &a.turn_id, &a.tool_call_id, |tc| {
-        let base = tool_call_meta(&tc);
+        let mut base = tool_call_meta(&tc);
+        base.intention = a.intention.clone().or(base.intention);
+        base.contributor = refine_tool_call_contributor(base.contributor, a.contributor.clone());
         let meta = a.meta.clone().or(base.meta);
         let pending = match &tc {
             ToolCallState::PendingConfirmation(value) => Some(value.clone()),

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -480,6 +480,12 @@ public struct ChatToolCallReadyAction: Codable, Sendable {
     /// contain escape sequences).
     public var meta: [String: AnyCodable]?
     public var type: ActionType
+    /// Final contributor metadata. MUST NOT change execution ownership established
+    /// at `chat/toolCallStart`; a client contributor must keep the same `clientId`.
+    public var contributor: ToolCallContributor?
+    /// Final human-readable description of what the tool invocation intends to do.
+    /// When present, replaces the provisional intention from `chat/toolCallStart`.
+    public var intention: String?
     /// Message describing what the tool will do or what confirmation is needed
     public var invocationMessage: StringOrMarkdown
     /// Raw tool input
@@ -505,6 +511,8 @@ public struct ChatToolCallReadyAction: Codable, Sendable {
         case toolCallId
         case meta = "_meta"
         case type
+        case contributor
+        case intention
         case invocationMessage
         case toolInput
         case confirmationTitle
@@ -520,6 +528,8 @@ public struct ChatToolCallReadyAction: Codable, Sendable {
         toolCallId: String,
         meta: [String: AnyCodable]? = nil,
         type: ActionType,
+        contributor: ToolCallContributor? = nil,
+        intention: String? = nil,
         invocationMessage: StringOrMarkdown,
         toolInput: String? = nil,
         confirmationTitle: StringOrMarkdown? = nil,
@@ -533,6 +543,8 @@ public struct ChatToolCallReadyAction: Codable, Sendable {
         self.toolCallId = toolCallId
         self.meta = meta
         self.type = type
+        self.contributor = contributor
+        self.intention = intention
         self.invocationMessage = invocationMessage
         self.toolInput = toolInput
         self.confirmationTitle = confirmationTitle

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -47,6 +47,22 @@ private func resolveSelectedOption(_ options: [ConfirmationOption]?, id: String?
     return options.first { $0.id == id }
 }
 
+private func refineToolCallContributor(_ current: ToolCallContributor?, _ next: ToolCallContributor?) -> ToolCallContributor? {
+    guard let next else {
+        return current
+    }
+    if let current, case .client(let currentClient) = current {
+        if case .client(let nextClient) = next, nextClient.clientId == currentClient.clientId {
+            return next
+        }
+        return current
+    }
+    if case .client = next {
+        return current
+    }
+    return next
+}
+
 /// Extracts the stable `id` of a session input request, or `nil` for unknown variants.
 private func sessionInputRequestID(_ r: SessionInputRequest) -> String? {
     switch r {
@@ -206,6 +222,8 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
             default: return tc
             }
             let base = tc.baseFields
+            let intention = a.intention ?? base.intention
+            let contributor = refineToolCallContributor(base.contributor, a.contributor)
             let meta = a.meta ?? base.meta
             let pending: ToolCallPendingConfirmationState?
             if case .pendingConfirmation(let value) = tc {
@@ -218,8 +236,8 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
                     toolCallId: base.toolCallId,
                     toolName: base.toolName,
                     displayName: base.displayName,
-                    intention: base.intention,
-                    contributor: base.contributor,
+                    intention: intention,
+                    contributor: contributor,
                     meta: meta,
                     invocationMessage: a.invocationMessage,
                     toolInput: a.toolInput,
@@ -231,8 +249,8 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
                 toolCallId: base.toolCallId,
                 toolName: base.toolName,
                 displayName: base.displayName,
-                intention: base.intention,
-                contributor: base.contributor,
+                intention: intention,
+                contributor: contributor,
                 meta: meta,
                 invocationMessage: a.invocationMessage,
                 toolInput: a.toolInput ?? pending?.toolInput,

--- a/docs/.changes/20260728-toolcall-ready-metadata.json
+++ b/docs/.changes/20260728-toolcall-ready-metadata.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "`chat/toolCallReady` may finalize a tool call's provisional contributor and intention without changing client execution ownership."
+}

--- a/docs/specification/chat-channel.md
+++ b/docs/specification/chat-channel.md
@@ -177,6 +177,20 @@ Once a chat exists and its session is `lifecycle: 'ready'`, the chat accepts tur
 
 All actions dispatched on this channel travel on `ActionEnvelope`s whose `channel` is the chat URI. Action payloads do NOT carry their own chat URI — the channel comes from the envelope.
 
+### Tool call metadata refinement
+
+A host MAY open a tool call before all display metadata is known so clients can
+render progress while the model is still generating parameters. In that case,
+`chat/toolCallStart` carries the metadata available at discovery time and
+`chat/toolCallReady` MAY provide a final `contributor` and `intention`.
+
+Ready-time contributor refinement MUST NOT change execution ownership. A tool
+that started as client-contributed remains owned by the same `clientId`, and a
+tool that did not start as client-contributed cannot become client-owned at
+Ready. Other refinements, such as discovering the MCP customization that owns a
+server-executed tool, are allowed. Reducers ignore contributor changes that
+would violate this invariant.
+
 ### Disposal
 
 A chat is implicitly disposed when its owning session is disposed. The protocol does not currently expose a `disposeChat` command; chats live for the life of their session unless the server prunes them. When a chat is removed (whether explicitly or because its session was torn down), the server MUST update the session's `chats` catalog via `session/chatRemoved` so subscribers can release their per-chat subscriptions.

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -871,6 +871,14 @@
         "type": {
           "const": "chat/toolCallReady"
         },
+        "contributor": {
+          "$ref": "#/$defs/ToolCallContributor",
+          "description": "Final contributor metadata. MUST NOT change execution ownership established\nat `chat/toolCallStart`; a client contributor must keep the same `clientId`."
+        },
+        "intention": {
+          "type": "string",
+          "description": "Final human-readable description of what the tool invocation intends to do.\nWhen present, replaces the provisional intention from `chat/toolCallStart`."
+        },
         "invocationMessage": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Message describing what the tool will do or what confirmation is needed"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -7125,6 +7125,14 @@
         "type": {
           "const": "chat/toolCallReady"
         },
+        "contributor": {
+          "$ref": "#/$defs/ToolCallContributor",
+          "description": "Final contributor metadata. MUST NOT change execution ownership established\nat `chat/toolCallStart`; a client contributor must keep the same `clientId`."
+        },
+        "intention": {
+          "type": "string",
+          "description": "Final human-readable description of what the tool invocation intends to do.\nWhen present, replaces the provisional intention from `chat/toolCallStart`."
+        },
         "invocationMessage": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Message describing what the tool will do or what confirmation is needed"

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -8118,6 +8118,14 @@
         "type": {
           "const": "chat/toolCallReady"
         },
+        "contributor": {
+          "$ref": "#/$defs/ToolCallContributor",
+          "description": "Final contributor metadata. MUST NOT change execution ownership established\nat `chat/toolCallStart`; a client contributor must keep the same `clientId`."
+        },
+        "intention": {
+          "type": "string",
+          "description": "Final human-readable description of what the tool invocation intends to do.\nWhen present, replaces the provisional intention from `chat/toolCallStart`."
+        },
         "invocationMessage": {
           "$ref": "#/$defs/StringOrMarkdown",
           "description": "Message describing what the tool will do or what confirmation is needed"

--- a/types/channels-chat/actions.ts
+++ b/types/channels-chat/actions.ts
@@ -199,6 +199,16 @@ export interface ChatToolCallDeltaAction extends ToolCallActionBase {
  */
 export interface ChatToolCallReadyAction extends ToolCallActionBase {
   type: ActionType.ChatToolCallReady;
+  /**
+   * Final contributor metadata. MUST NOT change execution ownership established
+   * at `chat/toolCallStart`; a client contributor must keep the same `clientId`.
+   */
+  contributor?: ToolCallContributor;
+  /**
+   * Final human-readable description of what the tool invocation intends to do.
+   * When present, replaces the provisional intention from `chat/toolCallStart`.
+   */
+  intention?: string;
   /** Message describing what the tool will do or what confirmation is needed */
   invocationMessage: StringOrMarkdown;
   /** Raw tool input */

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -15,6 +15,7 @@ import type {
   Turn,
   PendingMessage,
   ConfirmationOption,
+  ToolCallContributor,
 } from './state.js';
 import {
   TurnState,
@@ -48,6 +49,28 @@ function tcBaseWithMeta(tc: ToolCallState, meta: Record<string, unknown> | undef
     ...tcBase(tc),
     _meta: meta ?? tc._meta,
   };
+}
+
+function refineToolCallContributor(
+  current: ToolCallContributor | undefined,
+  next: ToolCallContributor | undefined,
+  log?: (msg: string) => void,
+): ToolCallContributor | undefined {
+  if (!next) {
+    return current;
+  }
+  if (current?.kind === ToolCallContributorKind.Client) {
+    if (next.kind === ToolCallContributorKind.Client && next.clientId === current.clientId) {
+      return next;
+    }
+    log?.(`Ignoring contributor change for client tool call from '${current.clientId}'`);
+    return current;
+  }
+  if (next.kind === ToolCallContributorKind.Client) {
+    log?.(`Ignoring late client contributor '${next.clientId}' because client execution ownership must be established at tool call start`);
+    return current;
+  }
+  return next;
 }
 
 /** Resolves a selected option from the confirmation options array by ID. */
@@ -456,7 +479,11 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
         ) {
           return tc;
         }
-        const base = tcBaseWithMeta(tc, action._meta);
+        const base = {
+          ...tcBaseWithMeta(tc, action._meta),
+          contributor: refineToolCallContributor(tc.contributor, action.contributor, log),
+          intention: action.intention ?? tc.intention,
+        };
         if (action.confirmed) {
           return {
             status: ToolCallStatus.Running,

--- a/types/test-cases/reducers/257-toolcallready-refines-metadata-without-changing-client-ownership.json
+++ b/types/test-cases/reducers/257-toolcallready-refines-metadata-without-changing-client-ownership.json
@@ -1,0 +1,236 @@
+{
+  "description": "toolCallReady refines contributor and intention without changing client execution ownership",
+  "reducer": "chat",
+  "initial": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "startedAt": "1970-01-01T00:00:01.000Z",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [],
+      "usage": null
+    },
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 8,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/toolCallStart",
+      "turnId": "turn-1",
+      "toolCallId": "tc-mcp",
+      "toolName": "lookup",
+      "displayName": "Lookup",
+      "intention": "Query"
+    },
+    {
+      "type": "chat/toolCallReady",
+      "turnId": "turn-1",
+      "toolCallId": "tc-mcp",
+      "contributor": {
+        "kind": "mcp",
+        "customizationId": "mcp-1"
+      },
+      "intention": "Query project metadata",
+      "invocationMessage": "Querying project metadata",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "chat/toolCallStart",
+      "turnId": "turn-1",
+      "toolCallId": "tc-client-same",
+      "toolName": "client-tool",
+      "displayName": "Client Tool",
+      "contributor": {
+        "kind": "client",
+        "clientId": "client-1"
+      }
+    },
+    {
+      "type": "chat/toolCallReady",
+      "turnId": "turn-1",
+      "toolCallId": "tc-client-same",
+      "contributor": {
+        "kind": "client",
+        "clientId": "client-1"
+      },
+      "invocationMessage": "Running client tool",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "chat/toolCallStart",
+      "turnId": "turn-1",
+      "toolCallId": "tc-client-change",
+      "toolName": "client-tool",
+      "displayName": "Client Tool",
+      "contributor": {
+        "kind": "client",
+        "clientId": "client-1"
+      }
+    },
+    {
+      "type": "chat/toolCallReady",
+      "turnId": "turn-1",
+      "toolCallId": "tc-client-change",
+      "contributor": {
+        "kind": "client",
+        "clientId": "client-2"
+      },
+      "invocationMessage": "Running client tool",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "chat/toolCallStart",
+      "turnId": "turn-1",
+      "toolCallId": "tc-client-to-mcp",
+      "toolName": "client-tool",
+      "displayName": "Client Tool",
+      "contributor": {
+        "kind": "client",
+        "clientId": "client-1"
+      }
+    },
+    {
+      "type": "chat/toolCallReady",
+      "turnId": "turn-1",
+      "toolCallId": "tc-client-to-mcp",
+      "contributor": {
+        "kind": "mcp",
+        "customizationId": "mcp-1"
+      },
+      "invocationMessage": "Running client tool",
+      "confirmed": "not-needed"
+    },
+    {
+      "type": "chat/toolCallStart",
+      "turnId": "turn-1",
+      "toolCallId": "tc-late-client",
+      "toolName": "host-tool",
+      "displayName": "Host Tool"
+    },
+    {
+      "type": "chat/toolCallReady",
+      "turnId": "turn-1",
+      "toolCallId": "tc-late-client",
+      "contributor": {
+        "kind": "client",
+        "clientId": "client-1"
+      },
+      "invocationMessage": "Running host tool",
+      "confirmed": "not-needed"
+    }
+  ],
+  "expected": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "startedAt": "1970-01-01T00:00:01.000Z",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "running",
+            "toolCallId": "tc-mcp",
+            "toolName": "lookup",
+            "displayName": "Lookup",
+            "intention": "Query project metadata",
+            "contributor": {
+              "kind": "mcp",
+              "customizationId": "mcp-1"
+            },
+            "_meta": null,
+            "invocationMessage": "Querying project metadata",
+            "toolInput": null,
+            "confirmed": "not-needed"
+          }
+        },
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "running",
+            "toolCallId": "tc-client-same",
+            "toolName": "client-tool",
+            "displayName": "Client Tool",
+            "intention": null,
+            "contributor": {
+              "kind": "client",
+              "clientId": "client-1"
+            },
+            "_meta": null,
+            "invocationMessage": "Running client tool",
+            "toolInput": null,
+            "confirmed": "not-needed"
+          }
+        },
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "running",
+            "toolCallId": "tc-client-change",
+            "toolName": "client-tool",
+            "displayName": "Client Tool",
+            "intention": null,
+            "contributor": {
+              "kind": "client",
+              "clientId": "client-1"
+            },
+            "_meta": null,
+            "invocationMessage": "Running client tool",
+            "toolInput": null,
+            "confirmed": "not-needed"
+          }
+        },
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "running",
+            "toolCallId": "tc-client-to-mcp",
+            "toolName": "client-tool",
+            "displayName": "Client Tool",
+            "intention": null,
+            "contributor": {
+              "kind": "client",
+              "clientId": "client-1"
+            },
+            "_meta": null,
+            "invocationMessage": "Running client tool",
+            "toolInput": null,
+            "confirmed": "not-needed"
+          }
+        },
+        {
+          "kind": "toolCall",
+          "toolCall": {
+            "status": "running",
+            "toolCallId": "tc-late-client",
+            "toolName": "host-tool",
+            "displayName": "Host Tool",
+            "intention": null,
+            "contributor": null,
+            "_meta": null,
+            "invocationMessage": "Running host tool",
+            "toolInput": null,
+            "confirmed": "not-needed"
+          }
+        }
+      ],
+      "usage": null
+    },
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 8,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Allow `chat/toolCallReady` to provide final `contributor` and `intention` metadata after a tool call starts streaming.
- Preserve execution ownership established at `chat/toolCallStart`: client tools keep the same `clientId`, and server tools cannot become client-owned at Ready.
- Update generated wire types and the TypeScript, Rust, Kotlin, Swift, and Go reducers.
- Add a shared cross-language reducer fixture, protocol documentation, and a changelog fragment.

## Validation

- `npm run generate` with no drift
- `npm test`
- TypeScript client tests and build
- `cargo test --workspace`
- `swift build && swift test`
- `go test ./...`
- Kotlin Gradle build under JDK 17

(Written by Copilot)