### PR TITLE
session: scoped customization enablement

### DIFF
--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -367,39 +367,68 @@ func containerChildren(c *ahptypes.Customization) *[]ahptypes.ChildCustomization
 	return nil
 }
 
-func setContainerEnabled(c *ahptypes.Customization, enabled bool) {
+func effectiveEnablement(enablement []ahptypes.CustomizationEnablement) bool {
+	if len(enablement) == 0 {
+		return true
+	}
+	switch decision := enablement[0].Value.(type) {
+	case *ahptypes.CustomizationEnablementGlobal:
+		return decision.Enabled
+	case *ahptypes.CustomizationEnablementWorkspace:
+		return decision.Enabled
+	case *ahptypes.CustomizationEnablementSession:
+		return decision.Enabled
+	default:
+		return true
+	}
+}
+
+func applyContainerEnablement(c *ahptypes.Customization, enablement []ahptypes.CustomizationEnablement) {
+	enabled := effectiveEnablement(enablement)
+	provenance := append([]ahptypes.CustomizationEnablement(nil), enablement...)
 	switch v := c.Value.(type) {
 	case *ahptypes.PluginCustomization:
 		v.Enabled = enabled
+		v.Enablement = provenance
 	case *ahptypes.DirectoryCustomization:
 		v.Enabled = enabled
+		v.Enablement = provenance
 	case *ahptypes.McpServerCustomization:
 		v.Enabled = enabled
+		v.Enablement = provenance
 	}
 }
 
-func setChildEnabled(c *ahptypes.ChildCustomization, enabled bool) {
+func applyChildEnablement(c *ahptypes.ChildCustomization, enablement []ahptypes.CustomizationEnablement) {
+	enabled := effectiveEnablement(enablement)
+	provenance := append([]ahptypes.CustomizationEnablement(nil), enablement...)
 	switch v := c.Value.(type) {
 	case *ahptypes.AgentCustomization:
 		v.Enabled = &enabled
+		v.Enablement = provenance
 	case *ahptypes.SkillCustomization:
 		v.Enabled = &enabled
+		v.Enablement = provenance
 	case *ahptypes.PromptCustomization:
 		v.Enabled = &enabled
+		v.Enablement = provenance
 	case *ahptypes.RuleCustomization:
 		v.Enabled = &enabled
+		v.Enablement = provenance
 	case *ahptypes.HookCustomization:
 		v.Enabled = &enabled
+		v.Enablement = provenance
 	case *ahptypes.McpServerCustomization:
 		v.Enabled = enabled
+		v.Enablement = provenance
 	}
 }
 
-func applyToggle(list []ahptypes.Customization, id string, enabled bool) bool {
+func applyToggle(list []ahptypes.Customization, id string, enablement []ahptypes.CustomizationEnablement) bool {
 	for i := range list {
 		got, ok := customizationID(list[i])
 		if ok && got == id {
-			setContainerEnabled(&list[i], enabled)
+			applyContainerEnablement(&list[i], enablement)
 			return true
 		}
 	}
@@ -411,7 +440,7 @@ func applyToggle(list []ahptypes.Customization, id string, enabled bool) bool {
 		for j := range *children {
 			got, ok := childCustomizationID((*children)[j])
 			if ok && got == id {
-				setChildEnabled(&(*children)[j], enabled)
+				applyChildEnablement(&(*children)[j], enablement)
 				return true
 			}
 		}
@@ -938,7 +967,7 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 		if state.Customizations == nil {
 			return ReduceOutcomeNoOp
 		}
-		if applyToggle(state.Customizations, a.Id, a.Enabled) {
+		if applyToggle(state.Customizations, a.Id, a.Enablement) {
 			return ReduceOutcomeApplied
 		}
 		return ReduceOutcomeNoOp

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -992,12 +992,15 @@ type SessionCustomizationsChangedAction struct {
 // `container.enabled && (child.enabled ?? true)` — so toggling a child
 // only matters while its container is enabled. Is a no-op when no
 // customization has the given `id`.
+//
+// The `enablement` array completely replaces all explicit decisions. A caller
+// changing one scope must include every decision it intends to preserve.
 type SessionCustomizationToggledAction struct {
 	Type ActionType `json:"type"`
-	// The id of the container or child to toggle.
+	// The id of the container or child to update.
 	Id string `json:"id"`
-	// Whether to enable or disable the targeted customization.
-	Enabled bool `json:"enabled"`
+	// The complete set of explicit decisions, replacing any existing set.
+	Enablement []CustomizationEnablement `json:"enablement"`
 }
 
 // Upserts a top-level customization (plugin or directory).

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -320,6 +320,15 @@ const (
 	CustomizationTypeMcpServer CustomizationType = "mcpServer"
 )
 
+// Scope at which customization enablement is decided.
+type CustomizationEnablementKind string
+
+const (
+	CustomizationEnablementKindGlobal    CustomizationEnablementKind = "global"
+	CustomizationEnablementKindWorkspace CustomizationEnablementKind = "workspace"
+	CustomizationEnablementKindSession   CustomizationEnablementKind = "session"
+)
+
 // Discriminant values for {@link CustomizationLoadState}.
 type CustomizationLoadStatus string
 
@@ -2384,6 +2393,18 @@ type PluginCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2445,6 +2466,18 @@ type ClientPluginCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2508,6 +2541,18 @@ type DirectoryCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2562,6 +2607,18 @@ type AgentCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2634,6 +2691,18 @@ type SkillCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2689,6 +2758,18 @@ type PromptCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2743,6 +2824,18 @@ type RuleCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2796,6 +2889,18 @@ type HookCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2847,6 +2952,18 @@ type McpServerCustomization struct {
 	Uri URI `json:"uri"`
 	// Human-readable name.
 	Name string `json:"name"`
+	// Explicit enablement decisions for this customization, one entry per scope
+	// that has one. This is a wire contract: producers MUST publish entries
+	// sorted by descending specificity (Session, Workspace, then Global).
+	// The agent host emits at most one Workspace entry, for the session's primary
+	// working directory. Consumers MAY treat
+	// `enablement[0]` as the decisive decision and
+	// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+	// absent or empty array means no explicit decision exists, so the
+	// customization is enabled by default.
+	//
+	// Only the agent host publishes this; clients treat it as read-only provenance.
+	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
 	// Icons for UI display.
 	Icons []Icon `json:"icons,omitempty"`
 	// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -2861,7 +2978,8 @@ type McpServerCustomization struct {
 	// out-of-band.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
 	Type CustomizationType          `json:"type"`
-	// Whether this MCP server is currently enabled.
+	// Whether this MCP server is effectively enabled after resolving all scopes.
+	// {@link CustomizationBase.enablement | `enablement`} records its inputs.
 	Enabled bool `json:"enabled"`
 	// Current lifecycle state of the MCP server.
 	State McpServerState `json:"state"`
@@ -3555,6 +3673,74 @@ type ResourceChange struct {
 	Uri URI `json:"uri"`
 	// The kind of change observed.
 	Type ResourceChangeType `json:"type"`
+}
+
+// ─── Customization Enablement Union ───────────────────────────────────────
+
+// CustomizationEnablement is a single explicit customization enablement decision.
+type CustomizationEnablement struct {
+	Value isCustomizationEnablement
+}
+
+type isCustomizationEnablement interface{ isCustomizationEnablement() }
+
+type CustomizationEnablementGlobal struct {
+	Kind    string `json:"kind"`
+	Enabled bool   `json:"enabled"`
+}
+
+func (*CustomizationEnablementGlobal) isCustomizationEnablement() {}
+
+type CustomizationEnablementWorkspace struct {
+	Kind    string `json:"kind"`
+	URI     URI    `json:"uri"`
+	Enabled bool   `json:"enabled"`
+}
+
+func (*CustomizationEnablementWorkspace) isCustomizationEnablement() {}
+
+type CustomizationEnablementSession struct {
+	Kind    string `json:"kind"`
+	Enabled bool   `json:"enabled"`
+}
+
+func (*CustomizationEnablementSession) isCustomizationEnablement() {}
+
+func (e *CustomizationEnablement) UnmarshalJSON(data []byte) error {
+	disc, _, err := readDiscriminator(data, "kind")
+	if err != nil {
+		return err
+	}
+	switch disc {
+	case "global":
+		var value CustomizationEnablementGlobal
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		e.Value = &value
+	case "workspace":
+		var value CustomizationEnablementWorkspace
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		e.Value = &value
+	case "session":
+		var value CustomizationEnablementSession
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		e.Value = &value
+	default:
+		return &json.UnmarshalTypeError{Value: "CustomizationEnablement"}
+	}
+	return nil
+}
+
+func (e CustomizationEnablement) MarshalJSON() ([]byte, error) {
+	if e.Value == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(e.Value)
 }
 
 // ToolInput is raw tool input represented inline or by content reference.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -271,21 +271,36 @@ private fun withCustomizationChildren(c: Customization, children: List<ChildCust
     is CustomizationUnknown -> c
 }
 
-private fun withCustomizationEnabled(c: Customization, enabled: Boolean): Customization = when (c) {
-    is CustomizationPlugin -> CustomizationPlugin(c.value.copy(enabled = enabled))
-    is CustomizationDirectory -> CustomizationDirectory(c.value.copy(enabled = enabled))
-    is CustomizationMcpServer -> CustomizationMcpServer(c.value.copy(enabled = enabled))
-    is CustomizationUnknown -> c
+private fun effectiveEnablement(enablement: List<CustomizationEnablement>): Boolean = when (val decision = enablement.firstOrNull()) {
+    is CustomizationEnablement.Global -> decision.value.enabled
+    is CustomizationEnablement.Workspace -> decision.value.enabled
+    is CustomizationEnablement.Session -> decision.value.enabled
+    null -> true
 }
 
-private fun withChildCustomizationEnabled(c: ChildCustomization, enabled: Boolean): ChildCustomization = when (c) {
-    is ChildCustomizationAgent -> ChildCustomizationAgent(c.value.copy(enabled = enabled))
-    is ChildCustomizationSkill -> ChildCustomizationSkill(c.value.copy(enabled = enabled))
-    is ChildCustomizationPrompt -> ChildCustomizationPrompt(c.value.copy(enabled = enabled))
-    is ChildCustomizationRule -> ChildCustomizationRule(c.value.copy(enabled = enabled))
-    is ChildCustomizationHook -> ChildCustomizationHook(c.value.copy(enabled = enabled))
-    is ChildCustomizationMcpServer -> ChildCustomizationMcpServer(c.value.copy(enabled = enabled))
+private fun withCustomizationEnablement(c: Customization, enablement: List<CustomizationEnablement>): Customization {
+    val enabled = effectiveEnablement(enablement)
+    val provenance = enablement.takeIf { it.isNotEmpty() }?.toList()
+    return when (c) {
+    is CustomizationPlugin -> CustomizationPlugin(c.value.copy(enabled = enabled, enablement = provenance))
+    is CustomizationDirectory -> CustomizationDirectory(c.value.copy(enabled = enabled, enablement = provenance))
+    is CustomizationMcpServer -> CustomizationMcpServer(c.value.copy(enabled = enabled, enablement = provenance))
+    is CustomizationUnknown -> c
+    }
+}
+
+private fun withChildCustomizationEnablement(c: ChildCustomization, enablement: List<CustomizationEnablement>): ChildCustomization {
+    val enabled = effectiveEnablement(enablement)
+    val provenance = enablement.takeIf { it.isNotEmpty() }?.toList()
+    return when (c) {
+    is ChildCustomizationAgent -> ChildCustomizationAgent(c.value.copy(enabled = enabled, enablement = provenance))
+    is ChildCustomizationSkill -> ChildCustomizationSkill(c.value.copy(enabled = enabled, enablement = provenance))
+    is ChildCustomizationPrompt -> ChildCustomizationPrompt(c.value.copy(enabled = enabled, enablement = provenance))
+    is ChildCustomizationRule -> ChildCustomizationRule(c.value.copy(enabled = enabled, enablement = provenance))
+    is ChildCustomizationHook -> ChildCustomizationHook(c.value.copy(enabled = enabled, enablement = provenance))
+    is ChildCustomizationMcpServer -> ChildCustomizationMcpServer(c.value.copy(enabled = enabled, enablement = provenance))
     is ChildCustomizationUnknown -> c
+    }
 }
 
 private fun childCustomizationId(c: ChildCustomization): String? = when (c) {
@@ -685,7 +700,7 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
             val idx = list.indexOfFirst { customizationId(it) == a.id }
             if (idx >= 0) {
                 val updated = list.toMutableList()
-                updated[idx] = withCustomizationEnabled(updated[idx], a.enabled)
+                updated[idx] = withCustomizationEnablement(updated[idx], a.enablement)
                 state.copy(customizations = updated)
             } else run {
                 for (i in list.indices) {
@@ -693,7 +708,7 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
                     val childIdx = children.indexOfFirst { childCustomizationId(it) == a.id }
                     if (childIdx < 0) continue
                     val newChildren = children.toMutableList()
-                    newChildren[childIdx] = withChildCustomizationEnabled(newChildren[childIdx], a.enabled)
+                    newChildren[childIdx] = withChildCustomizationEnablement(newChildren[childIdx], a.enablement)
                     val updated = list.toMutableList()
                     updated[i] = withCustomizationChildren(list[i], newChildren)
                     return@run state.copy(customizations = updated)

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -1058,13 +1058,13 @@ data class SessionCustomizationsChangedAction(
 data class SessionCustomizationToggledAction(
     val type: ActionType,
     /**
-     * The id of the container or child to toggle.
+     * The id of the container or child to update.
      */
     val id: String,
     /**
-     * Whether to enable or disable the targeted customization.
+     * The complete set of explicit decisions, replacing any existing set.
      */
-    val enabled: Boolean
+    val enablement: List<CustomizationEnablement>
 )
 
 @Serializable

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -558,6 +558,19 @@ enum class CustomizationType {
 }
 
 /**
+ * Scope at which customization enablement is decided.
+ */
+@Serializable
+enum class CustomizationEnablementKind {
+    @SerialName("global")
+    GLOBAL,
+    @SerialName("workspace")
+    WORKSPACE,
+    @SerialName("session")
+    SESSION
+}
+
+/**
  * Discriminant values for {@link CustomizationLoadState}.
  */
 @Serializable
@@ -3257,6 +3270,20 @@ data class PluginCustomization(
      */
     val name: String,
     /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
+    /**
      * Icons for UI display.
      */
     val icons: List<Icon>? = null,
@@ -3332,6 +3359,20 @@ data class ClientPluginCustomization(
      * Human-readable name.
      */
     val name: String,
+    /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
     /**
      * Icons for UI display.
      */
@@ -3413,6 +3454,20 @@ data class DirectoryCustomization(
      */
     val name: String,
     /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
+    /**
      * Icons for UI display.
      */
     val icons: List<Icon>? = null,
@@ -3487,6 +3542,20 @@ data class AgentCustomization(
      * Human-readable name.
      */
     val name: String,
+    /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
     /**
      * Icons for UI display.
      */
@@ -3580,6 +3649,20 @@ data class SkillCustomization(
      */
     val name: String,
     /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
+    /**
      * Icons for UI display.
      */
     val icons: List<Icon>? = null,
@@ -3656,6 +3739,20 @@ data class PromptCustomization(
      */
     val name: String,
     /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
+    /**
      * Icons for UI display.
      */
     val icons: List<Icon>? = null,
@@ -3718,6 +3815,20 @@ data class RuleCustomization(
      * Human-readable name.
      */
     val name: String,
+    /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
     /**
      * Icons for UI display.
      */
@@ -3793,6 +3904,20 @@ data class HookCustomization(
      */
     val name: String,
     /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
+    /**
      * Icons for UI display.
      */
     val icons: List<Icon>? = null,
@@ -3852,6 +3977,20 @@ data class McpServerCustomization(
      */
     val name: String,
     /**
+     * Explicit enablement decisions for this customization, one entry per scope
+     * that has one. This is a wire contract: producers MUST publish entries
+     * sorted by descending specificity (Session, Workspace, then Global).
+     * The agent host emits at most one Workspace entry, for the session's primary
+     * working directory. Consumers MAY treat
+     * `enablement[0]` as the decisive decision and
+     * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+     * absent or empty array means no explicit decision exists, so the
+     * customization is enabled by default.
+     *
+     * Only the agent host publishes this; clients treat it as read-only provenance.
+     */
+    val enablement: List<CustomizationEnablement>? = null,
+    /**
      * Icons for UI display.
      */
     val icons: List<Icon>? = null,
@@ -3873,7 +4012,8 @@ data class McpServerCustomization(
     val meta: Map<String, JsonElement>? = null,
     val type: CustomizationType,
     /**
-     * Whether this MCP server is currently enabled.
+     * Whether this MCP server is effectively enabled after resolving all scopes.
+     * {@link CustomizationBase.enablement | `enablement`} records its inputs.
      */
     val enabled: Boolean,
     /**
@@ -4661,6 +4801,76 @@ data class ResourceChange(
      */
     val type: ResourceChangeType
 )
+
+// ─── Customization Enablement Union ─────────────────────────────────────
+
+/**
+ * A single explicit customization enablement decision.
+ */
+@Serializable(with = CustomizationEnablementSerializer::class)
+sealed interface CustomizationEnablement {
+    @JvmInline value class Global(val value: CustomizationEnablementGlobal) : CustomizationEnablement
+    @JvmInline value class Workspace(val value: CustomizationEnablementWorkspace) : CustomizationEnablement
+    @JvmInline value class Session(val value: CustomizationEnablementSession) : CustomizationEnablement
+}
+
+@Serializable
+data class CustomizationEnablementGlobal(
+    val enabled: Boolean,
+    val kind: String = "global",
+)
+
+@Serializable
+data class CustomizationEnablementWorkspace(
+    val uri: URI,
+    val enabled: Boolean,
+    val kind: String = "workspace",
+)
+
+@Serializable
+data class CustomizationEnablementSession(
+    val enabled: Boolean,
+    val kind: String = "session",
+)
+
+internal object CustomizationEnablementSerializer : KSerializer<CustomizationEnablement> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("CustomizationEnablement")
+
+    override fun deserialize(decoder: Decoder): CustomizationEnablement {
+        val input = decoder as? JsonDecoder
+            ?: error("CustomizationEnablement can only be deserialized from JSON")
+        val element = input.decodeJsonElement()
+        val obj = element as? JsonObject
+            ?: error("Expected JsonObject for CustomizationEnablement")
+        return when ((obj["kind"] as? JsonPrimitive)?.contentOrNull) {
+            "global" -> CustomizationEnablement.Global(
+                input.json.decodeFromJsonElement(CustomizationEnablementGlobal.serializer(), element),
+            )
+            "workspace" -> CustomizationEnablement.Workspace(
+                input.json.decodeFromJsonElement(CustomizationEnablementWorkspace.serializer(), element),
+            )
+            "session" -> CustomizationEnablement.Session(
+                input.json.decodeFromJsonElement(CustomizationEnablementSession.serializer(), element),
+            )
+            else -> error("Unknown CustomizationEnablement kind")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: CustomizationEnablement) {
+        val output = encoder as? JsonEncoder
+            ?: error("CustomizationEnablement can only be serialized to JSON")
+        val element: JsonElement = when (value) {
+            is CustomizationEnablement.Global ->
+                output.json.encodeToJsonElement(CustomizationEnablementGlobal.serializer(), value.value)
+            is CustomizationEnablement.Workspace ->
+                output.json.encodeToJsonElement(CustomizationEnablementWorkspace.serializer(), value.value)
+            is CustomizationEnablement.Session ->
+                output.json.encodeToJsonElement(CustomizationEnablementSession.serializer(), value.value)
+        }
+        output.encodeJsonElement(element)
+    }
+}
 
 // ─── Tool Input ──────────────────────────────────────────────────────────────
 

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -16,11 +16,12 @@ use crate::state::{
     AgentInfo, AgentSelection, Annotation, AnnotationEntry, Changeset, ChangesetFile,
     ChangesetOperation, ChangesetOperationStatus, ChangesetStatus, ChatInputAnswer,
     ChatInputRequest, ChatInputResponseKind, ChatInteractivity, ChatOrigin, ChatSummary,
-    ConfirmationOption, ContentRef, Customization, ErrorInfo, McpAuthRequirement, McpServerState,
-    Message, ModelSelection, PendingMessageKind, ResponsePart, SessionActiveClient,
-    SessionInputRequest, SideChatSelection, TerminalClaim, TerminalInfo, TextRange,
-    ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallContributor, ToolCallResult,
-    ToolCallRiskAssessment, ToolDefinition, ToolInput, ToolResultContent, Turn, UsageInfo,
+    ConfirmationOption, ContentRef, Customization, CustomizationEnablement, ErrorInfo,
+    McpAuthRequirement, McpServerState, Message, ModelSelection, PendingMessageKind, ResponsePart,
+    SessionActiveClient, SessionInputRequest, SideChatSelection, TerminalClaim, TerminalInfo,
+    TextRange, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallContributor,
+    ToolCallResult, ToolCallRiskAssessment, ToolDefinition, ToolInput, ToolResultContent, Turn,
+    UsageInfo,
 };
 
 // ─── ActionType ──────────────────────────────────────────────────────
@@ -1168,13 +1169,16 @@ pub struct SessionCustomizationsChangedAction {
 /// `container.enabled && (child.enabled ?? true)` — so toggling a child
 /// only matters while its container is enabled. Is a no-op when no
 /// customization has the given `id`.
+///
+/// The `enablement` array completely replaces all explicit decisions. A caller
+/// changing one scope must include every decision it intends to preserve.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCustomizationToggledAction {
-    /// The id of the container or child to toggle.
+    /// The id of the container or child to update.
     pub id: String,
-    /// Whether to enable or disable the targeted customization.
-    pub enabled: bool,
+    /// The complete set of explicit decisions, replacing any existing set.
+    pub enablement: Vec<CustomizationEnablement>,
 }
 
 /// Upserts a top-level customization (plugin or directory).

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -446,6 +446,17 @@ pub enum CustomizationType {
     McpServer,
 }
 
+/// Scope at which customization enablement is decided.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CustomizationEnablementKind {
+    #[serde(rename = "global")]
+    Global,
+    #[serde(rename = "workspace")]
+    Workspace,
+    #[serde(rename = "session")]
+    Session,
+}
+
 /// Discriminant values for {@link CustomizationLoadState}.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CustomizationLoadStatus {
@@ -2913,6 +2924,19 @@ pub struct PluginCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -2982,6 +3006,19 @@ pub struct ClientPluginCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3054,6 +3091,19 @@ pub struct DirectoryCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3115,6 +3165,19 @@ pub struct AgentCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3197,6 +3260,19 @@ pub struct SkillCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3260,6 +3336,19 @@ pub struct PromptCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3320,6 +3409,19 @@ pub struct RuleCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3381,6 +3483,19 @@ pub struct HookCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3437,6 +3552,19 @@ pub struct McpServerCustomization {
     pub uri: Uri,
     /// Human-readable name.
     pub name: String,
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enablement: Option<Vec<CustomizationEnablement>>,
     /// Icons for UI display.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -3453,7 +3581,8 @@ pub struct McpServerCustomization {
     /// out-of-band.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<JsonObject>,
-    /// Whether this MCP server is currently enabled.
+    /// Whether this MCP server is effectively enabled after resolving all scopes.
+    /// {@link CustomizationBase.enablement | `enablement`} records its inputs.
     pub enabled: bool,
     /// Current lifecycle state of the MCP server.
     pub state: McpServerState,
@@ -4256,6 +4385,20 @@ pub struct ResourceChange {
     pub uri: Uri,
     /// The kind of change observed.
     pub r#type: ResourceChangeType,
+}
+
+// ─── Customization Enablement Union ───────────────────────────────────────
+
+/// A single explicit customization enablement decision.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum CustomizationEnablement {
+    #[serde(rename = "global")]
+    Global { enabled: bool },
+    #[serde(rename = "workspace")]
+    Workspace { uri: Uri, enabled: bool },
+    #[serde(rename = "session")]
+    Session { enabled: bool },
 }
 
 /// Raw tool input represented inline or by content reference.

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -59,7 +59,8 @@ use ahp_types::actions::{
 };
 use ahp_types::state::{
     ActiveTurn, AnnotationsState, ChangesetOperationStatus, ChangesetState, ChangesetStatus,
-    ChatInputRequest, ChatState, ChildCustomization, ConfirmationOption, Customization, ErrorInfo,
+    ChatInputRequest, ChatState, ChildCustomization, ConfirmationOption, Customization,
+    CustomizationEnablement, ErrorInfo,
     InputRequestResponsePart, McpServerStartingState, McpServerState, McpServerStoppedState,
     PendingMessage, PendingMessageKind, ResourceWatchState, ResponsePart, RootState,
     SessionInputRequest, SessionLifecycle, SessionState, SessionStatus, TerminalCommandPart,
@@ -496,36 +497,76 @@ fn container_children_mut(c: &mut Customization) -> Option<&mut Vec<ChildCustomi
     }
 }
 
-fn set_container_enabled(c: &mut Customization, enabled: bool) {
+fn effective_enablement(enablement: &[CustomizationEnablement]) -> bool {
+    match enablement.first() {
+        Some(CustomizationEnablement::Global { enabled }) => *enabled,
+        Some(CustomizationEnablement::Workspace { enabled, .. }) => *enabled,
+        Some(CustomizationEnablement::Session { enabled }) => *enabled,
+        None => true,
+    }
+}
+
+fn apply_container_enablement(c: &mut Customization, enablement: &[CustomizationEnablement]) {
+    let enabled = effective_enablement(enablement);
+    let provenance = (!enablement.is_empty()).then(|| enablement.to_vec());
     match c {
-        Customization::Plugin(p) => p.enabled = enabled,
-        Customization::Directory(d) => d.enabled = enabled,
-        Customization::McpServer(m) => m.enabled = enabled,
+        Customization::Plugin(p) => {
+            p.enabled = enabled;
+            p.enablement = provenance;
+        }
+        Customization::Directory(d) => {
+            d.enabled = enabled;
+            d.enablement = provenance;
+        }
+        Customization::McpServer(m) => {
+            m.enabled = enabled;
+            m.enablement = provenance;
+        }
         Customization::Unknown(_) => {}
     }
 }
 
-fn set_child_enabled(c: &mut ChildCustomization, enabled: bool) {
+fn apply_child_enablement(c: &mut ChildCustomization, enablement: &[CustomizationEnablement]) {
+    let enabled = effective_enablement(enablement);
+    let provenance = (!enablement.is_empty()).then(|| enablement.to_vec());
     match c {
-        ChildCustomization::Agent(x) => x.enabled = Some(enabled),
-        ChildCustomization::Skill(x) => x.enabled = Some(enabled),
-        ChildCustomization::Prompt(x) => x.enabled = Some(enabled),
-        ChildCustomization::Rule(x) => x.enabled = Some(enabled),
-        ChildCustomization::Hook(x) => x.enabled = Some(enabled),
-        ChildCustomization::McpServer(x) => x.enabled = enabled,
+        ChildCustomization::Agent(x) => {
+            x.enabled = Some(enabled);
+            x.enablement = provenance;
+        }
+        ChildCustomization::Skill(x) => {
+            x.enabled = Some(enabled);
+            x.enablement = provenance;
+        }
+        ChildCustomization::Prompt(x) => {
+            x.enabled = Some(enabled);
+            x.enablement = provenance;
+        }
+        ChildCustomization::Rule(x) => {
+            x.enabled = Some(enabled);
+            x.enablement = provenance;
+        }
+        ChildCustomization::Hook(x) => {
+            x.enabled = Some(enabled);
+            x.enablement = provenance;
+        }
+        ChildCustomization::McpServer(x) => {
+            x.enabled = enabled;
+            x.enablement = provenance;
+        }
         ChildCustomization::Unknown(_) => {}
     }
 }
 
-fn apply_toggle(list: &mut [Customization], id: &str, enabled: bool) -> bool {
+fn apply_toggle(list: &mut [Customization], id: &str, enablement: &[CustomizationEnablement]) -> bool {
     if let Some(container) = list.iter_mut().find(|c| customization_id(c) == Some(id)) {
-        set_container_enabled(container, enabled);
+        apply_container_enablement(container, enablement);
         return true;
     }
     for container in list.iter_mut() {
         if let Some(children) = container_children_mut(container) {
             if let Some(child) = children.iter_mut().find(|c| child_id_of(c) == Some(id)) {
-                set_child_enabled(child, enabled);
+                apply_child_enablement(child, enablement);
                 return true;
             }
         }
@@ -841,7 +882,7 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
             let Some(list) = state.customizations.as_mut() else {
                 return ReduceOutcome::NoOp;
             };
-            if apply_toggle(list, &a.id, a.enabled) {
+            if apply_toggle(list, &a.id, &a.enablement) {
                 ReduceOutcome::Applied
             } else {
                 ReduceOutcome::NoOp

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -1354,19 +1354,19 @@ public struct SessionCustomizationsChangedAction: Codable, Sendable {
 
 public struct SessionCustomizationToggledAction: Codable, Sendable {
     public var type: ActionType
-    /// The id of the container or child to toggle.
+    /// The id of the container or child to update.
     public var id: String
-    /// Whether to enable or disable the targeted customization.
-    public var enabled: Bool
+    /// The complete set of explicit decisions, replacing any existing set.
+    public var enablement: [CustomizationEnablement]
 
     public init(
         type: ActionType,
         id: String,
-        enabled: Bool
+        enablement: [CustomizationEnablement]
     ) {
         self.type = type
         self.id = id
-        self.enabled = enabled
+        self.enablement = enablement
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -294,6 +294,13 @@ public enum CustomizationType: String, Codable, Sendable {
     case mcpServer = "mcpServer"
 }
 
+/// Scope at which customization enablement is decided.
+public enum CustomizationEnablementKind: String, Codable, Sendable {
+    case global = "global"
+    case workspace = "workspace"
+    case session = "session"
+}
+
 /// Discriminant values for {@link CustomizationLoadState}.
 public enum CustomizationLoadStatus: String, Codable, Sendable {
     case loading = "loading"
@@ -3497,6 +3504,18 @@ public struct PluginCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -3537,6 +3556,7 @@ public struct PluginCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -3552,6 +3572,7 @@ public struct PluginCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -3565,6 +3586,7 @@ public struct PluginCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -3592,6 +3614,18 @@ public struct ClientPluginCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -3634,6 +3668,7 @@ public struct ClientPluginCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -3650,6 +3685,7 @@ public struct ClientPluginCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -3664,6 +3700,7 @@ public struct ClientPluginCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -3692,6 +3729,18 @@ public struct DirectoryCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -3729,6 +3778,7 @@ public struct DirectoryCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -3745,6 +3795,7 @@ public struct DirectoryCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -3759,6 +3810,7 @@ public struct DirectoryCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -3787,6 +3839,18 @@ public struct AgentCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -3841,6 +3905,7 @@ public struct AgentCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -3857,6 +3922,7 @@ public struct AgentCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -3871,6 +3937,7 @@ public struct AgentCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -3899,6 +3966,18 @@ public struct SkillCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -3941,6 +4020,7 @@ public struct SkillCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -3955,6 +4035,7 @@ public struct SkillCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -3967,6 +4048,7 @@ public struct SkillCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -3993,6 +4075,18 @@ public struct PromptCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -4026,6 +4120,7 @@ public struct PromptCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -4038,6 +4133,7 @@ public struct PromptCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -4048,6 +4144,7 @@ public struct PromptCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -4072,6 +4169,18 @@ public struct RuleCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -4112,6 +4221,7 @@ public struct RuleCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -4126,6 +4236,7 @@ public struct RuleCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -4138,6 +4249,7 @@ public struct RuleCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -4164,6 +4276,18 @@ public struct HookCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -4195,6 +4319,7 @@ public struct HookCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -4206,6 +4331,7 @@ public struct HookCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -4215,6 +4341,7 @@ public struct HookCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -4238,6 +4365,18 @@ public struct McpServerCustomization: Codable, Sendable {
     public var uri: String
     /// Human-readable name.
     public var name: String
+    /// Explicit enablement decisions for this customization, one entry per scope
+    /// that has one. This is a wire contract: producers MUST publish entries
+    /// sorted by descending specificity (Session, Workspace, then Global).
+    /// The agent host emits at most one Workspace entry, for the session's primary
+    /// working directory. Consumers MAY treat
+    /// `enablement[0]` as the decisive decision and
+    /// `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+    /// absent or empty array means no explicit decision exists, so the
+    /// customization is enabled by default.
+    ///
+    /// Only the agent host publishes this; clients treat it as read-only provenance.
+    public var enablement: [CustomizationEnablement]?
     /// Icons for UI display.
     public var icons: [Icon]?
     /// Optional span within {@link CustomizationBase.uri | `uri`} when this
@@ -4252,7 +4391,8 @@ public struct McpServerCustomization: Codable, Sendable {
     /// out-of-band.
     public var meta: [String: AnyCodable]?
     public var type: CustomizationType
-    /// Whether this MCP server is currently enabled.
+    /// Whether this MCP server is effectively enabled after resolving all scopes.
+    /// {@link CustomizationBase.enablement | `enablement`} records its inputs.
     public var enabled: Bool
     /// Current lifecycle state of the MCP server.
     public var state: McpServerState
@@ -4280,6 +4420,7 @@ public struct McpServerCustomization: Codable, Sendable {
         case id
         case uri
         case name
+        case enablement
         case icons
         case range
         case meta = "_meta"
@@ -4294,6 +4435,7 @@ public struct McpServerCustomization: Codable, Sendable {
         id: String,
         uri: String,
         name: String,
+        enablement: [CustomizationEnablement]? = nil,
         icons: [Icon]? = nil,
         range: TextRange? = nil,
         meta: [String: AnyCodable]? = nil,
@@ -4306,6 +4448,7 @@ public struct McpServerCustomization: Codable, Sendable {
         self.id = id
         self.uri = uri
         self.name = name
+        self.enablement = enablement
         self.icons = icons
         self.range = range
         self.meta = meta
@@ -5224,6 +5367,70 @@ public struct ResourceChange: Codable, Sendable {
     ) {
         self.uri = uri
         self.type = type
+    }
+}
+
+// MARK: - Customization Enablement Union
+
+/// A single explicit customization enablement decision.
+public enum CustomizationEnablement: Codable, Sendable {
+    case global(CustomizationEnablementGlobal)
+    case workspace(CustomizationEnablementWorkspace)
+    case session(CustomizationEnablementSession)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case kind
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        switch try container.decode(String.self, forKey: .kind) {
+        case "global":
+            self = .global(try CustomizationEnablementGlobal(from: decoder))
+        case "workspace":
+            self = .workspace(try CustomizationEnablementWorkspace(from: decoder))
+        case "session":
+            self = .session(try CustomizationEnablementSession(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unknown CustomizationEnablement kind")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .global(let value): try value.encode(to: encoder)
+        case .workspace(let value): try value.encode(to: encoder)
+        case .session(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public struct CustomizationEnablementGlobal: Codable, Sendable {
+    public var kind: String = "global"
+    public var enabled: Bool
+
+    public init(enabled: Bool) {
+        self.enabled = enabled
+    }
+}
+
+public struct CustomizationEnablementWorkspace: Codable, Sendable {
+    public var kind: String = "workspace"
+    public var uri: URI
+    public var enabled: Bool
+
+    public init(uri: URI, enabled: Bool) {
+        self.uri = uri
+        self.enabled = enabled
+    }
+}
+
+public struct CustomizationEnablementSession: Codable, Sendable {
+    public var kind: String = "session"
+    public var enabled: Bool
+
+    public init(enabled: Bool) {
+        self.enabled = enabled
     }
 }
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
@@ -216,16 +216,30 @@ func setCustomizationChildren(_ c: inout Customization, _ children: [ChildCustom
     }
 }
 
-func setCustomizationEnabled(_ c: inout Customization, _ enabled: Bool) {
+func effectiveEnablement(_ enablement: [CustomizationEnablement]) -> Bool {
+    guard let decision = enablement.first else { return true }
+    switch decision {
+    case .global(let value): return value.enabled
+    case .workspace(let value): return value.enabled
+    case .session(let value): return value.enabled
+    }
+}
+
+func applyCustomizationEnablement(_ c: inout Customization, _ enablement: [CustomizationEnablement]) {
+    let enabled = effectiveEnablement(enablement)
+    let provenance = enablement.isEmpty ? nil : enablement
     switch c {
     case .plugin(var p):
         p.enabled = enabled
+        p.enablement = provenance
         c = .plugin(p)
     case .directory(var d):
         d.enabled = enabled
+        d.enablement = provenance
         c = .directory(d)
     case .mcpServer(var m):
         m.enabled = enabled
+        m.enablement = provenance
         c = .mcpServer(m)
     // Unknown/future customization: opaque payload, nothing to mutate.
     case .unknown:
@@ -233,25 +247,33 @@ func setCustomizationEnabled(_ c: inout Customization, _ enabled: Bool) {
     }
 }
 
-func setChildCustomizationEnabled(_ c: inout ChildCustomization, _ enabled: Bool) {
+func applyChildCustomizationEnablement(_ c: inout ChildCustomization, _ enablement: [CustomizationEnablement]) {
+    let enabled = effectiveEnablement(enablement)
+    let provenance = enablement.isEmpty ? nil : enablement
     switch c {
     case .agent(var x):
         x.enabled = enabled
+        x.enablement = provenance
         c = .agent(x)
     case .skill(var x):
         x.enabled = enabled
+        x.enablement = provenance
         c = .skill(x)
     case .prompt(var x):
         x.enabled = enabled
+        x.enablement = provenance
         c = .prompt(x)
     case .rule(var x):
         x.enabled = enabled
+        x.enablement = provenance
         c = .rule(x)
     case .hook(var x):
         x.enabled = enabled
+        x.enablement = provenance
         c = .hook(x)
     case .mcpServer(var x):
         x.enabled = enabled
+        x.enablement = provenance
         c = .mcpServer(x)
     // Unknown/future child customization: opaque payload, nothing to mutate.
     case .unknown:
@@ -259,11 +281,11 @@ func setChildCustomizationEnabled(_ c: inout ChildCustomization, _ enabled: Bool
     }
 }
 
-func toggleCustomization(in list: inout [Customization], id: String, enabled: Bool) -> Bool {
+func toggleCustomization(in list: inout [Customization], id: String, enablement: [CustomizationEnablement]) -> Bool {
     for i in list.indices {
         if customizationId(list[i]) == id {
             var entry = list[i]
-            setCustomizationEnabled(&entry, enabled)
+            applyCustomizationEnablement(&entry, enablement)
             list[i] = entry
             return true
         }
@@ -273,7 +295,7 @@ func toggleCustomization(in list: inout [Customization], id: String, enabled: Bo
         guard var children = customizationChildren(container) else { continue }
         guard let childIdx = children.firstIndex(where: { childId($0) == id }) else { continue }
         var child = children[childIdx]
-        setChildCustomizationEnabled(&child, enabled)
+        applyChildCustomizationEnablement(&child, enablement)
         children[childIdx] = child
         setCustomizationChildren(&container, children)
         list[containerIdx] = container

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -817,7 +817,7 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
 
     case .sessionCustomizationToggled(let a):
         guard var list = state.customizations else { return state }
-        guard toggleCustomization(in: &list, id: a.id, enabled: a.enabled) else { return state }
+        guard toggleCustomization(in: &list, id: a.id, enablement: a.enablement) else { return state }
         var next = state
         next.customizations = list
         return next

--- a/docs/.changes/20260804-scoped-customization-enablement.json
+++ b/docs/.changes/20260804-scoped-customization-enablement.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "`Customization` enablement now carries scoped host-published provenance, and `session/customizationToggled` replaces its complete decision set."
+}

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -125,7 +125,7 @@ See [Elicitation](/guide/elicitation) for the request lifecycle.
 | Type | Client-dispatchable? | When |
 |---|---|---|
 | `session/customizationsChanged` | No | Server replaced the session's top-level customization list (full replacement) |
-| `session/customizationToggled` | **Yes** | Client toggled a container or child customization on or off by id |
+| `session/customizationToggled` | **Yes** | Client replaced a customization's explicit enablement decisions by id |
 | `session/customizationUpdated` | No | Server upserted a top-level container (plugin or directory) by id (full-entry replacement, including children) |
 | `session/customizationRemoved` | No | Server removed a customization by id (containers cascade to children) |
 
@@ -193,7 +193,7 @@ The client applies the action **optimistically** to its local state before sendi
 | `chat/pendingMessageSet` | Stores a steering or queued message (upsert); if queued and idle, auto-starts a turn |
 | `chat/pendingMessageRemoved` | Cancels a pending message before it is consumed |
 | `chat/queuedMessagesReordered` | Reorders queued messages; unknown IDs ignored, unmentioned messages kept at end |
-| `session/customizationToggled` | Toggles a container or child customization on or off by id |
+| `session/customizationToggled` | Replaces a customization's explicit enablement decisions by id |
 | `session/isReadChanged` | Marks the session as read or unread |
 | `session/isArchivedChanged` | Archives or unarchives the session |
 

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -5,7 +5,7 @@ Customizations extend agent sessions with additional capabilities — agents, sk
 - **Top-level entries are typically containers**: a `PluginCustomization` (an [Open Plugins](https://open-plugins.com/) package) or a `DirectoryCustomization` (a directory the host watches on disk). The host MAY also surface a bare `McpServerCustomization` at the top level (for example, a globally-configured MCP server that isn't bundled in a plugin).
 - **Other children live inside a container**: `AgentCustomization`, `SkillCustomization`, `PromptCustomization`, `RuleCustomization`, `HookCustomization`, `McpServerCustomization`. MCP servers can therefore appear in either position.
 
-The agent host is authoritative on the effective tree. Clients publish plugins, the host expands them into children, and the host owns disk-backed directories and bare top-level MCP servers.
+The agent host is authoritative on the effective tree and its enablement. Clients publish plugins, the host expands them into children, and the host owns disk-backed directories and bare top-level MCP servers.
 
 For MCP-specific behaviour (server lifecycle, authentication, App support), see [MCP Servers](/guide/mcp).
 
@@ -58,6 +58,7 @@ PluginCustomization {
   name: string
   icons?: Icon[]
   enabled: boolean
+  enablement?: CustomizationEnablement[] // host-published explicit decisions
   clientId?: string              // set when published by a client
   load?: CustomizationLoadState  // host-reported parse/load state
   children?: ChildCustomization[]
@@ -70,6 +71,7 @@ DirectoryCustomization {
   name: string
   icons?: Icon[]
   enabled: boolean
+  enablement?: CustomizationEnablement[]
   clientId?: string
   load?: CustomizationLoadState
   children?: ChildCustomization[]
@@ -108,7 +110,7 @@ stateDiagram-v2
 
 ## Children
 
-Every child carries the same base fields (`id`, `uri`, `name`, optional `icons`) plus an `enabled` flag — optional for the five leaf children (absent means enabled) and always present on an `McpServerCustomization`. Children are leaf nodes — no further nesting — and their parent is implied by which container holds them in its `children` array. A child's `enabled` is independent of its container's. Children have no `clientId`: client provenance lives on the container since clients can only contribute containers, not individual children.
+Every child carries the same base fields (`id`, `uri`, `name`, optional `icons`, optional `enablement`) plus an `enabled` flag — optional for the five leaf children (absent means enabled) and always present on an `McpServerCustomization`. Children are leaf nodes — no further nesting — and their parent is implied by which container holds them in its `children` array. A child's `enabled` is independent of its container's. Children have no `clientId`: client provenance lives on the container since clients can only contribute containers, not individual children.
 
 Each child type carries optional metadata sourced from its [Open Plugins](https://open-plugins.com/plugin-builders/specification.md) component definition (typically the file's YAML frontmatter):
 
@@ -133,19 +135,51 @@ state.customizations
   .filter(c => c.type === CustomizationType.Agent)
 ```
 
+## Enablement
+
+Every customization may carry an `enablement` array of explicit decisions:
+
+```typescript
+CustomizationEnablement =
+  | { kind: 'global'; enabled: boolean }
+  | { kind: 'workspace'; uri: URI; enabled: boolean }
+  | { kind: 'session'; enabled: boolean }
+```
+
+The agent host is the only publisher of this read-only provenance. Producers
+MUST publish the entries in descending specificity: session, workspace, then
+global. The host emits at most one workspace decision, for the session's
+primary working directory. Consumers MAY use `enablement[0]` as the decisive
+decision, with `enablement?.[0]?.enabled ?? true` as the effective value. An
+absent or empty array has no explicit decision and means enabled by default.
+
+`enabled` remains the display-ready, effective value. Both containers and
+children carry it; a child's final state is
+`container.enabled && (child.enabled ?? true)`, so disabling a container still
+disables all of its children.
+
 ## Toggling
 
-Any client can enable or disable any customization by dispatching `session/customizationToggled` with that entry's `id`:
+Any client can request an enablement update with
+`session/customizationToggled`. It carries the complete set of explicit
+decisions for the entry:
 
 ```typescript
 {
   type: 'session/customizationToggled'
   id: string         // any customization id
-  enabled: boolean
+  enablement: CustomizationEnablement[]
 }
 ```
 
-Both containers and children carry an `enabled` flag. The reducer matches `id` against every top-level customization first — plugins, directories, and bare top-level MCP servers — then against the children inside every container, and sets that entry's `enabled`. A child's effective state is `container.enabled && (child.enabled ?? true)`, so disabling a container disables all of its children regardless of each child's own flag, and a child toggle only takes effect while its container is enabled. The action is a no-op if no customization has that id.
+The action replaces the entry's array wholesale rather than merging a single
+scope. A caller changing one scope must include every decision it intends to
+preserve. The reducer matches `id` against every top-level customization first
+— plugins, directories, and bare top-level MCP servers — then against the
+children inside every container, replaces the matched entry's `enablement`,
+and recomputes its `enabled` from the first decision. An empty array clears
+the explicit provenance and restores the default enabled value. The action is
+a no-op if no customization has that id.
 
 ```mermaid
 sequenceDiagram
@@ -154,7 +188,7 @@ sequenceDiagram
 
     Note over Server: customizations: [Plugin A (enabled), Plugin B (enabled)]
 
-    Client->>Server: customizationToggled (id: plugin-a, enabled: false)
+    Client->>Server: customizationToggled (id: plugin-a, enablement: [session: false])
     Server->>Client: action echoed
     Note over Server: customizations: [Plugin A (disabled), Plugin B (enabled)]
 ```

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -495,24 +495,27 @@
     },
     "SessionCustomizationToggledAction": {
       "type": "object",
-      "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.",
+      "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.\n\nThe `enablement` array completely replaces all explicit decisions. A caller\nchanging one scope must include every decision it intends to preserve.",
       "properties": {
         "type": {
           "const": "session/customizationToggled"
         },
         "id": {
           "type": "string",
-          "description": "The id of the container or child to toggle."
+          "description": "The id of the container or child to update."
         },
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether to enable or disable the targeted customization."
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "The complete set of explicit decisions, replacing any existing set."
         }
       },
       "required": [
         "type",
         "id",
-        "enabled"
+        "enablement"
       ]
     },
     "SessionCustomizationUpdatedAction": {
@@ -3535,6 +3538,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3632,6 +3642,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3690,6 +3707,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3757,6 +3781,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3828,6 +3859,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3902,6 +3940,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3944,6 +3989,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -4015,6 +4067,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -4074,6 +4133,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -4124,6 +4190,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -4187,6 +4260,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -4234,6 +4314,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -4255,7 +4342,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Whether this MCP server is currently enabled."
+          "description": "Whether this MCP server is effectively enabled after resolving all scopes.\n{@link CustomizationBase.enablement | `enablement`} records its inputs."
         },
         "state": {
           "$ref": "#/$defs/McpServerState",
@@ -7126,6 +7213,60 @@
         }
       ],
       "description": "One outstanding piece of input a session is blocked on, aggregated across all\nchats in {@link SessionState.inputNeeded}.\n\nEach entry is self-sufficient: it carries the owning\n{@link SessionInputRequestBase.chat | `chat`} URI plus every identifier needed\nto construct the response, so a client can answer by dispatching the ordinary\n`chat/*` action (`chat/inputCompleted`, `chat/toolCallConfirmed`,\n`chat/toolCallComplete`, …) to that chat's channel **without having subscribed\nto the chat** — except {@link SessionToolAuthenticationRequest}, which is\nresolved via the `authenticate` command instead. The host removes the entry\nwith `session/inputNeededRemoved` once the underlying request resolves."
+    },
+    "CustomizationEnablement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "global"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "workspace"
+            },
+            "uri": {
+              "$ref": "#/$defs/URI"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "uri",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "session"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        }
+      ],
+      "description": "A single explicit enablement decision."
     },
     "ChildCustomizationType": {
       "oneOf": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2844,6 +2844,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2941,6 +2948,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2999,6 +3013,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3066,6 +3087,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3137,6 +3165,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3211,6 +3246,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3253,6 +3295,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3324,6 +3373,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3383,6 +3439,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3433,6 +3496,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -3496,6 +3566,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3543,6 +3620,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -3564,7 +3648,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Whether this MCP server is currently enabled."
+          "description": "Whether this MCP server is effectively enabled after resolving all scopes.\n{@link CustomizationBase.enablement | `enablement`} records its inputs."
         },
         "state": {
           "$ref": "#/$defs/McpServerState",
@@ -6873,24 +6957,27 @@
     },
     "SessionCustomizationToggledAction": {
       "type": "object",
-      "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.",
+      "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.\n\nThe `enablement` array completely replaces all explicit decisions. A caller\nchanging one scope must include every decision it intends to preserve.",
       "properties": {
         "type": {
           "const": "session/customizationToggled"
         },
         "id": {
           "type": "string",
-          "description": "The id of the container or child to toggle."
+          "description": "The id of the container or child to update."
         },
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether to enable or disable the targeted customization."
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "The complete set of explicit decisions, replacing any existing set."
         }
       },
       "required": [
         "type",
         "id",
-        "enabled"
+        "enablement"
       ]
     },
     "SessionCustomizationUpdatedAction": {
@@ -8990,6 +9077,60 @@
         }
       ],
       "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
+    },
+    "CustomizationEnablement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "global"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "workspace"
+            },
+            "uri": {
+              "$ref": "#/$defs/URI"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "uri",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "session"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        }
+      ],
+      "description": "A single explicit enablement decision."
     },
     "CustomizationLoadState": {
       "oneOf": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -1440,6 +1440,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1537,6 +1544,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1595,6 +1609,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1662,6 +1683,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1733,6 +1761,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1807,6 +1842,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1849,6 +1891,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1920,6 +1969,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1979,6 +2035,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2029,6 +2092,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -2092,6 +2162,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2139,6 +2216,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2160,7 +2244,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Whether this MCP server is currently enabled."
+          "description": "Whether this MCP server is effectively enabled after resolving all scopes.\n{@link CustomizationBase.enablement | `enablement`} records its inputs."
         },
         "state": {
           "$ref": "#/$defs/McpServerState",
@@ -6591,6 +6675,60 @@
       ],
       "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
     },
+    "CustomizationEnablement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "global"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "workspace"
+            },
+            "uri": {
+              "$ref": "#/$defs/URI"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "uri",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "session"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        }
+      ],
+      "description": "A single explicit enablement decision."
+    },
     "CustomizationLoadState": {
       "oneOf": [
         {
@@ -7831,24 +7969,27 @@
     },
     "SessionCustomizationToggledAction": {
       "type": "object",
-      "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.",
+      "description": "A client toggled a customization on or off.\n\nMatches `id` against every top-level customization first — a plugin or\ndirectory container, or a bare top-level MCP server — then against the\nchildren inside each container (a skill, agent, or other entry), and\nsets the matched entry's `enabled` flag. Disabling a container still\ndisables all of its children — the effective state of a child is\n`container.enabled && (child.enabled ?? true)` — so toggling a child\nonly matters while its container is enabled. Is a no-op when no\ncustomization has the given `id`.\n\nThe `enablement` array completely replaces all explicit decisions. A caller\nchanging one scope must include every decision it intends to preserve.",
       "properties": {
         "type": {
           "const": "session/customizationToggled"
         },
         "id": {
           "type": "string",
-          "description": "The id of the container or child to toggle."
+          "description": "The id of the container or child to update."
         },
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether to enable or disable the targeted customization."
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "The complete set of explicit decisions, replacing any existing set."
         }
       },
       "required": [
         "type",
         "id",
-        "enabled"
+        "enablement"
       ]
     },
     "SessionCustomizationUpdatedAction": {

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1603,6 +1603,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1700,6 +1707,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1758,6 +1772,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1825,6 +1846,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1896,6 +1924,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1970,6 +2005,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2012,6 +2054,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -2083,6 +2132,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2142,6 +2198,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2192,6 +2255,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -2255,6 +2325,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2302,6 +2379,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2323,7 +2407,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Whether this MCP server is currently enabled."
+          "description": "Whether this MCP server is effectively enabled after resolving all scopes.\n{@link CustomizationBase.enablement | `enablement`} records its inputs."
         },
         "state": {
           "$ref": "#/$defs/McpServerState",
@@ -5268,6 +5352,60 @@
         }
       ],
       "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
+    },
+    "CustomizationEnablement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "global"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "workspace"
+            },
+            "uri": {
+              "$ref": "#/$defs/URI"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "uri",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "session"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        }
+      ],
+      "description": "A single explicit enablement decision."
     },
     "CustomizationLoadState": {
       "oneOf": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -1351,6 +1351,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1448,6 +1455,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1506,6 +1520,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1573,6 +1594,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1644,6 +1672,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1718,6 +1753,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1760,6 +1802,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -1831,6 +1880,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1890,6 +1946,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -1940,6 +2003,13 @@
         "name": {
           "type": "string",
           "description": "Human-readable name."
+        },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
         },
         "icons": {
           "type": "array",
@@ -2003,6 +2073,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2050,6 +2127,13 @@
           "type": "string",
           "description": "Human-readable name."
         },
+        "enablement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomizationEnablement"
+          },
+          "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nOnly the agent host publishes this; clients treat it as read-only provenance."
+        },
         "icons": {
           "type": "array",
           "items": {
@@ -2071,7 +2155,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Whether this MCP server is currently enabled."
+          "description": "Whether this MCP server is effectively enabled after resolving all scopes.\n{@link CustomizationBase.enablement | `enablement`} records its inputs."
         },
         "state": {
           "$ref": "#/$defs/McpServerState",
@@ -4942,6 +5026,60 @@
         }
       ],
       "description": "One outstanding piece of input a session is blocked on, aggregated across all\nchats in {@link SessionState.inputNeeded}.\n\nEach entry is self-sufficient: it carries the owning\n{@link SessionInputRequestBase.chat | `chat`} URI plus every identifier needed\nto construct the response, so a client can answer by dispatching the ordinary\n`chat/*` action (`chat/inputCompleted`, `chat/toolCallConfirmed`,\n`chat/toolCallComplete`, …) to that chat's channel **without having subscribed\nto the chat** — except {@link SessionToolAuthenticationRequest}, which is\nresolved via the `authenticate` command instead. The host removes the entry\nwith `session/inputNeededRemoved` once the underlying request resolves."
+    },
+    "CustomizationEnablement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "global"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "workspace"
+            },
+            "uri": {
+              "$ref": "#/$defs/URI"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "uri",
+            "enabled"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "session"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "enabled"
+          ]
+        }
+      ],
+      "description": "A single explicit enablement decision."
     },
     "ChildCustomizationType": {
       "oneOf": [

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -695,7 +695,7 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason',
   'ConfirmationOptionKind', 'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
 ];
@@ -1315,6 +1315,11 @@ function generateStateFile(project: Project): string {
     }
   }
 
+  lines.push('// ─── Customization Enablement Union ───────────────────────────────────────');
+  lines.push('');
+  lines.push(generateCustomizationEnablementGo());
+  lines.push('');
+
   lines.push(generateToolInput());
   lines.push('');
 
@@ -1609,6 +1614,74 @@ const CHAT_SOURCE_UNION: UnionConfig = {
     { variantName: 'SideChat', innerType: 'SideChatSource', wireValue: 'sideChat' },
   ],
 };
+
+function generateCustomizationEnablementGo(): string {
+  return `// CustomizationEnablement is a single explicit customization enablement decision.
+type CustomizationEnablement struct {
+\tValue isCustomizationEnablement
+}
+
+type isCustomizationEnablement interface{ isCustomizationEnablement() }
+
+type CustomizationEnablementGlobal struct {
+\tKind    string \`json:"kind"\`
+\tEnabled bool   \`json:"enabled"\`
+}
+
+func (*CustomizationEnablementGlobal) isCustomizationEnablement() {}
+
+type CustomizationEnablementWorkspace struct {
+\tKind    string \`json:"kind"\`
+\tURI     URI    \`json:"uri"\`
+\tEnabled bool   \`json:"enabled"\`
+}
+
+func (*CustomizationEnablementWorkspace) isCustomizationEnablement() {}
+
+type CustomizationEnablementSession struct {
+\tKind    string \`json:"kind"\`
+\tEnabled bool   \`json:"enabled"\`
+}
+
+func (*CustomizationEnablementSession) isCustomizationEnablement() {}
+
+func (e *CustomizationEnablement) UnmarshalJSON(data []byte) error {
+\tdisc, _, err := readDiscriminator(data, "kind")
+\tif err != nil {
+\t\treturn err
+\t}
+\tswitch disc {
+\tcase "global":
+\t\tvar value CustomizationEnablementGlobal
+\t\tif err := json.Unmarshal(data, &value); err != nil {
+\t\t\treturn err
+\t\t}
+\t\te.Value = &value
+\tcase "workspace":
+\t\tvar value CustomizationEnablementWorkspace
+\t\tif err := json.Unmarshal(data, &value); err != nil {
+\t\t\treturn err
+\t\t}
+\t\te.Value = &value
+\tcase "session":
+\t\tvar value CustomizationEnablementSession
+\t\tif err := json.Unmarshal(data, &value); err != nil {
+\t\t\treturn err
+\t\t}
+\t\te.Value = &value
+\tdefault:
+\t\treturn &json.UnmarshalTypeError{Value: "CustomizationEnablement"}
+\t}
+\treturn nil
+}
+
+func (e CustomizationEnablement) MarshalJSON() ([]byte, error) {
+\tif e.Value == nil {
+\t\treturn []byte("null"), nil
+\t}
+\treturn json.Marshal(e.Value)
+}`;
+}
 
 function generateChangesetOperationTargetGo(): string {
   return `// ChangesetOperationTarget identifies the file or range a
@@ -2095,6 +2168,7 @@ function checkExhaustiveness(project: Project): void {
     'AhpErrorCodeWithData',
     'JsonRpcErrorCode',
     'ChangesetOperationTarget',
+    'CustomizationEnablement',
   ]);
 
   const missing = [...imported].filter((n) => !coveredByLists.has(n) && !knownSpecial.has(n));

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -900,7 +900,7 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason', 'ConfirmationOptionKind',
   'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
 ];
@@ -1256,6 +1256,11 @@ function generateStateFile(project: Project): string {
     }
   }
 
+  lines.push('// ─── Customization Enablement Union ─────────────────────────────────────');
+  lines.push('');
+  lines.push(generateCustomizationEnablementKotlin());
+  lines.push('');
+
   lines.push('// ─── Tool Input ──────────────────────────────────────────────────────────────');
   lines.push('');
   lines.push(generateToolInput());
@@ -1599,6 +1604,76 @@ const CHAT_SOURCE_UNION: UnionConfig = {
     { caseName: 'SideChat', structName: 'SideChatSource', discriminantValue: 'sideChat' },
   ],
 };
+
+function generateCustomizationEnablementKotlin(): string {
+  return `/**
+ * A single explicit customization enablement decision.
+ */
+@Serializable(with = CustomizationEnablementSerializer::class)
+sealed interface CustomizationEnablement {
+    @JvmInline value class Global(val value: CustomizationEnablementGlobal) : CustomizationEnablement
+    @JvmInline value class Workspace(val value: CustomizationEnablementWorkspace) : CustomizationEnablement
+    @JvmInline value class Session(val value: CustomizationEnablementSession) : CustomizationEnablement
+}
+
+@Serializable
+data class CustomizationEnablementGlobal(
+    val enabled: Boolean,
+    val kind: String = "global",
+)
+
+@Serializable
+data class CustomizationEnablementWorkspace(
+    val uri: URI,
+    val enabled: Boolean,
+    val kind: String = "workspace",
+)
+
+@Serializable
+data class CustomizationEnablementSession(
+    val enabled: Boolean,
+    val kind: String = "session",
+)
+
+internal object CustomizationEnablementSerializer : KSerializer<CustomizationEnablement> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("CustomizationEnablement")
+
+    override fun deserialize(decoder: Decoder): CustomizationEnablement {
+        val input = decoder as? JsonDecoder
+            ?: error("CustomizationEnablement can only be deserialized from JSON")
+        val element = input.decodeJsonElement()
+        val obj = element as? JsonObject
+            ?: error("Expected JsonObject for CustomizationEnablement")
+        return when ((obj["kind"] as? JsonPrimitive)?.contentOrNull) {
+            "global" -> CustomizationEnablement.Global(
+                input.json.decodeFromJsonElement(CustomizationEnablementGlobal.serializer(), element),
+            )
+            "workspace" -> CustomizationEnablement.Workspace(
+                input.json.decodeFromJsonElement(CustomizationEnablementWorkspace.serializer(), element),
+            )
+            "session" -> CustomizationEnablement.Session(
+                input.json.decodeFromJsonElement(CustomizationEnablementSession.serializer(), element),
+            )
+            else -> error("Unknown CustomizationEnablement kind")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: CustomizationEnablement) {
+        val output = encoder as? JsonEncoder
+            ?: error("CustomizationEnablement can only be serialized to JSON")
+        val element: JsonElement = when (value) {
+            is CustomizationEnablement.Global ->
+                output.json.encodeToJsonElement(CustomizationEnablementGlobal.serializer(), value.value)
+            is CustomizationEnablement.Workspace ->
+                output.json.encodeToJsonElement(CustomizationEnablementWorkspace.serializer(), value.value)
+            is CustomizationEnablement.Session ->
+                output.json.encodeToJsonElement(CustomizationEnablementSession.serializer(), value.value)
+        }
+        output.encodeJsonElement(element)
+    }
+}`;
+}
 
 /**
  * ChangesetOperationTarget — TS discriminated union over `{ kind: "resource" }`
@@ -2120,6 +2195,7 @@ function checkExhaustiveness(project: Project): void {
     'ForkChatSource',               // generateFixedChatSourceBranchKotlin()
     'SideChatSource',               // generateFixedChatSourceBranchKotlin()
     'ChangesetOperationTarget',     // generateChangesetOperationTargetKotlin()
+    'CustomizationEnablement',      // generateCustomizationEnablementKotlin()
   ]);
 
   const missing = [...imported].filter(n => !coveredByLists.has(n) && !knownSpecial.has(n));

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -657,7 +657,7 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason',
   'ConfirmationOptionKind', 'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
 ];
@@ -1151,6 +1151,10 @@ function generateStateFile(project: Project): string {
     }
   }
 
+  lines.push('// ─── Customization Enablement Union ───────────────────────────────────────\n');
+  lines.push(generateCustomizationEnablementRust());
+  lines.push('');
+
   lines.push(generateToolInput());
   lines.push('');
 
@@ -1330,7 +1334,7 @@ pub struct ${scope}ToolCallConfirmedAction {
 function generateActionsFile(project: Project): string {
   const lines: string[] = [GENERATED_HEADER];
   lines.push('#[allow(unused_imports)]');
-  lines.push('use crate::state::{AgentInfo, AgentSelection, Annotation, AnnotationEntry, ChatInputAnswer, ChatInputRequest, ChatInputResponseKind, ChatInteractivity, ChatOrigin, ConfirmationOption, ContentRef, Customization, ErrorInfo, McpAuthRequirement, McpServerState, ModelSelection, ResponsePart, SessionActiveClient, SessionInputRequest, SideChatSelection, TerminalClaim, TerminalInfo, TextRange, ToolCallContributor, ToolCallResult, ToolCallRiskAssessment, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolInput, ToolResultContent, UsageInfo, Message, PendingMessageKind, Turn, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, Changeset, ChatSummary};');
+  lines.push('use crate::state::{AgentInfo, AgentSelection, Annotation, AnnotationEntry, ChatInputAnswer, ChatInputRequest, ChatInputResponseKind, ChatInteractivity, ChatOrigin, ConfirmationOption, ContentRef, Customization, CustomizationEnablement, ErrorInfo, McpAuthRequirement, McpServerState, ModelSelection, ResponsePart, SessionActiveClient, SessionInputRequest, SideChatSelection, TerminalClaim, TerminalInfo, TextRange, ToolCallContributor, ToolCallResult, ToolCallRiskAssessment, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolInput, ToolResultContent, UsageInfo, Message, PendingMessageKind, Turn, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, Changeset, ChatSummary};');
   lines.push('');
 
   // ActionType enum
@@ -1536,6 +1540,27 @@ function generateCommandsFile(project: Project): string {
   lines.push('');
 
   return lines.join('\n');
+}
+
+function generateCustomizationEnablementRust(): string {
+  return `/// A single explicit customization enablement decision.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum CustomizationEnablement {
+    #[serde(rename = "global")]
+    Global {
+        enabled: bool,
+    },
+    #[serde(rename = "workspace")]
+    Workspace {
+        uri: Uri,
+        enabled: bool,
+    },
+    #[serde(rename = "session")]
+    Session {
+        enabled: bool,
+    },
+}`;
 }
 
 function generateSubscribeParamsImplRust(): string {
@@ -1927,6 +1952,7 @@ function checkExhaustiveness(project: Project): void {
     'AhpErrorCodeWithData',
     'JsonRpcErrorCode',
     'ChangesetOperationTarget',
+    'CustomizationEnablement',
   ]);
 
   const missing = [...imported].filter(n => !coveredByLists.has(n) && !knownSpecial.has(n));

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -609,7 +609,7 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason', 'ConfirmationOptionKind',
   'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
 ];
@@ -1151,6 +1151,10 @@ function generateStateFile(project: Project): string {
     }
   }
 
+  lines.push('// MARK: - Customization Enablement Union\n');
+  lines.push(generateCustomizationEnablementSwift());
+  lines.push('');
+
   lines.push('// MARK: - Tool Input\n');
   lines.push(generateToolInput());
   lines.push('');
@@ -1557,6 +1561,70 @@ function generateCommandsFile(project: Project): string {
   lines.push('');
 
   return lines.join('\n');
+}
+
+function generateCustomizationEnablementSwift(): string {
+  return `/// A single explicit customization enablement decision.
+public enum CustomizationEnablement: Codable, Sendable {
+    case global(CustomizationEnablementGlobal)
+    case workspace(CustomizationEnablementWorkspace)
+    case session(CustomizationEnablementSession)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case kind
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        switch try container.decode(String.self, forKey: .kind) {
+        case "global":
+            self = .global(try CustomizationEnablementGlobal(from: decoder))
+        case "workspace":
+            self = .workspace(try CustomizationEnablementWorkspace(from: decoder))
+        case "session":
+            self = .session(try CustomizationEnablementSession(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unknown CustomizationEnablement kind")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .global(let value): try value.encode(to: encoder)
+        case .workspace(let value): try value.encode(to: encoder)
+        case .session(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public struct CustomizationEnablementGlobal: Codable, Sendable {
+    public var kind: String = "global"
+    public var enabled: Bool
+
+    public init(enabled: Bool) {
+        self.enabled = enabled
+    }
+}
+
+public struct CustomizationEnablementWorkspace: Codable, Sendable {
+    public var kind: String = "workspace"
+    public var uri: URI
+    public var enabled: Bool
+
+    public init(uri: URI, enabled: Bool) {
+        self.uri = uri
+        self.enabled = enabled
+    }
+}
+
+public struct CustomizationEnablementSession: Codable, Sendable {
+    public var kind: String = "session"
+    public var enabled: Bool
+
+    public init(enabled: Bool) {
+        self.enabled = enabled
+    }
+}`;
 }
 
 function generateChangesetOperationTargetSwift(): string {
@@ -2139,6 +2207,7 @@ function checkExhaustiveness(project: Project): void {
     'ForkChatSource',               // generateFixedChatSourceBranchSwift()
     'SideChatSource',               // generateFixedChatSourceBranchSwift()
     'ChangesetOperationTarget',     // TS discriminated union; consumers should add a Swift case-iterable enum
+    'CustomizationEnablement',      // generateCustomizationEnablementSwift()
   ]);
 
   const missing = [...imported].filter(n => !coveredByLists.has(n) && !knownSpecial.has(n));

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -11,6 +11,7 @@ import type {
   SessionActiveClient,
   SessionInputRequest,
   Customization,
+  CustomizationEnablement,
   McpServerState,
 } from './state.js';
 import type { URI } from '../common/state.js';
@@ -370,16 +371,19 @@ export interface SessionCustomizationsChangedAction {
  * only matters while its container is enabled. Is a no-op when no
  * customization has the given `id`.
  *
+ * The `enablement` array completely replaces all explicit decisions. A caller
+ * changing one scope must include every decision it intends to preserve.
+ *
  * @category Session Actions
  * @version 1
  * @clientDispatchable
  */
 export interface SessionCustomizationToggledAction {
   type: ActionType.SessionCustomizationToggled;
-  /** The id of the container or child to toggle. */
+  /** The id of the container or child to update. */
   id: string;
-  /** Whether to enable or disable the targeted customization. */
-  enabled: boolean;
+  /** The complete set of explicit decisions, replacing any existing set. */
+  enablement: CustomizationEnablement[];
 }
 
 /**

--- a/types/channels-session/reducer.ts
+++ b/types/channels-session/reducer.ts
@@ -8,6 +8,9 @@ import { ActionType } from '../common/actions.js';
 import type {
   SessionState,
   SessionInputRequest,
+  ChildCustomization,
+  Customization,
+  CustomizationEnablement,
   McpServerCustomization,
 } from './state.js';
 import {
@@ -103,6 +106,23 @@ function updateMcpServerCustomization(
     return state;
   }
   return { ...state, customizations: updated };
+}
+
+/**
+ * Replaces a customization's explicit enablement decisions and recomputes its
+ * effective {@link CustomizationBase.enabled | `enabled`} value. An empty set
+ * drops the field entirely, so a customization at its default carries no
+ * provenance.
+ */
+function applyCustomizationEnablement<T extends Customization | ChildCustomization>(customization: T, enablement: readonly CustomizationEnablement[]): T {
+  const next = { ...customization };
+  next.enabled = enablement[0]?.enabled ?? true;
+  if (enablement.length > 0) {
+    next.enablement = [...enablement];
+  } else {
+    delete next.enablement;
+  }
+  return next;
 }
 
 // ─── Session Reducer ─────────────────────────────────────────────────────────
@@ -308,7 +328,7 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
       const topIdx = list.findIndex(c => c.id === action.id);
       if (topIdx >= 0) {
         const updated = list.slice();
-        updated[topIdx] = { ...list[topIdx], enabled: action.enabled };
+        updated[topIdx] = applyCustomizationEnablement(list[topIdx], action.enablement);
         return { ...state, customizations: updated };
       }
       for (let i = 0; i < list.length; i++) {
@@ -325,7 +345,7 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
           continue;
         }
         const newChildren = children.slice();
-        newChildren[childIdx] = { ...children[childIdx], enabled: action.enabled };
+        newChildren[childIdx] = applyCustomizationEnablement(children[childIdx], action.enablement);
         const updated = list.slice();
         updated[i] = { ...container, children: newChildren };
         return { ...state, customizations: updated };

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -646,6 +646,23 @@ export const enum CustomizationType {
 }
 
 /**
+ * Scope at which customization enablement is decided.
+ *
+ * @category Customization Types
+ */
+export const enum CustomizationEnablementKind {
+  Global = 'global',
+  Workspace = 'workspace',
+  Session = 'session',
+}
+
+/** A single explicit enablement decision. */
+export type CustomizationEnablement =
+  | { kind: CustomizationEnablementKind.Global; enabled: boolean }
+  | { kind: CustomizationEnablementKind.Workspace; uri: URI; enabled: boolean }
+  | { kind: CustomizationEnablementKind.Session; enabled: boolean };
+
+/**
  * Customization types that appear as children of a
  * {@link PluginCustomization} or {@link DirectoryCustomization}.
  *
@@ -683,6 +700,20 @@ interface CustomizationBase {
   uri: URI;
   /** Human-readable name. */
   name: string;
+  /**
+   * Explicit enablement decisions for this customization, one entry per scope
+   * that has one. This is a wire contract: producers MUST publish entries
+   * sorted by descending specificity (Session, Workspace, then Global).
+   * The agent host emits at most one Workspace entry, for the session's primary
+   * working directory. Consumers MAY treat
+   * `enablement[0]` as the decisive decision and
+   * `enablement?.[0]?.enabled ?? true` as the effective enabled value. An
+   * absent or empty array means no explicit decision exists, so the
+   * customization is enabled by default.
+   *
+   * Only the agent host publishes this; clients treat it as read-only provenance.
+   */
+  enablement?: CustomizationEnablement[];
   /** Icons for UI display. */
   icons?: Icon[];
   /**
@@ -1024,7 +1055,8 @@ export interface HookCustomization extends ChildCustomizationBase {
 export interface McpServerCustomization extends CustomizationBase {
   type: CustomizationType.McpServer;
   /**
-   * Whether this MCP server is currently enabled.
+   * Whether this MCP server is effectively enabled after resolving all scopes.
+   * {@link CustomizationBase.enablement | `enablement`} records its inputs.
    */
   enabled: boolean;
   /**

--- a/types/test-cases/reducers/060-session-customizationtoggled-toggles-by-id.json
+++ b/types/test-cases/reducers/060-session-customizationtoggled-toggles-by-id.json
@@ -29,7 +29,21 @@
     {
       "type": "session/customizationToggled",
       "id": "plugin-a",
-      "enabled": false
+      "enablement": [
+        {
+          "kind": "session",
+          "enabled": false
+        },
+        {
+          "kind": "workspace",
+          "uri": "file:///workspace",
+          "enabled": true
+        },
+        {
+          "kind": "global",
+          "enabled": true
+        }
+      ]
     }
   ],
   "expected": {
@@ -43,7 +57,22 @@
         "id": "plugin-a",
         "uri": "https://plugins.example/a",
         "name": "Plugin A",
-        "enabled": false
+        "enabled": false,
+        "enablement": [
+          {
+            "kind": "session",
+            "enabled": false
+          },
+          {
+            "kind": "workspace",
+            "uri": "file:///workspace",
+            "enabled": true
+          },
+          {
+            "kind": "global",
+            "enabled": true
+          }
+        ]
       },
       {
         "type": "plugin",

--- a/types/test-cases/reducers/061-session-customizationtoggled-is-no-op-for-unknown-id.json
+++ b/types/test-cases/reducers/061-session-customizationtoggled-is-no-op-for-unknown-id.json
@@ -22,7 +22,12 @@
     {
       "type": "session/customizationToggled",
       "id": "plugin-unknown",
-      "enabled": false
+      "enablement": [
+        {
+          "kind": "session",
+          "enabled": false
+        }
+      ]
     }
   ],
   "expected": {

--- a/types/test-cases/reducers/062-session-customizationtoggled-is-no-op-when-customizations-undefined.json
+++ b/types/test-cases/reducers/062-session-customizationtoggled-is-no-op-when-customizations-undefined.json
@@ -13,7 +13,12 @@
     {
       "type": "session/customizationToggled",
       "id": "plugin-a",
-      "enabled": false
+      "enablement": [
+        {
+          "kind": "session",
+          "enabled": false
+        }
+      ]
     }
   ],
   "expected": {

--- a/types/test-cases/reducers/225-session-customizationtoggled-toggles-child-by-id.json
+++ b/types/test-cases/reducers/225-session-customizationtoggled-toggles-child-by-id.json
@@ -47,7 +47,12 @@
     {
       "type": "session/customizationToggled",
       "id": "skill-1",
-      "enabled": false
+      "enablement": [
+        {
+          "kind": "session",
+          "enabled": false
+        }
+      ]
     }
   ],
   "expected": {
@@ -79,6 +84,12 @@
             "uri": "https://plugins.example/a#skills/lint",
             "name": "lint",
             "enabled": false,
+            "enablement": [
+              {
+                "kind": "session",
+                "enabled": false
+              }
+            ],
             "disableUserInvocation": true
           },
           {

--- a/types/test-cases/reducers/226-session-customizationtoggled-is-no-op-for-unknown-child-id.json
+++ b/types/test-cases/reducers/226-session-customizationtoggled-is-no-op-for-unknown-child-id.json
@@ -30,7 +30,12 @@
     {
       "type": "session/customizationToggled",
       "id": "does-not-exist",
-      "enabled": false
+      "enablement": [
+        {
+          "kind": "session",
+          "enabled": false
+        }
+      ]
     }
   ],
   "expected": {

--- a/types/test-cases/reducers/263-session-customizationtoggled-clears-enablement.json
+++ b/types/test-cases/reducers/263-session-customizationtoggled-clears-enablement.json
@@ -1,0 +1,62 @@
+{
+  "description": "session/customizationToggled clears enablement and restores the default",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "creating",
+    "customizations": [
+      {
+        "type": "mcpServer",
+        "id": "server-a",
+        "uri": "file:///workspace/.vscode/mcp.json",
+        "name": "Server A",
+        "enabled": false,
+        "enablement": [
+          {
+            "kind": "workspace",
+            "uri": "file:///workspace",
+            "enabled": false
+          },
+          {
+            "kind": "global",
+            "enabled": true
+          }
+        ],
+        "state": {
+          "kind": "stopped"
+        }
+      }
+    ],
+    "activeClients": [],
+    "chats": []
+  },
+  "actions": [
+    {
+      "type": "session/customizationToggled",
+      "id": "server-a",
+      "enablement": []
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "creating",
+    "customizations": [
+      {
+        "type": "mcpServer",
+        "id": "server-a",
+        "uri": "file:///workspace/.vscode/mcp.json",
+        "name": "Server A",
+        "enabled": true,
+        "state": {
+          "kind": "stopped"
+        }
+      }
+    ],
+    "activeClients": [],
+    "chats": []
+  }
+}


### PR DESCRIPTION
Protocol side of the scoped customization enablement work in microsoft/vscode#329047. Draft until that PR settles, since the two need to agree.

## What changed

Customizations gain an optional `enablement` array of explicit decisions, one entry per scope that has one:

```typescript
CustomizationEnablement =
  | { kind: 'global'; enabled: boolean }
  | { kind: 'workspace'; uri: URI; enabled: boolean }
  | { kind: 'session'; enabled: boolean }
```

The array is a **wire contract**, not just a bag of data. Producers MUST publish entries sorted by descending specificity — session, workspace, then global — and the agent host emits at most one workspace entry, for the session's primary working directory. Consumers MAY therefore treat `enablement[0]` as decisive, with `enablement?.[0]?.enabled ?? true` as the effective value, and never have to implement precedence themselves. An absent or empty array means no explicit decision, so the customization is enabled by default.

Only the host publishes this; clients treat it as read-only provenance.

The field lives on the customization base rather than on `McpServerCustomization` alone, so it applies to every customization type. The VS Code side already uses it for both MCP servers and plugins.

`session/customizationToggled` now carries `enablement` in place of `enabled`, and **replaces the complete decision set**. A caller changing one scope must include every decision it intends to preserve; an empty array clears all decisions and restores the default. Wholesale replacement avoids needing a separate "clear this scope" action and keeps the reducer total.

## Why not merge semantics

Merging would need a way to express "remove the workspace decision" distinctly from "no opinion about the workspace decision", which either means a nullable field or a second action. Replacement makes the client state the full intent it wants, which is also what the UI naturally has on hand.

## Container cascade

Note for reviewers, since the guide currently says a child's `enabled` is independent of its container: on the VS Code side a disabled container short-circuits its children, but that is applied at *consumption*, not by rewriting the child's published `enabled`. A child keeps its own decisions and its own resolved value, so re-enabling a container restores each child's prior state. This is what keeps the `enablement[0]` invariant true for the customization it appears on. I have deliberately **not** changed the guide wording here — if you would rather the spec state the cascade explicitly, say so and I will add it.

## Validation

- `npm run generate` is reproducible: re-running it produces zero diff, so the generated Go/Kotlin/Rust/Swift sources and JSON schemas are genuinely generated rather than hand-edited.
- `npm test` — 389 passing, 0 failing, 100% reducer coverage.
- `go test ./...` and `cargo test --workspace` pass. Both consume the shared `types/test-cases/reducers/` fixtures, so the new fixture exercises the TypeScript, Go, and Rust reducers alike.
- New fixture `263-session-customizationtoggled-clears-enablement` pins the subtle case: an empty array drops the field and restores the default.

**Not verified:** Kotlin Gradle tests (no Java runtime available) and Swift tests (missing CoreSimulator). Swift sources compile. Those two clients' reducer ports would benefit from a reviewer running them.
