### PR TITLE
types: reserve x- prefix for extensions

### DIFF
--- a/docs/.changes/20260813-reserve-extension-prefix.json
+++ b/docs/.changes/20260813-reserve-extension-prefix.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "Reserve the `x-` prefix for implementation-defined channel URI schemes, commands, notifications, and actions.",
+  "issues": [367]
+}

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -12,6 +12,12 @@ This specification is a working draft and is under active development. Breaking 
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this specification are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
+### Extensions
+
+The `x-` prefix is reserved for implementation-defined extensions to channel URI schemes, command methods, notification methods, and action types. AHP-defined names in these namespaces MUST NOT begin with `x-`, and future protocol versions will not assign names with that prefix.
+
+Implementations MAY use `x-` names by prior agreement between peers. Such names are not part of the AHP standard; their semantics, discovery, and negotiation are implementation-defined.
+
 ## Protocol Version
 
 Protocol versions are [SemVer](https://semver.org) `MAJOR.MINOR.PATCH` strings; see the [GitHub Releases](https://github.com/microsoft/agent-host-protocol/releases) page for the current published version. Peers negotiate a shared version at initialization: the client offers `InitializeParams.protocolVersions` (an array, most-preferred first) and the server selects one and returns it as `InitializeResult.protocolVersion`.

--- a/types/extension-prefix.test.ts
+++ b/types/extension-prefix.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Ensures first-party protocol names do not use the extension namespace.
+ *
+ * Run: npx tsx --test types/extension-prefix.test.ts
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)));
+const extensionPrefix = 'x-';
+
+function readSource(file: string): string {
+  return readFileSync(resolve(root, file), 'utf-8');
+}
+
+function parseInterfaceKeys(source: string, interfaceName: string): string[] {
+  const match = new RegExp(`interface\\s+${interfaceName}\\s*\\{([^]*?)^\\}`, 'm').exec(source);
+  assert.ok(match, `Interface ${interfaceName} not found`);
+  return [...match[1].matchAll(/^\s*'([^']+)'\s*:/gm)].map(key => key[1]);
+}
+
+function parseActionTypes(source: string): string[] {
+  const match = /enum\s+ActionType\s*\{([^]*?)^\}/m.exec(source);
+  assert.ok(match, 'ActionType enum not found');
+  return [...match[1].matchAll(/=\s*'([^']+)'/g)].map(value => value[1]);
+}
+
+function assertNoReservedNames(names: string[], namespace: string): void {
+  assert.notDeepStrictEqual(names, [], `No ${namespace} found`);
+  const reserved = names.filter(name => name.startsWith(extensionPrefix));
+  assert.deepStrictEqual(
+    reserved,
+    [],
+    `First-party ${namespace} must not use the reserved ${extensionPrefix} prefix: ${reserved.join(', ')}`,
+  );
+}
+
+describe('reserved extension prefix', () => {
+  const messagesSource = readSource('common/messages.ts');
+
+  it('is not used by first-party command methods', () => {
+    const commands = [
+      ...parseInterfaceKeys(messagesSource, 'CommandMap'),
+      ...parseInterfaceKeys(messagesSource, 'ServerCommandMap'),
+    ];
+    assertNoReservedNames(commands, 'command methods');
+  });
+
+  it('is not used by first-party notification methods', () => {
+    const notifications = [
+      ...parseInterfaceKeys(messagesSource, 'ClientNotificationMap'),
+      ...parseInterfaceKeys(messagesSource, 'ServerNotificationMap'),
+    ];
+    assertNoReservedNames(notifications, 'notification methods');
+  });
+
+  it('is not used by first-party action types', () => {
+    assertNoReservedNames(parseActionTypes(readSource('common/actions.ts')), 'action types');
+  });
+
+  it('is not used by first-party channel URI schemes', () => {
+    const channelSchemes = readdirSync(root, { withFileTypes: true })
+      .filter(entry => entry.isDirectory() && entry.name.startsWith('channels-'))
+      .flatMap(entry => {
+        const source = readSource(`${entry.name}/state.ts`);
+        const moduleDoc = source.match(/^\/\*\*([^]*?)\*\//)?.[1];
+        assert.ok(moduleDoc, `Module documentation not found in ${entry.name}/state.ts`);
+        const schemes = [...moduleDoc.matchAll(/\b([a-z][a-z0-9+.-]*):/g)].map(match => match[1]);
+        assert.notDeepStrictEqual(schemes, [], `Channel URI scheme not documented in ${entry.name}/state.ts`);
+        return schemes;
+      });
+
+    assertNoReservedNames(channelSchemes, 'channel URI schemes');
+  });
+});


### PR DESCRIPTION
types: reserve x- prefix for extensions

Reserve the x- prefix so implementations can define extensions without a
future collision with first-party protocol names.

- Adds tests that reject first-party x- channel URI schemes, commands,
  notifications, and actions.
- Documents the reserved extension prefix and its implementation-defined use.
- Adds the release-note fragment for all protocol artifacts.

Fixes https://github.com/microsoft/agent-host-protocol/issues/367

(Commit message generated by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>