### PR TITLE
session: add atomic working directory replacement

### DIFF
--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -925,13 +925,21 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 		}
 		return ReduceOutcomeNoOp
 	case *ahptypes.SessionWorkingDirectoryReplacedAction:
-		if len(state.WorkingDirectories) == 0 || state.WorkingDirectories[0] != a.Directory {
+		idx := -1
+		for i, directory := range state.WorkingDirectories {
+			if directory == a.Directory {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
 			return ReduceOutcomeNoOp
 		}
 		updated := make([]ahptypes.URI, 0, len(state.WorkingDirectories))
-		updated = append(updated, a.Replacement)
-		for _, directory := range state.WorkingDirectories[1:] {
-			if directory != a.Replacement {
+		for i, directory := range state.WorkingDirectories {
+			if i == idx {
+				updated = append(updated, a.Replacement)
+			} else if directory != a.Replacement {
 				updated = append(updated, directory)
 			}
 		}

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -935,6 +935,12 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 		if idx < 0 {
 			return ReduceOutcomeNoOp
 		}
+		for i := 0; i < idx; i++ {
+			if state.WorkingDirectories[i] == a.Replacement {
+				state.WorkingDirectories = append(state.WorkingDirectories[:idx], state.WorkingDirectories[idx+1:]...)
+				return ReduceOutcomeApplied
+			}
+		}
 		updated := make([]ahptypes.URI, 0, len(state.WorkingDirectories))
 		for i, directory := range state.WorkingDirectories {
 			if i == idx {

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -924,6 +924,19 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 			}
 		}
 		return ReduceOutcomeNoOp
+	case *ahptypes.SessionWorkingDirectoryReplacedAction:
+		if len(state.WorkingDirectories) == 0 || state.WorkingDirectories[0] != a.Directory {
+			return ReduceOutcomeNoOp
+		}
+		updated := make([]ahptypes.URI, 0, len(state.WorkingDirectories))
+		updated = append(updated, a.Replacement)
+		for _, directory := range state.WorkingDirectories[1:] {
+			if directory != a.Replacement {
+				updated = append(updated, directory)
+			}
+		}
+		state.WorkingDirectories = updated
+		return ReduceOutcomeApplied
 	case *ahptypes.SessionInputNeededSetAction:
 		id, ok := sessionInputRequestID(a.Request)
 		if !ok {

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -921,10 +921,12 @@ type SessionWorkingDirectoryRemovedAction struct {
 //
 // This is a targeted compare-and-swap: the reducer is a no-op when
 // {@link SessionState.workingDirectories} does not contain `directory`.
-// Otherwise it replaces that entry in place with `replacement` and removes
-// any other occurrence of `replacement`, preserving every other directory's
-// relative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,
-// while `[A, B, C]` with `B → C` becomes `[A, C]`.
+// Otherwise it replaces that entry with `replacement` and deduplicates the
+// result, preserving every other directory's relative order. When
+// `replacement` occurs after the target, it moves to the target's position;
+// for example, `[A, B, C]` with `B → C` becomes `[A, C]`. When it occurs
+// before the target, it retains its earlier position and the target is removed;
+// `[A, B, C]` with `C → A` becomes `[A, B]`.
 //
 // Only valid when the agent advertises
 // {@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -917,25 +917,26 @@ type SessionWorkingDirectoryRemovedAction struct {
 	Directory URI `json:"directory"`
 }
 
-// Atomically replaces the session's protected primary working-directory slot.
+// Atomically replaces one of the session's working directories.
 //
 // This is a targeted compare-and-swap: the reducer is a no-op when
-// {@link SessionState.workingDirectories} is absent or empty, or when index
-// `0` is not `directory`. Otherwise it replaces index `0` with `replacement`
-// and removes a later duplicate of `replacement`, preserving every other
-// directory's relative order. For example, `[A, C]` with `A → B` becomes
-// `[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.
+// {@link SessionState.workingDirectories} does not contain `directory`.
+// Otherwise it replaces that entry in place with `replacement` and removes
+// any other occurrence of `replacement`, preserving every other directory's
+// relative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,
+// while `[A, B, C]` with `B → C` becomes `[A, C]`.
 //
 // Only valid when the agent advertises
-// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host
-// MUST validate and apply its backend side effect before broadcasting an
-// accepted action, or reject it. Clients MUST NOT dispatch this action for an
-// immutable primary.
+// {@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`
+// additionally requires
+// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients
+// MUST NOT target an immutable primary. The host MUST validate and apply its
+// backend side effect before broadcasting an accepted action, or reject it.
 type SessionWorkingDirectoryReplacedAction struct {
 	Type ActionType `json:"type"`
-	// Expected current URI in the protected primary slot.
+	// URI of the existing entry to replace.
 	Directory URI `json:"directory"`
-	// New URI for the protected primary slot.
+	// URI to place in the replaced entry's position.
 	Replacement URI `json:"replacement"`
 }
 

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -53,6 +53,7 @@ const (
 	ActionTypeSessionActiveClientRemoved        ActionType = "session/activeClientRemoved"
 	ActionTypeSessionWorkingDirectorySet        ActionType = "session/workingDirectorySet"
 	ActionTypeSessionWorkingDirectoryRemoved    ActionType = "session/workingDirectoryRemoved"
+	ActionTypeSessionWorkingDirectoryReplaced   ActionType = "session/workingDirectoryReplaced"
 	ActionTypeSessionInputNeededSet             ActionType = "session/inputNeededSet"
 	ActionTypeSessionInputNeededRemoved         ActionType = "session/inputNeededRemoved"
 	ActionTypeChatPendingMessageSet             ActionType = "chat/pendingMessageSet"
@@ -906,11 +907,36 @@ type SessionWorkingDirectorySetAction struct {
 // reduced set — so this action is safe to model as idempotent. A host MAY
 // decline to apply the removal (e.g. an immutable primary directory, see
 // {@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves
-// the set unchanged.
+// the set unchanged. When the agent advertises
+// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}, clients MUST
+// NOT use this generic membership action to remove index `0`; the host MUST
+// reject such a removal, leaving the protected slot intact.
 type SessionWorkingDirectoryRemovedAction struct {
 	Type ActionType `json:"type"`
 	// The working directory to revoke the session's agent tool access to.
 	Directory URI `json:"directory"`
+}
+
+// Atomically replaces the session's protected primary working-directory slot.
+//
+// This is a targeted compare-and-swap: the reducer is a no-op when
+// {@link SessionState.workingDirectories} is absent or empty, or when index
+// `0` is not `directory`. Otherwise it replaces index `0` with `replacement`
+// and removes a later duplicate of `replacement`, preserving every other
+// directory's relative order. For example, `[A, C]` with `A → B` becomes
+// `[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.
+//
+// Only valid when the agent advertises
+// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host
+// MUST validate and apply its backend side effect before broadcasting an
+// accepted action, or reject it. Clients MUST NOT dispatch this action for an
+// immutable primary.
+type SessionWorkingDirectoryReplacedAction struct {
+	Type ActionType `json:"type"`
+	// Expected current URI in the protected primary slot.
+	Directory URI `json:"directory"`
+	// New URI for the protected primary slot.
+	Replacement URI `json:"replacement"`
 }
 
 // A working directory was added to this chat's
@@ -1541,6 +1567,7 @@ func (*SessionActiveClientSetAction) isStateAction()            {}
 func (*SessionActiveClientRemovedAction) isStateAction()        {}
 func (*SessionWorkingDirectorySetAction) isStateAction()        {}
 func (*SessionWorkingDirectoryRemovedAction) isStateAction()    {}
+func (*SessionWorkingDirectoryReplacedAction) isStateAction()   {}
 func (*ChatWorkingDirectorySetAction) isStateAction()           {}
 func (*ChatWorkingDirectoryRemovedAction) isStateAction()       {}
 func (*SessionInputNeededSetAction) isStateAction()             {}
@@ -1867,6 +1894,12 @@ func (u *StateAction) UnmarshalJSON(data []byte) error {
 		u.Value = &value
 	case "session/workingDirectoryRemoved":
 		var value SessionWorkingDirectoryRemovedAction
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "session/workingDirectoryReplaced":
+		var value SessionWorkingDirectoryReplacedAction
 		if err := json.Unmarshal(data, &value); err != nil {
 			return err
 		}

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -329,16 +329,17 @@ type CreateSessionParams struct {
 	Provider *string `json:"provider,omitempty"`
 	// The working directories the session's agent is granted tool access to.
 	// A session may span multiple directories; they are equal peers except when
-	// the agent advertises
-	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (in which case
-	// the first entry is a fixed process root).
+	// the agent advertises a protected-primary capability. An
+	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable
+	// primary} is fixed, while a
+	// {@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable
+	// primary} is changed only with `session/workingDirectoryReplaced`.
 	//
 	// A client MUST NOT supply more than one entry unless the agent advertises
 	// {@link AgentCapabilities.multipleWorkingDirectories}; a server without that
 	// capability treats only the first entry as the session's working directory
-	// and ignores the rest. Dispatch `session/workingDirectorySet` /
-	// `session/workingDirectoryRemoved` to change the set after the session has
-	// started.
+	// and ignores the rest. Dispatch working-directory actions to change the set
+	// after the session has started.
 	//
 	// Ignored for forked sessions — a fork inherits its working directories
 	// from the source session identified by `fork`.

--- a/clients/go/ahptypes/notifications.generated.go
+++ b/clients/go/ahptypes/notifications.generated.go
@@ -220,13 +220,13 @@ type PartialSessionSummary struct {
 	// The working directories the session's agent has tool access to, as
 	// maintained by working-directory actions. Directories are equal peers except
 	// when the agent advertises
-	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-	// entry is then a fixed process root) or
+	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
 	// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-	// entry is a protected, replaceable primary slot). Individual chats MAY
-	// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-	// `workingDirectories`}; a chat that sets none operates against this full
-	// set.
+	// entry is then a fixed process root), or advertises `primaryReplacement`
+	// (the first entry is a protected, replaceable primary slot). Individual chats
+	// MAY restrict to a subset via
+	// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+	// chat that sets none operates against this full set.
 	WorkingDirectories []URI `json:"workingDirectories,omitempty"`
 	// Lightweight summary of this session's inline annotations channel
 	// (`ahp-session:/<uuid>/annotations`). Surfaced so badge UI can render

--- a/clients/go/ahptypes/notifications.generated.go
+++ b/clients/go/ahptypes/notifications.generated.go
@@ -218,12 +218,13 @@ type PartialSessionSummary struct {
 	// Server-owned project for this session
 	Project *ProjectInfo `json:"project,omitempty"`
 	// The working directories the session's agent has tool access to, as
-	// maintained by the `session/workingDirectorySet` /
-	// `session/workingDirectoryRemoved` actions. Directories are equal peers
-	// except when the agent advertises
+	// maintained by working-directory actions. Directories are equal peers except
+	// when the agent advertises
 	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-	// entry is then a fixed process root). Individual chats MAY restrict to a
-	// subset via {@link ChatSummary.workingDirectories | their own
+	// entry is then a fixed process root) or
+	// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+	// entry is a protected, replaceable primary slot). Individual chats MAY
+	// restrict to a subset via {@link ChatSummary.workingDirectories | their own
 	// `workingDirectories`}; a chat that sets none operates against this full
 	// set.
 	WorkingDirectories []URI `json:"workingDirectories,omitempty"`

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -628,14 +628,19 @@ type MultipleChatsCapability struct {
 type MultipleWorkingDirectoriesCapability struct {
 	// The agent's **first** working directory (index `0` of
 	// {@link CreateSessionParams.workingDirectories}) is an immutable primary:
-	// it is fixed for the lifetime of the session — clients MUST NOT remove or
-	// reorder it. Additional directories after it remain equal peers that can be
-	// added and removed freely.
+	// its URI is fixed for the lifetime of the session — clients MUST NOT remove,
+	// reorder, or replace it. Additional directories after it remain equal peers
+	// that can be added and removed freely. When
+	// {@link primaryReplacement} is also `true`, clients that recognize that
+	// capability MUST instead treat the primary as protected and replaceable.
 	//
 	// Advertised by backends whose agent process is rooted at a single directory
-	// that cannot change once the session has started. When absent or `false`,
-	// all directories are equal peers unless {@link primaryReplacement} is
-	// `true`.
+	// that cannot change once the session has started. A backend MAY also
+	// advertise this with {@link primaryReplacement} for compatibility with
+	// clients that do not recognize the newer capability: those clients retain
+	// the safe immutable-primary behavior, while newer clients allow only the
+	// targeted replacement action. When both are absent or `false`, all
+	// directories are equal peers.
 	ImmutablePrimary *bool `json:"immutablePrimary,omitempty"`
 	// The agent's first working-directory slot (index `0`) is a protected primary
 	// whose URI can be atomically replaced with
@@ -643,9 +648,10 @@ type MultipleWorkingDirectoriesCapability struct {
 	// generic membership actions; additional directories remain equal peers.
 	//
 	// Backends use this when their cwd-bearing directory can move during a
-	// session. A backend MUST NOT set this to `true` together with
-	// `immutablePrimary: true`: an immutable primary fixes the value, while a
-	// replaceable primary permits changing it.
+	// session. It MAY be `true` together with {@link immutablePrimary}; this
+	// preserves the immutable-primary guarantee for older clients that do not
+	// recognize this capability. Clients that recognize this capability MUST
+	// allow a targeted replacement even when `immutablePrimary` is also `true`.
 	PrimaryReplacement *bool `json:"primaryReplacement,omitempty"`
 }
 
@@ -772,13 +778,13 @@ type SessionState struct {
 	// The working directories the session's agent has tool access to, as
 	// maintained by working-directory actions. Directories are equal peers except
 	// when the agent advertises
-	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-	// entry is then a fixed process root) or
+	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
 	// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-	// entry is a protected, replaceable primary slot). Individual chats MAY
-	// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-	// `workingDirectories`}; a chat that sets none operates against this full
-	// set.
+	// entry is then a fixed process root), or advertises `primaryReplacement`
+	// (the first entry is a protected, replaceable primary slot). Individual chats
+	// MAY restrict to a subset via
+	// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+	// chat that sets none operates against this full set.
 	WorkingDirectories []URI `json:"workingDirectories,omitempty"`
 	// Lightweight summary of this session's inline annotations channel
 	// (`ahp-session:/<uuid>/annotations`). Surfaced so badge UI can render
@@ -1047,13 +1053,13 @@ type SessionSummary struct {
 	// The working directories the session's agent has tool access to, as
 	// maintained by working-directory actions. Directories are equal peers except
 	// when the agent advertises
-	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-	// entry is then a fixed process root) or
+	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
 	// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-	// entry is a protected, replaceable primary slot). Individual chats MAY
-	// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-	// `workingDirectories`}; a chat that sets none operates against this full
-	// set.
+	// entry is then a fixed process root), or advertises `primaryReplacement`
+	// (the first entry is a protected, replaceable primary slot). Individual chats
+	// MAY restrict to a subset via
+	// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+	// chat that sets none operates against this full set.
 	WorkingDirectories []URI `json:"workingDirectories,omitempty"`
 	// Lightweight summary of this session's inline annotations channel
 	// (`ahp-session:/<uuid>/annotations`). Surfaced so badge UI can render

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -595,8 +595,8 @@ type AgentCapabilities struct {
 	MultipleChats *MultipleChatsCapability `json:"multipleChats,omitempty"`
 	// The session's agent can be granted tool access to more than one working
 	// directory. The directories are treated as equal peers except where the
-	// agent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}
-	// (some backends pin their first directory as a fixed process root).
+	// agent advertises a protected primary-slot option (some backends pin or
+	// replace their first directory as a process root).
 	//
 	// When absent, clients MUST NOT mutate a session's or chat's working-directory
 	// set and MUST NOT set more than one entry in
@@ -633,10 +633,20 @@ type MultipleWorkingDirectoriesCapability struct {
 	// added and removed freely.
 	//
 	// Advertised by backends whose agent process is rooted at a single directory
-	// that cannot change once the session has started (e.g. the SDK's primary
-	// `workingDirectory`). When absent or `false`, all directories are equal
-	// peers and any of them may be removed.
+	// that cannot change once the session has started. When absent or `false`,
+	// all directories are equal peers unless {@link primaryReplacement} is
+	// `true`.
 	ImmutablePrimary *bool `json:"immutablePrimary,omitempty"`
+	// The agent's first working-directory slot (index `0`) is a protected primary
+	// whose URI can be atomically replaced with
+	// `session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with
+	// generic membership actions; additional directories remain equal peers.
+	//
+	// Backends use this when their cwd-bearing directory can move during a
+	// session. A backend MUST NOT set this to `true` together with
+	// `immutablePrimary: true`: an immutable primary fixes the value, while a
+	// replaceable primary permits changing it.
+	PrimaryReplacement *bool `json:"primaryReplacement,omitempty"`
 }
 
 type SessionModelInfo struct {
@@ -760,12 +770,13 @@ type SessionState struct {
 	// Server-owned project for this session
 	Project *ProjectInfo `json:"project,omitempty"`
 	// The working directories the session's agent has tool access to, as
-	// maintained by the `session/workingDirectorySet` /
-	// `session/workingDirectoryRemoved` actions. Directories are equal peers
-	// except when the agent advertises
+	// maintained by working-directory actions. Directories are equal peers except
+	// when the agent advertises
 	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-	// entry is then a fixed process root). Individual chats MAY restrict to a
-	// subset via {@link ChatSummary.workingDirectories | their own
+	// entry is then a fixed process root) or
+	// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+	// entry is a protected, replaceable primary slot). Individual chats MAY
+	// restrict to a subset via {@link ChatSummary.workingDirectories | their own
 	// `workingDirectories`}; a chat that sets none operates against this full
 	// set.
 	WorkingDirectories []URI `json:"workingDirectories,omitempty"`
@@ -1034,12 +1045,13 @@ type SessionSummary struct {
 	// Server-owned project for this session
 	Project *ProjectInfo `json:"project,omitempty"`
 	// The working directories the session's agent has tool access to, as
-	// maintained by the `session/workingDirectorySet` /
-	// `session/workingDirectoryRemoved` actions. Directories are equal peers
-	// except when the agent advertises
+	// maintained by working-directory actions. Directories are equal peers except
+	// when the agent advertises
 	// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-	// entry is then a fixed process root). Individual chats MAY restrict to a
-	// subset via {@link ChatSummary.workingDirectories | their own
+	// entry is then a fixed process root) or
+	// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+	// entry is a protected, replaceable primary slot). Individual chats MAY
+	// restrict to a subset via {@link ChatSummary.workingDirectories | their own
 	// `workingDirectories`}; a chat that sets none operates against this full
 	// set.
 	WorkingDirectories []URI `json:"workingDirectories,omitempty"`

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -663,12 +663,18 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
 
     is StateActionSessionWorkingDirectoryReplaced -> {
         val list = state.workingDirectories
-        if (list.isNullOrEmpty() || list.first() != action.value.directory) {
+        val idx = list?.indexOf(action.value.directory) ?: -1
+        if (list == null || idx < 0) {
             state
         } else {
             state.copy(
-                workingDirectories = listOf(action.value.replacement) +
-                    list.drop(1).filter { it != action.value.replacement },
+                workingDirectories = list.mapIndexedNotNull { index, directory ->
+                    when {
+                        index == idx -> action.value.replacement
+                        directory == action.value.replacement -> null
+                        else -> directory
+                    }
+                },
             )
         }
     }

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -661,6 +661,18 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
         }
     }
 
+    is StateActionSessionWorkingDirectoryReplaced -> {
+        val list = state.workingDirectories
+        if (list.isNullOrEmpty() || list.first() != action.value.directory) {
+            state
+        } else {
+            state.copy(
+                workingDirectories = listOf(action.value.replacement) +
+                    list.drop(1).filter { it != action.value.replacement },
+            )
+        }
+    }
+
     is StateActionSessionInputNeededSet -> {
         val request = action.value.request
         val id = sessionInputRequestId(request)

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -667,15 +667,20 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
         if (list == null || idx < 0) {
             state
         } else {
-            state.copy(
-                workingDirectories = list.mapIndexedNotNull { index, directory ->
-                    when {
-                        index == idx -> action.value.replacement
-                        directory == action.value.replacement -> null
-                        else -> directory
-                    }
-                },
-            )
+            val replacementIdx = list.indexOf(action.value.replacement)
+            if (replacementIdx in 0 until idx) {
+                state.copy(workingDirectories = list.filterIndexed { index, _ -> index != idx })
+            } else {
+                state.copy(
+                    workingDirectories = list.mapIndexedNotNull { index, directory ->
+                        when {
+                            index == idx -> action.value.replacement
+                            directory == action.value.replacement -> null
+                            else -> directory
+                        }
+                    },
+                )
+            }
         }
     }
 

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -924,11 +924,11 @@ data class SessionWorkingDirectoryRemovedAction(
 data class SessionWorkingDirectoryReplacedAction(
     val type: ActionType,
     /**
-     * Expected current URI in the protected primary slot.
+     * URI of the existing entry to replace.
      */
     val directory: String,
     /**
-     * New URI for the protected primary slot.
+     * URI to place in the replaced entry's position.
      */
     val replacement: String
 )

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -94,6 +94,8 @@ enum class ActionType {
     SESSION_WORKING_DIRECTORY_SET,
     @SerialName("session/workingDirectoryRemoved")
     SESSION_WORKING_DIRECTORY_REMOVED,
+    @SerialName("session/workingDirectoryReplaced")
+    SESSION_WORKING_DIRECTORY_REPLACED,
     @SerialName("session/inputNeededSet")
     SESSION_INPUT_NEEDED_SET,
     @SerialName("session/inputNeededRemoved")
@@ -919,6 +921,19 @@ data class SessionWorkingDirectoryRemovedAction(
 )
 
 @Serializable
+data class SessionWorkingDirectoryReplacedAction(
+    val type: ActionType,
+    /**
+     * Expected current URI in the protected primary slot.
+     */
+    val directory: String,
+    /**
+     * New URI for the protected primary slot.
+     */
+    val replacement: String
+)
+
+@Serializable
 data class ChatWorkingDirectorySetAction(
     val type: ActionType,
     /**
@@ -1573,6 +1588,7 @@ sealed interface StateAction
 @JvmInline value class StateActionSessionActiveClientRemoved(val value: SessionActiveClientRemovedAction) : StateAction
 @JvmInline value class StateActionSessionWorkingDirectorySet(val value: SessionWorkingDirectorySetAction) : StateAction
 @JvmInline value class StateActionSessionWorkingDirectoryRemoved(val value: SessionWorkingDirectoryRemovedAction) : StateAction
+@JvmInline value class StateActionSessionWorkingDirectoryReplaced(val value: SessionWorkingDirectoryReplacedAction) : StateAction
 @JvmInline value class StateActionChatWorkingDirectorySet(val value: ChatWorkingDirectorySetAction) : StateAction
 @JvmInline value class StateActionChatWorkingDirectoryRemoved(val value: ChatWorkingDirectoryRemovedAction) : StateAction
 @JvmInline value class StateActionSessionInputNeededSet(val value: SessionInputNeededSetAction) : StateAction
@@ -1673,6 +1689,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             "session/activeClientRemoved" -> StateActionSessionActiveClientRemoved(input.json.decodeFromJsonElement(SessionActiveClientRemovedAction.serializer(), element))
             "session/workingDirectorySet" -> StateActionSessionWorkingDirectorySet(input.json.decodeFromJsonElement(SessionWorkingDirectorySetAction.serializer(), element))
             "session/workingDirectoryRemoved" -> StateActionSessionWorkingDirectoryRemoved(input.json.decodeFromJsonElement(SessionWorkingDirectoryRemovedAction.serializer(), element))
+            "session/workingDirectoryReplaced" -> StateActionSessionWorkingDirectoryReplaced(input.json.decodeFromJsonElement(SessionWorkingDirectoryReplacedAction.serializer(), element))
             "chat/workingDirectorySet" -> StateActionChatWorkingDirectorySet(input.json.decodeFromJsonElement(ChatWorkingDirectorySetAction.serializer(), element))
             "chat/workingDirectoryRemoved" -> StateActionChatWorkingDirectoryRemoved(input.json.decodeFromJsonElement(ChatWorkingDirectoryRemovedAction.serializer(), element))
             "session/inputNeededSet" -> StateActionSessionInputNeededSet(input.json.decodeFromJsonElement(SessionInputNeededSetAction.serializer(), element))
@@ -1766,6 +1783,7 @@ internal object StateActionSerializer : KSerializer<StateAction> {
             is StateActionSessionActiveClientRemoved -> output.json.encodeToJsonElement(SessionActiveClientRemovedAction.serializer(), value.value)
             is StateActionSessionWorkingDirectorySet -> output.json.encodeToJsonElement(SessionWorkingDirectorySetAction.serializer(), value.value)
             is StateActionSessionWorkingDirectoryRemoved -> output.json.encodeToJsonElement(SessionWorkingDirectoryRemovedAction.serializer(), value.value)
+            is StateActionSessionWorkingDirectoryReplaced -> output.json.encodeToJsonElement(SessionWorkingDirectoryReplacedAction.serializer(), value.value)
             is StateActionChatWorkingDirectorySet -> output.json.encodeToJsonElement(ChatWorkingDirectorySetAction.serializer(), value.value)
             is StateActionChatWorkingDirectoryRemoved -> output.json.encodeToJsonElement(ChatWorkingDirectoryRemovedAction.serializer(), value.value)
             is StateActionSessionInputNeededSet -> output.json.encodeToJsonElement(SessionInputNeededSetAction.serializer(), value.value)

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -528,16 +528,17 @@ data class CreateSessionParams(
     /**
      * The working directories the session's agent is granted tool access to.
      * A session may span multiple directories; they are equal peers except when
-     * the agent advertises
-     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (in which case
-     * the first entry is a fixed process root).
+     * the agent advertises a protected-primary capability. An
+     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable
+     * primary} is fixed, while a
+     * {@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable
+     * primary} is changed only with `session/workingDirectoryReplaced`.
      *
      * A client MUST NOT supply more than one entry unless the agent advertises
      * {@link AgentCapabilities.multipleWorkingDirectories}; a server without that
      * capability treats only the first entry as the session's working directory
-     * and ignores the rest. Dispatch `session/workingDirectorySet` /
-     * `session/workingDirectoryRemoved` to change the set after the session has
-     * started.
+     * and ignores the rest. Dispatch working-directory actions to change the set
+     * after the session has started.
      *
      * Ignored for forked sessions — a fork inherits its working directories
      * from the source session identified by `fork`.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
@@ -199,13 +199,13 @@ data class PartialSessionSummary(
      * The working directories the session's agent has tool access to, as
      * maintained by working-directory actions. Directories are equal peers except
      * when the agent advertises
-     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-     * entry is then a fixed process root) or
+     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
      * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-     * entry is a protected, replaceable primary slot). Individual chats MAY
-     * restrict to a subset via {@link ChatSummary.workingDirectories | their own
-     * `workingDirectories`}; a chat that sets none operates against this full
-     * set.
+     * entry is then a fixed process root), or advertises `primaryReplacement`
+     * (the first entry is a protected, replaceable primary slot). Individual chats
+     * MAY restrict to a subset via
+     * {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+     * chat that sets none operates against this full set.
      */
     val workingDirectories: List<String>? = null,
     /**

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
@@ -197,12 +197,13 @@ data class PartialSessionSummary(
     val project: ProjectInfo? = null,
     /**
      * The working directories the session's agent has tool access to, as
-     * maintained by the `session/workingDirectorySet` /
-     * `session/workingDirectoryRemoved` actions. Directories are equal peers
-     * except when the agent advertises
+     * maintained by working-directory actions. Directories are equal peers except
+     * when the agent advertises
      * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-     * entry is then a fixed process root). Individual chats MAY restrict to a
-     * subset via {@link ChatSummary.workingDirectories | their own
+     * entry is then a fixed process root) or
+     * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+     * entry is a protected, replaceable primary slot). Individual chats MAY
+     * restrict to a subset via {@link ChatSummary.workingDirectories | their own
      * `workingDirectories`}; a chat that sets none operates against this full
      * set.
      */

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -968,8 +968,8 @@ data class AgentCapabilities(
     /**
      * The session's agent can be granted tool access to more than one working
      * directory. The directories are treated as equal peers except where the
-     * agent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}
-     * (some backends pin their first directory as a fixed process root).
+     * agent advertises a protected primary-slot option (some backends pin or
+     * replace their first directory as a process root).
      *
      * When absent, clients MUST NOT mutate a session's or chat's working-directory
      * set and MUST NOT set more than one entry in
@@ -1012,11 +1012,23 @@ data class MultipleWorkingDirectoriesCapability(
      * added and removed freely.
      *
      * Advertised by backends whose agent process is rooted at a single directory
-     * that cannot change once the session has started (e.g. the SDK's primary
-     * `workingDirectory`). When absent or `false`, all directories are equal
-     * peers and any of them may be removed.
+     * that cannot change once the session has started. When absent or `false`,
+     * all directories are equal peers unless {@link primaryReplacement} is
+     * `true`.
      */
-    val immutablePrimary: Boolean? = null
+    val immutablePrimary: Boolean? = null,
+    /**
+     * The agent's first working-directory slot (index `0`) is a protected primary
+     * whose URI can be atomically replaced with
+     * `session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with
+     * generic membership actions; additional directories remain equal peers.
+     *
+     * Backends use this when their cwd-bearing directory can move during a
+     * session. A backend MUST NOT set this to `true` together with
+     * `immutablePrimary: true`: an immutable primary fixes the value, while a
+     * replaceable primary permits changing it.
+     */
+    val primaryReplacement: Boolean? = null
 )
 
 @Serializable
@@ -1348,12 +1360,13 @@ data class SessionState(
     val project: ProjectInfo? = null,
     /**
      * The working directories the session's agent has tool access to, as
-     * maintained by the `session/workingDirectorySet` /
-     * `session/workingDirectoryRemoved` actions. Directories are equal peers
-     * except when the agent advertises
+     * maintained by working-directory actions. Directories are equal peers except
+     * when the agent advertises
      * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-     * entry is then a fixed process root). Individual chats MAY restrict to a
-     * subset via {@link ChatSummary.workingDirectories | their own
+     * entry is then a fixed process root) or
+     * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+     * entry is a protected, replaceable primary slot). Individual chats MAY
+     * restrict to a subset via {@link ChatSummary.workingDirectories | their own
      * `workingDirectories`}; a chat that sets none operates against this full
      * set.
      */
@@ -1625,12 +1638,13 @@ data class SessionSummary(
     val project: ProjectInfo? = null,
     /**
      * The working directories the session's agent has tool access to, as
-     * maintained by the `session/workingDirectorySet` /
-     * `session/workingDirectoryRemoved` actions. Directories are equal peers
-     * except when the agent advertises
+     * maintained by working-directory actions. Directories are equal peers except
+     * when the agent advertises
      * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-     * entry is then a fixed process root). Individual chats MAY restrict to a
-     * subset via {@link ChatSummary.workingDirectories | their own
+     * entry is then a fixed process root) or
+     * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+     * entry is a protected, replaceable primary slot). Individual chats MAY
+     * restrict to a subset via {@link ChatSummary.workingDirectories | their own
      * `workingDirectories`}; a chat that sets none operates against this full
      * set.
      */

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -1007,14 +1007,19 @@ data class MultipleWorkingDirectoriesCapability(
     /**
      * The agent's **first** working directory (index `0` of
      * {@link CreateSessionParams.workingDirectories}) is an immutable primary:
-     * it is fixed for the lifetime of the session — clients MUST NOT remove or
-     * reorder it. Additional directories after it remain equal peers that can be
-     * added and removed freely.
+     * its URI is fixed for the lifetime of the session — clients MUST NOT remove,
+     * reorder, or replace it. Additional directories after it remain equal peers
+     * that can be added and removed freely. When
+     * {@link primaryReplacement} is also `true`, clients that recognize that
+     * capability MUST instead treat the primary as protected and replaceable.
      *
      * Advertised by backends whose agent process is rooted at a single directory
-     * that cannot change once the session has started. When absent or `false`,
-     * all directories are equal peers unless {@link primaryReplacement} is
-     * `true`.
+     * that cannot change once the session has started. A backend MAY also
+     * advertise this with {@link primaryReplacement} for compatibility with
+     * clients that do not recognize the newer capability: those clients retain
+     * the safe immutable-primary behavior, while newer clients allow only the
+     * targeted replacement action. When both are absent or `false`, all
+     * directories are equal peers.
      */
     val immutablePrimary: Boolean? = null,
     /**
@@ -1024,9 +1029,10 @@ data class MultipleWorkingDirectoriesCapability(
      * generic membership actions; additional directories remain equal peers.
      *
      * Backends use this when their cwd-bearing directory can move during a
-     * session. A backend MUST NOT set this to `true` together with
-     * `immutablePrimary: true`: an immutable primary fixes the value, while a
-     * replaceable primary permits changing it.
+     * session. It MAY be `true` together with {@link immutablePrimary}; this
+     * preserves the immutable-primary guarantee for older clients that do not
+     * recognize this capability. Clients that recognize this capability MUST
+     * allow a targeted replacement even when `immutablePrimary` is also `true`.
      */
     val primaryReplacement: Boolean? = null
 )
@@ -1362,13 +1368,13 @@ data class SessionState(
      * The working directories the session's agent has tool access to, as
      * maintained by working-directory actions. Directories are equal peers except
      * when the agent advertises
-     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-     * entry is then a fixed process root) or
+     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
      * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-     * entry is a protected, replaceable primary slot). Individual chats MAY
-     * restrict to a subset via {@link ChatSummary.workingDirectories | their own
-     * `workingDirectories`}; a chat that sets none operates against this full
-     * set.
+     * entry is then a fixed process root), or advertises `primaryReplacement`
+     * (the first entry is a protected, replaceable primary slot). Individual chats
+     * MAY restrict to a subset via
+     * {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+     * chat that sets none operates against this full set.
      */
     val workingDirectories: List<String>? = null,
     /**
@@ -1640,13 +1646,13 @@ data class SessionSummary(
      * The working directories the session's agent has tool access to, as
      * maintained by working-directory actions. Directories are equal peers except
      * when the agent advertises
-     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-     * entry is then a fixed process root) or
+     * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
      * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-     * entry is a protected, replaceable primary slot). Individual chats MAY
-     * restrict to a subset via {@link ChatSummary.workingDirectories | their own
-     * `workingDirectories`}; a chat that sets none operates against this full
-     * set.
+     * entry is then a fixed process root), or advertises `primaryReplacement`
+     * (the first entry is a protected, replaceable primary slot). Individual chats
+     * MAY restrict to a subset via
+     * {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+     * chat that sets none operates against this full set.
      */
     val workingDirectories: List<String>? = null,
     /**

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -97,6 +97,8 @@ pub enum ActionType {
     SessionWorkingDirectorySet,
     #[serde(rename = "session/workingDirectoryRemoved")]
     SessionWorkingDirectoryRemoved,
+    #[serde(rename = "session/workingDirectoryReplaced")]
+    SessionWorkingDirectoryReplaced,
     #[serde(rename = "session/inputNeededSet")]
     SessionInputNeededSet,
     #[serde(rename = "session/inputNeededRemoved")]
@@ -966,12 +968,38 @@ pub struct SessionWorkingDirectorySetAction {
 /// reduced set — so this action is safe to model as idempotent. A host MAY
 /// decline to apply the removal (e.g. an immutable primary directory, see
 /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves
-/// the set unchanged.
+/// the set unchanged. When the agent advertises
+/// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}, clients MUST
+/// NOT use this generic membership action to remove index `0`; the host MUST
+/// reject such a removal, leaving the protected slot intact.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionWorkingDirectoryRemovedAction {
     /// The working directory to revoke the session's agent tool access to.
     pub directory: Uri,
+}
+
+/// Atomically replaces the session's protected primary working-directory slot.
+///
+/// This is a targeted compare-and-swap: the reducer is a no-op when
+/// {@link SessionState.workingDirectories} is absent or empty, or when index
+/// `0` is not `directory`. Otherwise it replaces index `0` with `replacement`
+/// and removes a later duplicate of `replacement`, preserving every other
+/// directory's relative order. For example, `[A, C]` with `A → B` becomes
+/// `[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.
+///
+/// Only valid when the agent advertises
+/// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host
+/// MUST validate and apply its backend side effect before broadcasting an
+/// accepted action, or reject it. Clients MUST NOT dispatch this action for an
+/// immutable primary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkingDirectoryReplacedAction {
+    /// Expected current URI in the protected primary slot.
+    pub directory: Uri,
+    /// New URI for the protected primary slot.
+    pub replacement: Uri,
 }
 
 /// A working directory was added to this chat's
@@ -1858,6 +1886,8 @@ pub enum StateAction {
     SessionWorkingDirectorySet(SessionWorkingDirectorySetAction),
     #[serde(rename = "session/workingDirectoryRemoved")]
     SessionWorkingDirectoryRemoved(SessionWorkingDirectoryRemovedAction),
+    #[serde(rename = "session/workingDirectoryReplaced")]
+    SessionWorkingDirectoryReplaced(SessionWorkingDirectoryReplacedAction),
     #[serde(rename = "chat/workingDirectorySet")]
     ChatWorkingDirectorySet(ChatWorkingDirectorySetAction),
     #[serde(rename = "chat/workingDirectoryRemoved")]

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -979,26 +979,27 @@ pub struct SessionWorkingDirectoryRemovedAction {
     pub directory: Uri,
 }
 
-/// Atomically replaces the session's protected primary working-directory slot.
+/// Atomically replaces one of the session's working directories.
 ///
 /// This is a targeted compare-and-swap: the reducer is a no-op when
-/// {@link SessionState.workingDirectories} is absent or empty, or when index
-/// `0` is not `directory`. Otherwise it replaces index `0` with `replacement`
-/// and removes a later duplicate of `replacement`, preserving every other
-/// directory's relative order. For example, `[A, C]` with `A → B` becomes
-/// `[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.
+/// {@link SessionState.workingDirectories} does not contain `directory`.
+/// Otherwise it replaces that entry in place with `replacement` and removes
+/// any other occurrence of `replacement`, preserving every other directory's
+/// relative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,
+/// while `[A, B, C]` with `B → C` becomes `[A, C]`.
 ///
 /// Only valid when the agent advertises
-/// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host
-/// MUST validate and apply its backend side effect before broadcasting an
-/// accepted action, or reject it. Clients MUST NOT dispatch this action for an
-/// immutable primary.
+/// {@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`
+/// additionally requires
+/// {@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients
+/// MUST NOT target an immutable primary. The host MUST validate and apply its
+/// backend side effect before broadcasting an accepted action, or reject it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionWorkingDirectoryReplacedAction {
-    /// Expected current URI in the protected primary slot.
+    /// URI of the existing entry to replace.
     pub directory: Uri,
-    /// New URI for the protected primary slot.
+    /// URI to place in the replaced entry's position.
     pub replacement: Uri,
 }
 

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -983,10 +983,12 @@ pub struct SessionWorkingDirectoryRemovedAction {
 ///
 /// This is a targeted compare-and-swap: the reducer is a no-op when
 /// {@link SessionState.workingDirectories} does not contain `directory`.
-/// Otherwise it replaces that entry in place with `replacement` and removes
-/// any other occurrence of `replacement`, preserving every other directory's
-/// relative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,
-/// while `[A, B, C]` with `B → C` becomes `[A, C]`.
+/// Otherwise it replaces that entry with `replacement` and deduplicates the
+/// result, preserving every other directory's relative order. When
+/// `replacement` occurs after the target, it moves to the target's position;
+/// for example, `[A, B, C]` with `B → C` becomes `[A, C]`. When it occurs
+/// before the target, it retains its earlier position and the target is removed;
+/// `[A, B, C]` with `C → A` becomes `[A, B]`.
 ///
 /// Only valid when the agent advertises
 /// {@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -423,16 +423,17 @@ pub struct CreateSessionParams {
     pub provider: Option<String>,
     /// The working directories the session's agent is granted tool access to.
     /// A session may span multiple directories; they are equal peers except when
-    /// the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (in which case
-    /// the first entry is a fixed process root).
+    /// the agent advertises a protected-primary capability. An
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable
+    /// primary} is fixed, while a
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable
+    /// primary} is changed only with `session/workingDirectoryReplaced`.
     ///
     /// A client MUST NOT supply more than one entry unless the agent advertises
     /// {@link AgentCapabilities.multipleWorkingDirectories}; a server without that
     /// capability treats only the first entry as the session's working directory
-    /// and ignores the rest. Dispatch `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` to change the set after the session has
-    /// started.
+    /// and ignores the rest. Dispatch working-directory actions to change the set
+    /// after the session has started.
     ///
     /// Ignored for forked sessions — a fork inherits its working directories
     /// from the source session identified by `fork`.

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -251,13 +251,13 @@ pub struct PartialSessionSummary {
     /// The working directories the session's agent has tool access to, as
     /// maintained by working-directory actions. Directories are equal peers except
     /// when the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
     /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-    /// entry is a protected, replaceable primary slot). Individual chats MAY
-    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-    /// `workingDirectories`}; a chat that sets none operates against this full
-    /// set.
+    /// entry is then a fixed process root), or advertises `primaryReplacement`
+    /// (the first entry is a protected, replaceable primary slot). Individual chats
+    /// MAY restrict to a subset via
+    /// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+    /// chat that sets none operates against this full set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directories: Option<Vec<Uri>>,
     /// Lightweight summary of this session's inline annotations channel

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -249,12 +249,13 @@ pub struct PartialSessionSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project: Option<ProjectInfo>,
     /// The working directories the session's agent has tool access to, as
-    /// maintained by the `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` actions. Directories are equal peers
-    /// except when the agent advertises
+    /// maintained by working-directory actions. Directories are equal peers except
+    /// when the agent advertises
     /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root). Individual chats MAY restrict to a
-    /// subset via {@link ChatSummary.workingDirectories | their own
+    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+    /// entry is a protected, replaceable primary slot). Individual chats MAY
+    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
     /// `workingDirectories`}; a chat that sets none operates against this full
     /// set.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -847,14 +847,19 @@ pub struct MultipleChatsCapability {
 pub struct MultipleWorkingDirectoriesCapability {
     /// The agent's **first** working directory (index `0` of
     /// {@link CreateSessionParams.workingDirectories}) is an immutable primary:
-    /// it is fixed for the lifetime of the session — clients MUST NOT remove or
-    /// reorder it. Additional directories after it remain equal peers that can be
-    /// added and removed freely.
+    /// its URI is fixed for the lifetime of the session — clients MUST NOT remove,
+    /// reorder, or replace it. Additional directories after it remain equal peers
+    /// that can be added and removed freely. When
+    /// {@link primaryReplacement} is also `true`, clients that recognize that
+    /// capability MUST instead treat the primary as protected and replaceable.
     ///
     /// Advertised by backends whose agent process is rooted at a single directory
-    /// that cannot change once the session has started. When absent or `false`,
-    /// all directories are equal peers unless {@link primaryReplacement} is
-    /// `true`.
+    /// that cannot change once the session has started. A backend MAY also
+    /// advertise this with {@link primaryReplacement} for compatibility with
+    /// clients that do not recognize the newer capability: those clients retain
+    /// the safe immutable-primary behavior, while newer clients allow only the
+    /// targeted replacement action. When both are absent or `false`, all
+    /// directories are equal peers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub immutable_primary: Option<bool>,
     /// The agent's first working-directory slot (index `0`) is a protected primary
@@ -863,9 +868,10 @@ pub struct MultipleWorkingDirectoriesCapability {
     /// generic membership actions; additional directories remain equal peers.
     ///
     /// Backends use this when their cwd-bearing directory can move during a
-    /// session. A backend MUST NOT set this to `true` together with
-    /// `immutablePrimary: true`: an immutable primary fixes the value, while a
-    /// replaceable primary permits changing it.
+    /// session. It MAY be `true` together with {@link immutablePrimary}; this
+    /// preserves the immutable-primary guarantee for older clients that do not
+    /// recognize this capability. Clients that recognize this capability MUST
+    /// allow a targeted replacement even when `immutablePrimary` is also `true`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub primary_replacement: Option<bool>,
 }
@@ -1178,13 +1184,13 @@ pub struct SessionState {
     /// The working directories the session's agent has tool access to, as
     /// maintained by working-directory actions. Directories are equal peers except
     /// when the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
     /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-    /// entry is a protected, replaceable primary slot). Individual chats MAY
-    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-    /// `workingDirectories`}; a chat that sets none operates against this full
-    /// set.
+    /// entry is then a fixed process root), or advertises `primaryReplacement`
+    /// (the first entry is a protected, replaceable primary slot). Individual chats
+    /// MAY restrict to a subset via
+    /// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+    /// chat that sets none operates against this full set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directories: Option<Vec<Uri>>,
     /// Lightweight summary of this session's inline annotations channel
@@ -1475,13 +1481,13 @@ pub struct SessionSummary {
     /// The working directories the session's agent has tool access to, as
     /// maintained by working-directory actions. Directories are equal peers except
     /// when the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
     /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-    /// entry is a protected, replaceable primary slot). Individual chats MAY
-    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-    /// `workingDirectories`}; a chat that sets none operates against this full
-    /// set.
+    /// entry is then a fixed process root), or advertises `primaryReplacement`
+    /// (the first entry is a protected, replaceable primary slot). Individual chats
+    /// MAY restrict to a subset via
+    /// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+    /// chat that sets none operates against this full set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directories: Option<Vec<Uri>>,
     /// Lightweight summary of this session's inline annotations channel

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -807,8 +807,8 @@ pub struct AgentCapabilities {
     pub multiple_chats: Option<MultipleChatsCapability>,
     /// The session's agent can be granted tool access to more than one working
     /// directory. The directories are treated as equal peers except where the
-    /// agent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}
-    /// (some backends pin their first directory as a fixed process root).
+    /// agent advertises a protected primary-slot option (some backends pin or
+    /// replace their first directory as a process root).
     ///
     /// When absent, clients MUST NOT mutate a session's or chat's working-directory
     /// set and MUST NOT set more than one entry in
@@ -852,11 +852,22 @@ pub struct MultipleWorkingDirectoriesCapability {
     /// added and removed freely.
     ///
     /// Advertised by backends whose agent process is rooted at a single directory
-    /// that cannot change once the session has started (e.g. the SDK's primary
-    /// `workingDirectory`). When absent or `false`, all directories are equal
-    /// peers and any of them may be removed.
+    /// that cannot change once the session has started. When absent or `false`,
+    /// all directories are equal peers unless {@link primaryReplacement} is
+    /// `true`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub immutable_primary: Option<bool>,
+    /// The agent's first working-directory slot (index `0`) is a protected primary
+    /// whose URI can be atomically replaced with
+    /// `session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with
+    /// generic membership actions; additional directories remain equal peers.
+    ///
+    /// Backends use this when their cwd-bearing directory can move during a
+    /// session. A backend MUST NOT set this to `true` together with
+    /// `immutablePrimary: true`: an immutable primary fixes the value, while a
+    /// replaceable primary permits changing it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_replacement: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1165,12 +1176,13 @@ pub struct SessionState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project: Option<ProjectInfo>,
     /// The working directories the session's agent has tool access to, as
-    /// maintained by the `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` actions. Directories are equal peers
-    /// except when the agent advertises
+    /// maintained by working-directory actions. Directories are equal peers except
+    /// when the agent advertises
     /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root). Individual chats MAY restrict to a
-    /// subset via {@link ChatSummary.workingDirectories | their own
+    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+    /// entry is a protected, replaceable primary slot). Individual chats MAY
+    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
     /// `workingDirectories`}; a chat that sets none operates against this full
     /// set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1461,12 +1473,13 @@ pub struct SessionSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project: Option<ProjectInfo>,
     /// The working directories the session's agent has tool access to, as
-    /// maintained by the `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` actions. Directories are equal peers
-    /// except when the agent advertises
+    /// maintained by working-directory actions. Directories are equal peers except
+    /// when the agent advertises
     /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root). Individual chats MAY restrict to a
-    /// subset via {@link ChatSummary.workingDirectories | their own
+    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+    /// entry is a protected, replaceable primary slot). Individual chats MAY
+    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
     /// `workingDirectories`}; a chat that sets none operates against this full
     /// set.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -827,6 +827,23 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
             list.remove(idx);
             ReduceOutcome::Applied
         }
+        StateAction::SessionWorkingDirectoryReplaced(a) => {
+            let Some(list) = state.working_directories.as_mut() else {
+                return ReduceOutcome::NoOp;
+            };
+            if list.first() != Some(&a.directory) {
+                return ReduceOutcome::NoOp;
+            }
+            let mut updated = Vec::with_capacity(list.len());
+            updated.push(a.replacement.clone());
+            for directory in list.iter().skip(1) {
+                if directory != &a.replacement {
+                    updated.push(directory.clone());
+                }
+            }
+            *list = updated;
+            ReduceOutcome::Applied
+        }
         StateAction::SessionInputNeededSet(a) => {
             let Some(action_id) = session_input_request_id(&a.request) else {
                 return ReduceOutcome::NoOp;

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -834,6 +834,13 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
             let Some(idx) = list.iter().position(|directory| directory == &a.directory) else {
                 return ReduceOutcome::NoOp;
             };
+            if list[..idx]
+                .iter()
+                .any(|directory| directory == &a.replacement)
+            {
+                list.remove(idx);
+                return ReduceOutcome::Applied;
+            }
             let mut updated = Vec::with_capacity(list.len());
             for (i, directory) in list.iter().enumerate() {
                 if i == idx {

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -831,13 +831,14 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
             let Some(list) = state.working_directories.as_mut() else {
                 return ReduceOutcome::NoOp;
             };
-            if list.first() != Some(&a.directory) {
+            let Some(idx) = list.iter().position(|directory| directory == &a.directory) else {
                 return ReduceOutcome::NoOp;
-            }
+            };
             let mut updated = Vec::with_capacity(list.len());
-            updated.push(a.replacement.clone());
-            for directory in list.iter().skip(1) {
-                if directory != &a.replacement {
+            for (i, directory) in list.iter().enumerate() {
+                if i == idx {
+                    updated.push(a.replacement.clone());
+                } else if directory != &a.replacement {
                     updated.push(directory.clone());
                 }
             }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -1159,9 +1159,9 @@ public struct SessionWorkingDirectoryRemovedAction: Codable, Sendable {
 
 public struct SessionWorkingDirectoryReplacedAction: Codable, Sendable {
     public var type: ActionType
-    /// Expected current URI in the protected primary slot.
+    /// URI of the existing entry to replace.
     public var directory: String
-    /// New URI for the protected primary slot.
+    /// URI to place in the replaced entry's position.
     public var replacement: String
 
     public init(

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -40,6 +40,7 @@ public enum ActionType: String, Codable, Sendable {
     case sessionActiveClientRemoved = "session/activeClientRemoved"
     case sessionWorkingDirectorySet = "session/workingDirectorySet"
     case sessionWorkingDirectoryRemoved = "session/workingDirectoryRemoved"
+    case sessionWorkingDirectoryReplaced = "session/workingDirectoryReplaced"
     case sessionInputNeededSet = "session/inputNeededSet"
     case sessionInputNeededRemoved = "session/inputNeededRemoved"
     case chatPendingMessageSet = "chat/pendingMessageSet"
@@ -1156,6 +1157,24 @@ public struct SessionWorkingDirectoryRemovedAction: Codable, Sendable {
     }
 }
 
+public struct SessionWorkingDirectoryReplacedAction: Codable, Sendable {
+    public var type: ActionType
+    /// Expected current URI in the protected primary slot.
+    public var directory: String
+    /// New URI for the protected primary slot.
+    public var replacement: String
+
+    public init(
+        type: ActionType,
+        directory: String,
+        replacement: String
+    ) {
+        self.type = type
+        self.directory = directory
+        self.replacement = replacement
+    }
+}
+
 public struct ChatWorkingDirectorySetAction: Codable, Sendable {
     public var type: ActionType
     /// The working directory to add to this chat's subset.
@@ -2053,6 +2072,7 @@ public enum StateAction: Codable, Sendable {
     case sessionActiveClientRemoved(SessionActiveClientRemovedAction)
     case sessionWorkingDirectorySet(SessionWorkingDirectorySetAction)
     case sessionWorkingDirectoryRemoved(SessionWorkingDirectoryRemovedAction)
+    case sessionWorkingDirectoryReplaced(SessionWorkingDirectoryReplacedAction)
     case chatWorkingDirectorySet(ChatWorkingDirectorySetAction)
     case chatWorkingDirectoryRemoved(ChatWorkingDirectoryRemovedAction)
     case sessionInputNeededSet(SessionInputNeededSetAction)
@@ -2186,6 +2206,8 @@ public enum StateAction: Codable, Sendable {
             self = .sessionWorkingDirectorySet(try SessionWorkingDirectorySetAction(from: decoder))
         case "session/workingDirectoryRemoved":
             self = .sessionWorkingDirectoryRemoved(try SessionWorkingDirectoryRemovedAction(from: decoder))
+        case "session/workingDirectoryReplaced":
+            self = .sessionWorkingDirectoryReplaced(try SessionWorkingDirectoryReplacedAction(from: decoder))
         case "chat/workingDirectorySet":
             self = .chatWorkingDirectorySet(try ChatWorkingDirectorySetAction(from: decoder))
         case "chat/workingDirectoryRemoved":
@@ -2327,6 +2349,7 @@ public enum StateAction: Codable, Sendable {
         case .sessionActiveClientRemoved(let v): try v.encode(to: encoder)
         case .sessionWorkingDirectorySet(let v): try v.encode(to: encoder)
         case .sessionWorkingDirectoryRemoved(let v): try v.encode(to: encoder)
+        case .sessionWorkingDirectoryReplaced(let v): try v.encode(to: encoder)
         case .chatWorkingDirectorySet(let v): try v.encode(to: encoder)
         case .chatWorkingDirectoryRemoved(let v): try v.encode(to: encoder)
         case .sessionInputNeededSet(let v): try v.encode(to: encoder)

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -508,16 +508,17 @@ public struct CreateSessionParams: Codable, Sendable {
     public var provider: String?
     /// The working directories the session's agent is granted tool access to.
     /// A session may span multiple directories; they are equal peers except when
-    /// the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (in which case
-    /// the first entry is a fixed process root).
+    /// the agent advertises a protected-primary capability. An
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable
+    /// primary} is fixed, while a
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable
+    /// primary} is changed only with `session/workingDirectoryReplaced`.
     ///
     /// A client MUST NOT supply more than one entry unless the agent advertises
     /// {@link AgentCapabilities.multipleWorkingDirectories}; a server without that
     /// capability treats only the first entry as the session's working directory
-    /// and ignores the rest. Dispatch `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` to change the set after the session has
-    /// started.
+    /// and ignores the rest. Dispatch working-directory actions to change the set
+    /// after the session has started.
     ///
     /// Ignored for forked sessions — a fork inherits its working directories
     /// from the source session identified by `fork`.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -185,13 +185,13 @@ public struct PartialSessionSummary: Codable, Sendable {
     /// The working directories the session's agent has tool access to, as
     /// maintained by working-directory actions. Directories are equal peers except
     /// when the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
     /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-    /// entry is a protected, replaceable primary slot). Individual chats MAY
-    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-    /// `workingDirectories`}; a chat that sets none operates against this full
-    /// set.
+    /// entry is then a fixed process root), or advertises `primaryReplacement`
+    /// (the first entry is a protected, replaceable primary slot). Individual chats
+    /// MAY restrict to a subset via
+    /// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+    /// chat that sets none operates against this full set.
     public var workingDirectories: [String]?
     /// Lightweight summary of this session's inline annotations channel
     /// (`ahp-session:/<uuid>/annotations`). Surfaced so badge UI can render

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -183,12 +183,13 @@ public struct PartialSessionSummary: Codable, Sendable {
     /// Server-owned project for this session
     public var project: ProjectInfo?
     /// The working directories the session's agent has tool access to, as
-    /// maintained by the `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` actions. Directories are equal peers
-    /// except when the agent advertises
+    /// maintained by working-directory actions. Directories are equal peers except
+    /// when the agent advertises
     /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root). Individual chats MAY restrict to a
-    /// subset via {@link ChatSummary.workingDirectories | their own
+    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+    /// entry is a protected, replaceable primary slot). Individual chats MAY
+    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
     /// `workingDirectories`}; a chat that sets none operates against this full
     /// set.
     public var workingDirectories: [String]?

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -635,8 +635,8 @@ public struct AgentCapabilities: Codable, Sendable {
     public var multipleChats: MultipleChatsCapability?
     /// The session's agent can be granted tool access to more than one working
     /// directory. The directories are treated as equal peers except where the
-    /// agent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}
-    /// (some backends pin their first directory as a fixed process root).
+    /// agent advertises a protected primary-slot option (some backends pin or
+    /// replace their first directory as a process root).
     ///
     /// When absent, clients MUST NOT mutate a session's or chat's working-directory
     /// set and MUST NOT set more than one entry in
@@ -687,15 +687,27 @@ public struct MultipleWorkingDirectoriesCapability: Codable, Sendable {
     /// added and removed freely.
     ///
     /// Advertised by backends whose agent process is rooted at a single directory
-    /// that cannot change once the session has started (e.g. the SDK's primary
-    /// `workingDirectory`). When absent or `false`, all directories are equal
-    /// peers and any of them may be removed.
+    /// that cannot change once the session has started. When absent or `false`,
+    /// all directories are equal peers unless {@link primaryReplacement} is
+    /// `true`.
     public var immutablePrimary: Bool?
+    /// The agent's first working-directory slot (index `0`) is a protected primary
+    /// whose URI can be atomically replaced with
+    /// `session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with
+    /// generic membership actions; additional directories remain equal peers.
+    ///
+    /// Backends use this when their cwd-bearing directory can move during a
+    /// session. A backend MUST NOT set this to `true` together with
+    /// `immutablePrimary: true`: an immutable primary fixes the value, while a
+    /// replaceable primary permits changing it.
+    public var primaryReplacement: Bool?
 
     public init(
-        immutablePrimary: Bool? = nil
+        immutablePrimary: Bool? = nil,
+        primaryReplacement: Bool? = nil
     ) {
         self.immutablePrimary = immutablePrimary
+        self.primaryReplacement = primaryReplacement
     }
 }
 
@@ -1087,12 +1099,13 @@ public struct SessionState: Codable, Sendable {
     /// Server-owned project for this session
     public var project: ProjectInfo?
     /// The working directories the session's agent has tool access to, as
-    /// maintained by the `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` actions. Directories are equal peers
-    /// except when the agent advertises
+    /// maintained by working-directory actions. Directories are equal peers except
+    /// when the agent advertises
     /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root). Individual chats MAY restrict to a
-    /// subset via {@link ChatSummary.workingDirectories | their own
+    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+    /// entry is a protected, replaceable primary slot). Individual chats MAY
+    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
     /// `workingDirectories`}; a chat that sets none operates against this full
     /// set.
     public var workingDirectories: [String]?
@@ -1410,12 +1423,13 @@ public struct SessionSummary: Codable, Sendable {
     /// Server-owned project for this session
     public var project: ProjectInfo?
     /// The working directories the session's agent has tool access to, as
-    /// maintained by the `session/workingDirectorySet` /
-    /// `session/workingDirectoryRemoved` actions. Directories are equal peers
-    /// except when the agent advertises
+    /// maintained by working-directory actions. Directories are equal peers except
+    /// when the agent advertises
     /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root). Individual chats MAY restrict to a
-    /// subset via {@link ChatSummary.workingDirectories | their own
+    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+    /// entry is a protected, replaceable primary slot). Individual chats MAY
+    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
     /// `workingDirectories`}; a chat that sets none operates against this full
     /// set.
     public var workingDirectories: [String]?

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -682,14 +682,19 @@ public struct MultipleChatsCapability: Codable, Sendable {
 public struct MultipleWorkingDirectoriesCapability: Codable, Sendable {
     /// The agent's **first** working directory (index `0` of
     /// {@link CreateSessionParams.workingDirectories}) is an immutable primary:
-    /// it is fixed for the lifetime of the session — clients MUST NOT remove or
-    /// reorder it. Additional directories after it remain equal peers that can be
-    /// added and removed freely.
+    /// its URI is fixed for the lifetime of the session — clients MUST NOT remove,
+    /// reorder, or replace it. Additional directories after it remain equal peers
+    /// that can be added and removed freely. When
+    /// {@link primaryReplacement} is also `true`, clients that recognize that
+    /// capability MUST instead treat the primary as protected and replaceable.
     ///
     /// Advertised by backends whose agent process is rooted at a single directory
-    /// that cannot change once the session has started. When absent or `false`,
-    /// all directories are equal peers unless {@link primaryReplacement} is
-    /// `true`.
+    /// that cannot change once the session has started. A backend MAY also
+    /// advertise this with {@link primaryReplacement} for compatibility with
+    /// clients that do not recognize the newer capability: those clients retain
+    /// the safe immutable-primary behavior, while newer clients allow only the
+    /// targeted replacement action. When both are absent or `false`, all
+    /// directories are equal peers.
     public var immutablePrimary: Bool?
     /// The agent's first working-directory slot (index `0`) is a protected primary
     /// whose URI can be atomically replaced with
@@ -697,9 +702,10 @@ public struct MultipleWorkingDirectoriesCapability: Codable, Sendable {
     /// generic membership actions; additional directories remain equal peers.
     ///
     /// Backends use this when their cwd-bearing directory can move during a
-    /// session. A backend MUST NOT set this to `true` together with
-    /// `immutablePrimary: true`: an immutable primary fixes the value, while a
-    /// replaceable primary permits changing it.
+    /// session. It MAY be `true` together with {@link immutablePrimary}; this
+    /// preserves the immutable-primary guarantee for older clients that do not
+    /// recognize this capability. Clients that recognize this capability MUST
+    /// allow a targeted replacement even when `immutablePrimary` is also `true`.
     public var primaryReplacement: Bool?
 
     public init(
@@ -1101,13 +1107,13 @@ public struct SessionState: Codable, Sendable {
     /// The working directories the session's agent has tool access to, as
     /// maintained by working-directory actions. Directories are equal peers except
     /// when the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
     /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-    /// entry is a protected, replaceable primary slot). Individual chats MAY
-    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-    /// `workingDirectories`}; a chat that sets none operates against this full
-    /// set.
+    /// entry is then a fixed process root), or advertises `primaryReplacement`
+    /// (the first entry is a protected, replaceable primary slot). Individual chats
+    /// MAY restrict to a subset via
+    /// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+    /// chat that sets none operates against this full set.
     public var workingDirectories: [String]?
     /// Lightweight summary of this session's inline annotations channel
     /// (`ahp-session:/<uuid>/annotations`). Surfaced so badge UI can render
@@ -1425,13 +1431,13 @@ public struct SessionSummary: Codable, Sendable {
     /// The working directories the session's agent has tool access to, as
     /// maintained by working-directory actions. Directories are equal peers except
     /// when the agent advertises
-    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-    /// entry is then a fixed process root) or
+    /// {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
     /// {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-    /// entry is a protected, replaceable primary slot). Individual chats MAY
-    /// restrict to a subset via {@link ChatSummary.workingDirectories | their own
-    /// `workingDirectories`}; a chat that sets none operates against this full
-    /// set.
+    /// entry is then a fixed process root), or advertises `primaryReplacement`
+    /// (the first entry is a protected, replaceable primary slot). Individual chats
+    /// MAY restrict to a subset via
+    /// {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+    /// chat that sets none operates against this full set.
     public var workingDirectories: [String]?
     /// Lightweight summary of this session's inline annotations channel
     /// (`ahp-session:/<uuid>/annotations`). Surfaced so badge UI can render

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -790,9 +790,15 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
         guard let directories = state.workingDirectories,
               let idx = directories.firstIndex(of: a.directory) else { return state }
         var next = state
-        next.workingDirectories = directories.enumerated().compactMap { index, directory in
-            if index == idx { return a.replacement }
-            return directory == a.replacement ? nil : directory
+        if let replacementIdx = directories.firstIndex(of: a.replacement), replacementIdx < idx {
+            next.workingDirectories = directories.enumerated().compactMap { index, directory in
+                index == idx ? nil : directory
+            }
+        } else {
+            next.workingDirectories = directories.enumerated().compactMap { index, directory in
+                if index == idx { return a.replacement }
+                return directory == a.replacement ? nil : directory
+            }
         }
         return next
 

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -788,10 +788,12 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
 
     case .sessionWorkingDirectoryReplaced(let a):
         guard let directories = state.workingDirectories,
-              directories.first == a.directory else { return state }
+              let idx = directories.firstIndex(of: a.directory) else { return state }
         var next = state
-        next.workingDirectories = [a.replacement] +
-            directories.dropFirst().filter { $0 != a.replacement }
+        next.workingDirectories = directories.enumerated().compactMap { index, directory in
+            if index == idx { return a.replacement }
+            return directory == a.replacement ? nil : directory
+        }
         return next
 
     case .sessionInputNeededSet(let a):

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -786,6 +786,14 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
         next.workingDirectories?.remove(at: idx)
         return next
 
+    case .sessionWorkingDirectoryReplaced(let a):
+        guard let directories = state.workingDirectories,
+              directories.first == a.directory else { return state }
+        var next = state
+        next.workingDirectories = [a.replacement] +
+            directories.dropFirst().filter { $0 != a.replacement }
+        return next
+
     case .sessionInputNeededSet(let a):
         guard let id = sessionInputRequestID(a.request) else { return state }
         var next = state

--- a/docs/.changes/20260814-primary-working-directory-replacement.json
+++ b/docs/.changes/20260814-primary-working-directory-replacement.json
@@ -1,5 +1,5 @@
 {
   "type": "added",
-  "message": "`session/workingDirectoryReplaced` atomically replaces a replaceable primary working-directory slot.",
+  "message": "`session/workingDirectoryReplaced` atomically replaces a working-directory entry, including a replaceable primary.",
   "issues": [392]
 }

--- a/docs/.changes/20260814-primary-working-directory-replacement.json
+++ b/docs/.changes/20260814-primary-working-directory-replacement.json
@@ -1,0 +1,5 @@
+{
+  "type": "added",
+  "message": "`session/workingDirectoryReplaced` atomically replaces a replaceable primary working-directory slot.",
+  "issues": [392]
+}

--- a/docs/.changes/20260817-preserve-primary-working-directory-on-deduplication.json
+++ b/docs/.changes/20260817-preserve-primary-working-directory-on-deduplication.json
@@ -1,0 +1,4 @@
+{
+  "type": "fixed",
+  "message": "`session/workingDirectoryReplaced` retains an earlier duplicate replacement so a later replacement cannot move a protected primary, and `primaryReplacement` may accompany `immutablePrimary` for safe legacy-client compatibility."
+}

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -578,11 +578,12 @@ The forked session is an independent copy — subsequent changes to either sessi
 
 A session can be granted tool access to more than one working directory when the
 agent advertises the `multipleWorkingDirectories` capability. The directories are
-**equal peers** unless the agent advertises
-`multipleWorkingDirectories.immutablePrimary`, in which case the first entry
-(`workingDirectories[0]`) is a fixed primary root that clients MUST NOT remove or
-reorder — the remaining entries stay equal peers that can be added and removed
-freely.
+**equal peers** unless the agent advertises a protected-primary option. With
+`multipleWorkingDirectories.immutablePrimary`, the first entry
+(`workingDirectories[0]`) is a fixed primary root. With
+`multipleWorkingDirectories.primaryReplacement`, it is a protected primary slot
+that can only be atomically replaced. The remaining entries stay equal peers that
+can be added and removed freely.
 
 ### Creating a multiroot session
 
@@ -607,6 +608,12 @@ When the agent advertises `multipleWorkingDirectories.immutablePrimary`, the
 first entry (`workingDirectories[0]`) is a fixed process root for the lifetime of
 the session — clients MUST NOT remove or reorder it.
 
+When the agent advertises `multipleWorkingDirectories.primaryReplacement`, the
+first entry is a protected, replaceable primary slot. Clients MUST NOT remove it
+with a generic membership action; they instead use
+`session/workingDirectoryReplaced`. A backend MUST NOT advertise both
+`immutablePrimary: true` and `primaryReplacement: true`.
+
 Forked sessions ignore `workingDirectories` — they inherit the working
 directories of the source session.
 
@@ -619,8 +626,9 @@ mutate it by **dispatching actions**, not by calling commands:
 | --- | --- |
 | `session/workingDirectorySet` | Adds `directory` to the set (creating it if absent). A no-op when the directory is already present. |
 | `session/workingDirectoryRemoved` | Removes `directory` from the set. A no-op when it is not present. There is no atomic backend "remove one" primitive — the host reconfigures its agent to the reduced set. A host MAY decline to apply the removal (e.g. the immutable primary at index 0), leaving the set unchanged. |
+| `session/workingDirectoryReplaced` | Targeted compare-and-swap replacement of index `0`: when `directory` is its expected current URI, replaces it with `replacement` and deduplicates a later `replacement`, preserving the relative order of all other directories. A no-op when the set is absent or empty, or index `0` differs. Only valid with `primaryReplacement`. |
 
-Both are `@clientDispatchable`. The resulting set is observed on
+All three are `@clientDispatchable`. The resulting set is observed on
 `SessionState.workingDirectories` like any other state — there is no separate
 result payload.
 
@@ -632,7 +640,13 @@ result payload.
 > layer, not in the reducer: a client MUST NOT dispatch a removal (or reorder) of
 > the primary, and a host MAY reject or reconcile one that arrives.
 
-Before dispatching either action, a client MUST verify that the agent advertises
+> **How replacement is enforced.** The host validates the
+> `primaryReplacement` capability and applies the backend side effect before
+> broadcasting `session/workingDirectoryReplaced`; otherwise it rejects the
+> action. The compare-and-swap payload prevents a stale client from replacing a
+> primary URI it no longer observed.
+
+Before dispatching any directory action, a client MUST verify that the agent advertises
 `multipleWorkingDirectories`.
 
 ### Per-chat working-directory subsets

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -626,7 +626,7 @@ mutate it by **dispatching actions**, not by calling commands:
 | --- | --- |
 | `session/workingDirectorySet` | Adds `directory` to the set (creating it if absent). A no-op when the directory is already present. |
 | `session/workingDirectoryRemoved` | Removes `directory` from the set. A no-op when it is not present. There is no atomic backend "remove one" primitive — the host reconfigures its agent to the reduced set. A host MAY decline to apply the removal (e.g. the immutable primary at index 0), leaving the set unchanged. |
-| `session/workingDirectoryReplaced` | Targeted compare-and-swap replacement of index `0`: when `directory` is its expected current URI, replaces it with `replacement` and deduplicates a later `replacement`, preserving the relative order of all other directories. A no-op when the set is absent or empty, or index `0` differs. Only valid with `primaryReplacement`. |
+| `session/workingDirectoryReplaced` | Targeted compare-and-swap replacement of any entry: replaces `directory` in place with `replacement` and removes any other occurrence of `replacement`, preserving the relative order of all other directories. A no-op when `directory` is absent. Replacing index `0` additionally requires `primaryReplacement`. |
 
 All three are `@clientDispatchable`. The resulting set is observed on
 `SessionState.workingDirectories` like any other state — there is no separate
@@ -640,11 +640,11 @@ result payload.
 > layer, not in the reducer: a client MUST NOT dispatch a removal (or reorder) of
 > the primary, and a host MAY reject or reconcile one that arrives.
 
-> **How replacement is enforced.** The host validates the
-> `primaryReplacement` capability and applies the backend side effect before
-> broadcasting `session/workingDirectoryReplaced`; otherwise it rejects the
-> action. The compare-and-swap payload prevents a stale client from replacing a
-> primary URI it no longer observed.
+> **How replacement is enforced.** The host applies the backend side effect
+> before broadcasting `session/workingDirectoryReplaced`; otherwise it rejects
+> the action. When the target is index `0`, the host also validates the
+> `primaryReplacement` capability. The compare-and-swap payload prevents a stale
+> client from replacing a directory URI it no longer observes.
 
 Before dispatching any directory action, a client MUST verify that the agent advertises
 `multipleWorkingDirectories`.

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -604,15 +604,18 @@ A client MUST NOT pass more than one entry unless the agent advertises
 `multipleWorkingDirectories`. Servers without that capability treat only the
 first entry as the session's working directory and ignore the rest.
 
-When the agent advertises `multipleWorkingDirectories.immutablePrimary`, the
-first entry (`workingDirectories[0]`) is a fixed process root for the lifetime of
-the session — clients MUST NOT remove or reorder it.
+When the agent advertises `multipleWorkingDirectories.immutablePrimary` without
+`primaryReplacement`, the first entry (`workingDirectories[0]`) is a fixed
+process root for the lifetime of the session — clients MUST NOT remove, reorder,
+or replace it.
 
 When the agent advertises `multipleWorkingDirectories.primaryReplacement`, the
 first entry is a protected, replaceable primary slot. Clients MUST NOT remove it
 with a generic membership action; they instead use
-`session/workingDirectoryReplaced`. A backend MUST NOT advertise both
-`immutablePrimary: true` and `primaryReplacement: true`.
+`session/workingDirectoryReplaced`. A backend MAY also advertise
+`immutablePrimary: true` for compatibility with older clients: clients that do
+not recognize `primaryReplacement` retain the safe immutable-primary behavior,
+while clients that do recognize it allow only the targeted replacement action.
 
 Forked sessions ignore `workingDirectories` — they inherit the working
 directories of the source session.
@@ -626,7 +629,7 @@ mutate it by **dispatching actions**, not by calling commands:
 | --- | --- |
 | `session/workingDirectorySet` | Adds `directory` to the set (creating it if absent). A no-op when the directory is already present. |
 | `session/workingDirectoryRemoved` | Removes `directory` from the set. A no-op when it is not present. There is no atomic backend "remove one" primitive — the host reconfigures its agent to the reduced set. A host MAY decline to apply the removal (e.g. the immutable primary at index 0), leaving the set unchanged. |
-| `session/workingDirectoryReplaced` | Targeted compare-and-swap replacement of any entry: replaces `directory` in place with `replacement` and removes any other occurrence of `replacement`, preserving the relative order of all other directories. A no-op when `directory` is absent. Replacing index `0` additionally requires `primaryReplacement`. |
+| `session/workingDirectoryReplaced` | Targeted compare-and-swap replacement of any entry that deduplicates `replacement`, preserving every other directory's relative order. An existing replacement after the target moves to the target's position (`[A, B, C]`, `B -> C` becomes `[A, C]`); an earlier replacement stays in place and the target is removed (`[A, B, C]`, `C -> A` becomes `[A, B]`). A no-op when `directory` is absent. Replacing index `0` additionally requires `primaryReplacement`. |
 
 All three are `@clientDispatchable`. The resulting set is observed on
 `SessionState.workingDirectories` like any other state — there is no separate
@@ -643,8 +646,11 @@ result payload.
 > **How replacement is enforced.** The host applies the backend side effect
 > before broadcasting `session/workingDirectoryReplaced`; otherwise it rejects
 > the action. When the target is index `0`, the host also validates the
-> `primaryReplacement` capability. The compare-and-swap payload prevents a stale
-> client from replacing a directory URI it no longer observes.
+> `primaryReplacement` capability, including when `immutablePrimary` is also
+> `true`. The compare-and-swap payload prevents a stale client from replacing a
+> directory URI it no longer observes. Deduplication retains an existing earlier
+> replacement, so an action targeting a later entry cannot move the primary at
+> index `0`.
 
 Before dispatching any directory action, a client MUST verify that the agent advertises
 `multipleWorkingDirectories`.

--- a/docs/proposals/multiroot-sessions.md
+++ b/docs/proposals/multiroot-sessions.md
@@ -296,8 +296,8 @@ interface SessionWorkingDirectoryRemovedAction {
 }
 interface SessionWorkingDirectoryReplacedAction {
   type: ActionType.SessionWorkingDirectoryReplaced; // 'session/workingDirectoryReplaced'
-  directory: URI;                                   // expected current index-0 URI
-  replacement: URI;                                 // replacement index-0 URI
+  directory: URI;                                   // existing entry to replace
+  replacement: URI;                                 // replacement URI at the same position
 }
 
 // ── Chat — channels-chat/state.ts, commands.ts & actions.ts ──────────────
@@ -334,8 +334,8 @@ interface ChatWorkingDirectoryRemovedAction {
   released `0.6.0`), and pre-1.0 breaking changes land in a MINOR.
   `SUPPORTED_PROTOCOL_VERSIONS` = `[0.7.0, 0.6.0, 0.5.2, 0.5.1]`.
 - The directory mutations are **state actions**. The original four carry
-  `ACTION_INTRODUCED_IN` entries at `0.7.0`; the session-only protected-primary
-  replacement carries one at `0.8.0`. All are `@clientDispatchable`.
+  `ACTION_INTRODUCED_IN` entries at `0.7.0`; the session-only atomic replacement
+  carries one at `0.8.0`. All are `@clientDispatchable`.
   Everything else — the capability and the create-time / state fields — is gated
   by the `multipleWorkingDirectories` capability plus the `initialize` version
   handshake.
@@ -391,10 +391,11 @@ interface ChatWorkingDirectoryRemovedAction {
 - **Replaceable primary.** *Resolved:* a backend that must move its cwd-bearing
   first directory advertises `primaryReplacement`; it MUST NOT also set
   `immutablePrimary: true`. `session/workingDirectoryReplaced` is a session-only,
-  client-dispatchable compare-and-swap action for index `0`. The host validates
-  the capability and applies the backend side effect before broadcasting it;
-  reducers replace only when the expected URI matches and remove a later
-  duplicate replacement URI.
+  client-dispatchable compare-and-swap action for any directory. The host
+  validates `primaryReplacement` when the target is index `0` and applies the
+  backend side effect before broadcasting it; reducers replace only when the
+  expected URI is present and remove any other occurrence of the replacement
+  URI.
 
 ---
 

--- a/docs/proposals/multiroot-sessions.md
+++ b/docs/proposals/multiroot-sessions.md
@@ -389,12 +389,14 @@ interface ChatWorkingDirectoryRemovedAction {
   idempotent and safe to retry. A host MAY decline (e.g. an immutable primary).
 
 - **Replaceable primary.** *Resolved:* a backend that must move its cwd-bearing
-  first directory advertises `primaryReplacement`; it MUST NOT also set
-  `immutablePrimary: true`. `session/workingDirectoryReplaced` is a session-only,
-  client-dispatchable compare-and-swap action for any directory. The host
-  validates `primaryReplacement` when the target is index `0` and applies the
-  backend side effect before broadcasting it; reducers replace only when the
-  expected URI is present and remove any other occurrence of the replacement
+  first directory advertises `primaryReplacement`. It MAY also advertise
+  `immutablePrimary: true` so clients that do not recognize `primaryReplacement`
+  retain the safe immutable-primary behavior; clients that recognize
+  `primaryReplacement` allow a targeted replacement. `session/workingDirectoryReplaced`
+  is a session-only, client-dispatchable compare-and-swap action for any
+  directory. The host validates `primaryReplacement` when the target is index
+  `0` and applies the backend side effect before broadcasting it; reducers
+  replace only when the expected URI is present and deduplicate the replacement
   URI.
 
 ---

--- a/docs/proposals/multiroot-sessions.md
+++ b/docs/proposals/multiroot-sessions.md
@@ -171,8 +171,11 @@ throughout — no juggling three disconnected sessions.
 
 - **No mandatory primary.** All directories are peers by default. A backend that
   *must* pin its first directory (a fixed process root) advertises
-  `immutablePrimary` on the capability; clients then keep index `0` fixed. The
-  protocol has no other notion of a "main" directory.
+  `immutablePrimary` on the capability; clients then keep index `0` fixed. A
+  backend whose cwd-bearing directory can move instead advertises
+  `primaryReplacement`, protecting index `0` from generic removal while allowing
+  its URI to change atomically. The protocol has no other notion of a "main"
+  directory.
 
 - **It is not multi-root *chats as sub-sessions*.** A chat narrowing to a subset
   is still one thread under one session's trust and identity. Independent agents
@@ -264,12 +267,14 @@ interface AgentCapabilities {
 interface MultipleWorkingDirectoriesCapability {
   /** First directory is a fixed process root; clients MUST NOT remove/reorder it. */
   immutablePrimary?: boolean;
+  /** Protected primary slot can be atomically replaced; cannot be true with immutablePrimary: true. */
+  primaryReplacement?: boolean;
 }
 
 // ── Session create — channels-session/commands.ts ────────────────────────
 interface CreateSessionParams extends BaseParams {
   // …existing…
-  /** The session's equal-peer working directories. */
+  /** The session's working directories; a capability may protect index 0. */
   workingDirectories?: URI[];
 }
 
@@ -288,6 +293,11 @@ interface SessionWorkingDirectorySetAction {
 interface SessionWorkingDirectoryRemovedAction {
   type: ActionType.SessionWorkingDirectoryRemoved; // 'session/workingDirectoryRemoved'
   directory: URI;                                   // removed; no-op if absent
+}
+interface SessionWorkingDirectoryReplacedAction {
+  type: ActionType.SessionWorkingDirectoryReplaced; // 'session/workingDirectoryReplaced'
+  directory: URI;                                   // expected current index-0 URI
+  replacement: URI;                                 // replacement index-0 URI
 }
 
 // ── Chat — channels-chat/state.ts, commands.ts & actions.ts ──────────────
@@ -323,8 +333,9 @@ interface ChatWorkingDirectoryRemovedAction {
   breaking (it removes the singular `workingDirectory` fields that shipped in the
   released `0.6.0`), and pre-1.0 breaking changes land in a MINOR.
   `SUPPORTED_PROTOCOL_VERSIONS` = `[0.7.0, 0.6.0, 0.5.2, 0.5.1]`.
-- The four directory mutations are **state actions**, so they carry
-  `ACTION_INTRODUCED_IN` entries at `0.7.0` (and are `@clientDispatchable`).
+- The directory mutations are **state actions**. The original four carry
+  `ACTION_INTRODUCED_IN` entries at `0.7.0`; the session-only protected-primary
+  replacement carries one at `0.8.0`. All are `@clientDispatchable`.
   Everything else — the capability and the create-time / state fields — is gated
   by the `multipleWorkingDirectories` capability plus the `initialize` version
   handshake.
@@ -376,6 +387,14 @@ interface ChatWorkingDirectoryRemovedAction {
 - **Removal semantics.** *Resolved:* no single-remove primitive is assumed; the
   `*/workingDirectoryRemoved` action reduces to the reduced set, so it is
   idempotent and safe to retry. A host MAY decline (e.g. an immutable primary).
+
+- **Replaceable primary.** *Resolved:* a backend that must move its cwd-bearing
+  first directory advertises `primaryReplacement`; it MUST NOT also set
+  `immutablePrimary: true`. `session/workingDirectoryReplaced` is a session-only,
+  client-dispatchable compare-and-swap action for index `0`. The host validates
+  the capability and applies the backend side effect before broadcasting it;
+  reducers replace only when the expected URI matches and remove a later
+  duplicate replacement URI.
 
 ---
 

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -441,18 +441,18 @@
     },
     "SessionWorkingDirectoryReplacedAction": {
       "type": "object",
-      "description": "Atomically replaces the session's protected primary working-directory slot.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} is absent or empty, or when index\n`0` is not `directory`. Otherwise it replaces index `0` with `replacement`\nand removes a later duplicate of `replacement`, preserving every other\ndirectory's relative order. For example, `[A, C]` with `A → B` becomes\n`[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.\n\nOnly valid when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host\nMUST validate and apply its backend side effect before broadcasting an\naccepted action, or reject it. Clients MUST NOT dispatch this action for an\nimmutable primary.",
+      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry in place with `replacement` and removes\nany other occurrence of `replacement`, preserving every other directory's\nrelative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,\nwhile `[A, B, C]` with `B → C` becomes `[A, C]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryReplaced"
         },
         "directory": {
           "$ref": "#/$defs/URI",
-          "description": "Expected current URI in the protected primary slot."
+          "description": "URI of the existing entry to replace."
         },
         "replacement": {
           "$ref": "#/$defs/URI",
-          "description": "New URI for the protected primary slot."
+          "description": "URI to place in the replaced entry's position."
         }
       },
       "required": [

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -441,7 +441,7 @@
     },
     "SessionWorkingDirectoryReplacedAction": {
       "type": "object",
-      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry in place with `replacement` and removes\nany other occurrence of `replacement`, preserving every other directory's\nrelative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,\nwhile `[A, B, C]` with `B → C` becomes `[A, C]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
+      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry with `replacement` and deduplicates the\nresult, preserving every other directory's relative order. When\n`replacement` occurs after the target, it moves to the target's position;\nfor example, `[A, B, C]` with `B → C` becomes `[A, C]`. When it occurs\nbefore the target, it retains its earlier position and the target is removed;\n`[A, B, C]` with `C → A` becomes `[A, B]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryReplaced"
@@ -2760,11 +2760,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nits URI is fixed for the lifetime of the session — clients MUST NOT remove,\nreorder, or replace it. Additional directories after it remain equal peers\nthat can be added and removed freely. When\n{@link primaryReplacement} is also `true`, clients that recognize that\ncapability MUST instead treat the primary as protected and replaceable.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. A backend MAY also\nadvertise this with {@link primaryReplacement} for compatibility with\nclients that do not recognize the newer capability: those clients retain\nthe safe immutable-primary behavior, while newer clients allow only the\ntargeted replacement action. When both are absent or `false`, all\ndirectories are equal peers."
         },
         "primaryReplacement": {
           "type": "boolean",
-          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. It MAY be `true` together with {@link immutablePrimary}; this\npreserves the immutable-primary guarantee for older clients that do not\nrecognize this capability. Clients that recognize this capability MUST\nallow a targeted replacement even when `immutablePrimary` is also `true`."
         }
       }
     },
@@ -2887,7 +2887,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -2929,7 +2929,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -3233,7 +3233,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -424,7 +424,7 @@
     },
     "SessionWorkingDirectoryRemovedAction": {
       "type": "object",
-      "description": "A working directory was removed from the session's\n{@link SessionState.workingDirectories} set.\n\nRemoves `directory` from the set; a no-op when it is not present. There is no\natomic backend \"remove one\" primitive — a host reconfigures its agent to the\nreduced set — so this action is safe to model as idempotent. A host MAY\ndecline to apply the removal (e.g. an immutable primary directory, see\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves\nthe set unchanged.",
+      "description": "A working directory was removed from the session's\n{@link SessionState.workingDirectories} set.\n\nRemoves `directory` from the set; a no-op when it is not present. There is no\natomic backend \"remove one\" primitive — a host reconfigures its agent to the\nreduced set — so this action is safe to model as idempotent. A host MAY\ndecline to apply the removal (e.g. an immutable primary directory, see\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves\nthe set unchanged. When the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}, clients MUST\nNOT use this generic membership action to remove index `0`; the host MUST\nreject such a removal, leaving the protected slot intact.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryRemoved"
@@ -437,6 +437,28 @@
       "required": [
         "type",
         "directory"
+      ]
+    },
+    "SessionWorkingDirectoryReplacedAction": {
+      "type": "object",
+      "description": "Atomically replaces the session's protected primary working-directory slot.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} is absent or empty, or when index\n`0` is not `directory`. Otherwise it replaces index `0` with `replacement`\nand removes a later duplicate of `replacement`, preserving every other\ndirectory's relative order. For example, `[A, C]` with `A → B` becomes\n`[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.\n\nOnly valid when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host\nMUST validate and apply its backend side effect before broadcasting an\naccepted action, or reject it. Clients MUST NOT dispatch this action for an\nimmutable primary.",
+      "properties": {
+        "type": {
+          "const": "session/workingDirectoryReplaced"
+        },
+        "directory": {
+          "$ref": "#/$defs/URI",
+          "description": "Expected current URI in the protected primary slot."
+        },
+        "replacement": {
+          "$ref": "#/$defs/URI",
+          "description": "New URI for the protected primary slot."
+        }
+      },
+      "required": [
+        "type",
+        "directory",
+        "replacement"
       ]
     },
     "SessionInputNeededSetAction": {
@@ -2714,7 +2736,7 @@
         },
         "multipleWorkingDirectories": {
           "$ref": "#/$defs/MultipleWorkingDirectoriesCapability",
-          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}\n(some backends pin their first directory as a fixed process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
+          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises a protected primary-slot option (some backends pin or\nreplace their first directory as a process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
         }
       }
     },
@@ -2738,7 +2760,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started (e.g. the SDK's primary\n`workingDirectory`). When absent or `false`, all directories are equal\npeers and any of them may be removed."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+        },
+        "primaryReplacement": {
+          "type": "boolean",
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
         }
       }
     },
@@ -2861,7 +2887,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -2903,7 +2929,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -3207,7 +3233,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -7626,6 +7652,9 @@
         },
         {
           "$ref": "#/$defs/SessionWorkingDirectoryRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionWorkingDirectoryReplacedAction"
         },
         {
           "$ref": "#/$defs/SessionInputNeededSetAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -2044,11 +2044,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nits URI is fixed for the lifetime of the session — clients MUST NOT remove,\nreorder, or replace it. Additional directories after it remain equal peers\nthat can be added and removed freely. When\n{@link primaryReplacement} is also `true`, clients that recognize that\ncapability MUST instead treat the primary as protected and replaceable.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. A backend MAY also\nadvertise this with {@link primaryReplacement} for compatibility with\nclients that do not recognize the newer capability: those clients retain\nthe safe immutable-primary behavior, while newer clients allow only the\ntargeted replacement action. When both are absent or `false`, all\ndirectories are equal peers."
         },
         "primaryReplacement": {
           "type": "boolean",
-          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. It MAY be `true` together with {@link immutablePrimary}; this\npreserves the immutable-primary guarantee for older clients that do not\nrecognize this capability. Clients that recognize this capability MUST\nallow a targeted replacement even when `immutablePrimary` is also `true`."
         }
       }
     },
@@ -2171,7 +2171,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -2213,7 +2213,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -2517,7 +2517,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -6834,7 +6834,7 @@
     },
     "SessionWorkingDirectoryReplacedAction": {
       "type": "object",
-      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry in place with `replacement` and removes\nany other occurrence of `replacement`, preserving every other directory's\nrelative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,\nwhile `[A, B, C]` with `B → C` becomes `[A, C]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
+      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry with `replacement` and deduplicates the\nresult, preserving every other directory's relative order. When\n`replacement` occurs after the target, it moves to the target's position;\nfor example, `[A, B, C]` with `B → C` becomes `[A, C]`. When it occurs\nbefore the target, it retains its earlier position and the target is removed;\n`[A, B, C]` with `C → A` becomes `[A, B]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryReplaced"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1062,7 +1062,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (in which case\nthe first entry is a fixed process root).\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` to change the set after the session has\nstarted.\n\nIgnored for forked sessions — a fork inherits its working directories\nfrom the source session identified by `fork`."
+          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises a protected-primary capability. An\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable\nprimary} is fixed, while a\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable\nprimary} is changed only with `session/workingDirectoryReplaced`.\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch working-directory actions to change the set\nafter the session has started.\n\nIgnored for forked sessions — a fork inherits its working directories\nfrom the source session identified by `fork`."
         },
         "fork": {
           "$ref": "#/$defs/SessionForkSource",
@@ -2020,7 +2020,7 @@
         },
         "multipleWorkingDirectories": {
           "$ref": "#/$defs/MultipleWorkingDirectoriesCapability",
-          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}\n(some backends pin their first directory as a fixed process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
+          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises a protected primary-slot option (some backends pin or\nreplace their first directory as a process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
         }
       }
     },
@@ -2044,7 +2044,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started (e.g. the SDK's primary\n`workingDirectory`). When absent or `false`, all directories are equal\npeers and any of them may be removed."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+        },
+        "primaryReplacement": {
+          "type": "boolean",
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
         }
       }
     },
@@ -2167,7 +2171,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -2209,7 +2213,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -2513,7 +2517,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -6813,7 +6817,7 @@
     },
     "SessionWorkingDirectoryRemovedAction": {
       "type": "object",
-      "description": "A working directory was removed from the session's\n{@link SessionState.workingDirectories} set.\n\nRemoves `directory` from the set; a no-op when it is not present. There is no\natomic backend \"remove one\" primitive — a host reconfigures its agent to the\nreduced set — so this action is safe to model as idempotent. A host MAY\ndecline to apply the removal (e.g. an immutable primary directory, see\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves\nthe set unchanged.",
+      "description": "A working directory was removed from the session's\n{@link SessionState.workingDirectories} set.\n\nRemoves `directory` from the set; a no-op when it is not present. There is no\natomic backend \"remove one\" primitive — a host reconfigures its agent to the\nreduced set — so this action is safe to model as idempotent. A host MAY\ndecline to apply the removal (e.g. an immutable primary directory, see\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves\nthe set unchanged. When the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}, clients MUST\nNOT use this generic membership action to remove index `0`; the host MUST\nreject such a removal, leaving the protected slot intact.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryRemoved"
@@ -6826,6 +6830,28 @@
       "required": [
         "type",
         "directory"
+      ]
+    },
+    "SessionWorkingDirectoryReplacedAction": {
+      "type": "object",
+      "description": "Atomically replaces the session's protected primary working-directory slot.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} is absent or empty, or when index\n`0` is not `directory`. Otherwise it replaces index `0` with `replacement`\nand removes a later duplicate of `replacement`, preserving every other\ndirectory's relative order. For example, `[A, C]` with `A → B` becomes\n`[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.\n\nOnly valid when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host\nMUST validate and apply its backend side effect before broadcasting an\naccepted action, or reject it. Clients MUST NOT dispatch this action for an\nimmutable primary.",
+      "properties": {
+        "type": {
+          "const": "session/workingDirectoryReplaced"
+        },
+        "directory": {
+          "$ref": "#/$defs/URI",
+          "description": "Expected current URI in the protected primary slot."
+        },
+        "replacement": {
+          "$ref": "#/$defs/URI",
+          "description": "New URI for the protected primary slot."
+        }
+      },
+      "required": [
+        "type",
+        "directory",
+        "replacement"
       ]
     },
     "SessionInputNeededSetAction": {
@@ -8532,6 +8558,9 @@
         },
         {
           "$ref": "#/$defs/SessionWorkingDirectoryRemovedAction"
+        },
+        {
+          "$ref": "#/$defs/SessionWorkingDirectoryReplacedAction"
         },
         {
           "$ref": "#/$defs/SessionInputNeededSetAction"

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -6834,18 +6834,18 @@
     },
     "SessionWorkingDirectoryReplacedAction": {
       "type": "object",
-      "description": "Atomically replaces the session's protected primary working-directory slot.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} is absent or empty, or when index\n`0` is not `directory`. Otherwise it replaces index `0` with `replacement`\nand removes a later duplicate of `replacement`, preserving every other\ndirectory's relative order. For example, `[A, C]` with `A → B` becomes\n`[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.\n\nOnly valid when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host\nMUST validate and apply its backend side effect before broadcasting an\naccepted action, or reject it. Clients MUST NOT dispatch this action for an\nimmutable primary.",
+      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry in place with `replacement` and removes\nany other occurrence of `replacement`, preserving every other directory's\nrelative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,\nwhile `[A, B, C]` with `B → C` becomes `[A, C]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryReplaced"
         },
         "directory": {
           "$ref": "#/$defs/URI",
-          "description": "Expected current URI in the protected primary slot."
+          "description": "URI of the existing entry to replace."
         },
         "replacement": {
           "$ref": "#/$defs/URI",
-          "description": "New URI for the protected primary slot."
+          "description": "URI to place in the replaced entry's position."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -7849,18 +7849,18 @@
     },
     "SessionWorkingDirectoryReplacedAction": {
       "type": "object",
-      "description": "Atomically replaces the session's protected primary working-directory slot.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} is absent or empty, or when index\n`0` is not `directory`. Otherwise it replaces index `0` with `replacement`\nand removes a later duplicate of `replacement`, preserving every other\ndirectory's relative order. For example, `[A, C]` with `A → B` becomes\n`[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.\n\nOnly valid when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host\nMUST validate and apply its backend side effect before broadcasting an\naccepted action, or reject it. Clients MUST NOT dispatch this action for an\nimmutable primary.",
+      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry in place with `replacement` and removes\nany other occurrence of `replacement`, preserving every other directory's\nrelative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,\nwhile `[A, B, C]` with `B → C` becomes `[A, C]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryReplaced"
         },
         "directory": {
           "$ref": "#/$defs/URI",
-          "description": "Expected current URI in the protected primary slot."
+          "description": "URI of the existing entry to replace."
         },
         "replacement": {
           "$ref": "#/$defs/URI",
-          "description": "New URI for the protected primary slot."
+          "description": "URI to place in the replaced entry's position."
         }
       },
       "required": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -616,7 +616,7 @@
         },
         "multipleWorkingDirectories": {
           "$ref": "#/$defs/MultipleWorkingDirectoriesCapability",
-          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}\n(some backends pin their first directory as a fixed process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
+          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises a protected primary-slot option (some backends pin or\nreplace their first directory as a process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
         }
       }
     },
@@ -640,7 +640,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started (e.g. the SDK's primary\n`workingDirectory`). When absent or `false`, all directories are equal\npeers and any of them may be removed."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+        },
+        "primaryReplacement": {
+          "type": "boolean",
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
         }
       }
     },
@@ -763,7 +767,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -805,7 +809,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -1109,7 +1113,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -6047,7 +6051,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (in which case\nthe first entry is a fixed process root).\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` to change the set after the session has\nstarted.\n\nIgnored for forked sessions — a fork inherits its working directories\nfrom the source session identified by `fork`."
+          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises a protected-primary capability. An\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable\nprimary} is fixed, while a\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable\nprimary} is changed only with `session/workingDirectoryReplaced`.\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch working-directory actions to change the set\nafter the session has started.\n\nIgnored for forked sessions — a fork inherits its working directories\nfrom the source session identified by `fork`."
         },
         "fork": {
           "$ref": "#/$defs/SessionForkSource",
@@ -7196,6 +7200,9 @@
           "$ref": "#/$defs/SessionWorkingDirectoryRemovedAction"
         },
         {
+          "$ref": "#/$defs/SessionWorkingDirectoryReplacedAction"
+        },
+        {
           "$ref": "#/$defs/SessionInputNeededSetAction"
         },
         {
@@ -7825,7 +7832,7 @@
     },
     "SessionWorkingDirectoryRemovedAction": {
       "type": "object",
-      "description": "A working directory was removed from the session's\n{@link SessionState.workingDirectories} set.\n\nRemoves `directory` from the set; a no-op when it is not present. There is no\natomic backend \"remove one\" primitive — a host reconfigures its agent to the\nreduced set — so this action is safe to model as idempotent. A host MAY\ndecline to apply the removal (e.g. an immutable primary directory, see\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves\nthe set unchanged.",
+      "description": "A working directory was removed from the session's\n{@link SessionState.workingDirectories} set.\n\nRemoves `directory` from the set; a no-op when it is not present. There is no\natomic backend \"remove one\" primitive — a host reconfigures its agent to the\nreduced set — so this action is safe to model as idempotent. A host MAY\ndecline to apply the removal (e.g. an immutable primary directory, see\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves\nthe set unchanged. When the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}, clients MUST\nNOT use this generic membership action to remove index `0`; the host MUST\nreject such a removal, leaving the protected slot intact.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryRemoved"
@@ -7838,6 +7845,28 @@
       "required": [
         "type",
         "directory"
+      ]
+    },
+    "SessionWorkingDirectoryReplacedAction": {
+      "type": "object",
+      "description": "Atomically replaces the session's protected primary working-directory slot.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} is absent or empty, or when index\n`0` is not `directory`. Otherwise it replaces index `0` with `replacement`\nand removes a later duplicate of `replacement`, preserving every other\ndirectory's relative order. For example, `[A, C]` with `A → B` becomes\n`[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.\n\nOnly valid when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host\nMUST validate and apply its backend side effect before broadcasting an\naccepted action, or reject it. Clients MUST NOT dispatch this action for an\nimmutable primary.",
+      "properties": {
+        "type": {
+          "const": "session/workingDirectoryReplaced"
+        },
+        "directory": {
+          "$ref": "#/$defs/URI",
+          "description": "Expected current URI in the protected primary slot."
+        },
+        "replacement": {
+          "$ref": "#/$defs/URI",
+          "description": "New URI for the protected primary slot."
+        }
+      },
+      "required": [
+        "type",
+        "directory",
+        "replacement"
       ]
     },
     "SessionInputNeededSetAction": {

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -640,11 +640,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nits URI is fixed for the lifetime of the session — clients MUST NOT remove,\nreorder, or replace it. Additional directories after it remain equal peers\nthat can be added and removed freely. When\n{@link primaryReplacement} is also `true`, clients that recognize that\ncapability MUST instead treat the primary as protected and replaceable.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. A backend MAY also\nadvertise this with {@link primaryReplacement} for compatibility with\nclients that do not recognize the newer capability: those clients retain\nthe safe immutable-primary behavior, while newer clients allow only the\ntargeted replacement action. When both are absent or `false`, all\ndirectories are equal peers."
         },
         "primaryReplacement": {
           "type": "boolean",
-          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. It MAY be `true` together with {@link immutablePrimary}; this\npreserves the immutable-primary guarantee for older clients that do not\nrecognize this capability. Clients that recognize this capability MUST\nallow a targeted replacement even when `immutablePrimary` is also `true`."
         }
       }
     },
@@ -767,7 +767,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -809,7 +809,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -1113,7 +1113,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -7849,7 +7849,7 @@
     },
     "SessionWorkingDirectoryReplacedAction": {
       "type": "object",
-      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry in place with `replacement` and removes\nany other occurrence of `replacement`, preserving every other directory's\nrelative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,\nwhile `[A, B, C]` with `B → C` becomes `[A, C]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
+      "description": "Atomically replaces one of the session's working directories.\n\nThis is a targeted compare-and-swap: the reducer is a no-op when\n{@link SessionState.workingDirectories} does not contain `directory`.\nOtherwise it replaces that entry with `replacement` and deduplicates the\nresult, preserving every other directory's relative order. When\n`replacement` occurs after the target, it moves to the target's position;\nfor example, `[A, B, C]` with `B → C` becomes `[A, C]`. When it occurs\nbefore the target, it retains its earlier position and the target is removed;\n`[A, B, C]` with `C → A` becomes `[A, B]`.\n\nOnly valid when the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`\nadditionally requires\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients\nMUST NOT target an immutable primary. The host MUST validate and apply its\nbackend side effect before broadcasting an accepted action, or reject it.",
       "properties": {
         "type": {
           "const": "session/workingDirectoryReplaced"

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -103,7 +103,7 @@
               "items": {
                 "$ref": "#/$defs/URI"
               },
-              "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+              "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
             },
             "annotations": {
               "$ref": "#/$defs/AnnotationsSummary",
@@ -779,7 +779,7 @@
         },
         "multipleWorkingDirectories": {
           "$ref": "#/$defs/MultipleWorkingDirectoriesCapability",
-          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}\n(some backends pin their first directory as a fixed process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
+          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises a protected primary-slot option (some backends pin or\nreplace their first directory as a process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
         }
       }
     },
@@ -803,7 +803,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started (e.g. the SDK's primary\n`workingDirectory`). When absent or `false`, all directories are equal\npeers and any of them may be removed."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+        },
+        "primaryReplacement": {
+          "type": "boolean",
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
         }
       }
     },
@@ -926,7 +930,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -968,7 +972,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -1272,7 +1276,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -103,7 +103,7 @@
               "items": {
                 "$ref": "#/$defs/URI"
               },
-              "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+              "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
             },
             "annotations": {
               "$ref": "#/$defs/AnnotationsSummary",
@@ -803,11 +803,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nits URI is fixed for the lifetime of the session — clients MUST NOT remove,\nreorder, or replace it. Additional directories after it remain equal peers\nthat can be added and removed freely. When\n{@link primaryReplacement} is also `true`, clients that recognize that\ncapability MUST instead treat the primary as protected and replaceable.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. A backend MAY also\nadvertise this with {@link primaryReplacement} for compatibility with\nclients that do not recognize the newer capability: those clients retain\nthe safe immutable-primary behavior, while newer clients allow only the\ntargeted replacement action. When both are absent or `false`, all\ndirectories are equal peers."
         },
         "primaryReplacement": {
           "type": "boolean",
-          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. It MAY be `true` together with {@link immutablePrimary}; this\npreserves the immutable-primary guarantee for older clients that do not\nrecognize this capability. Clients that recognize this capability MUST\nallow a targeted replacement even when `immutablePrimary` is also `true`."
         }
       }
     },
@@ -930,7 +930,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -972,7 +972,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -1276,7 +1276,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -527,7 +527,7 @@
         },
         "multipleWorkingDirectories": {
           "$ref": "#/$defs/MultipleWorkingDirectoriesCapability",
-          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}\n(some backends pin their first directory as a fixed process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
+          "description": "The session's agent can be granted tool access to more than one working\ndirectory. The directories are treated as equal peers except where the\nagent advertises a protected primary-slot option (some backends pin or\nreplace their first directory as a process root).\n\nWhen absent, clients MUST NOT mutate a session's or chat's working-directory\nset and MUST NOT set more than one entry in\n{@link CreateSessionParams.workingDirectories}."
         }
       }
     },
@@ -551,7 +551,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started (e.g. the SDK's primary\n`workingDirectory`). When absent or `false`, all directories are equal\npeers and any of them may be removed."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+        },
+        "primaryReplacement": {
+          "type": "boolean",
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
         }
       }
     },
@@ -674,7 +678,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -716,7 +720,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -1020,7 +1024,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by the `session/workingDirectorySet` /\n`session/workingDirectoryRemoved` actions. Directories are equal peers\nexcept when the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root). Individual chats MAY restrict to a\nsubset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -551,11 +551,11 @@
       "properties": {
         "immutablePrimary": {
           "type": "boolean",
-          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nit is fixed for the lifetime of the session — clients MUST NOT remove or\nreorder it. Additional directories after it remain equal peers that can be\nadded and removed freely.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. When absent or `false`,\nall directories are equal peers unless {@link primaryReplacement} is\n`true`."
+          "description": "The agent's **first** working directory (index `0` of\n{@link CreateSessionParams.workingDirectories}) is an immutable primary:\nits URI is fixed for the lifetime of the session — clients MUST NOT remove,\nreorder, or replace it. Additional directories after it remain equal peers\nthat can be added and removed freely. When\n{@link primaryReplacement} is also `true`, clients that recognize that\ncapability MUST instead treat the primary as protected and replaceable.\n\nAdvertised by backends whose agent process is rooted at a single directory\nthat cannot change once the session has started. A backend MAY also\nadvertise this with {@link primaryReplacement} for compatibility with\nclients that do not recognize the newer capability: those clients retain\nthe safe immutable-primary behavior, while newer clients allow only the\ntargeted replacement action. When both are absent or `false`, all\ndirectories are equal peers."
         },
         "primaryReplacement": {
           "type": "boolean",
-          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. A backend MUST NOT set this to `true` together with\n`immutablePrimary: true`: an immutable primary fixes the value, while a\nreplaceable primary permits changing it."
+          "description": "The agent's first working-directory slot (index `0`) is a protected primary\nwhose URI can be atomically replaced with\n`session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with\ngeneric membership actions; additional directories remain equal peers.\n\nBackends use this when their cwd-bearing directory can move during a\nsession. It MAY be `true` together with {@link immutablePrimary}; this\npreserves the immutable-primary guarantee for older clients that do not\nrecognize this capability. Clients that recognize this capability MUST\nallow a targeted replacement even when `immutablePrimary` is also `true`."
         }
       }
     },
@@ -678,7 +678,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -720,7 +720,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",
@@ -1024,7 +1024,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first\nentry is then a fixed process root) or\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is a protected, replaceable primary slot). Individual chats MAY\nrestrict to a subset via {@link ChatSummary.workingDirectories | their own\n`workingDirectories`}; a chat that sets none operates against this full\nset."
+          "description": "The working directories the session's agent has tool access to, as\nmaintained by working-directory actions. Directories are equal peers except\nwhen the agent advertises\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary} without\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first\nentry is then a fixed process root), or advertises `primaryReplacement`\n(the first entry is a protected, replaceable primary slot). Individual chats\nMAY restrict to a subset via\n{@link ChatSummary.workingDirectories | their own `workingDirectories`}; a\nchat that sets none operates against this full set."
         },
         "annotations": {
           "$ref": "#/$defs/AnnotationsSummary",

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -1419,6 +1419,7 @@ const ACTION_VARIANTS: {
   { type: 'session/activeClientRemoved', variantName: 'SessionActiveClientRemoved', tsInterface: 'SessionActiveClientRemovedAction' },
   { type: 'session/workingDirectorySet', variantName: 'SessionWorkingDirectorySet', tsInterface: 'SessionWorkingDirectorySetAction' },
   { type: 'session/workingDirectoryRemoved', variantName: 'SessionWorkingDirectoryRemoved', tsInterface: 'SessionWorkingDirectoryRemovedAction' },
+  { type: 'session/workingDirectoryReplaced', variantName: 'SessionWorkingDirectoryReplaced', tsInterface: 'SessionWorkingDirectoryReplacedAction' },
   { type: 'chat/workingDirectorySet', variantName: 'ChatWorkingDirectorySet', tsInterface: 'ChatWorkingDirectorySetAction' },
   { type: 'chat/workingDirectoryRemoved', variantName: 'ChatWorkingDirectoryRemoved', tsInterface: 'ChatWorkingDirectoryRemovedAction' },
   { type: 'session/inputNeededSet', variantName: 'SessionInputNeededSet', tsInterface: 'SessionInputNeededSetAction' },

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -1349,6 +1349,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'session/activeClientRemoved', caseName: 'SessionActiveClientRemoved', tsInterface: 'SessionActiveClientRemovedAction' },
   { type: 'session/workingDirectorySet', caseName: 'SessionWorkingDirectorySet', tsInterface: 'SessionWorkingDirectorySetAction' },
   { type: 'session/workingDirectoryRemoved', caseName: 'SessionWorkingDirectoryRemoved', tsInterface: 'SessionWorkingDirectoryRemovedAction' },
+  { type: 'session/workingDirectoryReplaced', caseName: 'SessionWorkingDirectoryReplaced', tsInterface: 'SessionWorkingDirectoryReplacedAction' },
   { type: 'chat/workingDirectorySet', caseName: 'ChatWorkingDirectorySet', tsInterface: 'ChatWorkingDirectorySetAction' },
   { type: 'chat/workingDirectoryRemoved', caseName: 'ChatWorkingDirectoryRemoved', tsInterface: 'ChatWorkingDirectoryRemovedAction' },
   { type: 'session/inputNeededSet', caseName: 'SessionInputNeededSet', tsInterface: 'SessionInputNeededSetAction' },

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -1248,6 +1248,7 @@ const ACTION_VARIANTS: {
   { type: 'session/activeClientRemoved', variantName: 'SessionActiveClientRemoved', tsInterface: 'SessionActiveClientRemovedAction' },
   { type: 'session/workingDirectorySet', variantName: 'SessionWorkingDirectorySet', tsInterface: 'SessionWorkingDirectorySetAction' },
   { type: 'session/workingDirectoryRemoved', variantName: 'SessionWorkingDirectoryRemoved', tsInterface: 'SessionWorkingDirectoryRemovedAction' },
+  { type: 'session/workingDirectoryReplaced', variantName: 'SessionWorkingDirectoryReplaced', tsInterface: 'SessionWorkingDirectoryReplacedAction' },
   { type: 'chat/workingDirectorySet', variantName: 'ChatWorkingDirectorySet', tsInterface: 'ChatWorkingDirectorySetAction' },
   { type: 'chat/workingDirectoryRemoved', variantName: 'ChatWorkingDirectoryRemoved', tsInterface: 'ChatWorkingDirectoryRemovedAction' },
   { type: 'session/inputNeededSet', variantName: 'SessionInputNeededSet', tsInterface: 'SessionInputNeededSetAction', boxed: true },

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -1242,6 +1242,7 @@ const ACTION_VARIANTS: { type: string; caseName: string; tsInterface: string }[]
   { type: 'session/activeClientRemoved', caseName: 'sessionActiveClientRemoved', tsInterface: 'SessionActiveClientRemovedAction' },
   { type: 'session/workingDirectorySet', caseName: 'sessionWorkingDirectorySet', tsInterface: 'SessionWorkingDirectorySetAction' },
   { type: 'session/workingDirectoryRemoved', caseName: 'sessionWorkingDirectoryRemoved', tsInterface: 'SessionWorkingDirectoryRemovedAction' },
+  { type: 'session/workingDirectoryReplaced', caseName: 'sessionWorkingDirectoryReplaced', tsInterface: 'SessionWorkingDirectoryReplacedAction' },
   { type: 'chat/workingDirectorySet', caseName: 'chatWorkingDirectorySet', tsInterface: 'ChatWorkingDirectorySetAction' },
   { type: 'chat/workingDirectoryRemoved', caseName: 'chatWorkingDirectoryRemoved', tsInterface: 'ChatWorkingDirectoryRemovedAction' },
   { type: 'session/inputNeededSet', caseName: 'sessionInputNeededSet', tsInterface: 'SessionInputNeededSetAction' },

--- a/types/action-origin.generated.ts
+++ b/types/action-origin.generated.ts
@@ -19,6 +19,7 @@ import type {
   SessionActiveClientRemovedAction,
   SessionWorkingDirectorySetAction,
   SessionWorkingDirectoryRemovedAction,
+  SessionWorkingDirectoryReplacedAction,
   SessionInputNeededSetAction,
   SessionInputNeededRemovedAction,
   SessionCustomizationsChangedAction,
@@ -128,6 +129,7 @@ export type SessionAction =
   | SessionActiveClientRemovedAction
   | SessionWorkingDirectorySetAction
   | SessionWorkingDirectoryRemovedAction
+  | SessionWorkingDirectoryReplacedAction
   | SessionInputNeededSetAction
   | SessionInputNeededRemovedAction
   | SessionCustomizationsChangedAction
@@ -152,6 +154,7 @@ export type ClientSessionAction =
   | SessionActiveClientRemovedAction
   | SessionWorkingDirectorySetAction
   | SessionWorkingDirectoryRemovedAction
+  | SessionWorkingDirectoryReplacedAction
   | SessionCustomizationToggledAction
   | SessionMcpServerStartRequestedAction
   | SessionMcpServerStopRequestedAction
@@ -373,6 +376,7 @@ export const IS_CLIENT_DISPATCHABLE: { readonly [K in StateAction['type']]: bool
   [ActionType.SessionActiveClientRemoved]: true,
   [ActionType.SessionWorkingDirectorySet]: true,
   [ActionType.SessionWorkingDirectoryRemoved]: true,
+  [ActionType.SessionWorkingDirectoryReplaced]: true,
   [ActionType.SessionInputNeededSet]: false,
   [ActionType.SessionInputNeededRemoved]: false,
   [ActionType.SessionCustomizationsChanged]: false,

--- a/types/channels-root/state.ts
+++ b/types/channels-root/state.ts
@@ -114,8 +114,8 @@ export interface AgentCapabilities {
   /**
    * The session's agent can be granted tool access to more than one working
    * directory. The directories are treated as equal peers except where the
-   * agent advertises {@link MultipleWorkingDirectoriesCapability.immutablePrimary}
-   * (some backends pin their first directory as a fixed process root).
+   * agent advertises a protected primary-slot option (some backends pin or
+   * replace their first directory as a process root).
    *
    * When absent, clients MUST NOT mutate a session's or chat's working-directory
    * set and MUST NOT set more than one entry in
@@ -166,11 +166,23 @@ export interface MultipleWorkingDirectoriesCapability {
    * added and removed freely.
    *
    * Advertised by backends whose agent process is rooted at a single directory
-   * that cannot change once the session has started (e.g. the SDK's primary
-   * `workingDirectory`). When absent or `false`, all directories are equal
-   * peers and any of them may be removed.
+   * that cannot change once the session has started. When absent or `false`,
+   * all directories are equal peers unless {@link primaryReplacement} is
+   * `true`.
    */
   immutablePrimary?: boolean;
+  /**
+   * The agent's first working-directory slot (index `0`) is a protected primary
+   * whose URI can be atomically replaced with
+   * `session/workingDirectoryReplaced`. Clients MUST NOT remove that slot with
+   * generic membership actions; additional directories remain equal peers.
+   *
+   * Backends use this when their cwd-bearing directory can move during a
+   * session. A backend MUST NOT set this to `true` together with
+   * `immutablePrimary: true`: an immutable primary fixes the value, while a
+   * replaceable primary permits changing it.
+   */
+  primaryReplacement?: boolean;
 }
 
 /**

--- a/types/channels-root/state.ts
+++ b/types/channels-root/state.ts
@@ -161,14 +161,19 @@ export interface MultipleWorkingDirectoriesCapability {
   /**
    * The agent's **first** working directory (index `0` of
    * {@link CreateSessionParams.workingDirectories}) is an immutable primary:
-   * it is fixed for the lifetime of the session — clients MUST NOT remove or
-   * reorder it. Additional directories after it remain equal peers that can be
-   * added and removed freely.
+   * its URI is fixed for the lifetime of the session — clients MUST NOT remove,
+   * reorder, or replace it. Additional directories after it remain equal peers
+   * that can be added and removed freely. When
+   * {@link primaryReplacement} is also `true`, clients that recognize that
+   * capability MUST instead treat the primary as protected and replaceable.
    *
    * Advertised by backends whose agent process is rooted at a single directory
-   * that cannot change once the session has started. When absent or `false`,
-   * all directories are equal peers unless {@link primaryReplacement} is
-   * `true`.
+   * that cannot change once the session has started. A backend MAY also
+   * advertise this with {@link primaryReplacement} for compatibility with
+   * clients that do not recognize the newer capability: those clients retain
+   * the safe immutable-primary behavior, while newer clients allow only the
+   * targeted replacement action. When both are absent or `false`, all
+   * directories are equal peers.
    */
   immutablePrimary?: boolean;
   /**
@@ -178,9 +183,10 @@ export interface MultipleWorkingDirectoriesCapability {
    * generic membership actions; additional directories remain equal peers.
    *
    * Backends use this when their cwd-bearing directory can move during a
-   * session. A backend MUST NOT set this to `true` together with
-   * `immutablePrimary: true`: an immutable primary fixes the value, while a
-   * replaceable primary permits changing it.
+   * session. It MAY be `true` together with {@link immutablePrimary}; this
+   * preserves the immutable-primary guarantee for older clients that do not
+   * recognize this capability. Clients that recognize this capability MUST
+   * allow a targeted replacement even when `immutablePrimary` is also `true`.
    */
   primaryReplacement?: boolean;
 }

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -306,10 +306,12 @@ export interface SessionWorkingDirectoryRemovedAction {
  *
  * This is a targeted compare-and-swap: the reducer is a no-op when
  * {@link SessionState.workingDirectories} does not contain `directory`.
- * Otherwise it replaces that entry in place with `replacement` and removes
- * any other occurrence of `replacement`, preserving every other directory's
- * relative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,
- * while `[A, B, C]` with `B → C` becomes `[A, C]`.
+ * Otherwise it replaces that entry with `replacement` and deduplicates the
+ * result, preserving every other directory's relative order. When
+ * `replacement` occurs after the target, it moves to the target's position;
+ * for example, `[A, B, C]` with `B → C` becomes `[A, C]`. When it occurs
+ * before the target, it retains its earlier position and the target is removed;
+ * `[A, B, C]` with `C → A` becomes `[A, B]`.
  *
  * Only valid when the agent advertises
  * {@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -302,20 +302,21 @@ export interface SessionWorkingDirectoryRemovedAction {
 }
 
 /**
- * Atomically replaces the session's protected primary working-directory slot.
+ * Atomically replaces one of the session's working directories.
  *
  * This is a targeted compare-and-swap: the reducer is a no-op when
- * {@link SessionState.workingDirectories} is absent or empty, or when index
- * `0` is not `directory`. Otherwise it replaces index `0` with `replacement`
- * and removes a later duplicate of `replacement`, preserving every other
- * directory's relative order. For example, `[A, C]` with `A → B` becomes
- * `[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.
+ * {@link SessionState.workingDirectories} does not contain `directory`.
+ * Otherwise it replaces that entry in place with `replacement` and removes
+ * any other occurrence of `replacement`, preserving every other directory's
+ * relative order. For example, `[A, B, C]` with `B → D` becomes `[A, D, C]`,
+ * while `[A, B, C]` with `B → C` becomes `[A, C]`.
  *
  * Only valid when the agent advertises
- * {@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host
- * MUST validate and apply its backend side effect before broadcasting an
- * accepted action, or reject it. Clients MUST NOT dispatch this action for an
- * immutable primary.
+ * {@link AgentCapabilities.multipleWorkingDirectories}. Replacing index `0`
+ * additionally requires
+ * {@link MultipleWorkingDirectoriesCapability.primaryReplacement}; clients
+ * MUST NOT target an immutable primary. The host MUST validate and apply its
+ * backend side effect before broadcasting an accepted action, or reject it.
  *
  * @category Session Actions
  * @version 1
@@ -323,9 +324,9 @@ export interface SessionWorkingDirectoryRemovedAction {
  */
 export interface SessionWorkingDirectoryReplacedAction {
   type: ActionType.SessionWorkingDirectoryReplaced;
-  /** Expected current URI in the protected primary slot. */
+  /** URI of the existing entry to replace. */
   directory: URI;
-  /** New URI for the protected primary slot. */
+  /** URI to place in the replaced entry's position. */
   replacement: URI;
 }
 

--- a/types/channels-session/actions.ts
+++ b/types/channels-session/actions.ts
@@ -286,7 +286,10 @@ export interface SessionWorkingDirectorySetAction {
  * reduced set — so this action is safe to model as idempotent. A host MAY
  * decline to apply the removal (e.g. an immutable primary directory, see
  * {@link MultipleWorkingDirectoriesCapability.immutablePrimary}); it then leaves
- * the set unchanged.
+ * the set unchanged. When the agent advertises
+ * {@link MultipleWorkingDirectoriesCapability.primaryReplacement}, clients MUST
+ * NOT use this generic membership action to remove index `0`; the host MUST
+ * reject such a removal, leaving the protected slot intact.
  *
  * @category Session Actions
  * @version 1
@@ -296,6 +299,34 @@ export interface SessionWorkingDirectoryRemovedAction {
   type: ActionType.SessionWorkingDirectoryRemoved;
   /** The working directory to revoke the session's agent tool access to. */
   directory: URI;
+}
+
+/**
+ * Atomically replaces the session's protected primary working-directory slot.
+ *
+ * This is a targeted compare-and-swap: the reducer is a no-op when
+ * {@link SessionState.workingDirectories} is absent or empty, or when index
+ * `0` is not `directory`. Otherwise it replaces index `0` with `replacement`
+ * and removes a later duplicate of `replacement`, preserving every other
+ * directory's relative order. For example, `[A, C]` with `A → B` becomes
+ * `[B, C]`, while `[A, B, C]` with `A → B` becomes `[B, C]`.
+ *
+ * Only valid when the agent advertises
+ * {@link MultipleWorkingDirectoriesCapability.primaryReplacement}. The host
+ * MUST validate and apply its backend side effect before broadcasting an
+ * accepted action, or reject it. Clients MUST NOT dispatch this action for an
+ * immutable primary.
+ *
+ * @category Session Actions
+ * @version 1
+ * @clientDispatchable
+ */
+export interface SessionWorkingDirectoryReplacedAction {
+  type: ActionType.SessionWorkingDirectoryReplaced;
+  /** Expected current URI in the protected primary slot. */
+  directory: URI;
+  /** New URI for the protected primary slot. */
+  replacement: URI;
 }
 
 // ─── Input Needed Actions ────────────────────────────────────────────────────

--- a/types/channels-session/commands.ts
+++ b/types/channels-session/commands.ts
@@ -69,16 +69,17 @@ export interface CreateSessionParams extends BaseParams {
   /**
    * The working directories the session's agent is granted tool access to.
    * A session may span multiple directories; they are equal peers except when
-   * the agent advertises
-   * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (in which case
-   * the first entry is a fixed process root).
+   * the agent advertises a protected-primary capability. An
+   * {@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable
+   * primary} is fixed, while a
+   * {@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable
+   * primary} is changed only with `session/workingDirectoryReplaced`.
    *
    * A client MUST NOT supply more than one entry unless the agent advertises
    * {@link AgentCapabilities.multipleWorkingDirectories}; a server without that
    * capability treats only the first entry as the session's working directory
-   * and ignores the rest. Dispatch `session/workingDirectorySet` /
-   * `session/workingDirectoryRemoved` to change the set after the session has
-   * started.
+   * and ignores the rest. Dispatch working-directory actions to change the set
+   * after the session has started.
    *
    * Ignored for forked sessions — a fork inherits its working directories
    * from the source session identified by `fork`.

--- a/types/channels-session/reducer.ts
+++ b/types/channels-session/reducer.ts
@@ -296,6 +296,13 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
       if (idx < 0) {
         return state;
       }
+      const replacementIdx = list.indexOf(action.replacement);
+      if (replacementIdx >= 0 && replacementIdx < idx) {
+        return {
+          ...state,
+          workingDirectories: list.filter((_, index) => index !== idx),
+        };
+      }
       return {
         ...state,
         workingDirectories: list

--- a/types/channels-session/reducer.ts
+++ b/types/channels-session/reducer.ts
@@ -289,15 +289,18 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
 
     case ActionType.SessionWorkingDirectoryReplaced: {
       const list = state.workingDirectories;
-      if (!list?.length || list[0] !== action.directory) {
+      if (!list) {
+        return state;
+      }
+      const idx = list.indexOf(action.directory);
+      if (idx < 0) {
         return state;
       }
       return {
         ...state,
-        workingDirectories: [
-          action.replacement,
-          ...list.slice(1).filter(directory => directory !== action.replacement),
-        ],
+        workingDirectories: list
+          .map((directory, index) => (index === idx ? action.replacement : directory))
+          .filter((directory, index) => index === idx || directory !== action.replacement),
       };
     }
 

--- a/types/channels-session/reducer.ts
+++ b/types/channels-session/reducer.ts
@@ -287,6 +287,20 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
       return { ...state, workingDirectories: updated };
     }
 
+    case ActionType.SessionWorkingDirectoryReplaced: {
+      const list = state.workingDirectories;
+      if (!list?.length || list[0] !== action.directory) {
+        return state;
+      }
+      return {
+        ...state,
+        workingDirectories: [
+          action.replacement,
+          ...list.slice(1).filter(directory => directory !== action.replacement),
+        ],
+      };
+    }
+
     // ── Input Needed ────────────────────────────────────────────────────
 
     case ActionType.SessionInputNeededSet: {

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -87,13 +87,13 @@ export interface SessionMetadata {
    * The working directories the session's agent has tool access to, as
    * maintained by working-directory actions. Directories are equal peers except
    * when the agent advertises
-   * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-   * entry is then a fixed process root) or
+   * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} without
    * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
-   * entry is a protected, replaceable primary slot). Individual chats MAY
-   * restrict to a subset via {@link ChatSummary.workingDirectories | their own
-   * `workingDirectories`}; a chat that sets none operates against this full
-   * set.
+   * entry is then a fixed process root), or advertises `primaryReplacement`
+   * (the first entry is a protected, replaceable primary slot). Individual chats
+   * MAY restrict to a subset via
+   * {@link ChatSummary.workingDirectories | their own `workingDirectories`}; a
+   * chat that sets none operates against this full set.
    */
   workingDirectories?: URI[];
   /**

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -85,12 +85,13 @@ export interface SessionMetadata {
   project?: ProjectInfo;
   /**
    * The working directories the session's agent has tool access to, as
-   * maintained by the `session/workingDirectorySet` /
-   * `session/workingDirectoryRemoved` actions. Directories are equal peers
-   * except when the agent advertises
+   * maintained by working-directory actions. Directories are equal peers except
+   * when the agent advertises
    * {@link MultipleWorkingDirectoriesCapability.immutablePrimary} (the first
-   * entry is then a fixed process root). Individual chats MAY restrict to a
-   * subset via {@link ChatSummary.workingDirectories | their own
+   * entry is then a fixed process root) or
+   * {@link MultipleWorkingDirectoriesCapability.primaryReplacement} (the first
+   * entry is a protected, replaceable primary slot). Individual chats MAY
+   * restrict to a subset via {@link ChatSummary.workingDirectories | their own
    * `workingDirectories`}; a chat that sets none operates against this full
    * set.
    */

--- a/types/common/actions.ts
+++ b/types/common/actions.ts
@@ -28,6 +28,7 @@ import type {
   SessionActiveClientRemovedAction,
   SessionWorkingDirectorySetAction,
   SessionWorkingDirectoryRemovedAction,
+  SessionWorkingDirectoryReplacedAction,
   SessionInputNeededSetAction,
   SessionInputNeededRemovedAction,
   SessionCustomizationsChangedAction,
@@ -156,6 +157,7 @@ export const enum ActionType {
   SessionActiveClientRemoved = 'session/activeClientRemoved',
   SessionWorkingDirectorySet = 'session/workingDirectorySet',
   SessionWorkingDirectoryRemoved = 'session/workingDirectoryRemoved',
+  SessionWorkingDirectoryReplaced = 'session/workingDirectoryReplaced',
   SessionInputNeededSet = 'session/inputNeededSet',
   SessionInputNeededRemoved = 'session/inputNeededRemoved',
   ChatPendingMessageSet = 'chat/pendingMessageSet',
@@ -259,6 +261,7 @@ export type StateAction =
   | SessionActiveClientRemovedAction
   | SessionWorkingDirectorySetAction
   | SessionWorkingDirectoryRemovedAction
+  | SessionWorkingDirectoryReplacedAction
   | SessionInputNeededSetAction
   | SessionInputNeededRemovedAction
   | SessionCustomizationsChangedAction

--- a/types/test-cases/reducers/264-session-workingdirectoryreplaced-no-op-when-absent.json
+++ b/types/test-cases/reducers/264-session-workingdirectoryreplaced-no-op-when-absent.json
@@ -1,0 +1,27 @@
+{
+  "description": "session-workingDirectoryReplaced is a no-op when working directories are absent",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": []
+  },
+  "actions": [
+    {
+      "type": "session/workingDirectoryReplaced",
+      "directory": "file:///repo-a",
+      "replacement": "file:///repo-b"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": []
+  }
+}

--- a/types/test-cases/reducers/266-session-workingdirectoryreplaced-no-op-when-directory-is-absent.json
+++ b/types/test-cases/reducers/266-session-workingdirectoryreplaced-no-op-when-directory-is-absent.json
@@ -1,5 +1,5 @@
 {
-  "description": "session-workingDirectoryReplaced is a no-op when the expected primary does not match",
+  "description": "session-workingDirectoryReplaced is a no-op when the directory is absent",
   "reducer": "session",
   "initial": {
     "provider": "copilot",

--- a/types/test-cases/reducers/266-session-workingdirectoryreplaced-no-op-when-primary-does-not-match.json
+++ b/types/test-cases/reducers/266-session-workingdirectoryreplaced-no-op-when-primary-does-not-match.json
@@ -1,0 +1,35 @@
+{
+  "description": "session-workingDirectoryReplaced is a no-op when the expected primary does not match",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "workingDirectories": [
+      "file:///repo-a",
+      "file:///repo-c"
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/workingDirectoryReplaced",
+      "directory": "file:///repo-b",
+      "replacement": "file:///repo-d"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "workingDirectories": [
+      "file:///repo-a",
+      "file:///repo-c"
+    ]
+  }
+}

--- a/types/test-cases/reducers/267-session-workingdirectoryreplaced-replaces-and-deduplicates.json
+++ b/types/test-cases/reducers/267-session-workingdirectoryreplaced-replaces-and-deduplicates.json
@@ -1,0 +1,36 @@
+{
+  "description": "session-workingDirectoryReplaced replaces the primary and deduplicates a later replacement",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "workingDirectories": [
+      "file:///repo-a",
+      "file:///repo-b",
+      "file:///repo-c"
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/workingDirectoryReplaced",
+      "directory": "file:///repo-a",
+      "replacement": "file:///repo-b"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "workingDirectories": [
+      "file:///repo-b",
+      "file:///repo-c"
+    ]
+  }
+}

--- a/types/test-cases/reducers/268-session-workingdirectoryreplaced-replaces-primary.json
+++ b/types/test-cases/reducers/268-session-workingdirectoryreplaced-replaces-primary.json
@@ -1,0 +1,35 @@
+{
+  "description": "session-workingDirectoryReplaced replaces the primary while preserving later directories",
+  "reducer": "session",
+  "initial": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "workingDirectories": [
+      "file:///repo-a",
+      "file:///repo-c"
+    ]
+  },
+  "actions": [
+    {
+      "type": "session/workingDirectoryReplaced",
+      "directory": "file:///repo-a",
+      "replacement": "file:///repo-b"
+    }
+  ],
+  "expected": {
+    "provider": "copilot",
+    "title": "Test Session",
+    "status": 1,
+    "lifecycle": "ready",
+    "activeClients": [],
+    "chats": [],
+    "workingDirectories": [
+      "file:///repo-b",
+      "file:///repo-c"
+    ]
+  }
+}

--- a/types/test-cases/reducers/269-session-workingdirectoryreplaced-replaces-non-primary.json
+++ b/types/test-cases/reducers/269-session-workingdirectoryreplaced-replaces-non-primary.json
@@ -1,5 +1,5 @@
 {
-  "description": "session-workingDirectoryReplaced replaces an entry and deduplicates a later replacement",
+  "description": "session-workingDirectoryReplaced replaces a non-primary entry in place",
   "reducer": "session",
   "initial": {
     "provider": "copilot",
@@ -18,7 +18,7 @@
     {
       "type": "session/workingDirectoryReplaced",
       "directory": "file:///repo-b",
-      "replacement": "file:///repo-c"
+      "replacement": "file:///repo-d"
     }
   ],
   "expected": {
@@ -30,6 +30,7 @@
     "chats": [],
     "workingDirectories": [
       "file:///repo-a",
+      "file:///repo-d",
       "file:///repo-c"
     ]
   }

--- a/types/test-cases/reducers/270-session-workingdirectoryreplaced-deduplicates-earlier-replacement.json
+++ b/types/test-cases/reducers/270-session-workingdirectoryreplaced-deduplicates-earlier-replacement.json
@@ -1,5 +1,5 @@
 {
-  "description": "session-workingDirectoryReplaced keeps the replacement at the target position when deduplicating an earlier entry",
+  "description": "session-workingDirectoryReplaced retains an earlier replacement when deduplicating",
   "reducer": "session",
   "initial": {
     "provider": "copilot",
@@ -29,8 +29,8 @@
     "activeClients": [],
     "chats": [],
     "workingDirectories": [
-      "file:///repo-b",
-      "file:///repo-a"
+      "file:///repo-a",
+      "file:///repo-b"
     ]
   }
 }

--- a/types/test-cases/reducers/270-session-workingdirectoryreplaced-deduplicates-earlier-replacement.json
+++ b/types/test-cases/reducers/270-session-workingdirectoryreplaced-deduplicates-earlier-replacement.json
@@ -1,5 +1,5 @@
 {
-  "description": "session-workingDirectoryReplaced replaces an entry and deduplicates a later replacement",
+  "description": "session-workingDirectoryReplaced keeps the replacement at the target position when deduplicating an earlier entry",
   "reducer": "session",
   "initial": {
     "provider": "copilot",
@@ -17,8 +17,8 @@
   "actions": [
     {
       "type": "session/workingDirectoryReplaced",
-      "directory": "file:///repo-b",
-      "replacement": "file:///repo-c"
+      "directory": "file:///repo-c",
+      "replacement": "file:///repo-a"
     }
   ],
   "expected": {
@@ -29,8 +29,8 @@
     "activeClients": [],
     "chats": [],
     "workingDirectories": [
-      "file:///repo-a",
-      "file:///repo-c"
+      "file:///repo-b",
+      "file:///repo-a"
     ]
   }
 }

--- a/types/version/registry.ts
+++ b/types/version/registry.ts
@@ -93,6 +93,7 @@ export const ACTION_INTRODUCED_IN: { readonly [K in StateAction['type']]: string
   [ActionType.SessionActiveClientRemoved]: '0.5.0',
   [ActionType.SessionWorkingDirectorySet]: '0.7.0',
   [ActionType.SessionWorkingDirectoryRemoved]: '0.7.0',
+  [ActionType.SessionWorkingDirectoryReplaced]: '0.8.0',
   [ActionType.SessionInputNeededSet]: '0.5.1',
   [ActionType.SessionInputNeededRemoved]: '0.5.1',
   [ActionType.SessionCustomizationsChanged]: '0.1.0',


### PR DESCRIPTION
## Summary

- add client-dispatchable `session/workingDirectoryReplaced` to atomically replace any matching working-directory entry in place
- use the existing URI as a compare-and-swap guard, deduplicate the replacement URI wherever it already exists, and preserve unrelated directory ordering
- add `MultipleWorkingDirectoriesCapability.primaryReplacement` to indicate that the protected index-0 entry may also be replaced
- propagate the action through schemas, generated clients, and the hand-written Go, Rust, Kotlin, and Swift reducers

Replacing an ordinary entry requires `multipleWorkingDirectories`. Targeting index 0 additionally requires `primaryReplacement: true`; `immutablePrimary: true` and `primaryReplacement: true` cannot both be advertised. This keeps `workingDirectories` as the protocol state instead of introducing a separate primary-working-directory field.

## Validation

- `npm run generate`
- `npm test`
- `cd clients/go && go test ./...`
- `cd clients/rust && cargo test -p ahp`
- `cd clients/swift/AgentHostProtocol && swift test --filter FixtureDrivenReducerTests`
- Kotlin `./gradlew test --no-daemon --console=plain` in the prescribed `eclipse-temurin:17-jdk` Podman container

Fixes #392