### PR TITLE
Restore secret-scanner-redacted authentication docs in types/

### DIFF
--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -863,7 +863,7 @@ type DispatchActionParams struct {
 	Action StateAction `json:"action"`
 }
 
-// Pushes a ****** for a protected resource. The `resource` field MUST
+// Pushes a Bearer token for a protected resource. The `resource` field MUST
 // match a protected-resource identifier the client has discovered from the
 // server — whether declared statically in `AgentInfo.protectedResources`,
 // or discovered dynamically from a live `McpServerAuthRequiredState.resource`
@@ -873,7 +873,7 @@ type DispatchActionParams struct {
 // through one of these three mechanisms.
 //
 // Tokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)
-// (****** Usage) semantics. The client obtains the token from the
+// (Bearer Token Usage) semantics. The client obtains the token from the
 // authorization server(s) listed in the resource's metadata and pushes it
 // to the server via this command.
 type AuthenticateParams struct {
@@ -884,7 +884,7 @@ type AuthenticateParams struct {
 	// `AgentInfo.protectedResources`, or via a live
 	// `McpServerAuthRequiredState.resource` / `ToolCallAuthRequiredState.auth.resource`.
 	Resource string `json:"resource"`
-	// ***** obtained from the resource's authorization server
+	// Bearer token obtained from the resource's authorization server
 	Token string `json:"token"`
 	// OAuth scopes the token grants, when known. Lets the server determine
 	// whether a specific challenge — e.g. the `requiredScopes` on a live

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -2947,7 +2947,7 @@ type McpServerAuthRequiredState struct {
 	// authorization spec.
 	Resource ProtectedResourceMetadata `json:"resource"`
 	// Scopes required for the current challenge, parsed from the
-	// `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+	// `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
 	// fallback). Authoritative for the next authorization request — clients
 	// MUST NOT assume any subset/superset relationship to
 	// `resource.scopes_supported`.
@@ -2985,7 +2985,7 @@ type McpOAuthClient struct {
 // Reusable MCP authentication challenge — the RFC 9728 discovery info a
 // client needs to obtain a token and push it via the `authenticate` command.
 // Deliberately carries **no token**: this describes what is being asked for,
-// never the ****** itself.
+// never the bearer token itself.
 //
 // Shared by two independent state machines that describe the same OAuth
 // challenge from different vantage points:
@@ -3011,7 +3011,7 @@ type McpAuthRequirement struct {
 	// authorization spec.
 	Resource ProtectedResourceMetadata `json:"resource"`
 	// Scopes required for the current challenge, parsed from the
-	// `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+	// `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
 	// fallback). Authoritative for the next authorization request — clients
 	// MUST NOT assume any subset/superset relationship to
 	// `resource.scopes_supported`.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -1026,7 +1026,7 @@ data class AuthenticateParams(
      */
     val resource: String,
     /**
-     * ***** obtained from the resource's authorization server
+     * Bearer token obtained from the resource's authorization server
      */
     val token: String,
     /**

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -3934,7 +3934,7 @@ data class McpServerAuthRequiredState(
     val resource: ProtectedResourceMetadata,
     /**
      * Scopes required for the current challenge, parsed from the
-     * `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+     * `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
      * fallback). Authoritative for the next authorization request — clients
      * MUST NOT assume any subset/superset relationship to
      * `resource.scopes_supported`.
@@ -3994,7 +3994,7 @@ data class McpAuthRequirement(
     val resource: ProtectedResourceMetadata,
     /**
      * Scopes required for the current challenge, parsed from the
-     * `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+     * `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
      * fallback). Authoritative for the next authorization request — clients
      * MUST NOT assume any subset/superset relationship to
      * `resource.scopes_supported`.

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -1037,7 +1037,7 @@ pub struct DispatchActionParams {
     pub action: StateAction,
 }
 
-/// Pushes a ****** for a protected resource. The `resource` field MUST
+/// Pushes a Bearer token for a protected resource. The `resource` field MUST
 /// match a protected-resource identifier the client has discovered from the
 /// server — whether declared statically in `AgentInfo.protectedResources`,
 /// or discovered dynamically from a live `McpServerAuthRequiredState.resource`
@@ -1047,7 +1047,7 @@ pub struct DispatchActionParams {
 /// through one of these three mechanisms.
 ///
 /// Tokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)
-/// (****** Usage) semantics. The client obtains the token from the
+/// (Bearer Token Usage) semantics. The client obtains the token from the
 /// authorization server(s) listed in the resource's metadata and pushes it
 /// to the server via this command.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1060,7 +1060,7 @@ pub struct AuthenticateParams {
     /// `AgentInfo.protectedResources`, or via a live
     /// `McpServerAuthRequiredState.resource` / `ToolCallAuthRequiredState.auth.resource`.
     pub resource: String,
-    /// ***** obtained from the resource's authorization server
+    /// Bearer token obtained from the resource's authorization server
     pub token: String,
     /// OAuth scopes the token grants, when known. Lets the server determine
     /// whether a specific challenge — e.g. the `requiredScopes` on a live

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -3552,7 +3552,7 @@ pub struct McpServerAuthRequiredState {
     /// authorization spec.
     pub resource: ProtectedResourceMetadata,
     /// Scopes required for the current challenge, parsed from the
-    /// `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+    /// `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
     /// fallback). Authoritative for the next authorization request — clients
     /// MUST NOT assume any subset/superset relationship to
     /// `resource.scopes_supported`.
@@ -3595,7 +3595,7 @@ pub struct McpOAuthClient {
 /// Reusable MCP authentication challenge — the RFC 9728 discovery info a
 /// client needs to obtain a token and push it via the `authenticate` command.
 /// Deliberately carries **no token**: this describes what is being asked for,
-/// never the ****** itself.
+/// never the bearer token itself.
 ///
 /// Shared by two independent state machines that describe the same OAuth
 /// challenge from different vantage points:
@@ -3624,7 +3624,7 @@ pub struct McpAuthRequirement {
     /// authorization spec.
     pub resource: ProtectedResourceMetadata,
     /// Scopes required for the current challenge, parsed from the
-    /// `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+    /// `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
     /// fallback). Authoritative for the next authorization request — clients
     /// MUST NOT assume any subset/superset relationship to
     /// `resource.scopes_supported`.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -1093,7 +1093,7 @@ public struct AuthenticateParams: Codable, Sendable {
     /// `AgentInfo.protectedResources`, or via a live
     /// `McpServerAuthRequiredState.resource` / `ToolCallAuthRequiredState.auth.resource`.
     public var resource: String
-    /// ***** obtained from the resource's authorization server
+    /// Bearer token obtained from the resource's authorization server
     public var token: String
     /// OAuth scopes the token grants, when known. Lets the server determine
     /// whether a specific challenge — e.g. the `requiredScopes` on a live

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -4354,7 +4354,7 @@ public struct McpServerAuthRequiredState: Codable, Sendable {
     /// authorization spec.
     public var resource: ProtectedResourceMetadata
     /// Scopes required for the current challenge, parsed from the
-    /// `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+    /// `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
     /// fallback). Authoritative for the next authorization request — clients
     /// MUST NOT assume any subset/superset relationship to
     /// `resource.scopes_supported`.
@@ -4432,7 +4432,7 @@ public struct McpAuthRequirement: Codable, Sendable {
     /// authorization spec.
     public var resource: ProtectedResourceMetadata
     /// Scopes required for the current challenge, parsed from the
-    /// `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+    /// `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
     /// fallback). Authoritative for the next authorization request — clients
     /// MUST NOT assume any subset/superset relationship to
     /// `resource.scopes_supported`.

--- a/docs/.changes/20260730-restore-redacted-auth-docs.json
+++ b/docs/.changes/20260730-restore-redacted-auth-docs.json
@@ -1,0 +1,4 @@
+{
+  "type": "fixed",
+  "message": "Restored authentication documentation in the `authenticate` command and `McpAuthRequirement` that a secret-scanner had redacted, including a corrupted `WWW-Authenticate: Bearer scope=\"…\"` header example."
+}

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -4380,7 +4380,7 @@
     },
     "McpAuthRequirement": {
       "type": "object",
-      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the ****** itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
+      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the bearer token itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
       "properties": {
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -4399,7 +4399,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",
@@ -4432,7 +4432,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -733,7 +733,7 @@
     },
     "AuthenticateParams": {
       "type": "object",
-      "description": "Pushes a ****** for a protected resource. The `resource` field MUST\nmatch a protected-resource identifier the client has discovered from the\nserver — whether declared statically in `AgentInfo.protectedResources`,\nor discovered dynamically from a live `McpServerAuthRequiredState.resource`\nor `ToolCallAuthRequiredState.auth.resource` (both surfaced only once the\ncorresponding MCP server or tool call actually challenges for auth).\nServers MUST accept any `resource` value they have themselves advertised\nthrough one of these three mechanisms.\n\nTokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)\n(****** Usage) semantics. The client obtains the token from the\nauthorization server(s) listed in the resource's metadata and pushes it\nto the server via this command.",
+      "description": "Pushes a Bearer token for a protected resource. The `resource` field MUST\nmatch a protected-resource identifier the client has discovered from the\nserver — whether declared statically in `AgentInfo.protectedResources`,\nor discovered dynamically from a live `McpServerAuthRequiredState.resource`\nor `ToolCallAuthRequiredState.auth.resource` (both surfaced only once the\ncorresponding MCP server or tool call actually challenges for auth).\nServers MUST accept any `resource` value they have themselves advertised\nthrough one of these three mechanisms.\n\nTokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)\n(Bearer Token Usage) semantics. The client obtains the token from the\nauthorization server(s) listed in the resource's metadata and pushes it\nto the server via this command.",
       "properties": {
         "channel": {
           "type": "string",
@@ -747,7 +747,7 @@
         },
         "token": {
           "type": "string",
-          "description": "***** obtained from the resource's authorization server"
+          "description": "Bearer token obtained from the resource's authorization server"
         },
         "scopes": {
           "type": "array",
@@ -3543,7 +3543,7 @@
     },
     "McpAuthRequirement": {
       "type": "object",
-      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the ****** itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
+      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the bearer token itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
       "properties": {
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -3562,7 +3562,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",
@@ -3595,7 +3595,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2279,7 +2279,7 @@
     },
     "McpAuthRequirement": {
       "type": "object",
-      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the ****** itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
+      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the bearer token itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
       "properties": {
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -2298,7 +2298,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",
@@ -2331,7 +2331,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",
@@ -5709,7 +5709,7 @@
     },
     "AuthenticateParams": {
       "type": "object",
-      "description": "Pushes a ****** for a protected resource. The `resource` field MUST\nmatch a protected-resource identifier the client has discovered from the\nserver — whether declared statically in `AgentInfo.protectedResources`,\nor discovered dynamically from a live `McpServerAuthRequiredState.resource`\nor `ToolCallAuthRequiredState.auth.resource` (both surfaced only once the\ncorresponding MCP server or tool call actually challenges for auth).\nServers MUST accept any `resource` value they have themselves advertised\nthrough one of these three mechanisms.\n\nTokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)\n(****** Usage) semantics. The client obtains the token from the\nauthorization server(s) listed in the resource's metadata and pushes it\nto the server via this command.",
+      "description": "Pushes a Bearer token for a protected resource. The `resource` field MUST\nmatch a protected-resource identifier the client has discovered from the\nserver — whether declared statically in `AgentInfo.protectedResources`,\nor discovered dynamically from a live `McpServerAuthRequiredState.resource`\nor `ToolCallAuthRequiredState.auth.resource` (both surfaced only once the\ncorresponding MCP server or tool call actually challenges for auth).\nServers MUST accept any `resource` value they have themselves advertised\nthrough one of these three mechanisms.\n\nTokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)\n(Bearer Token Usage) semantics. The client obtains the token from the\nauthorization server(s) listed in the resource's metadata and pushes it\nto the server via this command.",
       "properties": {
         "channel": {
           "type": "string",
@@ -5723,7 +5723,7 @@
         },
         "token": {
           "type": "string",
-          "description": "***** obtained from the resource's authorization server"
+          "description": "Bearer token obtained from the resource's authorization server"
         },
         "scopes": {
           "type": "array",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -2442,7 +2442,7 @@
     },
     "McpAuthRequirement": {
       "type": "object",
-      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the ****** itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
+      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the bearer token itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
       "properties": {
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -2461,7 +2461,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",
@@ -2494,7 +2494,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -2190,7 +2190,7 @@
     },
     "McpAuthRequirement": {
       "type": "object",
-      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the ****** itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
+      "description": "Reusable MCP authentication challenge — the RFC 9728 discovery info a\nclient needs to obtain a token and push it via the `authenticate` command.\nDeliberately carries **no token**: this describes what is being asked for,\nnever the bearer token itself.\n\nShared by two independent state machines that describe the same OAuth\nchallenge from different vantage points:\n\n- {@link McpServerAuthRequiredState} — the MCP server itself cannot serve\n  *any* request until the client authenticates.\n- {@link ToolCallAuthRequiredState} — a specific in-flight tool call is\n  paused pending authentication (typically\n  {@link McpAuthRequiredReason.InsufficientScope} step-up auth\n  mid-execution). The server state and the tool-call state remain\n  separate on purpose: the server saying \"I need auth\" and a tool\n  invocation saying \"I am waiting on that auth\" are different facts that\n  can be true independently.",
       "properties": {
         "reason": {
           "$ref": "#/$defs/McpAuthRequiredReason",
@@ -2209,7 +2209,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",
@@ -2242,7 +2242,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: ******\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
+          "description": "Scopes required for the current challenge, parsed from the\n`WWW-Authenticate: Bearer scope=\"…\"` header (or `scopes_supported`\nfallback). Authoritative for the next authorization request — clients\nMUST NOT assume any subset/superset relationship to\n`resource.scopes_supported`."
         },
         "description": {
           "type": "string",

--- a/scripts/no-redaction-marker.test.ts
+++ b/scripts/no-redaction-marker.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Directories whose text is authored/hand-edited and should never contain a
+ * secret-scanner redaction marker. `types/` is the canonical protocol source;
+ * a redaction here silently corrupts every generated client and schema.
+ */
+const SCANNED_DIRS = ['types', 'docs'] as const;
+
+/**
+ * A secret-scanner redacts a matched token by substituting a run of asterisks.
+ * We look for six or more consecutive asterisks, which never occurs in
+ * legitimate prose, Markdown emphasis (`*`/`**`), or comment banners built from
+ * this repo's own conventions. Built from a char class + quantifier so the
+ * marker literal does not appear verbatim in this file (which lives outside the
+ * scanned dirs, but keeping it out avoids any self-matching if that changes).
+ */
+const REDACTION_MARKER = new RegExp('\\*{6,}');
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'build', '.gradle', 'dist', 'target']);
+
+function collectFiles(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectFiles(full, out);
+    } else {
+      out.push(full);
+    }
+  }
+}
+
+describe('no redaction markers in authored sources', () => {
+  it('has no secret-scanner redaction run under types/ or docs/', () => {
+    const offences: string[] = [];
+    for (const relDir of SCANNED_DIRS) {
+      const files: string[] = [];
+      collectFiles(join(root, relDir), files);
+      for (const file of files) {
+        const contents = readFileSync(file, 'utf8');
+        if (!REDACTION_MARKER.test(contents)) {
+          continue;
+        }
+        const lines = contents.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          if (REDACTION_MARKER.test(lines[i])) {
+            // Report only the location, never the offending line: a genuine
+            // future redaction hides a real secret, and echoing it would leak
+            // it into CI logs.
+            offences.push(`${relative(root, file)}:${i + 1}`);
+          }
+        }
+      }
+    }
+
+    assert.deepEqual(
+      offences,
+      [],
+      offences.length === 0
+        ? ''
+        : `Found secret-scanner redaction marker(s) (a run of 6+ asterisks) at:\n` +
+            offences.map((o) => `  - ${o}`).join('\n') +
+            `\nA secret-scanning tool likely corrupted authored text here. Restore the ` +
+            `original wording from git history before the redaction (do not retype secrets).`,
+    );
+  });
+});

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -1253,7 +1253,7 @@ export interface McpOAuthClient {
  * Reusable MCP authentication challenge — the RFC 9728 discovery info a
  * client needs to obtain a token and push it via the `authenticate` command.
  * Deliberately carries **no token**: this describes what is being asked for,
- * never the ****** itself.
+ * never the bearer token itself.
  *
  * Shared by two independent state machines that describe the same OAuth
  * challenge from different vantage points:
@@ -1287,7 +1287,7 @@ export interface McpAuthRequirement {
   resource: ProtectedResourceMetadata;
   /**
    * Scopes required for the current challenge, parsed from the
-   * `WWW-Authenticate: ******"…"` header (or `scopes_supported`
+   * `WWW-Authenticate: Bearer scope="…"` header (or `scopes_supported`
    * fallback). Authoritative for the next authorization request — clients
    * MUST NOT assume any subset/superset relationship to
    * `resource.scopes_supported`.

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -1006,7 +1006,7 @@ export interface ResourceMkdirResult {
 // ─── authenticate ────────────────────────────────────────────────────────────
 
 /**
- * Pushes a ****** for a protected resource. The `resource` field MUST
+ * Pushes a Bearer token for a protected resource. The `resource` field MUST
  * match a protected-resource identifier the client has discovered from the
  * server — whether declared statically in `AgentInfo.protectedResources`,
  * or discovered dynamically from a live `McpServerAuthRequiredState.resource`
@@ -1016,7 +1016,7 @@ export interface ResourceMkdirResult {
  * through one of these three mechanisms.
  *
  * Tokens are delivered using [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)
- * (****** Usage) semantics. The client obtains the token from the
+ * (Bearer Token Usage) semantics. The client obtains the token from the
  * authorization server(s) listed in the resource's metadata and pushes it
  * to the server via this command.
  *
@@ -1048,7 +1048,7 @@ export interface AuthenticateParams extends BaseParams {
    * `McpServerAuthRequiredState.resource` / `ToolCallAuthRequiredState.auth.resource`.
    */
   resource: string;
-  /** ****** obtained from the resource's authorization server */
+  /** Bearer token obtained from the resource's authorization server */
   token: string;
   /**
    * OAuth scopes the token grants, when known. Lets the server determine


### PR DESCRIPTION
Five JSDoc fragments in the canonical protocol types had been replaced by a six-asterisk redaction run by a secret scanner, corrupting the `authenticate` command docs / `AuthenticateParams.token` and the `McpAuthRequirement` docs / `requiredScopes` field. The `WWW-Authenticate` header example in `state.ts` was left describing a header format that does not exist.

The four intact fragments were spliced back byte-exact from pre-redaction git history (commits 71d6b5f8 / 1ebc2066); the one line whose surrounding prose had since been rewritten and had no clean copy in history was reconstructed to match the scanner's `Bearer <token>` false-positive pattern and the surrounding text. Regenerated all five clients and schemas — the propagated diff is doc-comment / description only, no structural change.

Adds a scripts/*.test.ts guard asserting no file under types/ or docs/ contains a 6+-asterisk redaction run. The guard tests file bytes and reports only file:line on failure so a genuine future secret is never echoed into CI logs.