### PR TITLE
schema: stop marking `T | undefined` properties as required

### DIFF
--- a/docs/.changes/20260729-schema-undefined-not-required.json
+++ b/docs/.changes/20260729-schema-undefined-not-required.json
@@ -1,0 +1,5 @@
+{
+  "type": "fixed",
+  "message": "JSON Schema no longer marks properties declared as `T | undefined` (`ActionEnvelope.origin`, `Turn.usage`, `ActiveTurn.usage`, `SessionActivityChangedAction.activity`, `SessionMetaChangedAction._meta`, `SessionChangesetsChangedAction.changesets`, `ChangesetOperationsChangedAction.operations`) as `required`. Such properties are absent on the wire and every client emits them as optional, so the published schemas rejected valid protocol traffic.",
+  "targets": ["spec"]
+}

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -45,8 +45,7 @@
       "required": [
         "channel",
         "action",
-        "serverSeq",
-        "origin"
+        "serverSeq"
       ]
     },
     "RootAgentsChangedAction": {
@@ -330,8 +329,7 @@
         }
       },
       "required": [
-        "type",
-        "activity"
+        "type"
       ]
     },
     "SessionChangesetsChangedAction": {
@@ -350,8 +348,7 @@
         }
       },
       "required": [
-        "type",
-        "changesets"
+        "type"
       ]
     },
     "SessionServerToolsChangedAction": {
@@ -648,8 +645,7 @@
         }
       },
       "required": [
-        "type",
-        "_meta"
+        "type"
       ]
     },
     "ToolCallActionBase": {
@@ -1912,8 +1908,7 @@
         }
       },
       "required": [
-        "type",
-        "operations"
+        "type"
       ]
     },
     "ChangesetOperationStatusChangedAction": {
@@ -5143,7 +5138,6 @@
         "id",
         "message",
         "responseParts",
-        "usage",
         "state"
       ]
     },
@@ -5179,8 +5173,7 @@
         "id",
         "startedAt",
         "message",
-        "responseParts",
-        "usage"
+        "responseParts"
       ]
     },
     "MessageOrigin": {

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -4306,7 +4306,6 @@
         "id",
         "message",
         "responseParts",
-        "usage",
         "state"
       ]
     },
@@ -4342,8 +4341,7 @@
         "id",
         "startedAt",
         "message",
-        "responseParts",
-        "usage"
+        "responseParts"
       ]
     },
     "MessageOrigin": {
@@ -6299,8 +6297,7 @@
       "required": [
         "channel",
         "action",
-        "serverSeq",
-        "origin"
+        "serverSeq"
       ]
     },
     "RootAgentsChangedAction": {
@@ -6584,8 +6581,7 @@
         }
       },
       "required": [
-        "type",
-        "activity"
+        "type"
       ]
     },
     "SessionChangesetsChangedAction": {
@@ -6604,8 +6600,7 @@
         }
       },
       "required": [
-        "type",
-        "changesets"
+        "type"
       ]
     },
     "SessionServerToolsChangedAction": {
@@ -6902,8 +6897,7 @@
         }
       },
       "required": [
-        "type",
-        "_meta"
+        "type"
       ]
     },
     "ToolCallActionBase": {
@@ -8166,8 +8160,7 @@
         }
       },
       "required": [
-        "type",
-        "operations"
+        "type"
       ]
     },
     "ChangesetOperationStatusChangedAction": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -3042,7 +3042,6 @@
         "id",
         "message",
         "responseParts",
-        "usage",
         "state"
       ]
     },
@@ -3078,8 +3077,7 @@
         "id",
         "startedAt",
         "message",
-        "responseParts",
-        "usage"
+        "responseParts"
       ]
     },
     "MessageOrigin": {
@@ -6942,8 +6940,7 @@
       "required": [
         "channel",
         "action",
-        "serverSeq",
-        "origin"
+        "serverSeq"
       ]
     },
     "StateAction": {
@@ -7858,8 +7855,7 @@
         }
       },
       "required": [
-        "type",
-        "activity"
+        "type"
       ]
     },
     "SessionChangesetsChangedAction": {
@@ -7878,8 +7874,7 @@
         }
       },
       "required": [
-        "type",
-        "changesets"
+        "type"
       ]
     },
     "SessionConfigChangedAction": {
@@ -7918,8 +7913,7 @@
         }
       },
       "required": [
-        "type",
-        "_meta"
+        "type"
       ]
     },
     "ChatTurnStartedAction": {
@@ -8872,8 +8866,7 @@
         }
       },
       "required": [
-        "type",
-        "operations"
+        "type"
       ]
     },
     "ChangesetOperationStatusChangedAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -3205,7 +3205,6 @@
         "id",
         "message",
         "responseParts",
-        "usage",
         "state"
       ]
     },
@@ -3241,8 +3240,7 @@
         "id",
         "startedAt",
         "message",
-        "responseParts",
-        "usage"
+        "responseParts"
       ]
     },
     "MessageOrigin": {

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -2953,7 +2953,6 @@
         "id",
         "message",
         "responseParts",
-        "usage",
         "state"
       ]
     },
@@ -2989,8 +2988,7 @@
         "id",
         "startedAt",
         "message",
-        "responseParts",
-        "usage"
+        "responseParts"
       ]
     },
     "MessageOrigin": {

--- a/scripts/generate-json-schema.test.ts
+++ b/scripts/generate-json-schema.test.ts
@@ -10,12 +10,13 @@
  * Run: npx tsx --test scripts/generate-json-schema.test.ts
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, before } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Project } from 'ts-morph';
+import { typeAdmitsUndefined } from './generate-json-schema.js';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SCHEMA_FILES = [
@@ -270,6 +271,48 @@ describe('generated JSON schemas', () => {
   }
 });
 
+describe('typeAdmitsUndefined', () => {
+  // Guards the depth-aware union splitting these checks depend on: only a
+  // *top-level* `undefined` member means the property may be absent on the
+  // wire. A nested one (inside a generic argument, tuple, parenthesised union
+  // or inline object) does not — the property itself is still always present.
+
+  const admits: string[] = [
+    'string | undefined',
+    'undefined | string',
+    'UsageInfo | undefined',
+    'Changeset[] | undefined',
+    'Record<string, unknown> | undefined',
+    'A | B | undefined',
+    '  string   |   undefined  ',
+  ];
+
+  const doesNotAdmit: string[] = [
+    'string',
+    'UsageInfo',
+    'A | B',
+    'Array<string | undefined>',
+    'Record<string, string | undefined>',
+    '[string | undefined]',
+    '[ string | undefined ]',
+    '{ a: string | undefined }',
+    '(string | undefined)[]',
+    'Map<string, A | undefined>',
+  ];
+
+  for (const typeText of admits) {
+    it(`treats \`${typeText.trim()}\` as admitting undefined`, () => {
+      assert.equal(typeAdmitsUndefined(typeText), true);
+    });
+  }
+
+  for (const typeText of doesNotAdmit) {
+    it(`treats \`${typeText}\` as NOT admitting undefined`, () => {
+      assert.equal(typeAdmitsUndefined(typeText), false);
+    });
+  }
+});
+
 describe('`T | undefined` properties are not schema-required', () => {
   // The protocol writes a handful of properties as an explicit `T | undefined`
   // union rather than with a `?` question token, so that a producer building the
@@ -285,36 +328,42 @@ describe('`T | undefined` properties are not schema-required', () => {
   // reject the very traffic all five clients produce.
   //
   // Derived from the canonical sources rather than hardcoded, so a newly added
-  // `T | undefined` property is covered automatically.
-
-  const project = new Project({
-    tsConfigFilePath: resolve(root, 'types/tsconfig.json'),
-    skipAddingFilesFromTsConfig: false,
-  });
+  // `T | undefined` property is covered automatically. Classification reuses the
+  // generator's own `typeAdmitsUndefined` so the test and the generator can
+  // never disagree about what qualifies (in particular, both treat only
+  // *top-level* union members as admitting `undefined`).
 
   /** `interface name` → property names declared as an explicit `T | undefined` union. */
   const undefinedProps = new Map<string, Set<string>>();
-  for (const sourceFile of project.getSourceFiles()) {
-    for (const iface of sourceFile.getInterfaces()) {
-      for (const prop of iface.getProperties()) {
-        if (prop.hasQuestionToken()) {
-          continue;
+
+  // Built lazily in `before` rather than at module load: constructing a ts-morph
+  // Project is expensive, and doing it in the describe body would pay that cost
+  // even when running a filtered subset of tests from this file.
+  before(() => {
+    const project = new Project({
+      tsConfigFilePath: resolve(root, 'types/tsconfig.json'),
+      skipAddingFilesFromTsConfig: false,
+    });
+
+    for (const sourceFile of project.getSourceFiles()) {
+      for (const iface of sourceFile.getInterfaces()) {
+        for (const prop of iface.getProperties()) {
+          if (prop.hasQuestionToken()) {
+            continue;
+          }
+          if (!typeAdmitsUndefined(prop.getTypeNode()?.getText() ?? '')) {
+            continue;
+          }
+          let set = undefinedProps.get(iface.getName());
+          if (!set) {
+            set = new Set();
+            undefinedProps.set(iface.getName(), set);
+          }
+          set.add(prop.getName());
         }
-        const typeText = prop.getTypeNode()?.getText() ?? '';
-        // Top-level `| undefined` member; generics/inline objects never contain
-        // a bare `undefined` union member at depth 0 in this codebase.
-        if (!/(^|\|)\s*undefined\s*(\||$)/.test(typeText)) {
-          continue;
-        }
-        let set = undefinedProps.get(iface.getName());
-        if (!set) {
-          set = new Set();
-          undefinedProps.set(iface.getName(), set);
-        }
-        set.add(prop.getName());
       }
     }
-  }
+  });
 
   it('finds the known `T | undefined` properties in types/', () => {
     // Sanity-check the derivation itself: if this drops to zero because the

--- a/scripts/generate-json-schema.test.ts
+++ b/scripts/generate-json-schema.test.ts
@@ -15,6 +15,7 @@ import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { Project } from 'ts-morph';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SCHEMA_FILES = [
@@ -265,6 +266,95 @@ describe('generated JSON schemas', () => {
           false,
         );
       });
+    });
+  }
+});
+
+describe('`T | undefined` properties are not schema-required', () => {
+  // The protocol writes a handful of properties as an explicit `T | undefined`
+  // union rather than with a `?` question token, so that a producer building the
+  // object literal in TypeScript is forced to mention the key and consciously
+  // choose between a value and a clear (e.g. `session/activityChanged` clearing
+  // the activity string).
+  //
+  // That is an authoring-time constraint only. `JSON.stringify` drops
+  // `undefined` members, so on the wire such a property is simply **absent**,
+  // exactly like an optional one — and every language generator emits it as
+  // optional (`Option<T>` + `skip_serializing_if`, `*T` + `omitempty`,
+  // `T? = null`). Listing them under `required` made the published schemas
+  // reject the very traffic all five clients produce.
+  //
+  // Derived from the canonical sources rather than hardcoded, so a newly added
+  // `T | undefined` property is covered automatically.
+
+  const project = new Project({
+    tsConfigFilePath: resolve(root, 'types/tsconfig.json'),
+    skipAddingFilesFromTsConfig: false,
+  });
+
+  /** `interface name` → property names declared as an explicit `T | undefined` union. */
+  const undefinedProps = new Map<string, Set<string>>();
+  for (const sourceFile of project.getSourceFiles()) {
+    for (const iface of sourceFile.getInterfaces()) {
+      for (const prop of iface.getProperties()) {
+        if (prop.hasQuestionToken()) {
+          continue;
+        }
+        const typeText = prop.getTypeNode()?.getText() ?? '';
+        // Top-level `| undefined` member; generics/inline objects never contain
+        // a bare `undefined` union member at depth 0 in this codebase.
+        if (!/(^|\|)\s*undefined\s*(\||$)/.test(typeText)) {
+          continue;
+        }
+        let set = undefinedProps.get(iface.getName());
+        if (!set) {
+          set = new Set();
+          undefinedProps.set(iface.getName(), set);
+        }
+        set.add(prop.getName());
+      }
+    }
+  }
+
+  it('finds the known `T | undefined` properties in types/', () => {
+    // Sanity-check the derivation itself: if this drops to zero because the
+    // extraction broke, the per-schema assertions below would vacuously pass.
+    assert.ok(
+      undefinedProps.size > 0,
+      'expected to find at least one `T | undefined` property in types/ — the extraction is probably broken',
+    );
+  });
+
+  for (const file of SCHEMA_FILES) {
+    it(`${file} marks none of them required`, () => {
+      const schema = loadSchema(file);
+      const defs = (schema.$defs as Record<string, Record<string, unknown>>) ?? {};
+      const offenders: string[] = [];
+
+      for (const [typeName, properties] of undefinedProps) {
+        const def = defs[typeName];
+        if (!def) {
+          continue;
+        }
+        const required = Array.isArray(def.required) ? (def.required as string[]) : [];
+        const declared = (def.properties as Record<string, unknown> | undefined) ?? {};
+        for (const property of properties) {
+          if (required.includes(property)) {
+            offenders.push(`${typeName}.${property} is listed as required`);
+          }
+          // It must still be *declared* — dropping it from `required` is only
+          // correct if the property itself is still described.
+          if (!(property in declared)) {
+            offenders.push(`${typeName}.${property} is missing from properties`);
+          }
+        }
+      }
+
+      assert.deepEqual(
+        offenders.sort(),
+        [],
+        `${file}: a \`T | undefined\` property must be optional-but-declared, since it is absent on the wire and every client emits it as optional:\n  ${offenders.join('\n  ')}`,
+      );
     });
   }
 });

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -241,8 +241,14 @@ function splitUnionType(typeText: string): string[] {
   let depth = 0;
   let current = '';
   for (const char of typeText) {
-    if (char === '<' || char === '(' || char === '{') depth++;
-    else if (char === '>' || char === ')' || char === '}') depth--;
+    // Track every bracket pair so a `|` nested inside a generic argument
+    // (`Array<A | B>`), a parenthesised union, an inline object
+    // (`{ a: A | B }`) or a tuple (`[A | B]`) is not mistaken for a
+    // top-level union separator. `[`/`]` matter for callers that consume the
+    // split parts as type names — `typeTextToSchema`'s `oneOf` generation
+    // would otherwise emit `[A` and `B]` as two branches of a tuple type.
+    if (char === '<' || char === '(' || char === '{' || char === '[') depth++;
+    else if (char === '>' || char === ')' || char === '}' || char === ']') depth--;
     else if (char === '|' && depth === 0) {
       parts.push(current.trim());
       current = '';
@@ -258,6 +264,10 @@ function splitUnionType(typeText: string): string[] {
  * Whether a declared property type admits `undefined` — i.e. it is written as
  * an explicit `T | undefined` union rather than with a `?` question token.
  *
+ * Only a **top-level** union member counts: `A | undefined` does, while a
+ * nested `Array<A | undefined>` does not, since the property itself is still
+ * always present.
+ *
  * The protocol uses `T | undefined` (instead of `T?`) for fields whose "cleared"
  * state is semantically meaningful, so that a producer constructing the object
  * literal in TypeScript is forced to mention the key and consciously decide
@@ -269,8 +279,12 @@ function splitUnionType(typeText: string): string[] {
  *
  * The emitted JSON Schema therefore MUST NOT list these properties as
  * `required`, or it would reject the very messages the clients produce.
+ *
+ * Exported so the schema tests classify properties with exactly the same rule
+ * the generator applies, rather than duplicating the logic in a second place
+ * where the two could drift apart.
  */
-function typeAdmitsUndefined(typeText: string): boolean {
+export function typeAdmitsUndefined(typeText: string): boolean {
   return splitUnionType(typeText.trim()).some(part => part === 'undefined');
 }
 

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -254,6 +254,26 @@ function splitUnionType(typeText: string): string[] {
   return parts;
 }
 
+/**
+ * Whether a declared property type admits `undefined` — i.e. it is written as
+ * an explicit `T | undefined` union rather than with a `?` question token.
+ *
+ * The protocol uses `T | undefined` (instead of `T?`) for fields whose "cleared"
+ * state is semantically meaningful, so that a producer constructing the object
+ * literal in TypeScript is forced to mention the key and consciously decide
+ * between a value and a clear. That is purely an authoring-time constraint: at
+ * runtime `JSON.stringify` drops `undefined` members, so such a field is
+ * **absent** on the wire exactly like an optional one, and every language
+ * generator emits it as optional (`Option<T>` + `skip_serializing_if`,
+ * `*T` + `omitempty`, `T? = null`).
+ *
+ * The emitted JSON Schema therefore MUST NOT list these properties as
+ * `required`, or it would reject the very messages the clients produce.
+ */
+function typeAdmitsUndefined(typeText: string): boolean {
+  return splitUnionType(typeText.trim()).some(part => part === 'undefined');
+}
+
 function enumMemberToSchema(typeText: string, project: Project): JsonSchema | undefined {
   const match = typeText.match(/^([A-Z]\w*)\.(\w+)$/);
   if (!match) return undefined;
@@ -276,7 +296,7 @@ function inlineObjectToSchema(text: string, project: Project): JsonSchema {
       const [, name, optional, type] = match;
       const fieldType = type.trim();
       schema.properties![name] = typeTextToSchema(fieldType, project);
-      if (!optional) {
+      if (!optional && !typeAdmitsUndefined(fieldType)) {
         schema.required!.push(name);
       }
     }
@@ -303,7 +323,7 @@ function interfaceToSchema(iface: InterfaceDeclaration, project: Project): JsonS
     const propSchema = typeTextToSchema(typeText, project);
     if (desc) propSchema.description = desc;
     schema.properties![name] = propSchema;
-    if (!prop.hasQuestionToken()) {
+    if (!prop.hasQuestionToken() && !typeAdmitsUndefined(typeText)) {
       if (!schema.required!.includes(name)) {
         schema.required!.push(name);
       }


### PR DESCRIPTION
## Problem

Seven protocol properties are declared as an explicit `T | undefined` union rather than with a `?` question token:

| Property |
| --- |
| `ActionEnvelope.origin` |
| `Turn.usage` |
| `ActiveTurn.usage` |
| `SessionActivityChangedAction.activity` |
| `SessionMetaChangedAction._meta` |
| `SessionChangesetsChangedAction.changesets` |
| `ChangesetOperationsChangedAction.operations` |

The JSON Schema generator keyed `required` solely off the question token, so it emitted all seven as **required and non-nullable**. The published schemas therefore describe a shape the protocol can never produce — they reject any server-originated action (which has no `origin`), any turn without usage, and the very "clear this value" actions the `| undefined` spelling exists to express.

All five language generators already treat these as optional (`Option<T>` + `skip_serializing_if`, `*T` + `omitempty`, `T? = null`), so the schemas were the lone holdout and disagreed with every client.

## Why the fix is in the generator, not the types

`undefined` is not a JSON value. `JSON.stringify` drops the member, so a `T | undefined` property is simply **absent** on the wire — byte-identical to an omitted `T?`:

```js
JSON.stringify({ id: 't1', usage: undefined })  // {"id":"t1"}
JSON.stringify({ id: 't1' })                    // {"id":"t1"}
```

"Key may be absent" is exactly what omission from `required` expresses, so describing these as optional isn't an approximation — it's an exact description, with no information given up.

The obvious alternative was to change the seven properties to `?:`. I didn't, because **the `T | undefined` spelling is deliberate and worth keeping**: unlike `T?`, it forces a producer building the object literal in TypeScript to mention the key and consciously choose between a value and a clear. That matters precisely for these actions — `session/activityChanged` clearing an activity string, `session/metaChanged` clearing metadata — where "deliberately cleared" and "forgot to set" are different intentions worth making the compiler enforce. It's an authoring-time constraint with zero wire effect, so the bug was in the generator's reading of it.

## Change

`interfaceToSchema` and `inlineObjectToSchema` now key `required` off the declared type as well as the question token:

```ts
if (!prop.hasQuestionToken() && !typeAdmitsUndefined(typeText)) {
  schema.required!.push(name);
}
```

The seven properties remain **declared** in `properties` — they're optional, not removed.

## Test

The regression test **derives** the `T | undefined` property set from the canonical sources via ts-morph rather than hardcoding those seven names, so a newly added one is covered automatically. It asserts each stays optional-but-declared in all five schemas, and includes a guard that fails if the extraction itself ever silently finds nothing.

Verified it actually catches the regression by re-injecting `ActionEnvelope.origin` into `required` — the `actions.schema.json` case fails as expected.

## Scope / severity

Worth being upfront: **these schemas are published reference artifacts that nothing currently validates against.** They're live at stable `$id` URLs on the docs site, but they aren't consumed by the VS Code or copilot-host implementations, by any generator (the docs only *link* to them), or shipped in the npm package or Rust crate. So nothing was broken in practice.

The reason to fix it before the 1.0 freeze is that they're the only machine-readable artifact for an implementer *not* using one of the five generated clients, and 1.0 is when those URLs become authoritative.

A related observation, not addressed here: the reason this drifted undetected is that nothing consumes the schemas, so nothing keeps them honest. A broader guard — validating the existing `types/test-cases/round-trips/` fixtures against the generated schemas in CI — would make "the schema agrees with reality" enforced rather than noticed. Happy to do that separately if it's wanted.

## Verification

- `npm run generate` — full regenerate produces no drift beyond the intended schema changes
- `npm test` — 359 tests pass, reducers held at 100% branch coverage
- No changes to `types/`, so no client codegen or wire impact

Found during a pre-1.0 protocol stabilization review.

<sub>(Written by Copilot)</sub>
