### PR TITLE
typo in subscriptions.md : table mis-formatted

### DIFF
--- a/docs/specification/subscriptions.md
+++ b/docs/specification/subscriptions.md
@@ -11,9 +11,9 @@ The channel concept is woven into every wire message. **Every command and every 
 | Client → Server commands (channel-scoped) | `subscribe`, `createSession`, `disposeSession`, `createTerminal`, `disposeTerminal`, `fetchTurns`, `completions`, `invokeChangesetOperation` | The target channel's URI (e.g. `ahp-session:/<uuid>`). |
 | Client → Server commands (connection-level) | `initialize`, `ping`, `reconnect`, `listSessions`, `authenticate`, `resolveSessionConfig`, `sessionConfigCompletions`, `resourceRead`, `resourceWrite`, `resourceList`, `resourceCopy`, `resourceDelete`, `resourceMove`, `resourceResolve`, `resourceMkdir`, `resourceRequest`, `createResourceWatch` | Literal `'ahp-root://'`. |
 | Server → Client commands (bidirectional `resource*` family) | The same nine `resource*` request methods plus `createResourceWatch` may also be initiated by the server. Used for host-driven per-session filesystem providers and for fetching client-published URIs (e.g. `virtual://my-client/...` plugins). | Literal `'ahp-root://'`. |
-| Client → Server `dispatchAction` | The channel the action targets. |
-| Client → Server `unsubscribe` | The channel being unsubscribed. |
-| Server → Client `action` | The channel that owns the action envelope. |
+| Client → Server | `dispatchAction` | The channel the action targets. |
+| Client → Server | `unsubscribe` | The channel being unsubscribed. |
+| Server → Client | `action` | The channel that owns the action envelope. |
 | Server → Client protocol notifications | `root/sessionAdded`, `root/sessionRemoved`, `root/sessionSummaryChanged`, `auth/required`, `otlp/exportLogs`, `otlp/exportTraces`, `otlp/exportMetrics` | The channel the notification scopes to (the root channel for `root/*`; the channel the auth requirement targets for `auth/required`; the host-defined `ahp-otlp:` channel URI for `otlp/*`). |
 
 The constraint is encoded in the TypeScript types: every entry in `CommandMap` and the notification maps has params assignable to `BaseParams` (or, for notifications, structurally `{ channel: URI }`). The compile-time check in `types/version/message-checks.ts` fails if any new method omits the field.


### PR DESCRIPTION
The markdown table under "Every message carries channel" was missing 3 column delimiters