### PR TITLE
feat: add optional `_meta` request metadata to all command parameters

### DIFF
--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -94,6 +94,9 @@ const (
 type InitializeParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Protocol versions the client is willing to speak, ordered from most
 	// preferred to least preferred. Each entry is a [SemVer](https://semver.org)
 	// `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
@@ -215,6 +218,9 @@ type Implementation struct {
 type ReconnectParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Client identifier from the original connection
 	ClientId string `json:"clientId"`
 	// Last `serverSeq` the client received
@@ -251,6 +257,9 @@ type ReconnectSnapshotResult struct {
 type SubscribeParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Optional delivery preferences for this subscription.
 	//
 	// Servers MAY use these preferences to buffer and coalesce high-frequency
@@ -313,6 +322,9 @@ type SessionForkSource struct {
 type CreateSessionParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Agent provider ID
 	Provider *string `json:"provider,omitempty"`
 	// The working directories the session's agent is granted tool access to.
@@ -363,6 +375,9 @@ type CreateSessionParams struct {
 type DisposeSessionParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Copies source history through a completed turn into the new chat.
@@ -405,6 +420,9 @@ type SideChatSource struct {
 type CreateChatParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Chat URI (client-chosen, e.g. `ahp-chat:/<uuid>`).
 	Chat URI `json:"chat"`
 	// Optional initial message for the new chat.
@@ -439,6 +457,9 @@ type CreateChatParams struct {
 type DisposeChatParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Returns a list of session summaries. Used to populate session lists and sidebars.
@@ -456,6 +477,9 @@ type DisposeChatParams struct {
 type ListSessionsParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Maximum number of entries to return in this page. The server SHOULD respect
 	// this bound but MAY return fewer entries and MAY impose its own upper cap.
 	// Omit to let the server choose the page size.
@@ -494,6 +518,9 @@ type ListSessionsResult struct {
 type ResourceReadParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Content URI from a `ContentRef`
 	Uri string `json:"uri"`
 	// Preferred encoding for the returned data (default: server-chosen)
@@ -531,6 +558,9 @@ type ResourceReadResult struct {
 type ResourceWriteParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Target file URI on the server filesystem
 	Uri URI `json:"uri"`
 	// Content encoded as a string
@@ -580,6 +610,9 @@ type ResourceWriteResult struct {
 type ResourceListParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Directory URI on the server filesystem
 	Uri URI `json:"uri"`
 }
@@ -608,6 +641,9 @@ type DirectoryEntry struct {
 type ResourceCopyParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Source URI to copy from
 	Source URI `json:"source"`
 	// Destination URI to copy to
@@ -630,6 +666,9 @@ type ResourceCopyResult struct {
 type ResourceDeleteParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// URI of the resource to delete
 	Uri URI `json:"uri"`
 	// If `true` and the target is a directory, delete it and all its contents
@@ -653,6 +692,9 @@ type ResourceDeleteResult struct {
 type ResourceMoveParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Source URI to move from
 	Source URI `json:"source"`
 	// Destination URI to move to
@@ -682,6 +724,9 @@ type ResourceMoveResult struct {
 type ResourceResolveParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// URI to resolve
 	Uri URI `json:"uri"`
 	// When `true` (default), follow symlinks and report the metadata of the
@@ -725,6 +770,9 @@ type ResourceResolveResult struct {
 type ResourceMkdirParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Directory URI to create (parents created as needed).
 	Uri URI `json:"uri"`
 }
@@ -759,6 +807,9 @@ type ResourceMkdirResult struct {
 type ResourceRequestParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Resource URI being requested. Typically a `file:` URI on the receiver's
 	// filesystem, but any URI scheme that the receiver mediates access to is
 	// allowed.
@@ -793,6 +844,9 @@ type ResourceRequestResult struct {
 type CreateResourceWatchParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// URI to watch.
 	Uri URI `json:"uri"`
 	// If `true`, the receiver MUST report changes for descendants of `uri`.
@@ -829,6 +883,9 @@ type CreateResourceWatchResult struct {
 type FetchTurnsParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Opaque cursor from `ChatState.turnsNextCursor`.
 	//
 	// The host MUST reject unrecognised cursors with `InvalidParams`. Omit only
@@ -879,6 +936,9 @@ type DispatchActionParams struct {
 type AuthenticateParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// The protected resource identifier. MUST match a `resource` value the
 	// server has advertised — via `ProtectedResourceMetadata` in
 	// `AgentInfo.protectedResources`, or via a live
@@ -911,6 +971,9 @@ type AuthenticateResult struct {
 type CreateTerminalParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Initial owner of the terminal
 	Claim TerminalClaim `json:"claim"`
 	// Human-readable terminal name
@@ -930,6 +993,9 @@ type CreateTerminalParams struct {
 type DisposeTerminalParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 }
 
 // Iteratively resolves the session configuration schema. The client sends the
@@ -944,6 +1010,9 @@ type DisposeTerminalParams struct {
 type ResolveSessionConfigParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Agent provider ID
 	Provider *string `json:"provider,omitempty"`
 	// Working directory for the session
@@ -968,6 +1037,9 @@ type ResolveSessionConfigResult struct {
 type SessionConfigCompletionsParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Agent provider ID
 	Provider *string `json:"provider,omitempty"`
 	// Working directory for the session
@@ -1006,6 +1078,9 @@ type SessionConfigValueItem struct {
 type CompletionsParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// What kind of completion is being requested.
 	Kind CompletionItemKind `json:"kind"`
 	// The complete text of the input being completed (e.g. the full user
@@ -1065,6 +1140,9 @@ type CompletionsResult struct {
 type InvokeChangesetOperationParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
+	// Optional JSON-serializable metadata associated with this request.
+	// Receivers MUST ignore keys they do not understand.
+	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	// Matches {@link ChangesetOperation.id} from the changeset's `operations` list.
 	OperationId string `json:"operationId"`
 	// Target of the operation. Required iff the chosen scope is

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -243,6 +243,12 @@ data class InitializeParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Protocol versions the client is willing to speak, ordered from most
      * preferred to least preferred. Each entry is a [SemVer](https://semver.org)
      * `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
@@ -378,6 +384,12 @@ data class ReconnectParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Client identifier from the original connection
      */
     val clientId: String,
@@ -428,6 +440,12 @@ data class SubscribeParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Optional delivery preferences for this subscription.
      *
@@ -498,6 +516,12 @@ data class CreateSessionParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Agent provider ID
      */
     val provider: String? = null,
@@ -558,7 +582,13 @@ data class DisposeSessionParams(
     /**
      * Channel URI this command targets.
      */
-    val channel: String
+    val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -567,6 +597,12 @@ data class CreateChatParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Chat URI (client-chosen, e.g. `ahp-chat:/<uuid>`).
      */
@@ -610,7 +646,13 @@ data class DisposeChatParams(
     /**
      * Channel URI this command targets.
      */
-    val channel: String
+    val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -619,6 +661,12 @@ data class ListSessionsParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Maximum number of entries to return in this page. The server SHOULD respect
      * this bound but MAY return fewer entries and MAY impose its own upper cap.
@@ -656,6 +704,12 @@ data class ResourceReadParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Content URI from a `ContentRef`
      */
     val uri: String,
@@ -687,6 +741,12 @@ data class ResourceWriteParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Target file URI on the server filesystem
      */
@@ -742,6 +802,12 @@ data class ResourceListParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Directory URI on the server filesystem
      */
     val uri: String
@@ -774,6 +840,12 @@ data class ResourceCopyParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Source URI to copy from
      */
     val source: String,
@@ -798,6 +870,12 @@ data class ResourceDeleteParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * URI of the resource to delete
      */
     val uri: String,
@@ -817,6 +895,12 @@ data class ResourceMoveParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Source URI to move from
      */
@@ -841,6 +925,12 @@ data class ResourceResolveParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * URI to resolve
      */
@@ -897,6 +987,12 @@ data class ResourceMkdirParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Directory URI to create (parents created as needed).
      */
     val uri: String
@@ -911,6 +1007,12 @@ data class ResourceRequestParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Resource URI being requested. Typically a `file:` URI on the receiver's
      * filesystem, but any URI scheme that the receiver mediates access to is
@@ -936,6 +1038,12 @@ data class CreateResourceWatchParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * URI to watch.
      */
@@ -975,6 +1083,12 @@ data class FetchTurnsParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Opaque cursor from `ChatState.turnsNextCursor`.
      *
@@ -1019,6 +1133,12 @@ data class AuthenticateParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * The protected resource identifier. MUST match a `resource` value the
      * server has advertised — via `ProtectedResourceMetadata` in
      * `AgentInfo.protectedResources`, or via a live
@@ -1050,6 +1170,12 @@ data class CreateTerminalParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Initial owner of the terminal
      */
     val claim: TerminalClaim,
@@ -1076,7 +1202,13 @@ data class DisposeTerminalParams(
     /**
      * Channel URI this command targets.
      */
-    val channel: String
+    val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null
 )
 
 @Serializable
@@ -1085,6 +1217,12 @@ data class ResolveSessionConfigParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Agent provider ID
      */
@@ -1197,6 +1335,12 @@ data class SessionConfigCompletionsParams(
      */
     val channel: String,
     /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
+    /**
      * Agent provider ID
      */
     val provider: String? = null,
@@ -1248,6 +1392,12 @@ data class CompletionsParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * What kind of completion is being requested.
      */
@@ -1309,6 +1459,12 @@ data class InvokeChangesetOperationParams(
      * Channel URI this command targets.
      */
     val channel: String,
+    /**
+     * Optional JSON-serializable metadata associated with this request.
+     * Receivers MUST ignore keys they do not understand.
+     */
+    @SerialName("_meta")
+    val meta: Map<String, JsonElement>? = null,
     /**
      * Matches {@link ChangesetOperation.id} from the changeset's `operations` list.
      */

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -325,6 +325,7 @@ impl SubscribeParams {
     pub fn new(channel: impl Into<Uri>) -> Self {
         Self {
             channel: channel.into(),
+            meta: None,
             delivery: None,
             view: None,
         }
@@ -334,6 +335,7 @@ impl SubscribeParams {
     pub fn with_delivery(channel: impl Into<Uri>, delivery: SubscriptionDeliveryOptions) -> Self {
         Self {
             channel: channel.into(),
+            meta: None,
             delivery: Some(delivery),
             view: None,
         }
@@ -343,6 +345,7 @@ impl SubscribeParams {
     pub fn with_view(channel: impl Into<Uri>, view: SubscribeView) -> Self {
         Self {
             channel: channel.into(),
+            meta: None,
             delivery: None,
             view: Some(view),
         }

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -110,6 +110,10 @@ pub enum ResourceWriteMode {
 pub struct InitializeParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Protocol versions the client is willing to speak, ordered from most
     /// preferred to least preferred. Each entry is a [SemVer](https://semver.org)
     /// `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
@@ -251,6 +255,10 @@ pub struct Implementation {
 pub struct ReconnectParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Client identifier from the original connection
     pub client_id: String,
     /// Last `serverSeq` the client received
@@ -293,6 +301,10 @@ pub struct ReconnectSnapshotResult {
 pub struct SubscribeParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Optional delivery preferences for this subscription.
     ///
     /// Servers MAY use these preferences to buffer and coalesce high-frequency
@@ -399,6 +411,10 @@ pub struct SessionForkSource {
 pub struct CreateSessionParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Agent provider ID
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
@@ -457,6 +473,10 @@ pub struct CreateSessionParams {
 pub struct DisposeSessionParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Copies source history through a completed turn into the new chat.
@@ -502,6 +522,10 @@ pub struct SideChatSource {
 pub struct CreateChatParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Chat URI (client-chosen, e.g. `ahp-chat:/<uuid>`).
     pub chat: Uri,
     /// Optional initial message for the new chat.
@@ -541,6 +565,10 @@ pub struct CreateChatParams {
 pub struct DisposeChatParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Returns a list of session summaries. Used to populate session lists and sidebars.
@@ -560,6 +588,10 @@ pub struct DisposeChatParams {
 pub struct ListSessionsParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Maximum number of entries to return in this page. The server SHOULD respect
     /// this bound but MAY return fewer entries and MAY impose its own upper cap.
     /// Omit to let the server choose the page size.
@@ -605,6 +637,10 @@ pub struct ListSessionsResult {
 pub struct ResourceReadParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Content URI from a `ContentRef`
     pub uri: String,
     /// Preferred encoding for the returned data (default: server-chosen)
@@ -648,6 +684,10 @@ pub struct ResourceReadResult {
 pub struct ResourceWriteParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Target file URI on the server filesystem
     pub uri: Uri,
     /// Content encoded as a string
@@ -705,6 +745,10 @@ pub struct ResourceWriteResult {}
 pub struct ResourceListParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Directory URI on the server filesystem
     pub uri: Uri,
 }
@@ -739,6 +783,10 @@ pub struct DirectoryEntry {
 pub struct ResourceCopyParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Source URI to copy from
     pub source: Uri,
     /// Destination URI to copy to
@@ -765,6 +813,10 @@ pub struct ResourceCopyResult {}
 pub struct ResourceDeleteParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// URI of the resource to delete
     pub uri: Uri,
     /// If `true` and the target is a directory, delete it and all its contents
@@ -792,6 +844,10 @@ pub struct ResourceDeleteResult {}
 pub struct ResourceMoveParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Source URI to move from
     pub source: Uri,
     /// Destination URI to move to
@@ -825,6 +881,10 @@ pub struct ResourceMoveResult {}
 pub struct ResourceResolveParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// URI to resolve
     pub uri: Uri,
     /// When `true` (default), follow symlinks and report the metadata of the
@@ -878,6 +938,10 @@ pub struct ResourceResolveResult {
 pub struct ResourceMkdirParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Directory URI to create (parents created as needed).
     pub uri: Uri,
 }
@@ -915,6 +979,10 @@ pub struct ResourceMkdirResult {}
 pub struct ResourceRequestParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Resource URI being requested. Typically a `file:` URI on the receiver's
     /// filesystem, but any URI scheme that the receiver mediates access to is
     /// allowed.
@@ -954,6 +1022,10 @@ pub struct ResourceRequestResult {}
 pub struct CreateResourceWatchParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// URI to watch.
     pub uri: Uri,
     /// If `true`, the receiver MUST report changes for descendants of `uri`.
@@ -997,6 +1069,10 @@ pub struct CreateResourceWatchResult {
 pub struct FetchTurnsParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Opaque cursor from `ChatState.turnsNextCursor`.
     ///
     /// The host MUST reject unrecognised cursors with `InvalidParams`. Omit only
@@ -1055,6 +1131,10 @@ pub struct DispatchActionParams {
 pub struct AuthenticateParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// The protected resource identifier. MUST match a `resource` value the
     /// server has advertised — via `ProtectedResourceMetadata` in
     /// `AgentInfo.protectedResources`, or via a live
@@ -1091,6 +1171,10 @@ pub struct AuthenticateResult {}
 pub struct CreateTerminalParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Initial owner of the terminal
     pub claim: TerminalClaim,
     /// Human-readable terminal name
@@ -1116,6 +1200,10 @@ pub struct CreateTerminalParams {
 pub struct DisposeTerminalParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
 }
 
 /// Iteratively resolves the session configuration schema. The client sends the
@@ -1132,6 +1220,10 @@ pub struct DisposeTerminalParams {
 pub struct ResolveSessionConfigParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Agent provider ID
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
@@ -1163,6 +1255,10 @@ pub struct ResolveSessionConfigResult {
 pub struct SessionConfigCompletionsParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Agent provider ID
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
@@ -1212,6 +1308,10 @@ pub struct SessionConfigValueItem {
 pub struct CompletionsParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// What kind of completion is being requested.
     pub kind: CompletionItemKind,
     /// The complete text of the input being completed (e.g. the full user
@@ -1279,6 +1379,10 @@ pub struct CompletionsResult {
 pub struct InvokeChangesetOperationParams {
     /// Channel URI this command targets.
     pub channel: Uri,
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonObject>,
     /// Matches {@link ChangesetOperation.id} from the changeset's `operations` list.
     pub operation_id: String,
     /// Target of the operation. Required iff the chosen scope is

--- a/clients/rust/crates/ahp-types/src/lib.rs
+++ b/clients/rust/crates/ahp-types/src/lib.rs
@@ -63,6 +63,7 @@
 //!
 //! let params = InitializeParams {
 //!     channel: "ahp-root://".into(),
+//!     meta: None,
 //!     protocol_versions: vec![ahp_types::PROTOCOL_VERSION.to_string()],
 //!     client_id: "my-host/1.0".into(),
 //!     initial_subscriptions: Some(vec!["ahp-root://".into()]),

--- a/clients/rust/crates/ahp/src/client.rs
+++ b/clients/rust/crates/ahp/src/client.rs
@@ -498,6 +498,7 @@ impl Client {
     ) -> Result<InitializeResult, ClientError> {
         let params = InitializeParams {
             channel: ROOT_RESOURCE_URI.to_string(),
+            meta: None,
             protocol_versions,
             client_id,
             initial_subscriptions: if initial_subscriptions.is_empty() {
@@ -521,6 +522,7 @@ impl Client {
     ) -> Result<ReconnectResult, ClientError> {
         let params = ReconnectParams {
             channel: ROOT_RESOURCE_URI.to_string(),
+            meta: None,
             client_id,
             last_seen_server_seq,
             subscriptions,
@@ -583,6 +585,7 @@ impl Client {
                 "subscribe",
                 SubscribeParams {
                     channel: uri,
+                    meta: None,
                     delivery,
                     view,
                 },

--- a/clients/rust/crates/ahp/src/hosts/runtime.rs
+++ b/clients/rust/crates/ahp/src/hosts/runtime.rs
@@ -317,6 +317,7 @@ impl HostRuntime {
                 "listSessions",
                 ListSessionsParams {
                     channel: ROOT_RESOURCE_URI.to_string(),
+                    meta: None,
                     limit: None,
                     cursor: None,
                 },
@@ -623,6 +624,7 @@ impl HostRuntime {
                 "subscribe",
                 SubscribeParams {
                     channel: uri.clone(),
+                    meta: None,
                     delivery: None,
                     view: None,
                 },

--- a/clients/rust/crates/ahp/tests/client_roundtrip.rs
+++ b/clients/rust/crates/ahp/tests/client_roundtrip.rs
@@ -191,6 +191,7 @@ async fn resource_read_send_wrapper_targets_root_channel() {
     let result = client
         .resource_read(ResourceReadParams {
             channel: String::new(),
+            meta: None,
             uri: "ahp-resource:/notes.txt".into(),
             encoding: None,
         })
@@ -239,6 +240,7 @@ async fn completions_send_wrapper_preserves_channel() {
     let result = client
         .completions(CompletionsParams {
             channel: "ahp-chat:/abc".into(),
+            meta: None,
             kind: CompletionItemKind::UserMessage,
             text: "look at @foo".into(),
             offset: 12,
@@ -287,6 +289,7 @@ async fn session_config_completions_send_wrapper_targets_root_channel() {
     let result = client
         .session_config_completions(SessionConfigCompletionsParams {
             channel: String::new(),
+            meta: None,
             provider: None,
             working_directory: None,
             config: None,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -169,6 +169,9 @@ public struct SideChatSource: Codable, Sendable {
 public struct InitializeParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Protocol versions the client is willing to speak, ordered from most
     /// preferred to least preferred. Each entry is a [SemVer](https://semver.org)
     /// `MAJOR.MINOR.PATCH` string (e.g. `"0.1.0"`).
@@ -198,8 +201,20 @@ public struct InitializeParams: Codable, Sendable {
     /// MUST assume the client does not support the feature.
     public var capabilities: ClientCapabilities?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case protocolVersions
+        case clientId
+        case clientInfo
+        case initialSubscriptions
+        case locale
+        case capabilities
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         protocolVersions: [String],
         clientId: String,
         clientInfo: Implementation? = nil,
@@ -208,6 +223,7 @@ public struct InitializeParams: Codable, Sendable {
         capabilities: ClientCapabilities? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.protocolVersions = protocolVersions
         self.clientId = clientId
         self.clientInfo = clientInfo
@@ -316,6 +332,9 @@ public struct Implementation: Codable, Sendable {
 public struct ReconnectParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Client identifier from the original connection
     public var clientId: String
     /// Last `serverSeq` the client received
@@ -323,13 +342,23 @@ public struct ReconnectParams: Codable, Sendable {
     /// URIs the client was subscribed to
     public var subscriptions: [String]
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case clientId
+        case lastSeenServerSeq
+        case subscriptions
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         clientId: String,
         lastSeenServerSeq: Int,
         subscriptions: [String]
     ) {
         self.channel = channel
+        self.meta = meta
         self.clientId = clientId
         self.lastSeenServerSeq = lastSeenServerSeq
         self.subscriptions = subscriptions
@@ -376,6 +405,9 @@ public struct ReconnectSnapshotResult: Codable, Sendable {
 public struct SubscribeParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Optional delivery preferences for this subscription.
     ///
     /// Servers MAY use these preferences to buffer and coalesce high-frequency
@@ -388,12 +420,21 @@ public struct SubscribeParams: Codable, Sendable {
     /// default snapshot. Clients MUST tolerate receiving more state than requested.
     public var view: SubscribeView?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case delivery
+        case view
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         delivery: SubscriptionDeliveryOptions? = nil,
         view: SubscribeView? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.delivery = delivery
         self.view = view
     }
@@ -460,6 +501,9 @@ public struct SessionForkSource: Codable, Sendable {
 public struct CreateSessionParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Agent provider ID
     public var provider: String?
     /// The working directories the session's agent is granted tool access to.
@@ -503,8 +547,20 @@ public struct CreateSessionParams: Codable, Sendable {
     /// `progress` notifications are emitted.
     public var progressToken: String?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case provider
+        case workingDirectories
+        case fork
+        case config
+        case activeClient
+        case progressToken
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         provider: String? = nil,
         workingDirectories: [String]? = nil,
         fork: SessionForkSource? = nil,
@@ -513,6 +569,7 @@ public struct CreateSessionParams: Codable, Sendable {
         progressToken: String? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.provider = provider
         self.workingDirectories = workingDirectories
         self.fork = fork
@@ -525,17 +582,30 @@ public struct CreateSessionParams: Codable, Sendable {
 public struct DisposeSessionParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+    }
 
     public init(
-        channel: String
+        channel: String,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.channel = channel
+        self.meta = meta
     }
 }
 
 public struct CreateChatParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Chat URI (client-chosen, e.g. `ahp-chat:/<uuid>`).
     public var chat: String
     /// Optional initial message for the new chat.
@@ -565,14 +635,25 @@ public struct CreateChatParams: Codable, Sendable {
     /// {@link AgentCapabilities.multipleWorkingDirectories}.
     public var workingDirectories: [String]?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case chat
+        case initialMessage
+        case source
+        case workingDirectories
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         chat: String,
         initialMessage: Message? = nil,
         source: ChatSource? = nil,
         workingDirectories: [String]? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.chat = chat
         self.initialMessage = initialMessage
         self.source = source
@@ -583,17 +664,30 @@ public struct CreateChatParams: Codable, Sendable {
 public struct DisposeChatParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+    }
 
     public init(
-        channel: String
+        channel: String,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.channel = channel
+        self.meta = meta
     }
 }
 
 public struct ListSessionsParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Maximum number of entries to return in this page. The server SHOULD respect
     /// this bound but MAY return fewer entries and MAY impose its own upper cap.
     /// Omit to let the server choose the page size.
@@ -604,12 +698,21 @@ public struct ListSessionsParams: Codable, Sendable {
     /// unrecognised cursor SHOULD be rejected with an `InvalidParams` error.
     public var cursor: String?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case limit
+        case cursor
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         limit: Int? = nil,
         cursor: String? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.limit = limit
         self.cursor = cursor
     }
@@ -636,17 +739,29 @@ public struct ListSessionsResult: Codable, Sendable {
 public struct ResourceReadParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Content URI from a `ContentRef`
     public var uri: String
     /// Preferred encoding for the returned data (default: server-chosen)
     public var encoding: ContentEncoding?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+        case encoding
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String,
         encoding: ContentEncoding? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
         self.encoding = encoding
     }
@@ -674,6 +789,9 @@ public struct ResourceReadResult: Codable, Sendable {
 public struct ResourceWriteParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Target file URI on the server filesystem
     public var uri: String
     /// Content encoded as a string
@@ -702,8 +820,22 @@ public struct ResourceWriteParams: Codable, Sendable {
     /// updates between a `resourceResolve` and a subsequent `resourceWrite`.
     public var ifMatch: String?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+        case data
+        case encoding
+        case contentType
+        case createOnly
+        case mode
+        case position
+        case ifMatch
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String,
         data: String,
         encoding: ContentEncoding,
@@ -714,6 +846,7 @@ public struct ResourceWriteParams: Codable, Sendable {
         ifMatch: String? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
         self.data = data
         self.encoding = encoding
@@ -736,14 +869,25 @@ public struct ResourceWriteResult: Codable, Sendable {
 public struct ResourceListParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Directory URI on the server filesystem
     public var uri: String
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
     }
 }
@@ -777,6 +921,9 @@ public struct DirectoryEntry: Codable, Sendable {
 public struct ResourceCopyParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Source URI to copy from
     public var source: String
     /// Destination URI to copy to
@@ -785,13 +932,23 @@ public struct ResourceCopyParams: Codable, Sendable {
     /// of overwriting it.
     public var failIfExists: Bool?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case source
+        case destination
+        case failIfExists
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         source: String,
         destination: String,
         failIfExists: Bool? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.source = source
         self.destination = destination
         self.failIfExists = failIfExists
@@ -809,18 +966,30 @@ public struct ResourceCopyResult: Codable, Sendable {
 public struct ResourceDeleteParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// URI of the resource to delete
     public var uri: String
     /// If `true` and the target is a directory, delete it and all its contents
     /// recursively. If `false` (default), deleting a non-empty directory MUST fail.
     public var recursive: Bool?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+        case recursive
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String,
         recursive: Bool? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
         self.recursive = recursive
     }
@@ -837,6 +1006,9 @@ public struct ResourceDeleteResult: Codable, Sendable {
 public struct ResourceMoveParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Source URI to move from
     public var source: String
     /// Destination URI to move to
@@ -845,13 +1017,23 @@ public struct ResourceMoveParams: Codable, Sendable {
     /// of overwriting it.
     public var failIfExists: Bool?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case source
+        case destination
+        case failIfExists
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         source: String,
         destination: String,
         failIfExists: Bool? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.source = source
         self.destination = destination
         self.failIfExists = failIfExists
@@ -869,6 +1051,9 @@ public struct ResourceMoveResult: Codable, Sendable {
 public struct ResourceResolveParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// URI to resolve
     public var uri: String
     /// When `true` (default), follow symlinks and report the metadata of the
@@ -877,12 +1062,21 @@ public struct ResourceResolveParams: Codable, Sendable {
     /// `type: 'symlink'`.
     public var followSymlinks: Bool?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+        case followSymlinks
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String,
         followSymlinks: Bool? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
         self.followSymlinks = followSymlinks
     }
@@ -930,14 +1124,25 @@ public struct ResourceResolveResult: Codable, Sendable {
 public struct ResourceMkdirParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Directory URI to create (parents created as needed).
     public var uri: String
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
     }
 }
@@ -953,6 +1158,9 @@ public struct ResourceMkdirResult: Codable, Sendable {
 public struct ResourceRequestParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Resource URI being requested. Typically a `file:` URI on the receiver's
     /// filesystem, but any URI scheme that the receiver mediates access to is
     /// allowed.
@@ -962,13 +1170,23 @@ public struct ResourceRequestParams: Codable, Sendable {
     /// Whether the caller needs write access to the resource.
     public var write: Bool?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+        case read
+        case write
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String,
         read: Bool? = nil,
         write: Bool? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
         self.read = read
         self.write = write
@@ -986,6 +1204,9 @@ public struct ResourceRequestResult: Codable, Sendable {
 public struct CreateResourceWatchParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// URI to watch.
     public var uri: String
     /// If `true`, the receiver MUST report changes for descendants of `uri`.
@@ -1000,14 +1221,25 @@ public struct CreateResourceWatchParams: Codable, Sendable {
     /// Wrapped in `{ items }` for forward compatibility.
     public var includes: AnyCodable?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case uri
+        case recursive
+        case excludes
+        case includes
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         uri: String,
         recursive: Bool? = nil,
         excludes: AnyCodable? = nil,
         includes: AnyCodable? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.uri = uri
         self.recursive = recursive
         self.excludes = excludes
@@ -1031,6 +1263,9 @@ public struct CreateResourceWatchResult: Codable, Sendable {
 public struct FetchTurnsParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Opaque cursor from `ChatState.turnsNextCursor`.
     ///
     /// The host MUST reject unrecognised cursors with `InvalidParams`. Omit only
@@ -1038,11 +1273,19 @@ public struct FetchTurnsParams: Codable, Sendable {
     /// chat, if any.
     public var cursor: String?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case cursor
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         cursor: String? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.cursor = cursor
     }
 }
@@ -1088,6 +1331,9 @@ public struct DispatchActionParams: Codable, Sendable {
 public struct AuthenticateParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// The protected resource identifier. MUST match a `resource` value the
     /// server has advertised — via `ProtectedResourceMetadata` in
     /// `AgentInfo.protectedResources`, or via a live
@@ -1103,13 +1349,23 @@ public struct AuthenticateParams: Codable, Sendable {
     /// token.
     public var scopes: [String]?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case resource
+        case token
+        case scopes
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         resource: String,
         token: String,
         scopes: [String]? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.resource = resource
         self.token = token
         self.scopes = scopes
@@ -1127,6 +1383,9 @@ public struct AuthenticateResult: Codable, Sendable {
 public struct CreateTerminalParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Initial owner of the terminal
     public var claim: TerminalClaim
     /// Human-readable terminal name
@@ -1138,8 +1397,19 @@ public struct CreateTerminalParams: Codable, Sendable {
     /// Initial terminal height in rows
     public var rows: Int?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case claim
+        case name
+        case cwd
+        case cols
+        case rows
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         claim: TerminalClaim,
         name: String? = nil,
         cwd: String? = nil,
@@ -1147,6 +1417,7 @@ public struct CreateTerminalParams: Codable, Sendable {
         rows: Int? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.claim = claim
         self.name = name
         self.cwd = cwd
@@ -1158,17 +1429,30 @@ public struct CreateTerminalParams: Codable, Sendable {
 public struct DisposeTerminalParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+    }
 
     public init(
-        channel: String
+        channel: String,
+        meta: [String: AnyCodable]? = nil
     ) {
         self.channel = channel
+        self.meta = meta
     }
 }
 
 public struct ResolveSessionConfigParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Agent provider ID
     public var provider: String?
     /// Working directory for the session
@@ -1176,13 +1460,23 @@ public struct ResolveSessionConfigParams: Codable, Sendable {
     /// Current user-filled configuration values
     public var config: [String: AnyCodable]?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case provider
+        case workingDirectory
+        case config
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         provider: String? = nil,
         workingDirectory: String? = nil,
         config: [String: AnyCodable]? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.provider = provider
         self.workingDirectory = workingDirectory
         self.config = config
@@ -1309,6 +1603,9 @@ public struct SessionConfigSchema: Codable, Sendable {
 public struct SessionConfigCompletionsParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Agent provider ID
     public var provider: String?
     /// Working directory for the session
@@ -1320,8 +1617,19 @@ public struct SessionConfigCompletionsParams: Codable, Sendable {
     /// Search filter text (empty or omitted returns default/recent values)
     public var query: String?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case provider
+        case workingDirectory
+        case config
+        case property
+        case query
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         provider: String? = nil,
         workingDirectory: String? = nil,
         config: [String: AnyCodable]? = nil,
@@ -1329,6 +1637,7 @@ public struct SessionConfigCompletionsParams: Codable, Sendable {
         query: String? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.provider = provider
         self.workingDirectory = workingDirectory
         self.config = config
@@ -1370,6 +1679,9 @@ public struct SessionConfigValueItem: Codable, Sendable {
 public struct CompletionsParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// What kind of completion is being requested.
     public var kind: CompletionItemKind
     /// The complete text of the input being completed (e.g. the full user
@@ -1379,13 +1691,23 @@ public struct CompletionsParams: Codable, Sendable {
     /// measured in UTF-16 code units. MUST satisfy `0 <= offset <= text.length`.
     public var offset: Int
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case kind
+        case text
+        case offset
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         kind: CompletionItemKind,
         text: String,
         offset: Int
     ) {
         self.channel = channel
+        self.meta = meta
         self.kind = kind
         self.text = text
         self.offset = offset
@@ -1440,18 +1762,30 @@ public struct CompletionsResult: Codable, Sendable {
 public struct InvokeChangesetOperationParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
+    /// Optional JSON-serializable metadata associated with this request.
+    /// Receivers MUST ignore keys they do not understand.
+    public var meta: [String: AnyCodable]?
     /// Matches {@link ChangesetOperation.id} from the changeset's `operations` list.
     public var operationId: String
     /// Target of the operation. Required iff the chosen scope is
     /// `'resource'` or `'range'`. Omit for changeset-scoped operations.
     public var target: ChangesetOperationTarget?
 
+    enum CodingKeys: String, CodingKey {
+        case channel
+        case meta = "_meta"
+        case operationId
+        case target
+    }
+
     public init(
         channel: String,
+        meta: [String: AnyCodable]? = nil,
         operationId: String,
         target: ChangesetOperationTarget? = nil
     ) {
         self.channel = channel
+        self.meta = meta
         self.operationId = operationId
         self.target = target
     }

--- a/docs/.changes/20260804-request-metadata.json
+++ b/docs/.changes/20260804-request-metadata.json
@@ -1,0 +1,4 @@
+{
+  "type": "added",
+  "message": "Optional `_meta` request metadata on all command parameters."
+}

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -12,6 +12,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -72,6 +77,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "protocolVersions": {
           "type": "array",
@@ -179,6 +189,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -194,6 +209,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "clientId": {
           "type": "string",
@@ -275,6 +295,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "delivery": {
           "$ref": "#/$defs/SubscriptionDeliveryOptions",
@@ -365,6 +390,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "uri": {
           "type": "string",
           "description": "Content URI from a `ContentRef`"
@@ -410,6 +440,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -465,6 +500,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -524,6 +564,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "source": {
           "$ref": "#/$defs/URI",
           "description": "Source URI to copy from"
@@ -558,6 +603,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "uri": {
           "$ref": "#/$defs/URI",
           "description": "URI of the resource to delete"
@@ -586,6 +636,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -620,6 +675,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "source": {
           "$ref": "#/$defs/URI",
           "description": "Source URI to move from"
@@ -653,6 +713,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -716,6 +781,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "uri": {
           "$ref": "#/$defs/URI",
           "description": "Directory URI to create (parents created as needed)."
@@ -740,6 +810,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "resource": {
           "type": "string",
@@ -777,6 +852,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "limit": {
           "type": "number",
@@ -820,6 +900,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "provider": {
           "type": "string",
@@ -890,6 +975,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "provider": {
           "type": "string",
           "description": "Agent provider ID"
@@ -958,6 +1048,11 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI (client-chosen, e.g. `ahp-session:/<uuid>`)"
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "provider": {
           "type": "string",
           "description": "Agent provider ID"
@@ -998,6 +1093,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -1011,6 +1111,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Chat URI"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "cursor": {
           "type": "string",
@@ -1033,6 +1138,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "The chat URI the completion is being requested for."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "kind": {
           "$ref": "#/$defs/CompletionItemKind",
@@ -1154,6 +1264,11 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI containing the new chat."
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "chat": {
           "$ref": "#/$defs/URI",
           "description": "Chat URI (client-chosen, e.g. `ahp-chat:/<uuid>`)."
@@ -1186,6 +1301,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -1199,6 +1319,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Terminal URI (client-chosen)."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -1233,6 +1358,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -1262,6 +1392,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "The expanded changeset URI."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "operationId": {
           "type": "string",
@@ -1300,6 +1435,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -4986,6 +4986,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -5046,6 +5051,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "protocolVersions": {
           "type": "array",
@@ -5153,6 +5163,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -5168,6 +5183,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "clientId": {
           "type": "string",
@@ -5249,6 +5269,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "delivery": {
           "$ref": "#/$defs/SubscriptionDeliveryOptions",
@@ -5339,6 +5364,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "uri": {
           "type": "string",
           "description": "Content URI from a `ContentRef`"
@@ -5384,6 +5414,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -5439,6 +5474,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -5498,6 +5538,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "source": {
           "$ref": "#/$defs/URI",
           "description": "Source URI to copy from"
@@ -5532,6 +5577,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "uri": {
           "$ref": "#/$defs/URI",
           "description": "URI of the resource to delete"
@@ -5560,6 +5610,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -5594,6 +5649,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "source": {
           "$ref": "#/$defs/URI",
           "description": "Source URI to move from"
@@ -5627,6 +5687,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",
@@ -5690,6 +5755,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "uri": {
           "$ref": "#/$defs/URI",
           "description": "Directory URI to create (parents created as needed)."
@@ -5714,6 +5784,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "resource": {
           "type": "string",
@@ -5751,6 +5826,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "limit": {
           "type": "number",
@@ -5794,6 +5874,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "provider": {
           "type": "string",
@@ -5864,6 +5949,11 @@
             "ahp-root://"
           ]
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "provider": {
           "type": "string",
           "description": "Agent provider ID"
@@ -5932,6 +6022,11 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI (client-chosen, e.g. `ahp-session:/<uuid>`)"
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "provider": {
           "type": "string",
           "description": "Agent provider ID"
@@ -5972,6 +6067,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -5985,6 +6085,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Chat URI"
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "cursor": {
           "type": "string",
@@ -6007,6 +6112,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "The chat URI the completion is being requested for."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "kind": {
           "$ref": "#/$defs/CompletionItemKind",
@@ -6128,6 +6238,11 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI containing the new chat."
         },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
+        },
         "chat": {
           "$ref": "#/$defs/URI",
           "description": "Chat URI (client-chosen, e.g. `ahp-chat:/<uuid>`)."
@@ -6160,6 +6275,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -6173,6 +6293,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Terminal URI (client-chosen)."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -6207,6 +6332,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "Channel URI this command targets."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         }
       },
       "required": [
@@ -6236,6 +6366,11 @@
         "channel": {
           "$ref": "#/$defs/URI",
           "description": "The expanded changeset URI."
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "operationId": {
           "type": "string",
@@ -6274,6 +6409,11 @@
           "enum": [
             "ahp-root://"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Optional JSON-serializable metadata associated with this request.\nReceivers MUST ignore keys they do not understand."
         },
         "uri": {
           "$ref": "#/$defs/URI",

--- a/scripts/generate-json-schema.test.ts
+++ b/scripts/generate-json-schema.test.ts
@@ -173,6 +173,20 @@ describe('generated JSON schemas', () => {
         );
       });
 
+      it('inherits request metadata from BaseParams', () => {
+        if (file !== 'commands.schema.json') {
+          return;
+        }
+        const defs = schema.$defs as Record<string, Record<string, unknown>>;
+        for (const name of ['BaseParams', 'CreateSessionParams', 'PingParams']) {
+          const properties = defs[name].properties as Record<string, Record<string, unknown>>;
+          assert.equal(properties._meta.type, 'object');
+          assert.deepEqual(properties._meta.additionalProperties, {});
+        }
+        const baseProperties = defs.BaseParams.properties as Record<string, Record<string, unknown>>;
+        assert.match(baseProperties._meta.description as string, /Receivers MUST ignore keys/);
+      });
+
       it('constrains every ChatOrigin branch to a distinct kind', () => {
         const defs = schema.$defs as Record<string, Record<string, unknown>>;
         const chatOrigin = defs.ChatOrigin;

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1544,6 +1544,7 @@ function generateSubscribeParamsImplRust(): string {
     pub fn new(channel: impl Into<Uri>) -> Self {
         Self {
             channel: channel.into(),
+            meta: None,
             delivery: None,
             view: None,
         }
@@ -1553,6 +1554,7 @@ function generateSubscribeParamsImplRust(): string {
     pub fn with_delivery(channel: impl Into<Uri>, delivery: SubscriptionDeliveryOptions) -> Self {
         Self {
             channel: channel.into(),
+            meta: None,
             delivery: Some(delivery),
             view: None,
         }
@@ -1562,6 +1564,7 @@ function generateSubscribeParamsImplRust(): string {
     pub fn with_view(channel: impl Into<Uri>, view: SubscribeView) -> Self {
         Self {
             channel: channel.into(),
+            meta: None,
             delivery: None,
             view: Some(view),
         }

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -35,6 +35,11 @@ import type { TelemetryCapabilities } from '../channels-otlp/state.js';
 export interface BaseParams {
   /** Channel URI this command targets. */
   channel: URI;
+  /**
+   * Optional JSON-serializable metadata associated with this request.
+   * Receivers MUST ignore keys they do not understand.
+   */
+  _meta?: Record<string, unknown>;
 }
 
 // ─── Pagination ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Introduced an optional `_meta` field in the command schemas to allow for JSON-serializable metadata associated with requests. Receivers are instructed to ignore any keys they do not understand.
- Updated the `BaseParams` interface to include the `_meta` field.
- Added tests to ensure that the `_meta` field is inherited from `BaseParams` in relevant schemas.
- Documented the change in the changelog.