### PR TITLE
session: drop isClientBundled from MCP customizations

### DIFF
--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -2900,9 +2900,6 @@ type McpServerCustomization struct {
 	// publishes the fully resolved set across all scopes, and consumers derive
 	// the effective enabled value from that set.
 	Enablement []CustomizationEnablement `json:"enablement,omitempty"`
-	// Whether the client explicitly bundled this server and owns its Global
-	// enablement decision.
-	IsClientBundled *bool `json:"isClientBundled,omitempty"`
 	// Current lifecycle state of the MCP server.
 	State McpServerState `json:"state"`
 	// An `mcp://`-protocol channel the client uses to side-channel traffic

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -3920,11 +3920,6 @@ data class McpServerCustomization(
      */
     val enablement: List<CustomizationEnablement>? = null,
     /**
-     * Whether the client explicitly bundled this server and owns its Global
-     * enablement decision.
-     */
-    val isClientBundled: Boolean? = null,
-    /**
      * Current lifecycle state of the MCP server.
      */
     val state: McpServerState,

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -3498,10 +3498,6 @@ pub struct McpServerCustomization {
     /// the effective enabled value from that set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enablement: Option<Vec<CustomizationEnablement>>,
-    /// Whether the client explicitly bundled this server and owns its Global
-    /// enablement decision.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub is_client_bundled: Option<bool>,
     /// Current lifecycle state of the MCP server.
     pub state: McpServerState,
     /// An `mcp://`-protocol channel the client uses to side-channel traffic

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -4292,9 +4292,6 @@ public struct McpServerCustomization: Codable, Sendable {
     /// publishes the fully resolved set across all scopes, and consumers derive
     /// the effective enabled value from that set.
     public var enablement: [CustomizationEnablement]?
-    /// Whether the client explicitly bundled this server and owns its Global
-    /// enablement decision.
-    public var isClientBundled: Bool?
     /// Current lifecycle state of the MCP server.
     public var state: McpServerState
     /// An `mcp://`-protocol channel the client uses to side-channel traffic
@@ -4326,7 +4323,6 @@ public struct McpServerCustomization: Codable, Sendable {
         case meta = "_meta"
         case type
         case enablement
-        case isClientBundled
         case state
         case channel
         case mcpApp
@@ -4341,7 +4337,6 @@ public struct McpServerCustomization: Codable, Sendable {
         meta: [String: AnyCodable]? = nil,
         type: CustomizationType,
         enablement: [CustomizationEnablement]? = nil,
-        isClientBundled: Bool? = nil,
         state: McpServerState,
         channel: String? = nil,
         mcpApp: McpServerCustomizationApps? = nil
@@ -4354,7 +4349,6 @@ public struct McpServerCustomization: Codable, Sendable {
         self.meta = meta
         self.type = type
         self.enablement = enablement
-        self.isClientBundled = isClientBundled
         self.state = state
         self.channel = channel
         self.mcpApp = mcpApp

--- a/docs/.changes/20260812-client-bundled-customization-enablement.json
+++ b/docs/.changes/20260812-client-bundled-customization-enablement.json
@@ -1,4 +1,4 @@
 {
   "type": "added",
-  "message": "`McpServerCustomization` now exposes client-bundled enablement metadata, and `ClientPluginCustomization` can publish child enablement decisions."
+  "message": "`ClientPluginCustomization` can publish child enablement decisions."
 }

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -118,7 +118,7 @@ SkillCustomization        { type: 'skill';       description?, disableModelInvoc
 PromptCustomization       { type: 'prompt';      description? }
 RuleCustomization         { type: 'rule';        description?, alwaysApply?, globs? }    // covers "instruction" formats too
 HookCustomization         { type: 'hook';        event?, matcher? }
-McpServerCustomization    { type: 'mcpServer';   enablement?, isClientBundled?, state, channel?, mcpApp? }   // see /guide/mcp
+McpServerCustomization    { type: 'mcpServer';   enablement?, state, channel?, mcpApp? }   // see /guide/mcp
 ```
 
 Agents and skills carry a symmetric invocation matrix. `disableModelInvocation` removes the entry from the agent's automatic choices — a custom agent it won't auto-delegate to, or a skill it won't auto-invoke — while leaving it available for the user to pick. `disableUserInvocation` does the reverse: the entry stays available for the agent to invoke but is hidden from user-facing pickers and slash-commands. Both are absent/`false` by default (invocable by either party), and they are independent, so an entry can be agent-only, user-only, both, or neither.

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -34,7 +34,6 @@ McpServerCustomization {
   icons?: Icon[]
   range?: TextRange              // span inside `uri` for inline declarations
   enablement?: CustomizationEnablement[] // user-toggleable (see Customizations guide)
-  isClientBundled?: boolean      // client owns the Global enablement decision
   state: McpServerState // discriminated union — see below
   channel?: URI                  // optional mcp:// side-channel
   mcpApp?: McpServerCustomizationApps

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -4272,10 +4272,6 @@
           },
           "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nFlows in both directions. A client publishes this alongside a customization\nto assert its global decision, which is authoritative for the Global scope;\na client always includes its global entry, even when enabled. The host\npublishes the fully resolved set across all scopes, and consumers derive\nthe effective enabled value from that set."
         },
-        "isClientBundled": {
-          "type": "boolean",
-          "description": "Whether the client explicitly bundled this server and owns its Global\nenablement decision."
-        },
         "state": {
           "$ref": "#/$defs/McpServerState",
           "description": "Current lifecycle state of the MCP server."

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -3578,10 +3578,6 @@
           },
           "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nFlows in both directions. A client publishes this alongside a customization\nto assert its global decision, which is authoritative for the Global scope;\na client always includes its global entry, even when enabled. The host\npublishes the fully resolved set across all scopes, and consumers derive\nthe effective enabled value from that set."
         },
-        "isClientBundled": {
-          "type": "boolean",
-          "description": "Whether the client explicitly bundled this server and owns its Global\nenablement decision."
-        },
         "state": {
           "$ref": "#/$defs/McpServerState",
           "description": "Current lifecycle state of the MCP server."

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -2174,10 +2174,6 @@
           },
           "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nFlows in both directions. A client publishes this alongside a customization\nto assert its global decision, which is authoritative for the Global scope;\na client always includes its global entry, even when enabled. The host\npublishes the fully resolved set across all scopes, and consumers derive\nthe effective enabled value from that set."
         },
-        "isClientBundled": {
-          "type": "boolean",
-          "description": "Whether the client explicitly bundled this server and owns its Global\nenablement decision."
-        },
         "state": {
           "$ref": "#/$defs/McpServerState",
           "description": "Current lifecycle state of the MCP server."

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -2337,10 +2337,6 @@
           },
           "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nFlows in both directions. A client publishes this alongside a customization\nto assert its global decision, which is authoritative for the Global scope;\na client always includes its global entry, even when enabled. The host\npublishes the fully resolved set across all scopes, and consumers derive\nthe effective enabled value from that set."
         },
-        "isClientBundled": {
-          "type": "boolean",
-          "description": "Whether the client explicitly bundled this server and owns its Global\nenablement decision."
-        },
         "state": {
           "$ref": "#/$defs/McpServerState",
           "description": "Current lifecycle state of the MCP server."

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -2085,10 +2085,6 @@
           },
           "description": "Explicit enablement decisions for this customization, one entry per scope\nthat has one. This is a wire contract: producers MUST publish entries\nsorted by descending specificity (Session, Workspace, then Global).\nThe agent host emits at most one Workspace entry, for the session's primary\nworking directory. Consumers MAY treat\n`enablement[0]` as the decisive decision and\n`enablement?.[0]?.enabled ?? true` as the effective enabled value. An\nabsent or empty array means no explicit decision exists, so the\ncustomization is enabled by default.\n\nFlows in both directions. A client publishes this alongside a customization\nto assert its global decision, which is authoritative for the Global scope;\na client always includes its global entry, even when enabled. The host\npublishes the fully resolved set across all scopes, and consumers derive\nthe effective enabled value from that set."
         },
-        "isClientBundled": {
-          "type": "boolean",
-          "description": "Whether the client explicitly bundled this server and owns its Global\nenablement decision."
-        },
         "state": {
           "$ref": "#/$defs/McpServerState",
           "description": "Current lifecycle state of the MCP server."

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -1072,11 +1072,6 @@ export interface McpServerCustomization extends CustomizationBase {
    */
   enablement?: CustomizationEnablement[];
   /**
-   * Whether the client explicitly bundled this server and owns its Global
-   * enablement decision.
-   */
-  isClientBundled?: boolean;
-  /**
    * Current lifecycle state of the MCP server.
    */
   state: McpServerState;


### PR DESCRIPTION
## Summary
- remove the unreleased `isClientBundled` field from `McpServerCustomization` and all generated schemas and clients
- retain the existing client child-enablement surface and its changelog fragment

`isClientBundled` is a deterministic function of the client's own `childEnablement` map (`childEnablement !== undefined && Object.hasOwn(childEnablement, child.name)`). It adds no host information, so consumers now derive it locally rather than receiving it over AHP.

## Validation
- `npm run generate`
- `npm run test`
- `npm run verify:change-fragments`
- `cd clients/rust && cargo fmt --all -- --check`