### PR TITLE
Remove non-standard protected resource encryption metadata

### DIFF
--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -492,10 +492,6 @@ type ProtectedResourceMetadata struct {
 	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
 	// OPTIONAL. JSON array of JWS signing algorithms supported.
 	ResourceSigningAlgValuesSupported []string `json:"resource_signing_alg_values_supported,omitempty"`
-	// OPTIONAL. JSON array of JWE encryption algorithms (alg) supported.
-	ResourceEncryptionAlgValuesSupported []string `json:"resource_encryption_alg_values_supported,omitempty"`
-	// OPTIONAL. JSON array of JWE encryption algorithms (enc) supported.
-	ResourceEncryptionEncValuesSupported []string `json:"resource_encryption_enc_values_supported,omitempty"`
 	// OPTIONAL. URL of human-readable documentation for the resource.
 	ResourceDocumentation *string `json:"resource_documentation,omitempty"`
 	// OPTIONAL. URL of the resource's data-usage policy.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -825,16 +825,6 @@ data class ProtectedResourceMetadata(
     @SerialName("resource_signing_alg_values_supported")
     val resourceSigningAlgValuesSupported: List<String>? = null,
     /**
-     * OPTIONAL. JSON array of JWE encryption algorithms (alg) supported.
-     */
-    @SerialName("resource_encryption_alg_values_supported")
-    val resourceEncryptionAlgValuesSupported: List<String>? = null,
-    /**
-     * OPTIONAL. JSON array of JWE encryption algorithms (enc) supported.
-     */
-    @SerialName("resource_encryption_enc_values_supported")
-    val resourceEncryptionEncValuesSupported: List<String>? = null,
-    /**
      * OPTIONAL. URL of human-readable documentation for the resource.
      */
     @SerialName("resource_documentation")

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -670,20 +670,6 @@ pub struct ProtectedResourceMetadata {
         skip_serializing_if = "Option::is_none"
     )]
     pub resource_signing_alg_values_supported: Option<Vec<String>>,
-    /// OPTIONAL. JSON array of JWE encryption algorithms (alg) supported.
-    #[serde(
-        rename = "resource_encryption_alg_values_supported",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub resource_encryption_alg_values_supported: Option<Vec<String>>,
-    /// OPTIONAL. JSON array of JWE encryption algorithms (enc) supported.
-    #[serde(
-        rename = "resource_encryption_enc_values_supported",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub resource_encryption_enc_values_supported: Option<Vec<String>>,
     /// OPTIONAL. URL of human-readable documentation for the resource.
     #[serde(
         rename = "resource_documentation",

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -456,10 +456,6 @@ public struct ProtectedResourceMetadata: Codable, Sendable {
     public var bearerMethodsSupported: [String]?
     /// OPTIONAL. JSON array of JWS signing algorithms supported.
     public var resourceSigningAlgValuesSupported: [String]?
-    /// OPTIONAL. JSON array of JWE encryption algorithms (alg) supported.
-    public var resourceEncryptionAlgValuesSupported: [String]?
-    /// OPTIONAL. JSON array of JWE encryption algorithms (enc) supported.
-    public var resourceEncryptionEncValuesSupported: [String]?
     /// OPTIONAL. URL of human-readable documentation for the resource.
     public var resourceDocumentation: String?
     /// OPTIONAL. URL of the resource's data-usage policy.
@@ -485,8 +481,6 @@ public struct ProtectedResourceMetadata: Codable, Sendable {
         case scopesSupported = "scopes_supported"
         case bearerMethodsSupported = "bearer_methods_supported"
         case resourceSigningAlgValuesSupported = "resource_signing_alg_values_supported"
-        case resourceEncryptionAlgValuesSupported = "resource_encryption_alg_values_supported"
-        case resourceEncryptionEncValuesSupported = "resource_encryption_enc_values_supported"
         case resourceDocumentation = "resource_documentation"
         case resourcePolicyUri = "resource_policy_uri"
         case resourceTosUri = "resource_tos_uri"
@@ -501,8 +495,6 @@ public struct ProtectedResourceMetadata: Codable, Sendable {
         scopesSupported: [String]? = nil,
         bearerMethodsSupported: [String]? = nil,
         resourceSigningAlgValuesSupported: [String]? = nil,
-        resourceEncryptionAlgValuesSupported: [String]? = nil,
-        resourceEncryptionEncValuesSupported: [String]? = nil,
         resourceDocumentation: String? = nil,
         resourcePolicyUri: String? = nil,
         resourceTosUri: String? = nil,
@@ -515,8 +507,6 @@ public struct ProtectedResourceMetadata: Codable, Sendable {
         self.scopesSupported = scopesSupported
         self.bearerMethodsSupported = bearerMethodsSupported
         self.resourceSigningAlgValuesSupported = resourceSigningAlgValuesSupported
-        self.resourceEncryptionAlgValuesSupported = resourceEncryptionAlgValuesSupported
-        self.resourceEncryptionEncValuesSupported = resourceEncryptionEncValuesSupported
         self.resourceDocumentation = resourceDocumentation
         self.resourcePolicyUri = resourcePolicyUri
         self.resourceTosUri = resourceTosUri

--- a/docs/.changes/20260729-remove-resource-encryption-metadata.json
+++ b/docs/.changes/20260729-remove-resource-encryption-metadata.json
@@ -1,0 +1,5 @@
+{
+  "type": "removed",
+  "message": "Non-standard `resource_encryption_alg_values_supported` and `resource_encryption_enc_values_supported` fields from `ProtectedResourceMetadata`.",
+  "issues": [368]
+}

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -2271,20 +2271,6 @@
           },
           "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
         },
-        "resource_encryption_alg_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
-        },
-        "resource_encryption_enc_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
-        },
         "resource_documentation": {
           "type": "string",
           "description": "OPTIONAL. URL of human-readable documentation for the resource."

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1434,20 +1434,6 @@
           },
           "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
         },
-        "resource_encryption_alg_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
-        },
-        "resource_encryption_enc_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
-        },
         "resource_documentation": {
           "type": "string",
           "description": "OPTIONAL. URL of human-readable documentation for the resource."

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -170,20 +170,6 @@
           },
           "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
         },
-        "resource_encryption_alg_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
-        },
-        "resource_encryption_enc_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
-        },
         "resource_documentation": {
           "type": "string",
           "description": "OPTIONAL. URL of human-readable documentation for the resource."

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -333,20 +333,6 @@
           },
           "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
         },
-        "resource_encryption_alg_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
-        },
-        "resource_encryption_enc_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
-        },
         "resource_documentation": {
           "type": "string",
           "description": "OPTIONAL. URL of human-readable documentation for the resource."

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -81,20 +81,6 @@
           },
           "description": "OPTIONAL. JSON array of JWS signing algorithms supported."
         },
-        "resource_encryption_alg_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (alg) supported."
-        },
-        "resource_encryption_enc_values_supported": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "OPTIONAL. JSON array of JWE encryption algorithms (enc) supported."
-        },
         "resource_documentation": {
           "type": "string",
           "description": "OPTIONAL. URL of human-readable documentation for the resource."

--- a/types/common/state.ts
+++ b/types/common/state.ts
@@ -112,12 +112,6 @@ export interface ProtectedResourceMetadata {
   /** OPTIONAL. JSON array of JWS signing algorithms supported. */
   resource_signing_alg_values_supported?: string[];
 
-  /** OPTIONAL. JSON array of JWE encryption algorithms (alg) supported. */
-  resource_encryption_alg_values_supported?: string[];
-
-  /** OPTIONAL. JSON array of JWE encryption algorithms (enc) supported. */
-  resource_encryption_enc_values_supported?: string[];
-
   /** OPTIONAL. URL of human-readable documentation for the resource. */
   resource_documentation?: string;
 


### PR DESCRIPTION
## Summary
- remove the non-standard `resource_encryption_alg_values_supported` and `resource_encryption_enc_values_supported` fields from `ProtectedResourceMetadata`
- regenerate the JSON schemas and Go, Kotlin, Rust, and Swift client mirrors
- add an all-artifact changelog fragment

Closes #368

## Validation
- `npm run generate`
- `npm run test`
- `cargo test --manifest-path clients/rust/Cargo.toml`
- `swift test`
- `cd clients/go && go test ./...`
- Kotlin `./gradlew test` under the prescribed JDK 17 Podman container