### PR TITLE
protocol: shore up 1.0 state contracts

### DIFF
--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -2,7 +2,6 @@ package ahp
 
 import (
 	"encoding/json"
-	"sync"
 	"time"
 
 	"github.com/microsoft/agent-host-protocol/clients/go/ahptypes"
@@ -26,35 +25,16 @@ const (
 	ReduceOutcomeOutOfScope
 )
 
-// ─── Injectable timestamp ──────────────────────────────────────────────
-
-var (
-	nowMu       sync.RWMutex
-	nowProvider func() int64 = func() int64 { return time.Now().UnixMilli() }
-)
-
-// SetNowProvider overrides the clock reducers use to stamp modifiedAt fields.
-// Chat modifiedAt values are formatted as ISO 8601 strings from this clock;
-// session summary modifiedAt keeps the numeric millisecond timestamp. Pass nil
-// to restore the default ([time.Now].UnixMilli).
-func SetNowProvider(fn func() int64) {
-	nowMu.Lock()
-	defer nowMu.Unlock()
-	if fn == nil {
-		nowProvider = func() int64 { return time.Now().UnixMilli() }
-	} else {
-		nowProvider = fn
+func addMillisecondsToTimestamp(timestamp string, duration int64) string {
+	start, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		panic("invalid ISO 8601 timestamp: " + timestamp)
 	}
-}
-
-func nowMs() int64 {
-	nowMu.RLock()
-	defer nowMu.RUnlock()
-	return nowProvider()
-}
-
-func nowISOString() string {
-	return time.UnixMilli(nowMs()).UTC().Format("2006-01-02T15:04:05.000Z")
+	delta := time.Duration(duration) * time.Millisecond
+	if int64(delta/time.Millisecond) != duration {
+		panic("timestamp duration overflows time.Duration")
+	}
+	return start.Add(delta).UTC().Format("2006-01-02T15:04:05.000Z")
 }
 
 // ─── Status helpers ────────────────────────────────────────────────────
@@ -209,10 +189,6 @@ func refreshSummaryStatus(state *ahptypes.ChatState) {
 	state.Status = summaryStatus(state, nil)
 }
 
-func touchChatModified(state *ahptypes.ChatState) {
-	state.ModifiedAt = nowISOString()
-}
-
 // ─── Active-turn helpers ───────────────────────────────────────────────
 
 func endTurn(state *ahptypes.ChatState, turnID string, duration int64, turnState ahptypes.TurnState, terminalStatus *ahptypes.SessionStatus, errInfo *ahptypes.ErrorInfo) ReduceOutcome {
@@ -272,7 +248,7 @@ func endTurn(state *ahptypes.ChatState, turnID string, duration int64, turnState
 	}
 
 	state.Turns = append(state.Turns, turn)
-	state.ModifiedAt = nowISOString()
+	state.ModifiedAt = addMillisecondsToTimestamp(active.StartedAt, duration)
 	state.Status = summaryStatus(state, terminalStatus)
 	return ReduceOutcomeApplied
 }
@@ -294,7 +270,6 @@ func upsertInputRequest(state *ahptypes.ChatState, req ahptypes.ChatInputRequest
 			}
 			state.ActiveTurn.ResponseParts = parts
 			state.Status = summaryStatus(state, nil)
-			touchChatModified(state)
 			state.Status = withStatusFlag(state.Status, ahptypes.SessionStatusIsRead, false)
 			return ReduceOutcomeApplied
 		}
@@ -306,7 +281,6 @@ func upsertInputRequest(state *ahptypes.ChatState, req ahptypes.ChatInputRequest
 		},
 	})
 	state.Status = summaryStatus(state, nil)
-	touchChatModified(state)
 	state.Status = withStatusFlag(state.Status, ahptypes.SessionStatusIsRead, false)
 	return ReduceOutcomeApplied
 }
@@ -691,7 +665,6 @@ func ApplyActionToChat(state *ahptypes.ChatState, action ahptypes.StateAction) R
 				Response: &response,
 			}
 			refreshSummaryStatus(state)
-			touchChatModified(state)
 			return ReduceOutcomeApplied
 		}
 		return ReduceOutcomeNoOp
@@ -817,7 +790,7 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 		state.Lifecycle = ahptypes.SessionLifecycleReady
 		return ReduceOutcomeApplied
 	case *ahptypes.SessionCreationFailedAction:
-		state.Lifecycle = ahptypes.SessionLifecycleCreationFailed
+		state.Lifecycle = ahptypes.SessionLifecycleFailed
 		errCopy := a.Error
 		state.CreationError = &errCopy
 		return ReduceOutcomeApplied
@@ -1055,7 +1028,7 @@ func applyTurnStarted(state *ahptypes.ChatState, a *ahptypes.ChatTurnStartedActi
 		ResponseParts: []ahptypes.ResponsePart{},
 	}
 	state.Status = summaryStatus(state, nil)
-	state.ModifiedAt = nowISOString()
+	state.ModifiedAt = a.StartedAt
 	state.Status = withStatusFlag(state.Status, ahptypes.SessionStatusIsRead, false)
 
 	if a.QueuedMessageId != nil {
@@ -1533,7 +1506,6 @@ func applyTruncated(state *ahptypes.ChatState, turnID *string) ReduceOutcome {
 		state.Turns = state.Turns[:idx+1]
 	}
 	state.ActiveTurn = nil
-	touchChatModified(state)
 	state.Status = summaryStatus(state, nil)
 	return ReduceOutcomeApplied
 }
@@ -1559,7 +1531,6 @@ func applyInputAnswerChanged(state *ahptypes.ChatState, a *ahptypes.ChatInputAns
 		if len(req.Answers) == 0 {
 			req.Answers = nil
 		}
-		touchChatModified(state)
 		return ReduceOutcomeApplied
 	}
 	return ReduceOutcomeNoOp
@@ -1594,7 +1565,10 @@ func ApplyActionToTerminal(state *ahptypes.TerminalState, action ahptypes.StateA
 		state.Cwd = &cwd
 		return ReduceOutcomeApplied
 	case *ahptypes.TerminalExitedAction:
-		state.ExitCode = a.ExitCode
+		state.Lifecycle = ahptypes.TerminalLifecycleState{Value: &ahptypes.TerminalExitedLifecycleState{
+			Status:   ahptypes.TerminalLifecycleStatusExited,
+			ExitCode: a.ExitCode,
+		}}
 		return ReduceOutcomeApplied
 	case *ahptypes.TerminalClearedAction:
 		state.Content = []ahptypes.TerminalContentPart{}
@@ -1714,7 +1688,6 @@ func ApplyActionToChangeset(state *ahptypes.ChangesetState, action ahptypes.Stat
 		if a.Operations != nil {
 			state.Operations = a.Operations
 		}
-		state.Error = a.Error
 		return ReduceOutcomeApplied
 
 	case *ahptypes.ChangesetOperationsChangedAction:
@@ -1765,8 +1738,8 @@ func ApplyActionToAnnotations(state *ahptypes.AnnotationsState, action ahptypes.
 	case *ahptypes.AnnotationsUpdatedAction:
 		for i := range state.Annotations {
 			if state.Annotations[i].Id == a.AnnotationId {
-				if a.TurnId != nil {
-					state.Annotations[i].TurnId = *a.TurnId
+				if a.Origin != nil {
+					state.Annotations[i].Origin = *a.Origin
 				}
 				if a.Resource != nil {
 					state.Annotations[i].Resource = *a.Resource

--- a/clients/go/ahp/reducers_fixture_test.go
+++ b/clients/go/ahp/reducers_fixture_test.go
@@ -91,13 +91,6 @@ var reducerFixturesSkipList = map[string]string{
 func TestFixtureDrivenReducerParity(t *testing.T) {
 	dir := findFixtureDir(t)
 
-	// Use a deterministic timestamp so modifiedAt matches the TypeScript
-	// reference reducer: Date.now() === 9999, so chat timestamps become
-	// "1970-01-01T00:00:09.999Z".
-	const mockNowMillis int64 = 9999
-	SetNowProvider(func() int64 { return mockNowMillis })
-	t.Cleanup(func() { SetNowProvider(nil) })
-
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -1232,8 +1232,6 @@ type ChangesetContentChangedAction struct {
 	Files []ChangesetFile `json:"files"`
 	// Full replacement operation list. Omit when operations are unchanged.
 	Operations []ChangesetOperation `json:"operations,omitempty"`
-	// Error information, if the changeset content change failed.
-	Error *ErrorInfo `json:"error,omitempty"`
 }
 
 // The set of operations available on this changeset changed. Full
@@ -1321,10 +1319,8 @@ type AnnotationsUpdatedAction struct {
 	Type ActionType `json:"type"`
 	// The {@link Annotation.id} of the annotation to update.
 	AnnotationId string `json:"annotationId"`
-	// Re-anchors the annotation to the file versions this turn produced.
-	// Matches a {@link Turn.id} on the owning session. Omit to leave the
-	// current {@link Annotation.turnId} unchanged.
-	TurnId *string `json:"turnId,omitempty"`
+	// Replaces the annotation's provenance. Omit to leave it unchanged.
+	Origin *AnnotationOrigin `json:"origin,omitempty"`
 	// Re-anchors the annotation to this file. Omit to leave the current
 	// {@link Annotation.resource} unchanged.
 	Resource *URI `json:"resource,omitempty"`

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -366,13 +366,6 @@ type SubscribeResult struct {
 // After creation, the client should subscribe to the session URI to receive state
 // updates. The server also broadcasts a `root/sessionAdded` notification to all
 // clients.
-type SessionForkSource struct {
-	// URI of the existing session to fork from
-	Session URI `json:"session"`
-	// Turn ID in the source session; content up to and including this turn's response is copied
-	TurnId string `json:"turnId"`
-}
-
 type CreateSessionParams struct {
 	// Channel URI this command targets.
 	Channel URI `json:"channel"`
@@ -394,13 +387,7 @@ type CreateSessionParams struct {
 	// capability treats only the first entry as the session's working directory
 	// and ignores the rest. Dispatch working-directory actions to change the set
 	// after the session has started.
-	//
-	// Ignored for forked sessions — a fork inherits its working directories
-	// from the source session identified by `fork`.
 	WorkingDirectories []URI `json:"workingDirectories,omitempty"`
-	// Fork from an existing session. The new session is populated with content
-	// from the source session up to and including the specified turn's response.
-	Fork *SessionForkSource `json:"fork,omitempty"`
 	// Agent-specific configuration values collected via `resolveSessionConfig`.
 	// Keys and values correspond to the schema returned by the server.
 	Config map[string]json.RawMessage `json:"config,omitempty"`

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -28,9 +28,9 @@ const (
 type SessionLifecycle string
 
 const (
-	SessionLifecycleCreating       SessionLifecycle = "creating"
-	SessionLifecycleReady          SessionLifecycle = "ready"
-	SessionLifecycleCreationFailed SessionLifecycle = "creationFailed"
+	SessionLifecycleCreating SessionLifecycle = "creating"
+	SessionLifecycleReady    SessionLifecycle = "ready"
+	SessionLifecycleFailed   SessionLifecycle = "failed"
 )
 
 // Bitset of summary-level session status flags.
@@ -347,6 +347,14 @@ type TerminalClaimKind string
 const (
 	TerminalClaimKindClient  TerminalClaimKind = "client"
 	TerminalClaimKindSession TerminalClaimKind = "session"
+)
+
+// Lifecycle status of a terminal process.
+type TerminalLifecycleStatus string
+
+const (
+	TerminalLifecycleStatusRunning TerminalLifecycleStatus = "running"
+	TerminalLifecycleStatusExited  TerminalLifecycleStatus = "exited"
 )
 
 // Discriminant for the {@link McpServerState} union.
@@ -3248,8 +3256,8 @@ type TerminalInfo struct {
 	Title string `json:"title"`
 	// Who currently holds this terminal
 	Claim TerminalClaim `json:"claim"`
-	// Process exit code, if the terminal process has exited
-	ExitCode *int64 `json:"exitCode,omitempty"`
+	// Current terminal process lifecycle.
+	Lifecycle TerminalLifecycleState `json:"lifecycle"`
 }
 
 // A terminal claimed by a connected client.
@@ -3266,10 +3274,24 @@ type TerminalSessionClaim struct {
 	Kind TerminalClaimKind `json:"kind"`
 	// Session URI that claimed the terminal
 	Session URI `json:"session"`
-	// Optional turn identifier within the session
+	// Chat URI that claimed the terminal.
+	Chat URI `json:"chat"`
+	// Optional turn identifier within the chat.
 	TurnId *string `json:"turnId,omitempty"`
 	// Optional tool call identifier within the turn
 	ToolCallId *string `json:"toolCallId,omitempty"`
+}
+
+// A terminal process that is still running.
+type TerminalRunningLifecycleState struct {
+	Status TerminalLifecycleStatus `json:"status"`
+}
+
+// A terminal process that has exited.
+type TerminalExitedLifecycleState struct {
+	Status TerminalLifecycleStatus `json:"status"`
+	// Process exit code, if the runtime reported one.
+	ExitCode *int64 `json:"exitCode,omitempty"`
 }
 
 // Full state for a single terminal, loaded when a client subscribes to the terminal's URI.
@@ -3289,8 +3311,8 @@ type TerminalState struct {
 	//
 	// Consumers that need command boundaries can filter by part type.
 	Content []TerminalContentPart `json:"content"`
-	// Process exit code, set when the terminal process exits
-	ExitCode *int64 `json:"exitCode,omitempty"`
+	// Current terminal process lifecycle.
+	Lifecycle TerminalLifecycleState `json:"lifecycle"`
 	// Who currently holds this terminal
 	Claim TerminalClaim `json:"claim"`
 	// Whether this terminal emits `terminal/commandExecuted` and
@@ -3561,14 +3583,22 @@ type AnnotationsState struct {
 	Annotations []Annotation `json:"annotations"`
 }
 
-// A conversation anchored to a specific file produced by a specific turn,
-// optionally narrowed to a range within that file.
+// Provenance of the content an annotation is anchored to.
+type AnnotationOrigin struct {
+	// Owning session URI.
+	Session URI `json:"session"`
+	// Owning chat URI, when the annotation is scoped to a chat.
+	Chat *URI `json:"chat,omitempty"`
+	// Turn identifier within {@link chat}, when the annotation is scoped to a turn.
+	TurnId *string `json:"turnId,omitempty"`
+}
+
+// A conversation anchored to a specific file in a session, optionally scoped
+// to a chat and turn and narrowed to a range within that file.
 //
-// {@link turnId} anchors the annotation to the file versions that turn
-// produced, so a later turn that rewrites the same file does not silently
-// invalidate the annotation's anchor — clients can resolve {@link resource}
-// and {@link range} against the turn's changeset. When {@link range} is
-// omitted the annotation is anchored to the entire file.
+// {@link origin} identifies the owning session and, when available, the chat
+// and turn that produced the file version. When {@link range} is omitted the
+// annotation is anchored to the entire file.
 //
 // Every annotation MUST contain at least one {@link AnnotationEntry}. An
 // {@link AnnotationsSetAction} that creates an annotation therefore carries
@@ -3579,9 +3609,8 @@ type Annotation struct {
 	// Stable identifier within the annotations channel. Assigned by the client
 	// that dispatches the creating {@link AnnotationsSetAction}.
 	Id string `json:"id"`
-	// Turn that produced the file versions this annotation is anchored to.
-	// Matches a {@link Turn.id} on the owning session.
-	TurnId string `json:"turnId"`
+	// Provenance of the content this annotation is anchored to.
+	Origin AnnotationOrigin `json:"origin"`
 	// The file the annotation is anchored to.
 	Resource URI `json:"resource"`
 	// Range within {@link resource} the annotation is anchored to. When
@@ -5345,6 +5374,54 @@ func (u ToolCallRiskAssessment) MarshalJSON() ([]byte, error) {
 		}
 		return unk.Raw, nil
 	}
+	if u.Value == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(u.Value)
+}
+
+// TerminalLifecycleState is the current lifecycle of a terminal process.
+type TerminalLifecycleState struct {
+	Value isTerminalLifecycleState
+}
+
+// isTerminalLifecycleState is the marker interface implemented by every
+// concrete variant of TerminalLifecycleState.
+type isTerminalLifecycleState interface{ isTerminalLifecycleState() }
+
+func (*TerminalRunningLifecycleState) isTerminalLifecycleState() {}
+func (*TerminalExitedLifecycleState) isTerminalLifecycleState()  {}
+
+// UnmarshalJSON decodes the variant indicated by the "status" discriminator.
+func (u *TerminalLifecycleState) UnmarshalJSON(data []byte) error {
+	disc, ok, err := readDiscriminator(data, "status")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return missingDiscriminatorError("TerminalLifecycleState", "status")
+	}
+	switch disc {
+	case "running":
+		var value TerminalRunningLifecycleState
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	case "exited":
+		var value TerminalExitedLifecycleState
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		u.Value = &value
+	default:
+		return unknownDiscriminatorError("TerminalLifecycleState", "status", disc)
+	}
+	return nil
+}
+
+// MarshalJSON encodes the active variant back to JSON.
+func (u TerminalLifecycleState) MarshalJSON() ([]byte, error) {
 	if u.Value == nil {
 		return []byte("null"), nil
 	}

--- a/clients/kotlin/AGENTS.md
+++ b/clients/kotlin/AGENTS.md
@@ -177,15 +177,11 @@ The Kotlin port preserves Swift parity caveats already documented in PR #115:
 2. **Discriminator validation** — no runtime check that, e.g., a `MarkdownResponsePart`'s `kind` matches `MARKDOWN`. Mirrors Swift. For forward-compat unions, an *unrecognised* discriminator decodes to the `XUnknown(val raw: JsonObject)` variant (mirrors Rust's `Unknown(serde_json::Value)`) and round-trips its raw payload on re-encode.
 3. **`StateActionUnknown`** — captures the full raw JSON object of an unknown action (same shape as the state-channel `XUnknown` variants). The reducer treats it as a no-op. Re-encoding round-trips the original payload back to the wire.
 
-### Injectable timestamp
+### Deterministic timestamps
 
-The session reducer stamps `summary.modifiedAt` whenever it mutates fields that semantically advance the session's modification time (turn lifecycle, title change, agent change, customization update, input request changes, etc.). The stamp comes from a top-level `var`:
-
-```kotlin
-public var currentTimestampProvider: () -> Long = { System.currentTimeMillis() }
-```
-
-Tests override this with a constant to produce deterministic output, then restore the default in `@AfterEach`. The provider is global mutable state; if you parallelize tests across JVM threads, snap a value into a `ThreadLocal` first.
+Reducers never read the local clock. `chat/turnStarted` copies its producer-supplied
+`startedAt` into `modifiedAt`, and turn-ending actions derive `modifiedAt` by adding
+their producer-supplied duration to the active turn's `startedAt`.
 
 ### Cross-language parity tests
 
@@ -197,4 +193,4 @@ A small `SKIPPED_FIXTURES` set carries any fixtures intentionally skipped becaus
 
 ### `ReducersTest`
 
-`ReducersTest` covers a handful of behaviors that benefit from explicit local coverage: the `Reducer<S, A>` `object` wrappers delegating to the free functions, `terminal/input` being a no-op (returns the same instance), the queued message reorder algorithm (preserves messages not mentioned in `order`; ignores duplicates and unknown ids), pending steering vs. queued message upsert semantics, and the `currentTimestampProvider` override flowing through.
+`ReducersTest` covers a handful of behaviors that benefit from explicit local coverage: the `Reducer<S, A>` `object` wrappers delegating to the free functions, `terminal/input` being a no-op (returns the same instance), the queued message reorder algorithm (preserves messages not mentioned in `order`; ignores duplicates and unknown ids), pending steering vs. queued message upsert semantics, and deterministic turn timestamps.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -9,6 +9,7 @@ package com.microsoft.agenthostprotocol
 
 import com.microsoft.agenthostprotocol.generated.*
 import java.time.Instant
+import java.time.format.DateTimeFormatterBuilder
 import kotlinx.serialization.json.JsonElement
 
 // ─── Reducer Interface ──────────────────────────────────────────────────────
@@ -83,17 +84,10 @@ public object AutomationRunReducer : Reducer<AutomationRunState, StateAction> {
         automationRunReducer(state, action)
 }
 
-// ─── Timestamp Provider ─────────────────────────────────────────────────────
+private val isoTimestampFormatter = DateTimeFormatterBuilder().appendInstant(3).toFormatter()
 
-/**
- * Injectable timestamp provider. Returns epoch milliseconds.
- *
- * Tests override this to produce deterministic `modifiedAt` values when
- * exercising reducers; production callers should leave it on the default.
- */
-public var currentTimestampProvider: () -> Long = { System.currentTimeMillis() }
-
-private fun nowIsoString(): String = Instant.ofEpochMilli(currentTimestampProvider()).toString()
+private fun addMillisecondsToTimestamp(timestamp: String, duration: Long): String =
+    isoTimestampFormatter.format(Instant.parse(timestamp).plusMillis(duration))
 
 // ─── Status Bitset Helpers ──────────────────────────────────────────────────
 
@@ -466,7 +460,7 @@ private fun endTurn(
     val withoutTurn = state.copy(
         turns = state.turns + turn,
         activeTurn = null,
-        modifiedAt = nowIsoString(),
+        modifiedAt = addMillisecondsToTimestamp(active.startedAt, turn.duration ?: 0L),
     )
     return withoutTurn.copy(status = chatSummaryStatus(withoutTurn, terminalStatus))
 }
@@ -498,7 +492,6 @@ private fun upsertInputRequest(state: ChatState, request: ChatInputRequest): Cha
     val next = state.copy(activeTurn = activeTurn.copy(responseParts = updated))
     return next.copy(
         status = withStatusFlag(chatSummaryStatus(next), SessionStatus.IS_READ, false),
-        modifiedAt = nowIsoString(),
     )
 }
 
@@ -547,7 +540,7 @@ public fun sessionReducer(state: SessionState, action: StateAction): SessionStat
     is StateActionSessionReady -> state.copy(lifecycle = SessionLifecycle.READY)
 
     is StateActionSessionCreationFailed -> state.copy(
-        lifecycle = SessionLifecycle.CREATION_FAILED,
+        lifecycle = SessionLifecycle.FAILED,
         creationError = action.value.error,
     )
 
@@ -881,7 +874,7 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
         )
         val withStatus = withTurn.copy(
             status = withStatusFlag(chatSummaryStatus(withTurn), SessionStatus.IS_READ, false),
-            modifiedAt = nowIsoString(),
+            modifiedAt = a.startedAt,
         )
         if (a.queuedMessageId == null) {
             withStatus
@@ -1365,7 +1358,6 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
             turns = turns,
             turnsNextCursor = if (a.turnId == null) null else state.turnsNextCursor,
             activeTurn = null,
-            modifiedAt = nowIsoString(),
         )
         next.copy(status = chatSummaryStatus(next))
     }
@@ -1410,7 +1402,6 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
             }
             state.copy(
                 activeTurn = activeTurn.copy(responseParts = updated),
-                modifiedAt = nowIsoString(),
             )
         }
     }
@@ -1439,7 +1430,6 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
             val next = state.copy(activeTurn = activeTurn.copy(responseParts = updated))
             next.copy(
                 status = chatSummaryStatus(next),
-                modifiedAt = nowIsoString(),
             )
         }
     }
@@ -1571,7 +1561,14 @@ public fun terminalReducer(state: TerminalState, action: StateAction): TerminalS
 
     is StateActionTerminalCwdChanged -> state.copy(cwd = action.value.cwd)
 
-    is StateActionTerminalExited -> state.copy(exitCode = action.value.exitCode)
+    is StateActionTerminalExited -> state.copy(
+        lifecycle = TerminalLifecycleStateExited(
+            TerminalExitedLifecycleState(
+                status = TerminalLifecycleStatus.EXITED,
+                exitCode = action.value.exitCode,
+            ),
+        ),
+    )
 
     is StateActionTerminalCleared -> state.copy(content = emptyList())
 
@@ -1672,9 +1669,9 @@ public fun changesetReducer(state: ChangesetState, action: StateAction): Changes
 
     is StateActionChangesetContentChanged ->
         if (action.value.operations == null) {
-            state.copy(files = action.value.files, error = action.value.error)
+            state.copy(files = action.value.files)
         } else {
-            state.copy(files = action.value.files, operations = action.value.operations, error = action.value.error)
+            state.copy(files = action.value.files, operations = action.value.operations)
         }
 
     is StateActionChangesetOperationsChanged ->
@@ -1737,7 +1734,7 @@ public fun annotationsReducer(state: AnnotationsState, action: StateAction): Ann
         } else {
             val annotation = state.annotations[idx]
             val updated = annotation.copy(
-                turnId = action.value.turnId ?: annotation.turnId,
+                origin = action.value.origin ?: annotation.origin,
                 resource = action.value.resource ?: annotation.resource,
                 range = action.value.range ?: annotation.range,
                 resolved = action.value.resolved ?: annotation.resolved

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -1255,11 +1255,7 @@ data class ChangesetContentChangedAction(
     /**
      * Full replacement operation list. Omit when operations are unchanged.
      */
-    val operations: List<ChangesetOperation>? = null,
-    /**
-     * Error information, if the changeset content change failed.
-     */
-    val error: ErrorInfo? = null
+    val operations: List<ChangesetOperation>? = null
 )
 
 @Serializable
@@ -1310,11 +1306,9 @@ data class AnnotationsUpdatedAction(
      */
     val annotationId: String,
     /**
-     * Re-anchors the annotation to the file versions this turn produced.
-     * Matches a {@link Turn.id} on the owning session. Omit to leave the
-     * current {@link Annotation.turnId} unchanged.
+     * Replaces the annotation's provenance. Omit to leave it unchanged.
      */
-    val turnId: String? = null,
+    val origin: AnnotationOrigin? = null,
     /**
      * Re-anchors the annotation to this file. Omit to leave the current
      * {@link Annotation.resource} unchanged.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -544,18 +544,6 @@ data class SubscribeResult(
 )
 
 @Serializable
-data class SessionForkSource(
-    /**
-     * URI of the existing session to fork from
-     */
-    val session: String,
-    /**
-     * Turn ID in the source session; content up to and including this turn's response is copied
-     */
-    val turnId: String
-)
-
-@Serializable
 data class CreateSessionParams(
     /**
      * Channel URI this command targets.
@@ -585,16 +573,8 @@ data class CreateSessionParams(
      * capability treats only the first entry as the session's working directory
      * and ignores the rest. Dispatch working-directory actions to change the set
      * after the session has started.
-     *
-     * Ignored for forked sessions — a fork inherits its working directories
-     * from the source session identified by `fork`.
      */
     val workingDirectories: List<String>? = null,
-    /**
-     * Fork from an existing session. The new session is populated with content
-     * from the source session up to and including the specified turn's response.
-     */
-    val fork: SessionForkSource? = null,
     /**
      * Agent-specific configuration values collected via `resolveSessionConfig`.
      * Keys and values correspond to the schema returned by the server.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -111,8 +111,8 @@ enum class SessionLifecycle {
     CREATING,
     @SerialName("ready")
     READY,
-    @SerialName("creationFailed")
-    CREATION_FAILED
+    @SerialName("failed")
+    FAILED
 }
 
 /**
@@ -600,6 +600,17 @@ enum class TerminalClaimKind {
     CLIENT,
     @SerialName("session")
     SESSION
+}
+
+/**
+ * Lifecycle status of a terminal process.
+ */
+@Serializable
+enum class TerminalLifecycleStatus {
+    @SerialName("running")
+    RUNNING,
+    @SerialName("exited")
+    EXITED
 }
 
 /**
@@ -4316,9 +4327,9 @@ data class TerminalInfo(
      */
     val claim: TerminalClaim,
     /**
-     * Process exit code, if the terminal process has exited
+     * Current terminal process lifecycle.
      */
-    val exitCode: Long? = null
+    val lifecycle: TerminalLifecycleState
 )
 
 @Serializable
@@ -4344,13 +4355,31 @@ data class TerminalSessionClaim(
      */
     val session: String,
     /**
-     * Optional turn identifier within the session
+     * Chat URI that claimed the terminal.
+     */
+    val chat: String,
+    /**
+     * Optional turn identifier within the chat.
      */
     val turnId: String? = null,
     /**
      * Optional tool call identifier within the turn
      */
     val toolCallId: String? = null
+)
+
+@Serializable
+data class TerminalRunningLifecycleState(
+    val status: TerminalLifecycleStatus
+)
+
+@Serializable
+data class TerminalExitedLifecycleState(
+    val status: TerminalLifecycleStatus,
+    /**
+     * Process exit code, if the runtime reported one.
+     */
+    val exitCode: Long? = null
 )
 
 @Serializable
@@ -4381,9 +4410,9 @@ data class TerminalState(
      */
     val content: List<TerminalContentPart>,
     /**
-     * Process exit code, set when the terminal process exits
+     * Current terminal process lifecycle.
      */
-    val exitCode: Long? = null,
+    val lifecycle: TerminalLifecycleState,
     /**
      * Who currently holds this terminal
      */
@@ -4729,6 +4758,22 @@ data class AnnotationsState(
 )
 
 @Serializable
+data class AnnotationOrigin(
+    /**
+     * Owning session URI.
+     */
+    val session: String,
+    /**
+     * Owning chat URI, when the annotation is scoped to a chat.
+     */
+    val chat: String? = null,
+    /**
+     * Turn identifier within {@link chat}, when the annotation is scoped to a turn.
+     */
+    val turnId: String? = null
+)
+
+@Serializable
 data class Annotation(
     /**
      * Stable identifier within the annotations channel. Assigned by the client
@@ -4736,10 +4781,9 @@ data class Annotation(
      */
     val id: String,
     /**
-     * Turn that produced the file versions this annotation is anchored to.
-     * Matches a {@link Turn.id} on the owning session.
+     * Provenance of the content this annotation is anchored to.
      */
-    val turnId: String,
+    val origin: AnnotationOrigin,
     /**
      * The file the annotation is anchored to.
      */
@@ -6338,6 +6382,44 @@ internal object ToolCallRiskAssessmentSerializer : KSerializer<ToolCallRiskAsses
             is ToolCallRiskAssessmentLoading -> output.json.encodeToJsonElement(ToolCallRiskAssessmentLoadingState.serializer(), value.value)
             is ToolCallRiskAssessmentComplete -> output.json.encodeToJsonElement(ToolCallRiskAssessmentCompleteState.serializer(), value.value)
             is ToolCallRiskAssessmentUnknown -> value.raw
+        }
+        output.encodeJsonElement(element)
+    }
+}
+
+@Serializable(with = TerminalLifecycleStateSerializer::class)
+sealed interface TerminalLifecycleState
+
+@JvmInline
+value class TerminalLifecycleStateRunning(val value: TerminalRunningLifecycleState) : TerminalLifecycleState
+@JvmInline
+value class TerminalLifecycleStateExited(val value: TerminalExitedLifecycleState) : TerminalLifecycleState
+
+internal object TerminalLifecycleStateSerializer : KSerializer<TerminalLifecycleState> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("TerminalLifecycleState")
+
+    override fun deserialize(decoder: Decoder): TerminalLifecycleState {
+        val input = decoder as? JsonDecoder
+            ?: error("TerminalLifecycleState can only be deserialized from JSON")
+        val element = input.decodeJsonElement()
+        val obj = element as? JsonObject
+            ?: error("Expected JsonObject for TerminalLifecycleState")
+        val discriminant = (obj["status"] as? JsonPrimitive)?.content
+            ?: error("Missing status discriminator on TerminalLifecycleState")
+        return when (discriminant) {
+            "running" -> TerminalLifecycleStateRunning(input.json.decodeFromJsonElement(TerminalRunningLifecycleState.serializer(), element))
+            "exited" -> TerminalLifecycleStateExited(input.json.decodeFromJsonElement(TerminalExitedLifecycleState.serializer(), element))
+            else -> error("Unknown TerminalLifecycleState discriminator: $discriminant")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: TerminalLifecycleState) {
+        val output = encoder as? JsonEncoder
+            ?: error("TerminalLifecycleState can only be serialized to JSON")
+        val element: JsonElement = when (value) {
+            is TerminalLifecycleStateRunning -> output.json.encodeToJsonElement(TerminalRunningLifecycleState.serializer(), value.value)
+            is TerminalLifecycleStateExited -> output.json.encodeToJsonElement(TerminalExitedLifecycleState.serializer(), value.value)
         }
         output.encodeJsonElement(element)
     }

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/FixtureDrivenReducerTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/FixtureDrivenReducerTest.kt
@@ -15,8 +15,6 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
@@ -49,22 +47,6 @@ import kotlin.test.assertTrue
  * ```
  */
 class FixtureDrivenReducerTest {
-
-    private var originalProvider: (() -> Long)? = null
-
-    @BeforeEach
-    fun mockTimestamp() {
-        // Match the TypeScript test mock (`Date.now = () => 9999`) so chat
-        // fixtures assert the corresponding ISO `modifiedAt` value.
-        originalProvider = currentTimestampProvider
-        currentTimestampProvider = { MOCK_NOW }
-    }
-
-    @AfterEach
-    fun restoreTimestamp() {
-        originalProvider?.let { currentTimestampProvider = it }
-        originalProvider = null
-    }
 
     @TestFactory
     fun allFixtures(): List<DynamicTest> {
@@ -361,7 +343,6 @@ class FixtureDrivenReducerTest {
 
     private companion object {
         // Matches the TypeScript test mock: Date.now = () => 9999.
-        private const val MOCK_NOW: Long = 9999L
 
         /**
          * Fixture descriptions intentionally skipped because they exercise

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/ReducersTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/ReducersTest.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -17,25 +15,11 @@ import kotlin.test.assertTrue
 /**
  * Focused unit tests covering the reducer module's public surface, the
  * `Reducer<S, A>` fun-interface wrapper, and a handful of tricky behaviors
- * (queued message reorder algorithm, timestamp provider override). Broad
+ * (queued message reorder algorithm, deterministic turn timestamps). Broad
  * behavior parity is verified by [FixtureDrivenReducerTest] against the
  * shared cross-language fixtures.
  */
 class ReducersTest {
-
-    private var originalProvider: (() -> Long)? = null
-
-    @BeforeEach
-    fun mockTimestamp() {
-        originalProvider = currentTimestampProvider
-        currentTimestampProvider = { MOCK_NOW }
-    }
-
-    @AfterEach
-    fun restoreTimestamp() {
-        originalProvider?.let { currentTimestampProvider = it }
-        originalProvider = null
-    }
 
     @Test
     fun `Reducer object wrappers delegate to free functions`() {
@@ -86,6 +70,9 @@ class ReducersTest {
         val term = TerminalState(
             title = "term",
             content = emptyList(),
+            lifecycle = TerminalLifecycleStateRunning(
+                TerminalRunningLifecycleState(status = TerminalLifecycleStatus.RUNNING),
+            ),
             claim = TerminalClaimClient(
                 TerminalClientClaim(kind = TerminalClaimKind.CLIENT, clientId = "c-1"),
             ),
@@ -112,6 +99,9 @@ class ReducersTest {
                         value = "before",
                     ),
                 ),
+            ),
+            lifecycle = TerminalLifecycleStateRunning(
+                TerminalRunningLifecycleState(status = TerminalLifecycleStatus.RUNNING),
             ),
             claim = TerminalClaimClient(
                 TerminalClientClaim(kind = TerminalClaimKind.CLIENT, clientId = "c-1"),
@@ -209,7 +199,7 @@ class ReducersTest {
     }
 
     @Test
-    fun `turn start stores producer timestamp while modifiedAt uses local clock`() {
+    fun `turn start uses producer timestamp for modifiedAt`() {
         val chatResult = chatReducer(
             newChat(),
             StateActionChatTurnStarted(
@@ -221,7 +211,7 @@ class ReducersTest {
                 ),
             ),
         )
-        assertEquals("1970-01-01T00:00:09.999Z", chatResult.modifiedAt)
+        assertEquals("1970-01-01T00:00:12.345Z", chatResult.modifiedAt)
         assertEquals("1970-01-01T00:00:12.345Z", chatResult.activeTurn?.startedAt)
     }
 
@@ -323,7 +313,6 @@ class ReducersTest {
     }
 
     private companion object {
-        private const val MOCK_NOW: Long = 9999L
 
         private fun userMessage(text: String): Message =
             Message(text = text, origin = MessageOrigin(kind = MessageKind.USER))

--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.8.0"
 dependencies = [
  "ahp-types",
  "ahp-ws",
+ "jiff",
  "serde",
  "serde_json",
  "thiserror",
@@ -44,6 +45,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -122,6 +129,37 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "digest"
@@ -456,6 +494,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,7 +629,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -632,6 +706,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -726,7 +815,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -749,7 +838,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -823,7 +912,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1299,7 +1388,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1475,7 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -22,5 +22,6 @@ tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 tokio-util = "0.7"
 futures-util = "0.3"
 tracing = "0.1"
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 ahp-types = { path = "crates/ahp-types", version = "0.8.0" }
 ahp = { path = "crates/ahp", version = "0.8.0" }

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -13,7 +13,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[allow(unused_imports)]
 use crate::state::{
-    AgentInfo, AgentSelection, Annotation, AnnotationEntry, AutomationDefinition,
+    AgentInfo, AgentSelection, Annotation, AnnotationEntry, AnnotationOrigin, AutomationDefinition,
     AutomationDefinitionPatch, AutomationRunLifecycle, AutomationRunSummary, AutomationState,
     Changeset, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, ChangesetStatus,
     ChatInputAnswer, ChatInputRequest, ChatInputResponseKind, ChatInteractivity, ChatOrigin,
@@ -1473,9 +1473,6 @@ pub struct ChangesetContentChangedAction {
     /// Full replacement operation list. Omit when operations are unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub operations: Option<Vec<ChangesetOperation>>,
-    /// Error information, if the changeset content change failed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error: Option<ErrorInfo>,
 }
 
 /// The set of operations available on this changeset changed. Full
@@ -1569,11 +1566,9 @@ pub struct AnnotationsSetAction {
 pub struct AnnotationsUpdatedAction {
     /// The {@link Annotation.id} of the annotation to update.
     pub annotation_id: String,
-    /// Re-anchors the annotation to the file versions this turn produced.
-    /// Matches a {@link Turn.id} on the owning session. Omit to leave the
-    /// current {@link Annotation.turnId} unchanged.
+    /// Replaces the annotation's provenance. Omit to leave it unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<String>,
+    pub origin: Option<AnnotationOrigin>,
     /// Re-anchors the annotation to this file. Omit to leave the current
     /// {@link Annotation.resource} unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -469,15 +469,6 @@ pub struct SubscribeResult {
 /// clients.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SessionForkSource {
-    /// URI of the existing session to fork from
-    pub session: Uri,
-    /// Turn ID in the source session; content up to and including this turn's response is copied
-    pub turn_id: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateSessionParams {
     /// Channel URI this command targets.
     pub channel: Uri,
@@ -501,15 +492,8 @@ pub struct CreateSessionParams {
     /// capability treats only the first entry as the session's working directory
     /// and ignores the rest. Dispatch working-directory actions to change the set
     /// after the session has started.
-    ///
-    /// Ignored for forked sessions — a fork inherits its working directories
-    /// from the source session identified by `fork`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directories: Option<Vec<Uri>>,
-    /// Fork from an existing session. The new session is populated with content
-    /// from the source session up to and including the specified turn's response.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub fork: Option<SessionForkSource>,
     /// Agent-specific configuration values collected via `resolveSessionConfig`.
     /// Keys and values correspond to the schema returned by the server.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -42,8 +42,8 @@ pub enum SessionLifecycle {
     Creating,
     #[serde(rename = "ready")]
     Ready,
-    #[serde(rename = "creationFailed")]
-    CreationFailed,
+    #[serde(rename = "failed")]
+    Failed,
 }
 
 /// Bitset of summary-level session status flags.
@@ -480,6 +480,15 @@ pub enum TerminalClaimKind {
     Client,
     #[serde(rename = "session")]
     Session,
+}
+
+/// Lifecycle status of a terminal process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TerminalLifecycleStatus {
+    #[serde(rename = "running")]
+    Running,
+    #[serde(rename = "exited")]
+    Exited,
 }
 
 /// Discriminant for the {@link McpServerState} union.
@@ -3896,9 +3905,8 @@ pub struct TerminalInfo {
     pub title: String,
     /// Who currently holds this terminal
     pub claim: TerminalClaim,
-    /// Process exit code, if the terminal process has exited
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exit_code: Option<i64>,
+    /// Current terminal process lifecycle.
+    pub lifecycle: TerminalLifecycleState,
 }
 
 /// A terminal claimed by a connected client.
@@ -3915,12 +3923,28 @@ pub struct TerminalClientClaim {
 pub struct TerminalSessionClaim {
     /// Session URI that claimed the terminal
     pub session: Uri,
-    /// Optional turn identifier within the session
+    /// Chat URI that claimed the terminal.
+    pub chat: Uri,
+    /// Optional turn identifier within the chat.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<String>,
     /// Optional tool call identifier within the turn
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
+}
+
+/// A terminal process that is still running.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalRunningLifecycleState {}
+
+/// A terminal process that has exited.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalExitedLifecycleState {
+    /// Process exit code, if the runtime reported one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i64>,
 }
 
 /// Full state for a single terminal, loaded when a client subscribes to the terminal's URI.
@@ -3945,9 +3969,8 @@ pub struct TerminalState {
     ///
     /// Consumers that need command boundaries can filter by part type.
     pub content: Vec<TerminalContentPart>,
-    /// Process exit code, set when the terminal process exits
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exit_code: Option<i64>,
+    /// Current terminal process lifecycle.
+    pub lifecycle: TerminalLifecycleState,
     /// Who currently holds this terminal
     pub claim: TerminalClaim,
     /// Whether this terminal emits `terminal/commandExecuted` and
@@ -4263,14 +4286,26 @@ pub struct AnnotationsState {
     pub annotations: Vec<Annotation>,
 }
 
-/// A conversation anchored to a specific file produced by a specific turn,
-/// optionally narrowed to a range within that file.
+/// Provenance of the content an annotation is anchored to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotationOrigin {
+    /// Owning session URI.
+    pub session: Uri,
+    /// Owning chat URI, when the annotation is scoped to a chat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat: Option<Uri>,
+    /// Turn identifier within {@link chat}, when the annotation is scoped to a turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+}
+
+/// A conversation anchored to a specific file in a session, optionally scoped
+/// to a chat and turn and narrowed to a range within that file.
 ///
-/// {@link turnId} anchors the annotation to the file versions that turn
-/// produced, so a later turn that rewrites the same file does not silently
-/// invalidate the annotation's anchor — clients can resolve {@link resource}
-/// and {@link range} against the turn's changeset. When {@link range} is
-/// omitted the annotation is anchored to the entire file.
+/// {@link origin} identifies the owning session and, when available, the chat
+/// and turn that produced the file version. When {@link range} is omitted the
+/// annotation is anchored to the entire file.
 ///
 /// Every annotation MUST contain at least one {@link AnnotationEntry}. An
 /// {@link AnnotationsSetAction} that creates an annotation therefore carries
@@ -4283,9 +4318,8 @@ pub struct Annotation {
     /// Stable identifier within the annotations channel. Assigned by the client
     /// that dispatches the creating {@link AnnotationsSetAction}.
     pub id: String,
-    /// Turn that produced the file versions this annotation is anchored to.
-    /// Matches a {@link Turn.id} on the owning session.
-    pub turn_id: String,
+    /// Provenance of the content this annotation is anchored to.
+    pub origin: AnnotationOrigin,
     /// The file the annotation is anchored to.
     pub resource: Uri,
     /// Range within {@link resource} the annotation is anchored to. When
@@ -5192,6 +5226,16 @@ pub enum ToolCallRiskAssessment {
     /// Reducers treat this as a no-op.
     #[serde(untagged)]
     Unknown(serde_json::Value),
+}
+
+/// Current lifecycle of a terminal process.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status")]
+pub enum TerminalLifecycleState {
+    #[serde(rename = "running")]
+    Running(TerminalRunningLifecycleState),
+    #[serde(rename = "exited")]
+    Exited(TerminalExitedLifecycleState),
 }
 
 /// One outstanding piece of input a session is blocked on, aggregated across all chats.

--- a/clients/rust/crates/ahp/Cargo.toml
+++ b/clients/rust/crates/ahp/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+jiff = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/clients/rust/crates/ahp/src/lib.rs
+++ b/clients/rust/crates/ahp/src/lib.rs
@@ -130,9 +130,9 @@
 //! Each reducer returns a [`ReduceOutcome`] that distinguishes mutations
 //! ([`ReduceOutcome::Applied`]), recognized but inert events
 //! ([`ReduceOutcome::NoOp`]), and out-of-scope routing
-//! ([`ReduceOutcome::OutOfScope`]). A client holding all three state
-//! trees can blindly fan every action out to every reducer without
-//! special-casing.
+//! ([`ReduceOutcome::OutOfScope`]), and actions rejected as invalid
+//! ([`ReduceOutcome::Invalid`]). A client holding all three state trees can
+//! blindly fan every action out to every reducer without special-casing.
 //!
 //! # Cancellation and shutdown
 //!
@@ -162,6 +162,6 @@ pub use error::{ClientError, TransportError};
 pub use multi_host_state_mirror::{HostedResourceKey, MultiHostStateMirror};
 pub use reducers::{
     apply_action_to_automation, apply_action_to_automation_run, apply_action_to_root,
-    apply_action_to_session, apply_action_to_terminal, ReduceOutcome,
+    apply_action_to_session, apply_action_to_terminal, ReduceError, ReduceOutcome,
 };
 pub use transport::{BoxedTransport, DynTransport, Transport, TransportMessage};

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -49,7 +49,6 @@
 //! ```
 
 use std::collections::{HashMap, HashSet};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use ahp_types::actions::{
     ChatInputAnswerChangedAction, ChatToolCallAuthRequiredAction, ChatToolCallAuthResolvedAction,
@@ -64,15 +63,17 @@ use ahp_types::state::{
     InputRequestResponsePart, McpServerStartingState, McpServerState, McpServerStoppedState,
     PendingMessage, PendingMessageKind, ResourceWatchState, ResponsePart, RootState,
     SessionInputRequest, SessionLifecycle, SessionState, SessionStatus, TerminalCommandPart,
-    TerminalContentPart, TerminalState, TerminalUnclassifiedPart, ToolCallAuthRequiredState,
-    ToolCallCancellationReason, ToolCallCancelledState, ToolCallCompletedState,
-    ToolCallConfirmationReason, ToolCallContributor, ToolCallPendingConfirmationState,
-    ToolCallPendingResultConfirmationState, ToolCallResponsePart, ToolCallRunningState,
-    ToolCallState, ToolCallStatus, ToolCallStreamingState, ToolInput, Turn, TurnState,
+    TerminalContentPart, TerminalExitedLifecycleState, TerminalLifecycleState, TerminalState,
+    TerminalUnclassifiedPart, ToolCallAuthRequiredState, ToolCallCancellationReason,
+    ToolCallCancelledState, ToolCallCompletedState, ToolCallConfirmationReason,
+    ToolCallContributor, ToolCallPendingConfirmationState, ToolCallPendingResultConfirmationState,
+    ToolCallResponsePart, ToolCallRunningState, ToolCallState, ToolCallStatus,
+    ToolCallStreamingState, ToolInput, Turn, TurnState,
 };
+use jiff::{SignedDuration, Timestamp};
 
 /// What happened when an action was applied.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReduceOutcome {
     /// The action was applied and mutated state.
     Applied,
@@ -82,51 +83,51 @@ pub enum ReduceOutcome {
     /// The action targets a different scope (e.g. a session action
     /// applied to root). Caller should route to the right reducer.
     OutOfScope,
+    /// The action targeted this state but contained invalid data, so the state
+    /// was left unchanged.
+    Invalid(ReduceError),
 }
 
-#[cfg(test)]
-thread_local! {
-    static MOCK_NOW_MS: std::cell::Cell<Option<i64>> = const { std::cell::Cell::new(None) };
+/// Why an action could not be reduced safely.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ReduceError {
+    /// A turn carried a start timestamp that was not valid RFC 3339.
+    #[error("invalid RFC 3339 timestamp {timestamp:?}: {reason}")]
+    InvalidTimestamp {
+        /// Timestamp received from the active turn.
+        timestamp: String,
+        /// Parser diagnostic.
+        reason: String,
+    },
+    /// Adding a turn duration produced a timestamp outside Jiff's supported
+    /// range.
+    #[error("could not add {duration_ms}ms to timestamp {timestamp:?}: {reason}")]
+    TimestampArithmetic {
+        /// Timestamp received from the active turn.
+        timestamp: String,
+        /// Producer-supplied duration after reducer clamping.
+        duration_ms: i64,
+        /// Arithmetic diagnostic.
+        reason: String,
+    },
 }
 
-fn now_ms() -> i64 {
-    #[cfg(test)]
-    {
-        if let Some(v) = MOCK_NOW_MS.with(|c| c.get()) {
-            return v;
-        }
-    }
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0)
-}
-
-fn now_iso() -> String {
-    iso8601_from_unix_millis(now_ms())
-}
-
-fn iso8601_from_unix_millis(ms: i64) -> String {
-    let seconds = ms.div_euclid(1_000);
-    let millis = ms.rem_euclid(1_000);
-    let days = seconds.div_euclid(86_400);
-    let seconds_of_day = seconds.rem_euclid(86_400);
-    let hour = seconds_of_day / 3_600;
-    let minute = (seconds_of_day % 3_600) / 60;
-    let second = seconds_of_day % 60;
-
-    let z = days + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 }.div_euclid(146_097);
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let day = doy - (153 * mp + 2) / 5 + 1;
-    let month = mp + if mp < 10 { 3 } else { -9 };
-    let year = y + if month <= 2 { 1 } else { 0 };
-
-    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
+fn add_milliseconds_to_timestamp(timestamp: &str, duration: i64) -> Result<String, ReduceError> {
+    let start: Timestamp =
+        timestamp
+            .parse()
+            .map_err(|error: jiff::Error| ReduceError::InvalidTimestamp {
+                timestamp: timestamp.to_owned(),
+                reason: error.to_string(),
+            })?;
+    let end = start
+        .checked_add(SignedDuration::from_millis(duration))
+        .map_err(|error| ReduceError::TimestampArithmetic {
+            timestamp: timestamp.to_owned(),
+            duration_ms: duration,
+            reason: error.to_string(),
+        })?;
+    Ok(format!("{end:.3}"))
 }
 
 struct ToolCallBase {
@@ -331,10 +332,6 @@ fn refresh_summary_status(state: &mut ChatState) {
     state.status = summary_status(state, None);
 }
 
-fn touch_chat_modified(state: &mut ChatState) {
-    state.modified_at = now_iso();
-}
-
 fn end_turn(
     state: &mut ChatState,
     turn_id: &str,
@@ -349,6 +346,14 @@ fn end_turn(
     if active.id != turn_id {
         return ReduceOutcome::NoOp;
     }
+
+    // Validate and derive the timestamp before consuming the active turn so an
+    // invalid action leaves state untouched.
+    let duration = duration.max(0);
+    let modified_at = match add_milliseconds_to_timestamp(&active.started_at, duration) {
+        Ok(timestamp) => timestamp,
+        Err(error) => return ReduceOutcome::Invalid(error),
+    };
     let active = state.active_turn.take().unwrap();
 
     let response_parts: Vec<ResponsePart> = active
@@ -399,12 +404,10 @@ fn end_turn(
         })
         .collect();
 
-    // Defensive clamp: `duration` is producer-supplied and opaque to this
-    // reducer, but a negative value would be nonsensical to display.
     let turn = Turn {
         id: active.id,
         started_at: Some(active.started_at),
-        duration: Some(duration.max(0)),
+        duration: Some(duration),
         message: active.message,
         response_parts,
         usage: active.usage,
@@ -413,7 +416,7 @@ fn end_turn(
     };
 
     state.turns.push(turn);
-    state.modified_at = now_iso();
+    state.modified_at = modified_at;
     state.status = summary_status(state, terminal_status);
     ReduceOutcome::Applied
 }
@@ -451,7 +454,6 @@ fn upsert_input_request(state: &mut ChatState, request: ChatInputRequest) -> Red
             }));
     }
     state.status = summary_status(state, None);
-    touch_chat_modified(state);
     state.status = with_status_flag(state.status, SessionStatus::IsRead, false);
     ReduceOutcome::Applied
 }
@@ -691,7 +693,7 @@ pub fn apply_action_to_session(state: &mut SessionState, action: &StateAction) -
             ReduceOutcome::Applied
         }
         StateAction::SessionCreationFailed(a) => {
-            state.lifecycle = SessionLifecycle::CreationFailed;
+            state.lifecycle = SessionLifecycle::Failed;
             state.creation_error = Some(a.error.clone());
             ReduceOutcome::Applied
         }
@@ -1207,7 +1209,6 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
             };
             part.response = Some(a.response);
             refresh_summary_status(state);
-            touch_chat_modified(state);
             ReduceOutcome::Applied
         }
         StateAction::ChatPendingMessageSet(a) => {
@@ -1292,7 +1293,7 @@ fn apply_turn_started(state: &mut ChatState, a: &ChatTurnStartedAction) -> Reduc
         usage: None,
     });
     state.status = summary_status(state, None);
-    touch_chat_modified(state);
+    state.modified_at = a.started_at.clone();
     state.status = with_status_flag(state.status, SessionStatus::IsRead, false);
 
     if let Some(qmid) = &a.queued_message_id {
@@ -1689,7 +1690,6 @@ fn apply_truncated(state: &mut ChatState, turn_id: Option<&str>) -> ReduceOutcom
         }
     }
     state.active_turn = None;
-    touch_chat_modified(state);
     state.status = summary_status(state, None);
     ReduceOutcome::Applied
 }
@@ -1728,7 +1728,6 @@ fn apply_input_answer_changed(
     if answers.is_empty() {
         req.answers = None;
     }
-    touch_chat_modified(state);
     ReduceOutcome::Applied
 }
 
@@ -1775,7 +1774,9 @@ pub fn apply_action_to_terminal(state: &mut TerminalState, action: &StateAction)
             ReduceOutcome::Applied
         }
         StateAction::TerminalExited(a) => {
-            state.exit_code = a.exit_code;
+            state.lifecycle = TerminalLifecycleState::Exited(TerminalExitedLifecycleState {
+                exit_code: a.exit_code,
+            });
             ReduceOutcome::Applied
         }
         StateAction::TerminalCleared(_) => {
@@ -1877,7 +1878,6 @@ pub fn apply_action_to_changeset(
             if let Some(operations) = &a.operations {
                 state.operations = Some(operations.clone());
             }
-            state.error = a.error.clone();
             ReduceOutcome::Applied
         }
         StateAction::ChangesetOperationsChanged(a) => {
@@ -1945,8 +1945,8 @@ pub fn apply_action_to_annotations(
                 return ReduceOutcome::NoOp;
             };
             let ann = &mut state.annotations[idx];
-            if let Some(turn_id) = &a.turn_id {
-                ann.turn_id = turn_id.clone();
+            if let Some(origin) = &a.origin {
+                ann.origin = origin.clone();
             }
             if let Some(resource) = &a.resource {
                 ann.resource = resource.clone();
@@ -2230,6 +2230,66 @@ mod tests {
     }
 
     #[test]
+    fn turn_complete_rejects_invalid_timestamp_without_mutating_state() {
+        let mut state = empty_chat("copilot:/s1/chat/1");
+        state.active_turn = Some(ActiveTurn {
+            id: "t1".into(),
+            started_at: "not-a-timestamp".into(),
+            message: user_message("hi"),
+            response_parts: Vec::new(),
+            usage: None,
+        });
+        state.status = SessionStatus::InProgress.bits();
+        let original = state.clone();
+        let action = StateAction::ChatTurnComplete(ahp_types::actions::ChatTurnCompleteAction {
+            turn_id: "t1".into(),
+            duration: 1000,
+            meta: None,
+        });
+
+        let outcome = apply_action_to_chat(&mut state, &action);
+
+        assert!(matches!(
+            outcome,
+            ReduceOutcome::Invalid(ReduceError::InvalidTimestamp { ref timestamp, .. })
+                if timestamp == "not-a-timestamp"
+        ));
+        assert_eq!(state, original);
+    }
+
+    #[test]
+    fn turn_complete_rejects_timestamp_overflow_without_mutating_state() {
+        let started_at = format!("{:.9}", Timestamp::MAX);
+        let mut state = empty_chat("copilot:/s1/chat/1");
+        state.active_turn = Some(ActiveTurn {
+            id: "t1".into(),
+            started_at: started_at.clone(),
+            message: user_message("hi"),
+            response_parts: Vec::new(),
+            usage: None,
+        });
+        state.status = SessionStatus::InProgress.bits();
+        let original = state.clone();
+        let action = StateAction::ChatTurnComplete(ahp_types::actions::ChatTurnCompleteAction {
+            turn_id: "t1".into(),
+            duration: 1,
+            meta: None,
+        });
+
+        let outcome = apply_action_to_chat(&mut state, &action);
+
+        assert!(matches!(
+            outcome,
+            ReduceOutcome::Invalid(ReduceError::TimestampArithmetic {
+                ref timestamp,
+                duration_ms: 1,
+                ..
+            }) if timestamp == &started_at
+        ));
+        assert_eq!(state, original);
+    }
+
+    #[test]
     fn session_reducer_handles_ready_and_chat_catalog_actions() {
         let mut s = empty_session("copilot:/s1");
         let ready = StateAction::SessionReady(ahp_types::actions::SessionReadyAction {});
@@ -2322,10 +2382,13 @@ mod tests {
             cols: None,
             rows: None,
             content: Vec::new(),
-            exit_code: None,
+            lifecycle: TerminalLifecycleState::Running(
+                ahp_types::state::TerminalRunningLifecycleState {},
+            ),
             claim: ahp_types::state::TerminalClaim::Session(
                 ahp_types::state::TerminalSessionClaim {
                     session: "session:/s1".into(),
+                    chat: "chat:/c1".into(),
                     turn_id: None,
                     tool_call_id: None,
                 },
@@ -2368,16 +2431,6 @@ mod tests {
             }
             other => other,
         }
-    }
-
-    const MOCK_NOW: i64 = 9999;
-
-    fn set_mock_time() {
-        MOCK_NOW_MS.with(|c| c.set(Some(MOCK_NOW)));
-    }
-
-    fn clear_mock_time() {
-        MOCK_NOW_MS.with(|c| c.set(None));
     }
 
     /// Load all JSON fixtures from `types/test-cases/reducers/` and run
@@ -2425,8 +2478,6 @@ mod tests {
 
         let mut passed = 0usize;
         let skipped = 0usize;
-
-        set_mock_time();
 
         for entry in &entries {
             let path = entry.path();
@@ -2572,8 +2623,6 @@ mod tests {
 
             passed += 1;
         }
-
-        clear_mock_time();
 
         eprintln!(
             "Fixture results: {passed} passed, {skipped} skipped, {} total",

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -1617,19 +1617,15 @@ public struct ChangesetContentChangedAction: Codable, Sendable {
     public var files: [ChangesetFile]
     /// Full replacement operation list. Omit when operations are unchanged.
     public var operations: [ChangesetOperation]?
-    /// Error information, if the changeset content change failed.
-    public var error: ErrorInfo?
 
     public init(
         type: ActionType,
         files: [ChangesetFile],
-        operations: [ChangesetOperation]? = nil,
-        error: ErrorInfo? = nil
+        operations: [ChangesetOperation]? = nil
     ) {
         self.type = type
         self.files = files
         self.operations = operations
-        self.error = error
     }
 }
 
@@ -1697,10 +1693,8 @@ public struct AnnotationsUpdatedAction: Codable, Sendable {
     public var type: ActionType
     /// The {@link Annotation.id} of the annotation to update.
     public var annotationId: String
-    /// Re-anchors the annotation to the file versions this turn produced.
-    /// Matches a {@link Turn.id} on the owning session. Omit to leave the
-    /// current {@link Annotation.turnId} unchanged.
-    public var turnId: String?
+    /// Replaces the annotation's provenance. Omit to leave it unchanged.
+    public var origin: AnnotationOrigin?
     /// Re-anchors the annotation to this file. Omit to leave the current
     /// {@link Annotation.resource} unchanged.
     public var resource: String?
@@ -1716,14 +1710,14 @@ public struct AnnotationsUpdatedAction: Codable, Sendable {
     public init(
         type: ActionType,
         annotationId: String,
-        turnId: String? = nil,
+        origin: AnnotationOrigin? = nil,
         resource: String? = nil,
         range: TextRange? = nil,
         resolved: Bool? = nil
     ) {
         self.type = type
         self.annotationId = annotationId
-        self.turnId = turnId
+        self.origin = origin
         self.resource = resource
         self.range = range
         self.resolved = resolved

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -544,21 +544,6 @@ public struct SubscribeResult: Codable, Sendable {
     }
 }
 
-public struct SessionForkSource: Codable, Sendable {
-    /// URI of the existing session to fork from
-    public var session: String
-    /// Turn ID in the source session; content up to and including this turn's response is copied
-    public var turnId: String
-
-    public init(
-        session: String,
-        turnId: String
-    ) {
-        self.session = session
-        self.turnId = turnId
-    }
-}
-
 public struct CreateSessionParams: Codable, Sendable {
     /// Channel URI this command targets.
     public var channel: String
@@ -580,13 +565,7 @@ public struct CreateSessionParams: Codable, Sendable {
     /// capability treats only the first entry as the session's working directory
     /// and ignores the rest. Dispatch working-directory actions to change the set
     /// after the session has started.
-    ///
-    /// Ignored for forked sessions — a fork inherits its working directories
-    /// from the source session identified by `fork`.
     public var workingDirectories: [String]?
-    /// Fork from an existing session. The new session is populated with content
-    /// from the source session up to and including the specified turn's response.
-    public var fork: SessionForkSource?
     /// Agent-specific configuration values collected via `resolveSessionConfig`.
     /// Keys and values correspond to the schema returned by the server.
     public var config: [String: AnyCodable]?
@@ -614,7 +593,6 @@ public struct CreateSessionParams: Codable, Sendable {
         case meta = "_meta"
         case provider
         case workingDirectories
-        case fork
         case config
         case activeClient
         case progressToken
@@ -625,7 +603,6 @@ public struct CreateSessionParams: Codable, Sendable {
         meta: [String: AnyCodable]? = nil,
         provider: String? = nil,
         workingDirectories: [String]? = nil,
-        fork: SessionForkSource? = nil,
         config: [String: AnyCodable]? = nil,
         activeClient: SessionActiveClient? = nil,
         progressToken: String? = nil
@@ -634,7 +611,6 @@ public struct CreateSessionParams: Codable, Sendable {
         self.meta = meta
         self.provider = provider
         self.workingDirectories = workingDirectories
-        self.fork = fork
         self.config = config
         self.activeClient = activeClient
         self.progressToken = progressToken

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -59,7 +59,7 @@ public enum PendingMessageKind: String, Codable, Sendable {
 public enum SessionLifecycle: String, Codable, Sendable {
     case creating = "creating"
     case ready = "ready"
-    case creationFailed = "creationFailed"
+    case failed = "failed"
 }
 
 /// Bitset of summary-level session status flags.
@@ -315,6 +315,12 @@ public enum CustomizationLoadStatus: String, Codable, Sendable {
 public enum TerminalClaimKind: String, Codable, Sendable {
     case client = "client"
     case session = "session"
+}
+
+/// Lifecycle status of a terminal process.
+public enum TerminalLifecycleStatus: String, Codable, Sendable {
+    case running = "running"
+    case exited = "exited"
 }
 
 /// Discriminant for the {@link McpServerState} union.
@@ -4703,19 +4709,19 @@ public struct TerminalInfo: Codable, Sendable {
     public var title: String
     /// Who currently holds this terminal
     public var claim: TerminalClaim
-    /// Process exit code, if the terminal process has exited
-    public var exitCode: Int?
+    /// Current terminal process lifecycle.
+    public var lifecycle: TerminalLifecycleState
 
     public init(
         resource: String,
         title: String,
         claim: TerminalClaim,
-        exitCode: Int? = nil
+        lifecycle: TerminalLifecycleState
     ) {
         self.resource = resource
         self.title = title
         self.claim = claim
-        self.exitCode = exitCode
+        self.lifecycle = lifecycle
     }
 }
 
@@ -4739,7 +4745,9 @@ public struct TerminalSessionClaim: Codable, Sendable {
     public var kind: TerminalClaimKind
     /// Session URI that claimed the terminal
     public var session: String
-    /// Optional turn identifier within the session
+    /// Chat URI that claimed the terminal.
+    public var chat: String
+    /// Optional turn identifier within the chat.
     public var turnId: String?
     /// Optional tool call identifier within the turn
     public var toolCallId: String?
@@ -4747,13 +4755,39 @@ public struct TerminalSessionClaim: Codable, Sendable {
     public init(
         kind: TerminalClaimKind,
         session: String,
+        chat: String,
         turnId: String? = nil,
         toolCallId: String? = nil
     ) {
         self.kind = kind
         self.session = session
+        self.chat = chat
         self.turnId = turnId
         self.toolCallId = toolCallId
+    }
+}
+
+public struct TerminalRunningLifecycleState: Codable, Sendable {
+    public var status: TerminalLifecycleStatus
+
+    public init(
+        status: TerminalLifecycleStatus
+    ) {
+        self.status = status
+    }
+}
+
+public struct TerminalExitedLifecycleState: Codable, Sendable {
+    public var status: TerminalLifecycleStatus
+    /// Process exit code, if the runtime reported one.
+    public var exitCode: Int?
+
+    public init(
+        status: TerminalLifecycleStatus,
+        exitCode: Int? = nil
+    ) {
+        self.status = status
+        self.exitCode = exitCode
     }
 }
 
@@ -4773,8 +4807,8 @@ public struct TerminalState: Codable, Sendable {
     ///
     /// Consumers that need command boundaries can filter by part type.
     public var content: [TerminalContentPart]
-    /// Process exit code, set when the terminal process exits
-    public var exitCode: Int?
+    /// Current terminal process lifecycle.
+    public var lifecycle: TerminalLifecycleState
     /// Who currently holds this terminal
     public var claim: TerminalClaim
     /// Whether this terminal emits `terminal/commandExecuted` and
@@ -4795,7 +4829,7 @@ public struct TerminalState: Codable, Sendable {
         cols: Int? = nil,
         rows: Int? = nil,
         content: [TerminalContentPart],
-        exitCode: Int? = nil,
+        lifecycle: TerminalLifecycleState,
         claim: TerminalClaim,
         supportsCommandDetection: Bool? = nil,
         isPty: Bool? = nil
@@ -4805,7 +4839,7 @@ public struct TerminalState: Codable, Sendable {
         self.cols = cols
         self.rows = rows
         self.content = content
-        self.exitCode = exitCode
+        self.lifecycle = lifecycle
         self.claim = claim
         self.supportsCommandDetection = supportsCommandDetection
         self.isPty = isPty
@@ -5194,13 +5228,31 @@ public struct AnnotationsState: Codable, Sendable {
     }
 }
 
+public struct AnnotationOrigin: Codable, Sendable {
+    /// Owning session URI.
+    public var session: String
+    /// Owning chat URI, when the annotation is scoped to a chat.
+    public var chat: String?
+    /// Turn identifier within {@link chat}, when the annotation is scoped to a turn.
+    public var turnId: String?
+
+    public init(
+        session: String,
+        chat: String? = nil,
+        turnId: String? = nil
+    ) {
+        self.session = session
+        self.chat = chat
+        self.turnId = turnId
+    }
+}
+
 public struct Annotation: Codable, Sendable {
     /// Stable identifier within the annotations channel. Assigned by the client
     /// that dispatches the creating {@link AnnotationsSetAction}.
     public var id: String
-    /// Turn that produced the file versions this annotation is anchored to.
-    /// Matches a {@link Turn.id} on the owning session.
-    public var turnId: String
+    /// Provenance of the content this annotation is anchored to.
+    public var origin: AnnotationOrigin
     /// The file the annotation is anchored to.
     public var resource: String
     /// Range within {@link resource} the annotation is anchored to. When
@@ -5221,7 +5273,7 @@ public struct Annotation: Codable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case id
-        case turnId
+        case origin
         case resource
         case range
         case resolved
@@ -5231,7 +5283,7 @@ public struct Annotation: Codable, Sendable {
 
     public init(
         id: String,
-        turnId: String,
+        origin: AnnotationOrigin,
         resource: String,
         range: TextRange? = nil,
         resolved: Bool,
@@ -5239,7 +5291,7 @@ public struct Annotation: Codable, Sendable {
         meta: [String: AnyCodable]? = nil
     ) {
         self.id = id
-        self.turnId = turnId
+        self.origin = origin
         self.resource = resource
         self.range = range
         self.resolved = resolved
@@ -6711,6 +6763,35 @@ public enum ToolCallRiskAssessment: Codable, Sendable {
         case .loading(let value): try value.encode(to: encoder)
         case .complete(let value): try value.encode(to: encoder)
         case .unknown(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum TerminalLifecycleState: Codable, Sendable {
+    case running(TerminalRunningLifecycleState)
+    case exited(TerminalExitedLifecycleState)
+
+    private enum DiscriminantKey: String, CodingKey {
+        case discriminant = "status"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminantKey.self)
+        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        switch discriminant {
+        case "running":
+            self = .running(try TerminalRunningLifecycleState(from: decoder))
+        case "exited":
+            self = .exited(try TerminalExitedLifecycleState(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown TerminalLifecycleState discriminant: \(discriminant)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .running(let value): try value.encode(to: encoder)
+        case .exited(let value): try value.encode(to: encoder)
         }
     }
 }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/NativeReducer.swift
@@ -150,12 +150,6 @@ extension Reducer {
     }
 }
 
-// MARK: - Timestamp Helper
-
-private func currentTimestamp() -> Int {
-    currentTimestampProvider()
-}
-
 // MARK: - Customization Helpers
 
 func customizationId(_ c: Customization) -> String {

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -3,19 +3,14 @@
 
 import Foundation
 
-// MARK: - Timestamp Provider
-
-/// Injectable timestamp provider for testing. Returns epoch milliseconds.
-public var currentTimestampProvider: () -> Int = {
-    Int(Date().timeIntervalSince1970 * 1000)
-}
-
 private let iso8601TimestampFormatter: ISO8601DateFormatter = {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     formatter.timeZone = TimeZone(secondsFromGMT: 0)
     return formatter
 }()
+
+private let iso8601TimestampParser = ISO8601DateFormatter()
 
 // MARK: - Status Bitset Helpers
 
@@ -133,7 +128,7 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
 
     case .chatTurnStarted(let a):
         var next = state
-        next.modifiedAt = currentTimestamp()
+        next.modifiedAt = a.startedAt
         next.activeTurn = ActiveTurn(
             id: a.turnId,
             startedAt: a.startedAt,
@@ -541,7 +536,6 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
         }
         next.activeTurn = nil
         next.status = chatSummaryStatus(next)
-        next.modifiedAt = currentTimestamp()
         return next
 
     case .chatTurnsLoaded(let a):
@@ -578,7 +572,6 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
         activeTurn.responseParts[idx] = .inputRequest(part)
         var next = state
         next.activeTurn = activeTurn
-        next.modifiedAt = currentTimestamp()
         return next
 
     case .chatInputCompleted(let a):
@@ -602,7 +595,6 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
         var next = state
         next.activeTurn = activeTurn
         next.status = chatSummaryStatus(next)
-        next.modifiedAt = currentTimestamp()
         return next
 
     // ── Pending Messages ──────────────────────────────────────────────────
@@ -678,7 +670,7 @@ public func sessionReducer(state: SessionState, action: StateAction) -> SessionS
 
     case .sessionCreationFailed(let a):
         var next = state
-        next.lifecycle = .creationFailed
+        next.lifecycle = .failed
         next.creationError = a.error
         return next
 
@@ -942,9 +934,14 @@ public func isClientDispatchable(_ action: StateAction) -> Bool {
 
 // MARK: - Helpers
 
-private func currentTimestamp() -> String {
-    let date = Date(timeIntervalSince1970: Double(currentTimestampProvider()) / 1000)
-    return iso8601TimestampFormatter.string(from: date)
+private func addMillisecondsToTimestamp(_ timestamp: String, _ duration: Int) -> String {
+    guard let start = iso8601TimestampFormatter.date(from: timestamp)
+        ?? iso8601TimestampParser.date(from: timestamp) else {
+        preconditionFailure("Invalid ISO 8601 timestamp: \(timestamp)")
+    }
+    return iso8601TimestampFormatter.string(
+        from: start.addingTimeInterval(Double(duration) / 1_000)
+    )
 }
 
 private func updateMcpServerCustomizationState(
@@ -1055,7 +1052,6 @@ private func upsertInputRequest(state: ChatState, request: ChatInputRequest) -> 
     var next = state
     next.activeTurn = activeTurn
     next.status = withStatusFlag(chatSummaryStatus(next), .isRead, false)
-    next.modifiedAt = currentTimestamp()
     return next
 }
 
@@ -1131,7 +1127,7 @@ private func endTurn(
     next.turns.append(turn)
     next.activeTurn = nil
     next.status = chatSummaryStatus(next, terminalStatus: terminalStatus)
-    next.modifiedAt = currentTimestamp()
+    next.modifiedAt = addMillisecondsToTimestamp(activeTurn.startedAt, turn.duration ?? 0)
     return next
 }
 
@@ -1240,7 +1236,10 @@ public func terminalReducer(state: TerminalState, action: StateAction) -> Termin
 
     case .terminalExited(let a):
         var next = state
-        next.exitCode = a.exitCode
+        next.lifecycle = .exited(TerminalExitedLifecycleState(
+            status: .exited,
+            exitCode: a.exitCode
+        ))
         return next
 
     case .terminalCleared:
@@ -1340,7 +1339,6 @@ public func changesetReducer(state: ChangesetState, action: StateAction) -> Chan
         if let operations = a.operations {
             next.operations = operations
         }
-        next.error = a.error
         return next
 
     case .changesetOperationsChanged(let a):
@@ -1400,7 +1398,7 @@ public func annotationsReducer(state: AnnotationsState, action: StateAction) -> 
         }
         var next = state
         var annotation = next.annotations[idx]
-        if let turnId = a.turnId { annotation.turnId = turnId }
+        if let origin = a.origin { annotation.origin = origin }
         if let resource = a.resource { annotation.resource = resource }
         if let range = a.range { annotation.range = range }
         if let resolved = a.resolved { annotation.resolved = resolved }

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/FixtureDrivenReducerTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/FixtureDrivenReducerTests.swift
@@ -20,24 +20,6 @@ final class FixtureDrivenReducerTests: XCTestCase {
         let expected: AnyCodable
     }
 
-    // MARK: - Mock Timestamp
-
-    /// Match the TypeScript test mock: Date.now = () => 9999
-    private static let MOCK_NOW = 9999
-
-    private var originalTimestampProvider: (() -> Int)!
-
-    override func setUp() {
-        super.setUp()
-        originalTimestampProvider = currentTimestampProvider
-        currentTimestampProvider = { Self.MOCK_NOW }
-    }
-
-    override func tearDown() {
-        currentTimestampProvider = originalTimestampProvider
-        super.tearDown()
-    }
-
     // MARK: - Fixture Loading
 
     private static let fixtureDir: URL = {

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/ReducersTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/ReducersTests.swift
@@ -110,10 +110,6 @@ final class ReducersTests: XCTestCase {
     // MARK: - Timestamp Behavior
 
     func testChatTurnStartedUpdatesModifiedAt() {
-        let originalProvider = currentTimestampProvider
-        currentTimestampProvider = { 9_999 }
-        defer { currentTimestampProvider = originalProvider }
-
         let state = ChatState(
             resource: C,
             title: "Test Chat",
@@ -128,7 +124,7 @@ final class ReducersTests: XCTestCase {
                 message: Message(text: "Hello", origin: MessageOrigin(kind: .user))
             ))
         )
-        XCTAssertEqual(next.modifiedAt, "1970-01-01T00:00:09.999Z")
+        XCTAssertEqual(next.modifiedAt, "2026-07-09T20:00:00.000Z")
         XCTAssertEqual(next.activeTurn?.startedAt, "2026-07-09T20:00:00.000Z")
     }
 

--- a/docs/.changes/20260820-annotation-origin.json
+++ b/docs/.changes/20260820-annotation-origin.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "Annotations now carry an `origin` with a required session URI and optional chat URI and turn ID."
+}

--- a/docs/.changes/20260820-changeset-content-error.json
+++ b/docs/.changes/20260820-changeset-content-error.json
@@ -1,0 +1,4 @@
+{
+  "type": "removed",
+  "message": "Removed `error` from `changeset/contentChanged`; changeset failures are represented by `changeset/statusChanged`."
+}

--- a/docs/.changes/20260820-deterministic-chat-modified-at.json
+++ b/docs/.changes/20260820-deterministic-chat-modified-at.json
@@ -1,0 +1,4 @@
+{
+  "type": "fixed",
+  "message": "Chat reducers now derive `modifiedAt` from turn action data instead of local wall clocks."
+}

--- a/docs/.changes/20260820-remove-session-fork.json
+++ b/docs/.changes/20260820-remove-session-fork.json
@@ -1,0 +1,4 @@
+{
+  "type": "removed",
+  "message": "Removed session-level forking from `createSession`; use chat forking instead."
+}

--- a/docs/.changes/20260820-rust-invalid-reduce-outcome.json
+++ b/docs/.changes/20260820-rust-invalid-reduce-outcome.json
@@ -1,0 +1,5 @@
+{
+  "type": "changed",
+  "message": "Rust reducers now return `ReduceOutcome::Invalid(ReduceError)` for malformed action data instead of panicking.",
+  "targets": ["rust"]
+}

--- a/docs/.changes/20260820-session-lifecycle-failed.json
+++ b/docs/.changes/20260820-session-lifecycle-failed.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "Renamed the failed session lifecycle value from `creationFailed` to `failed`."
+}

--- a/docs/.changes/20260820-terminal-claim-chat.json
+++ b/docs/.changes/20260820-terminal-claim-chat.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "`TerminalSessionClaim` now requires the chat URI that owns the terminal."
+}

--- a/docs/.changes/20260820-terminal-lifecycle.json
+++ b/docs/.changes/20260820-terminal-lifecycle.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "Terminal state now uses an explicit `running`/`exited` lifecycle that preserves exits without an exit code."
+}

--- a/docs/guide/changesets.md
+++ b/docs/guide/changesets.md
@@ -98,7 +98,7 @@ of the changeset URI:
 | `changeset/fileSet`                 | No                   | Upsert a `ChangesetFile` (new or replacing existing by `id`).                |
 | `changeset/fileRemoved`             | No                   | A file is no longer in the changeset.                                        |
 | `changeset/filesReviewChanged`      | Yes                  | A reviewer toggled the `reviewed` flag on one or more files.                 |
-| `changeset/contentChanged`          | No                   | Full replacement of files, optionally with operations or error details.      |
+| `changeset/contentChanged`          | No                   | Full replacement of files, optionally with operations.                        |
 | `changeset/operationsChanged`       | No                   | The set of available `operations` changed.                                   |
 | `changeset/operationStatusChanged`  | No                   | A single operation's `status` transitioned (e.g. `idle → running → error`).  |
 | `changeset/cleared`                 | No                   | All files dropped (e.g. branch switched, or the owning session ended).       |

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -76,7 +76,7 @@ SessionState {
   workingDirectories?: URI[]   // equal-peer working directories
   annotations?: AnnotationsSummary
 
-  lifecycle: 'creating' | 'ready' | 'creationFailed'
+  lifecycle: 'creating' | 'ready' | 'failed'
   creationError?: ErrorInfo
   chats: ChatSummary[]                     // catalog of chats in this session
   defaultChat?: URI                        // input-routing hint
@@ -556,23 +556,6 @@ sequenceDiagram
 ```
 
 If the `turnId` is not found in the completed turns array, the action is a no-op.
-
-## Session Forking
-
-A new session can be created as a **fork** of an existing session by providing the optional `fork` field in `createSession`. The server populates the new session with content from the source session up to and including the response of the specified turn.
-
-```typescript
-createSession({
-  session: 'ahp-session:/<new-uuid>',
-  provider: 'copilot',
-  fork: {
-    session: 'ahp-session:/<source-uuid>',
-    turnId: 't-3',     // copy turns through t-3
-  },
-});
-```
-
-The forked session is an independent copy — subsequent changes to either session do not affect the other. The server broadcasts `root/sessionAdded` for the new session as usual.
 
 ## Multiroot Sessions
 

--- a/docs/guide/terminals.md
+++ b/docs/guide/terminals.md
@@ -30,7 +30,7 @@ TerminalInfo {
   resource: URI             // subscribable terminal URI
   title: string             // human-readable name
   claim: TerminalClaim      // who holds it
-  exitCode?: number         // present = process exited
+  lifecycle: TerminalLifecycleState
 }
 ```
 
@@ -45,11 +45,16 @@ TerminalState {
   cols?: number             // width in columns
   rows?: number             // height in rows
   content: TerminalContentPart[]  // structured content parts
-  exitCode?: number         // set when process exits
+  lifecycle: TerminalLifecycleState
   claim: TerminalClaim      // ownership
   supportsCommandDetection?: boolean  // true when command lifecycle actions are emitted
 }
 ```
+
+`TerminalLifecycleState` is a discriminated union: `{ status: 'running' }`
+while the process is active, and `{ status: 'exited', exitCode?: number }`
+after it exits. The explicit status preserves an exit even when the runtime
+does not report an exit code.
 
 The `content` field is an ordered array of typed content parts. Each part is either unstructured terminal output or a structured command with its command line and output:
 
@@ -99,6 +104,7 @@ TerminalClientClaim {
 TerminalSessionClaim {
   kind: 'session'
   session: URI
+  chat: URI
   turnId?: string           // present when actively used by a tool call
   toolCallId?: string
 }
@@ -108,8 +114,8 @@ The `turnId` and `toolCallId` fields on session claims distinguish between "acti
 
 | Claim State | Meaning |
 |---|---|
-| `{ kind: 'session', session, turnId, toolCallId }` | Actively used by a running tool call |
-| `{ kind: 'session', session }` | Backgrounded, still owned by the session |
+| `{ kind: 'session', session, chat, turnId, toolCallId }` | Actively used by a running tool call |
+| `{ kind: 'session', session, chat }` | Backgrounded, still owned by the chat |
 | `{ kind: 'client', clientId }` | User interacting directly in a terminal UI |
 
 Every terminal always has an owner. When a terminal is no longer needed, it should be disposed via the `disposeTerminal` command rather than released.
@@ -175,7 +181,7 @@ Clients MUST check `supportsCommandDetection` before relying on command boundari
 | `terminal/claimed` | Yes | Sets `claim` |
 | `terminal/titleChanged` | Yes | Sets `title` |
 | `terminal/cwdChanged` | No | Sets `cwd` |
-| `terminal/exited` | No | Sets `exitCode` |
+| `terminal/exited` | No | Sets `lifecycle` to `exited` with the optional `exitCode` |
 | `terminal/cleared` | Yes | Resets `content` to `[]` |
 
 The root terminal list is managed by the server via `root/terminalsChanged`, which uses full-replacement semantics.
@@ -204,10 +210,10 @@ sequenceDiagram
   A->>S: createTerminal({ terminal, name: "npm test" })
   S->>C: root/terminalsChanged (terminal added)
   S->>C: terminal/cwdChanged { cwd }
-  S->>C: terminal/claimed { claim: { kind: 'session', session, turnId, toolCallId } }
+  S->>C: terminal/claimed { claim: { kind: 'session', session, chat, turnId, toolCallId } }
   S->>C: terminal/data { data: "$ npm test\r\n..." }
   Note over S: Command finishes
-  S->>C: terminal/claimed { claim: { kind: 'session', session } }
+  S->>C: terminal/claimed { claim: { kind: 'session', session, chat } }
   S->>C: terminal/exited { exitCode: 0 }
   Note over C: Terminal remains in root list,<br/>client can view output or dispose
 ```
@@ -224,11 +230,11 @@ sequenceDiagram
 
   A->>S: createTerminal({ terminal, name: "dev-server" })
   S->>C: root/terminalsChanged (terminal added)
-  S->>C: terminal/claimed { claim: { kind: 'session', session, turnId, toolCallId } }
+  S->>C: terminal/claimed { claim: { kind: 'session', session, chat, turnId, toolCallId } }
   S->>C: terminal/data { data: "$ npm run dev\r\nServer running on port 3000\r\n" }
 
   Note over A: Tool call completes,<br/>terminal auto-detached
-  S->>C: terminal/claimed { claim: { kind: 'session', session } }
+  S->>C: terminal/claimed { claim: { kind: 'session', session, chat } }
   Note over S: Session still owns the terminal,<br/>but no active tool call
 
   S-->>C: terminal/data { data: "..." }
@@ -252,7 +258,7 @@ sequenceDiagram
   Note over S: Agent is running a build,<br/>terminal claimed by session+turn+toolCall
   S->>C: terminal/data { data: "Building..." }
 
-  C->>S: terminal/claimed { claim: { kind: 'session', session } }
+  C->>S: terminal/claimed { claim: { kind: 'session', session, chat } }
   Note over S: Server narrows claim,<br/>signals agent the tool call can complete
 
   S->>C: root/terminalsChanged (claim updated)
@@ -295,9 +301,9 @@ sequenceDiagram
   participant S as Server
   participant A as Agent
 
-  Note over S: Terminal is backgrounded,<br/>claim: { kind: 'session', session }
+  Note over S: Terminal is backgrounded,<br/>claim: { kind: 'session', session, chat }
 
-  A->>S: terminal/claimed { claim: { kind: 'session', session, turnId: "t2", toolCallId: "tc5" } }
+  A->>S: terminal/claimed { claim: { kind: 'session', session, chat, turnId: "t2", toolCallId: "tc5" } }
   S->>C: root/terminalsChanged (claim updated)
 
   Note over A: Agent reads recent output,<br/>sends input to the terminal
@@ -305,7 +311,7 @@ sequenceDiagram
   S->>C: terminal/data { data: "HTTP/1.1 200 OK\r\n" }
 
   Note over A: Tool call completes
-  S->>C: terminal/claimed { claim: { kind: 'session', session } }
+  S->>C: terminal/claimed { claim: { kind: 'session', session, chat } }
 ```
 
 ### Terminal Cleanup
@@ -317,7 +323,7 @@ sequenceDiagram
   participant C as Client
   participant S as Server
 
-  Note over S: Terminal has exited (exitCode set)
+  Note over S: Terminal lifecycle is exited
   C->>S: disposeTerminal({ terminal })
   S->>C: root/terminalsChanged (terminal removed)
   Note over S: Resources freed,<br/>subscribers receive no more actions

--- a/docs/specification/terminal-channel.md
+++ b/docs/specification/terminal-channel.md
@@ -23,7 +23,7 @@ TerminalState {
   cols?: number
   rows?: number
   content: TerminalContentPart[]
-  exitCode?: number
+  lifecycle: TerminalLifecycleState
   claim: TerminalClaim
   supportsCommandDetection?: boolean
 }
@@ -31,7 +31,7 @@ TerminalState {
 
 `content` is an ordered array of typed parts. Each part is either `unclassified` (raw VT output) or a structured `command` part carrying the command line, accumulated output, exit code, and duration. See the [Terminals guide](/guide/terminals#full-terminal-state) for the part shapes.
 
-A terminal is **always owned** — the [`claim`](/guide/terminals#claims-and-ownership) field records whether it belongs to a client or a session.
+A terminal is **always owned** — the [`claim`](/guide/terminals#claims-and-ownership) field records whether it belongs to a client or a session. Its `lifecycle` is `{ status: "running" }` while active and `{ status: "exited", exitCode?: number }` after exit.
 
 ## Lifecycle
 
@@ -119,7 +119,7 @@ The server MUST NOT include shell integration escape sequences in `terminal/data
 | `terminal/claimed` | Yes | Sets `claim` |
 | `terminal/titleChanged` | Yes | Sets `title` |
 | `terminal/cwdChanged` | No | Sets `cwd` |
-| `terminal/exited` | No | Sets `exitCode` |
+| `terminal/exited` | No | Sets `lifecycle` to `exited` with the optional `exitCode` |
 | `terminal/cleared` | Yes | Resets `content` to `[]` |
 
 ## Commands

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,4 +19,14 @@ export default [
       '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
     },
   },
+  {
+    files: ['types/**/*reducer*.ts'],
+    ignores: ['types/**/*.test.ts'],
+    rules: {
+      'no-restricted-globals': ['error', {
+        name: 'Date',
+        message: 'Reducers must be deterministic. Put timestamps on actions or derive them from action data.',
+      }],
+    },
+  },
 ];

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -1905,10 +1905,6 @@
             "$ref": "#/$defs/ChangesetOperation"
           },
           "description": "Full replacement operation list. Omit when operations are unchanged."
-        },
-        "error": {
-          "$ref": "#/$defs/ErrorInfo",
-          "description": "Error information, if the changeset content change failed."
         }
       },
       "required": [
@@ -2001,9 +1997,9 @@
           "type": "string",
           "description": "The {@link Annotation.id} of the annotation to update."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Re-anchors the annotation to the file versions this turn produced.\nMatches a {@link Turn.id} on the owning session. Omit to leave the\ncurrent {@link Annotation.turnId} unchanged."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Replaces the annotation's provenance. Omit to leave it unchanged."
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -6829,15 +6825,44 @@
           "$ref": "#/$defs/TerminalClaim",
           "description": "Who currently holds this terminal"
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, if the terminal process has exited"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         }
       },
       "required": [
         "resource",
         "title",
-        "claim"
+        "claim",
+        "lifecycle"
+      ]
+    },
+    "TerminalRunningLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that is still running.",
+      "properties": {
+        "status": {
+          "const": "running"
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
+    "TerminalExitedLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that has exited.",
+      "properties": {
+        "status": {
+          "const": "exited"
+        },
+        "exitCode": {
+          "type": "number",
+          "description": "Process exit code, if the runtime reported one."
+        }
+      },
+      "required": [
+        "status"
       ]
     },
     "TerminalClientClaim": {
@@ -6870,9 +6895,13 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI that claimed the terminal"
         },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Chat URI that claimed the terminal."
+        },
         "turnId": {
           "type": "string",
-          "description": "Optional turn identifier within the session"
+          "description": "Optional turn identifier within the chat."
         },
         "toolCallId": {
           "type": "string",
@@ -6881,7 +6910,8 @@
       },
       "required": [
         "kind",
-        "session"
+        "session",
+        "chat"
       ]
     },
     "TerminalState": {
@@ -6911,9 +6941,9 @@
           },
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, set when the terminal process exits"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -6931,6 +6961,7 @@
       "required": [
         "title",
         "content",
+        "lifecycle",
         "claim"
       ]
     },
@@ -7193,17 +7224,38 @@
         "annotations"
       ]
     },
+    "AnnotationOrigin": {
+      "type": "object",
+      "description": "Provenance of the content an annotation is anchored to.",
+      "properties": {
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning session URI."
+        },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning chat URI, when the annotation is scoped to a chat."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier within {@link chat}, when the annotation is scoped to a turn."
+        }
+      },
+      "required": [
+        "session"
+      ]
+    },
     "Annotation": {
       "type": "object",
-      "description": "A conversation anchored to a specific file produced by a specific turn,\noptionally narrowed to a range within that file.\n\n{@link turnId} anchors the annotation to the file versions that turn\nproduced, so a later turn that rewrites the same file does not silently\ninvalidate the annotation's anchor — clients can resolve {@link resource}\nand {@link range} against the turn's changeset. When {@link range} is\nomitted the annotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
+      "description": "A conversation anchored to a specific file in a session, optionally scoped\nto a chat and turn and narrowed to a range within that file.\n\n{@link origin} identifies the owning session and, when available, the chat\nand turn that produced the file version. When {@link range} is omitted the\nannotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
       "properties": {
         "id": {
           "type": "string",
           "description": "Stable identifier within the annotations channel. Assigned by the client\nthat dispatches the creating {@link AnnotationsSetAction}."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Turn that produced the file versions this annotation is anchored to.\nMatches a {@link Turn.id} on the owning session."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Provenance of the content this annotation is anchored to."
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -7232,7 +7284,7 @@
       },
       "required": [
         "id",
-        "turnId",
+        "origin",
         "resource",
         "resolved",
         "entries"
@@ -8361,6 +8413,17 @@
       ],
       "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output and\ncommand completion metadata, and\n`ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions)."
     },
+    "TerminalLifecycleState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalRunningLifecycleState"
+        },
+        {
+          "$ref": "#/$defs/TerminalExitedLifecycleState"
+        }
+      ],
+      "description": "Current lifecycle of a terminal process."
+    },
     "TerminalClaim": {
       "oneOf": [
         {
@@ -8801,7 +8864,7 @@
       "enum": [
         "creating",
         "ready",
-        "creationFailed"
+        "failed"
       ],
       "type": "string",
       "description": "Session initialization state."

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -1069,26 +1069,9 @@
         "items"
       ]
     },
-    "SessionForkSource": {
-      "type": "object",
-      "description": "Creates a new session with the specified agent provider.\n\nIf the session URI already exists, the server MUST return an error with code\n`-32003` (`SessionAlreadyExists`).\n\nAfter creation, the client should subscribe to the session URI to receive state\nupdates. The server also broadcasts a `root/sessionAdded` notification to all\nclients.",
-      "properties": {
-        "session": {
-          "$ref": "#/$defs/URI",
-          "description": "URI of the existing session to fork from"
-        },
-        "turnId": {
-          "type": "string",
-          "description": "Turn ID in the source session; content up to and including this turn's response is copied"
-        }
-      },
-      "required": [
-        "session",
-        "turnId"
-      ]
-    },
     "CreateSessionParams": {
       "type": "object",
+      "description": "Creates a new session with the specified agent provider.\n\nIf the session URI already exists, the server MUST return an error with code\n`-32003` (`SessionAlreadyExists`).\n\nAfter creation, the client should subscribe to the session URI to receive state\nupdates. The server also broadcasts a `root/sessionAdded` notification to all\nclients.",
       "properties": {
         "channel": {
           "$ref": "#/$defs/URI",
@@ -1108,11 +1091,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises a protected-primary capability. An\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable\nprimary} is fixed, while a\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable\nprimary} is changed only with `session/workingDirectoryReplaced`.\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch working-directory actions to change the set\nafter the session has started.\n\nIgnored for forked sessions — a fork inherits its working directories\nfrom the source session identified by `fork`."
-        },
-        "fork": {
-          "$ref": "#/$defs/SessionForkSource",
-          "description": "Fork from an existing session. The new session is populated with content\nfrom the source session up to and including the specified turn's response."
+          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises a protected-primary capability. An\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable\nprimary} is fixed, while a\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable\nprimary} is changed only with `session/workingDirectoryReplaced`.\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch working-directory actions to change the set\nafter the session has started."
         },
         "config": {
           "type": "object",
@@ -6100,15 +6079,44 @@
           "$ref": "#/$defs/TerminalClaim",
           "description": "Who currently holds this terminal"
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, if the terminal process has exited"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         }
       },
       "required": [
         "resource",
         "title",
-        "claim"
+        "claim",
+        "lifecycle"
+      ]
+    },
+    "TerminalRunningLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that is still running.",
+      "properties": {
+        "status": {
+          "const": "running"
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
+    "TerminalExitedLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that has exited.",
+      "properties": {
+        "status": {
+          "const": "exited"
+        },
+        "exitCode": {
+          "type": "number",
+          "description": "Process exit code, if the runtime reported one."
+        }
+      },
+      "required": [
+        "status"
       ]
     },
     "TerminalClientClaim": {
@@ -6141,9 +6149,13 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI that claimed the terminal"
         },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Chat URI that claimed the terminal."
+        },
         "turnId": {
           "type": "string",
-          "description": "Optional turn identifier within the session"
+          "description": "Optional turn identifier within the chat."
         },
         "toolCallId": {
           "type": "string",
@@ -6152,7 +6164,8 @@
       },
       "required": [
         "kind",
-        "session"
+        "session",
+        "chat"
       ]
     },
     "TerminalState": {
@@ -6182,9 +6195,9 @@
           },
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, set when the terminal process exits"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -6202,6 +6215,7 @@
       "required": [
         "title",
         "content",
+        "lifecycle",
         "claim"
       ]
     },
@@ -6464,17 +6478,38 @@
         "annotations"
       ]
     },
+    "AnnotationOrigin": {
+      "type": "object",
+      "description": "Provenance of the content an annotation is anchored to.",
+      "properties": {
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning session URI."
+        },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning chat URI, when the annotation is scoped to a chat."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier within {@link chat}, when the annotation is scoped to a turn."
+        }
+      },
+      "required": [
+        "session"
+      ]
+    },
     "Annotation": {
       "type": "object",
-      "description": "A conversation anchored to a specific file produced by a specific turn,\noptionally narrowed to a range within that file.\n\n{@link turnId} anchors the annotation to the file versions that turn\nproduced, so a later turn that rewrites the same file does not silently\ninvalidate the annotation's anchor — clients can resolve {@link resource}\nand {@link range} against the turn's changeset. When {@link range} is\nomitted the annotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
+      "description": "A conversation anchored to a specific file in a session, optionally scoped\nto a chat and turn and narrowed to a range within that file.\n\n{@link origin} identifies the owning session and, when available, the chat\nand turn that produced the file version. When {@link range} is omitted the\nannotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
       "properties": {
         "id": {
           "type": "string",
           "description": "Stable identifier within the annotations channel. Assigned by the client\nthat dispatches the creating {@link AnnotationsSetAction}."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Turn that produced the file versions this annotation is anchored to.\nMatches a {@link Turn.id} on the owning session."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Provenance of the content this annotation is anchored to."
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -6503,7 +6538,7 @@
       },
       "required": [
         "id",
-        "turnId",
+        "origin",
         "resource",
         "resolved",
         "entries"
@@ -9065,10 +9100,6 @@
             "$ref": "#/$defs/ChangesetOperation"
           },
           "description": "Full replacement operation list. Omit when operations are unchanged."
-        },
-        "error": {
-          "$ref": "#/$defs/ErrorInfo",
-          "description": "Error information, if the changeset content change failed."
         }
       },
       "required": [
@@ -9161,9 +9192,9 @@
           "type": "string",
           "description": "The {@link Annotation.id} of the annotation to update."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Re-anchors the annotation to the file versions this turn produced.\nMatches a {@link Turn.id} on the owning session. Omit to leave the\ncurrent {@link Annotation.turnId} unchanged."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Replaces the annotation's provenance. Omit to leave it unchanged."
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -9964,7 +9995,7 @@
       "enum": [
         "creating",
         "ready",
-        "creationFailed"
+        "failed"
       ],
       "type": "string",
       "description": "Session initialization state."
@@ -10441,6 +10472,17 @@
       ],
       "type": "string",
       "description": "Why a tool call was cancelled."
+    },
+    "TerminalLifecycleState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalRunningLifecycleState"
+        },
+        {
+          "$ref": "#/$defs/TerminalExitedLifecycleState"
+        }
+      ],
+      "description": "Current lifecycle of a terminal process."
     },
     "TerminalContentPart": {
       "oneOf": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -4518,15 +4518,44 @@
           "$ref": "#/$defs/TerminalClaim",
           "description": "Who currently holds this terminal"
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, if the terminal process has exited"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         }
       },
       "required": [
         "resource",
         "title",
-        "claim"
+        "claim",
+        "lifecycle"
+      ]
+    },
+    "TerminalRunningLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that is still running.",
+      "properties": {
+        "status": {
+          "const": "running"
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
+    "TerminalExitedLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that has exited.",
+      "properties": {
+        "status": {
+          "const": "exited"
+        },
+        "exitCode": {
+          "type": "number",
+          "description": "Process exit code, if the runtime reported one."
+        }
+      },
+      "required": [
+        "status"
       ]
     },
     "TerminalClientClaim": {
@@ -4559,9 +4588,13 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI that claimed the terminal"
         },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Chat URI that claimed the terminal."
+        },
         "turnId": {
           "type": "string",
-          "description": "Optional turn identifier within the session"
+          "description": "Optional turn identifier within the chat."
         },
         "toolCallId": {
           "type": "string",
@@ -4570,7 +4603,8 @@
       },
       "required": [
         "kind",
-        "session"
+        "session",
+        "chat"
       ]
     },
     "TerminalState": {
@@ -4600,9 +4634,9 @@
           },
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, set when the terminal process exits"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -4620,6 +4654,7 @@
       "required": [
         "title",
         "content",
+        "lifecycle",
         "claim"
       ]
     },
@@ -4882,17 +4917,38 @@
         "annotations"
       ]
     },
+    "AnnotationOrigin": {
+      "type": "object",
+      "description": "Provenance of the content an annotation is anchored to.",
+      "properties": {
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning session URI."
+        },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning chat URI, when the annotation is scoped to a chat."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier within {@link chat}, when the annotation is scoped to a turn."
+        }
+      },
+      "required": [
+        "session"
+      ]
+    },
     "Annotation": {
       "type": "object",
-      "description": "A conversation anchored to a specific file produced by a specific turn,\noptionally narrowed to a range within that file.\n\n{@link turnId} anchors the annotation to the file versions that turn\nproduced, so a later turn that rewrites the same file does not silently\ninvalidate the annotation's anchor — clients can resolve {@link resource}\nand {@link range} against the turn's changeset. When {@link range} is\nomitted the annotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
+      "description": "A conversation anchored to a specific file in a session, optionally scoped\nto a chat and turn and narrowed to a range within that file.\n\n{@link origin} identifies the owning session and, when available, the chat\nand turn that produced the file version. When {@link range} is omitted the\nannotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
       "properties": {
         "id": {
           "type": "string",
           "description": "Stable identifier within the annotations channel. Assigned by the client\nthat dispatches the creating {@link AnnotationsSetAction}."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Turn that produced the file versions this annotation is anchored to.\nMatches a {@link Turn.id} on the owning session."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Provenance of the content this annotation is anchored to."
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -4921,7 +4977,7 @@
       },
       "required": [
         "id",
-        "turnId",
+        "origin",
         "resource",
         "resolved",
         "entries"
@@ -6647,26 +6703,9 @@
         "items"
       ]
     },
-    "SessionForkSource": {
-      "type": "object",
-      "description": "Creates a new session with the specified agent provider.\n\nIf the session URI already exists, the server MUST return an error with code\n`-32003` (`SessionAlreadyExists`).\n\nAfter creation, the client should subscribe to the session URI to receive state\nupdates. The server also broadcasts a `root/sessionAdded` notification to all\nclients.",
-      "properties": {
-        "session": {
-          "$ref": "#/$defs/URI",
-          "description": "URI of the existing session to fork from"
-        },
-        "turnId": {
-          "type": "string",
-          "description": "Turn ID in the source session; content up to and including this turn's response is copied"
-        }
-      },
-      "required": [
-        "session",
-        "turnId"
-      ]
-    },
     "CreateSessionParams": {
       "type": "object",
+      "description": "Creates a new session with the specified agent provider.\n\nIf the session URI already exists, the server MUST return an error with code\n`-32003` (`SessionAlreadyExists`).\n\nAfter creation, the client should subscribe to the session URI to receive state\nupdates. The server also broadcasts a `root/sessionAdded` notification to all\nclients.",
       "properties": {
         "channel": {
           "$ref": "#/$defs/URI",
@@ -6686,11 +6725,7 @@
           "items": {
             "$ref": "#/$defs/URI"
           },
-          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises a protected-primary capability. An\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable\nprimary} is fixed, while a\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable\nprimary} is changed only with `session/workingDirectoryReplaced`.\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch working-directory actions to change the set\nafter the session has started.\n\nIgnored for forked sessions — a fork inherits its working directories\nfrom the source session identified by `fork`."
-        },
-        "fork": {
-          "$ref": "#/$defs/SessionForkSource",
-          "description": "Fork from an existing session. The new session is populated with content\nfrom the source session up to and including the specified turn's response."
+          "description": "The working directories the session's agent is granted tool access to.\nA session may span multiple directories; they are equal peers except when\nthe agent advertises a protected-primary capability. An\n{@link MultipleWorkingDirectoriesCapability.immutablePrimary | immutable\nprimary} is fixed, while a\n{@link MultipleWorkingDirectoriesCapability.primaryReplacement | replaceable\nprimary} is changed only with `session/workingDirectoryReplaced`.\n\nA client MUST NOT supply more than one entry unless the agent advertises\n{@link AgentCapabilities.multipleWorkingDirectories}; a server without that\ncapability treats only the first entry as the session's working directory\nand ignores the rest. Dispatch working-directory actions to change the set\nafter the session has started."
         },
         "config": {
           "type": "object",
@@ -7318,7 +7353,7 @@
       "enum": [
         "creating",
         "ready",
-        "creationFailed"
+        "failed"
       ],
       "type": "string",
       "description": "Session initialization state."
@@ -7845,6 +7880,17 @@
         }
       ],
       "description": "Describes who currently holds a terminal. A terminal may be claimed by\neither a connected client or a session (e.g. during a tool call)."
+    },
+    "TerminalLifecycleState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalRunningLifecycleState"
+        },
+        {
+          "$ref": "#/$defs/TerminalExitedLifecycleState"
+        }
+      ],
+      "description": "Current lifecycle of a terminal process."
     },
     "TerminalContentPart": {
       "oneOf": [
@@ -9930,10 +9976,6 @@
             "$ref": "#/$defs/ChangesetOperation"
           },
           "description": "Full replacement operation list. Omit when operations are unchanged."
-        },
-        "error": {
-          "$ref": "#/$defs/ErrorInfo",
-          "description": "Error information, if the changeset content change failed."
         }
       },
       "required": [
@@ -10026,9 +10068,9 @@
           "type": "string",
           "description": "The {@link Annotation.id} of the annotation to update."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Re-anchors the annotation to the file versions this turn produced.\nMatches a {@link Turn.id} on the owning session. Omit to leave the\ncurrent {@link Annotation.turnId} unchanged."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Replaces the annotation's provenance. Omit to leave it unchanged."
         },
         "resource": {
           "$ref": "#/$defs/URI",

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -4685,15 +4685,44 @@
           "$ref": "#/$defs/TerminalClaim",
           "description": "Who currently holds this terminal"
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, if the terminal process has exited"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         }
       },
       "required": [
         "resource",
         "title",
-        "claim"
+        "claim",
+        "lifecycle"
+      ]
+    },
+    "TerminalRunningLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that is still running.",
+      "properties": {
+        "status": {
+          "const": "running"
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
+    "TerminalExitedLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that has exited.",
+      "properties": {
+        "status": {
+          "const": "exited"
+        },
+        "exitCode": {
+          "type": "number",
+          "description": "Process exit code, if the runtime reported one."
+        }
+      },
+      "required": [
+        "status"
       ]
     },
     "TerminalClientClaim": {
@@ -4726,9 +4755,13 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI that claimed the terminal"
         },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Chat URI that claimed the terminal."
+        },
         "turnId": {
           "type": "string",
-          "description": "Optional turn identifier within the session"
+          "description": "Optional turn identifier within the chat."
         },
         "toolCallId": {
           "type": "string",
@@ -4737,7 +4770,8 @@
       },
       "required": [
         "kind",
-        "session"
+        "session",
+        "chat"
       ]
     },
     "TerminalState": {
@@ -4767,9 +4801,9 @@
           },
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, set when the terminal process exits"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -4787,6 +4821,7 @@
       "required": [
         "title",
         "content",
+        "lifecycle",
         "claim"
       ]
     },
@@ -5049,17 +5084,38 @@
         "annotations"
       ]
     },
+    "AnnotationOrigin": {
+      "type": "object",
+      "description": "Provenance of the content an annotation is anchored to.",
+      "properties": {
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning session URI."
+        },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning chat URI, when the annotation is scoped to a chat."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier within {@link chat}, when the annotation is scoped to a turn."
+        }
+      },
+      "required": [
+        "session"
+      ]
+    },
     "Annotation": {
       "type": "object",
-      "description": "A conversation anchored to a specific file produced by a specific turn,\noptionally narrowed to a range within that file.\n\n{@link turnId} anchors the annotation to the file versions that turn\nproduced, so a later turn that rewrites the same file does not silently\ninvalidate the annotation's anchor — clients can resolve {@link resource}\nand {@link range} against the turn's changeset. When {@link range} is\nomitted the annotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
+      "description": "A conversation anchored to a specific file in a session, optionally scoped\nto a chat and turn and narrowed to a range within that file.\n\n{@link origin} identifies the owning session and, when available, the chat\nand turn that produced the file version. When {@link range} is omitted the\nannotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
       "properties": {
         "id": {
           "type": "string",
           "description": "Stable identifier within the annotations channel. Assigned by the client\nthat dispatches the creating {@link AnnotationsSetAction}."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Turn that produced the file versions this annotation is anchored to.\nMatches a {@link Turn.id} on the owning session."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Provenance of the content this annotation is anchored to."
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -5088,7 +5144,7 @@
       },
       "required": [
         "id",
-        "turnId",
+        "origin",
         "resource",
         "resolved",
         "entries"
@@ -5822,7 +5878,7 @@
       "enum": [
         "creating",
         "ready",
-        "creationFailed"
+        "failed"
       ],
       "type": "string",
       "description": "Session initialization state."
@@ -6349,6 +6405,17 @@
         }
       ],
       "description": "Describes who currently holds a terminal. A terminal may be claimed by\neither a connected client or a session (e.g. during a tool call)."
+    },
+    "TerminalLifecycleState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalRunningLifecycleState"
+        },
+        {
+          "$ref": "#/$defs/TerminalExitedLifecycleState"
+        }
+      ],
+      "description": "Current lifecycle of a terminal process."
     },
     "TerminalContentPart": {
       "oneOf": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -4429,15 +4429,44 @@
           "$ref": "#/$defs/TerminalClaim",
           "description": "Who currently holds this terminal"
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, if the terminal process has exited"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         }
       },
       "required": [
         "resource",
         "title",
-        "claim"
+        "claim",
+        "lifecycle"
+      ]
+    },
+    "TerminalRunningLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that is still running.",
+      "properties": {
+        "status": {
+          "const": "running"
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
+    "TerminalExitedLifecycleState": {
+      "type": "object",
+      "description": "A terminal process that has exited.",
+      "properties": {
+        "status": {
+          "const": "exited"
+        },
+        "exitCode": {
+          "type": "number",
+          "description": "Process exit code, if the runtime reported one."
+        }
+      },
+      "required": [
+        "status"
       ]
     },
     "TerminalClientClaim": {
@@ -4470,9 +4499,13 @@
           "$ref": "#/$defs/URI",
           "description": "Session URI that claimed the terminal"
         },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Chat URI that claimed the terminal."
+        },
         "turnId": {
           "type": "string",
-          "description": "Optional turn identifier within the session"
+          "description": "Optional turn identifier within the chat."
         },
         "toolCallId": {
           "type": "string",
@@ -4481,7 +4514,8 @@
       },
       "required": [
         "kind",
-        "session"
+        "session",
+        "chat"
       ]
     },
     "TerminalState": {
@@ -4511,9 +4545,9 @@
           },
           "description": "Typed content parts, replacing the flat `content: string`.\n\nNaive consumers that only need the raw VT stream can reconstruct it with:\n  `content.map(p => p.type === 'command' ? p.output : p.value).join('')`\n\nConsumers that need command boundaries can filter by part type."
         },
-        "exitCode": {
-          "type": "number",
-          "description": "Process exit code, set when the terminal process exits"
+        "lifecycle": {
+          "$ref": "#/$defs/TerminalLifecycleState",
+          "description": "Current terminal process lifecycle."
         },
         "claim": {
           "$ref": "#/$defs/TerminalClaim",
@@ -4531,6 +4565,7 @@
       "required": [
         "title",
         "content",
+        "lifecycle",
         "claim"
       ]
     },
@@ -4793,17 +4828,38 @@
         "annotations"
       ]
     },
+    "AnnotationOrigin": {
+      "type": "object",
+      "description": "Provenance of the content an annotation is anchored to.",
+      "properties": {
+        "session": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning session URI."
+        },
+        "chat": {
+          "$ref": "#/$defs/URI",
+          "description": "Owning chat URI, when the annotation is scoped to a chat."
+        },
+        "turnId": {
+          "type": "string",
+          "description": "Turn identifier within {@link chat}, when the annotation is scoped to a turn."
+        }
+      },
+      "required": [
+        "session"
+      ]
+    },
     "Annotation": {
       "type": "object",
-      "description": "A conversation anchored to a specific file produced by a specific turn,\noptionally narrowed to a range within that file.\n\n{@link turnId} anchors the annotation to the file versions that turn\nproduced, so a later turn that rewrites the same file does not silently\ninvalidate the annotation's anchor — clients can resolve {@link resource}\nand {@link range} against the turn's changeset. When {@link range} is\nomitted the annotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
+      "description": "A conversation anchored to a specific file in a session, optionally scoped\nto a chat and turn and narrowed to a range within that file.\n\n{@link origin} identifies the owning session and, when available, the chat\nand turn that produced the file version. When {@link range} is omitted the\nannotation is anchored to the entire file.\n\nEvery annotation MUST contain at least one {@link AnnotationEntry}. An\n{@link AnnotationsSetAction} that creates an annotation therefore carries\nits mandatory first entry, and removing the last remaining entry collapses\nthe annotation via {@link AnnotationsRemovedAction} rather than leaving an\nempty annotation behind.",
       "properties": {
         "id": {
           "type": "string",
           "description": "Stable identifier within the annotations channel. Assigned by the client\nthat dispatches the creating {@link AnnotationsSetAction}."
         },
-        "turnId": {
-          "type": "string",
-          "description": "Turn that produced the file versions this annotation is anchored to.\nMatches a {@link Turn.id} on the owning session."
+        "origin": {
+          "$ref": "#/$defs/AnnotationOrigin",
+          "description": "Provenance of the content this annotation is anchored to."
         },
         "resource": {
           "$ref": "#/$defs/URI",
@@ -4832,7 +4888,7 @@
       },
       "required": [
         "id",
-        "turnId",
+        "origin",
         "resource",
         "resolved",
         "entries"
@@ -5961,6 +6017,17 @@
       ],
       "description": "Content block in a tool result.\n\nMirrors the content blocks in MCP `CallToolResult.content`, plus\n`ToolResultResourceContent` for lazy-loading large results,\n`ToolResultFileEditContent` for file edit diffs,\n`ToolResultTerminalContent` for live terminal output and\ncommand completion metadata, and\n`ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions)."
     },
+    "TerminalLifecycleState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TerminalRunningLifecycleState"
+        },
+        {
+          "$ref": "#/$defs/TerminalExitedLifecycleState"
+        }
+      ],
+      "description": "Current lifecycle of a terminal process."
+    },
     "TerminalClaim": {
       "oneOf": [
         {
@@ -6054,7 +6121,7 @@
       "enum": [
         "creating",
         "ready",
-        "creationFailed"
+        "failed"
       ],
       "type": "string",
       "description": "Session initialization state."

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -711,7 +711,8 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason',
   'ConfirmationOptionKind', 'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus',
+  'TerminalClaimKind', 'TerminalLifecycleStatus',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
   'SessionOriginKind',
@@ -830,6 +831,8 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: strin
   { name: 'TerminalInfo' },
   { name: 'TerminalClientClaim' },
   { name: 'TerminalSessionClaim' },
+  { name: 'TerminalRunningLifecycleState' },
+  { name: 'TerminalExitedLifecycleState' },
   { name: 'TerminalState' },
   { name: 'TerminalUnclassifiedPart' },
   { name: 'TerminalCommandPart' },
@@ -843,6 +846,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: strin
   { name: 'ChangesetOperation' },
   { name: 'AnnotationsSummary' },
   { name: 'AnnotationsState' },
+  { name: 'AnnotationOrigin' },
   { name: 'Annotation' },
   { name: 'AnnotationEntry' },
   { name: 'TelemetryCapabilities' },
@@ -1078,6 +1082,16 @@ const TOOL_CALL_RISK_ASSESSMENT_UNION: UnionConfig = {
     { variantName: 'Complete', innerType: 'ToolCallRiskAssessmentCompleteState', wireValue: 'complete' },
   ],
   unknown: true,
+};
+
+const TERMINAL_LIFECYCLE_STATE_UNION: UnionConfig = {
+  name: 'TerminalLifecycleState',
+  discriminantField: 'status',
+  doc: 'TerminalLifecycleState is the current lifecycle of a terminal process.',
+  variants: [
+    { variantName: 'Running', innerType: 'TerminalRunningLifecycleState', wireValue: 'running' },
+    { variantName: 'Exited', innerType: 'TerminalExitedLifecycleState', wireValue: 'exited' },
+  ],
 };
 
 const SESSION_INPUT_REQUEST_UNION: UnionConfig = {
@@ -1461,6 +1475,8 @@ function generateStateFile(project: Project): string {
   lines.push('');
   lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
   lines.push('');
+  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
+  lines.push('');
   lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
   lines.push('');
   lines.push(generateDiscriminatedUnion(SESSION_ORIGIN_UNION));
@@ -1695,7 +1711,7 @@ const COMMAND_STRUCTS: { name: string; omitDiscriminants?: boolean; goName?: str
   { name: 'ReconnectReplayResult', omitDiscriminants: true },
   { name: 'ReconnectSnapshotResult', omitDiscriminants: true },
   { name: 'SubscribeParams' }, { name: 'SubscribeView' }, { name: 'SubscriptionDeliveryOptions' }, { name: 'SubscribeResult' },
-  { name: 'SessionForkSource' }, { name: 'CreateSessionParams' },
+  { name: 'CreateSessionParams' },
   { name: 'DisposeSessionParams' },
   { name: 'ForkChatSource' }, { name: 'SideChatSource' }, { name: 'CreateChatParams' }, { name: 'DisposeChatParams' },
   { name: 'ListSessionsParams' }, { name: 'ListSessionsResult' },
@@ -2286,6 +2302,7 @@ function checkExhaustiveness(project: Project): void {
     'McpServerState',
     'ToolCallContributor',
     'ToolCallRiskAssessment',
+    'TerminalLifecycleState',
     'SessionInputRequest',
     'ToolCallConfirmationState',
     'ReconnectResult',

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -927,7 +927,8 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason', 'ConfirmationOptionKind',
   'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus',
+  'TerminalClaimKind', 'TerminalLifecycleStatus',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
   'SessionOriginKind',
@@ -981,11 +982,12 @@ const STATE_STRUCTS = [
   'McpServerErrorState', 'McpServerStoppedState', 'McpOAuthClient', 'McpAuthRequirement',
   'ToolCallClientContributor', 'ToolCallMcpContributor',
   'FileEdit', 'TerminalCommandResult', 'TerminalInfo',
-  'TerminalClientClaim', 'TerminalSessionClaim', 'TerminalState',
+  'TerminalClientClaim', 'TerminalSessionClaim',
+  'TerminalRunningLifecycleState', 'TerminalExitedLifecycleState', 'TerminalState',
   'TerminalUnclassifiedPart', 'TerminalCommandPart',
   'UsageInfo', 'ErrorInfo', 'Snapshot',
   'Changeset', 'ChangesetCapabilities', 'ChangesetState', 'ChangesetFile', 'ChangesetOperation',
-  'AnnotationsSummary', 'AnnotationsState', 'Annotation', 'AnnotationEntry',
+  'AnnotationsSummary', 'AnnotationsState', 'AnnotationOrigin', 'Annotation', 'AnnotationEntry',
   'TelemetryCapabilities',
   'ResourceWatchState', 'ResourceChange',
   'AutomationSessionOrigin', 'AutomationSchedule',
@@ -1250,6 +1252,15 @@ const TOOL_CALL_RISK_ASSESSMENT_UNION: UnionConfig = {
   unknown: true,
 };
 
+const TERMINAL_LIFECYCLE_STATE_UNION: UnionConfig = {
+  name: 'TerminalLifecycleState',
+  discriminantField: 'status',
+  variants: [
+    { caseName: 'Running', structName: 'TerminalRunningLifecycleState', discriminantValue: 'running' },
+    { caseName: 'Exited', structName: 'TerminalExitedLifecycleState', discriminantValue: 'exited' },
+  ],
+};
+
 const SESSION_INPUT_REQUEST_UNION: UnionConfig = {
   name: 'SessionInputRequest',
   discriminantField: 'kind',
@@ -1382,6 +1393,8 @@ function generateStateFile(project: Project): string {
   lines.push(generateDiscriminatedUnion(TOOL_CALL_CONTRIBUTOR_UNION));
   lines.push('');
   lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
+  lines.push('');
+  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
   lines.push('');
   lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
   lines.push('');
@@ -1666,7 +1679,7 @@ const COMMAND_STRUCTS = [
   'Implementation',
   'ReconnectParams', 'ReconnectReplayResult', 'ReconnectSnapshotResult',
   'SubscribeParams', 'SubscribeView', 'SubscriptionDeliveryOptions', 'SubscribeResult',
-  'SessionForkSource', 'CreateSessionParams', 'DisposeSessionParams',
+  'CreateSessionParams', 'DisposeSessionParams',
   'CreateChatParams', 'DisposeChatParams',
   'ListSessionsParams', 'ListSessionsResult',
   'ResourceReadParams', 'ResourceReadResult',
@@ -2287,6 +2300,7 @@ function checkExhaustiveness(project: Project): void {
     'McpServerState',              // MCP_SERVER_STATUS_UNION discriminated union
     'ToolCallContributor',          // TOOL_CALL_CONTRIBUTOR_UNION discriminated union
     'ToolCallRiskAssessment',       // TOOL_CALL_RISK_ASSESSMENT_UNION discriminated union
+    'TerminalLifecycleState',       // TERMINAL_LIFECYCLE_STATE_UNION discriminated union
     'SessionInputRequest',          // SESSION_INPUT_REQUEST_UNION discriminated union
     'ToolCallConfirmationState',    // TOOL_CALL_CONFIRMATION_STATE_UNION discriminated union
     'ChildCustomizationType',       // TS subset alias of CustomizationType; consumers reuse CustomizationType

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -658,7 +658,8 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason',
   'ConfirmationOptionKind', 'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus',
+  'TerminalClaimKind', 'TerminalLifecycleStatus',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
   'SessionOriginKind',
@@ -798,6 +799,8 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'TerminalInfo' },
   { name: 'TerminalClientClaim', omitDiscriminants: true },
   { name: 'TerminalSessionClaim', omitDiscriminants: true },
+  { name: 'TerminalRunningLifecycleState', omitDiscriminants: true },
+  { name: 'TerminalExitedLifecycleState', omitDiscriminants: true },
   { name: 'TerminalState' },
   { name: 'TerminalUnclassifiedPart', omitDiscriminants: true },
   { name: 'TerminalCommandPart', omitDiscriminants: true },
@@ -811,6 +814,7 @@ const STATE_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: str
   { name: 'ChangesetOperation' },
   { name: 'AnnotationsSummary' },
   { name: 'AnnotationsState' },
+  { name: 'AnnotationOrigin' },
   { name: 'Annotation' },
   { name: 'AnnotationEntry' },
   { name: 'TelemetryCapabilities' },
@@ -1053,6 +1057,16 @@ const TOOL_CALL_RISK_ASSESSMENT_UNION: UnionConfig = {
   unknown: true,
 };
 
+const TERMINAL_LIFECYCLE_STATE_UNION: UnionConfig = {
+  name: 'TerminalLifecycleState',
+  discriminantField: 'status',
+  doc: 'Current lifecycle of a terminal process.',
+  variants: [
+    { variantName: 'Running', innerType: 'TerminalRunningLifecycleState', wireValue: 'running' },
+    { variantName: 'Exited', innerType: 'TerminalExitedLifecycleState', wireValue: 'exited' },
+  ],
+};
+
 const SESSION_INPUT_REQUEST_UNION: UnionConfig = {
   name: 'SessionInputRequest',
   discriminantField: 'kind',
@@ -1261,6 +1275,8 @@ function generateStateFile(project: Project): string {
   lines.push('');
   lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
   lines.push('');
+  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
+  lines.push('');
   lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
   lines.push('');
   lines.push(generateDiscriminatedUnion(SESSION_ORIGIN_UNION));
@@ -1420,7 +1436,7 @@ pub struct ${scope}ToolCallConfirmedAction {
 function generateActionsFile(project: Project): string {
   const lines: string[] = [GENERATED_HEADER];
   lines.push('#[allow(unused_imports)]');
-  lines.push('use crate::state::{AgentInfo, AgentSelection, Annotation, AnnotationEntry, AutomationDefinition, AutomationDefinitionPatch, AutomationRunLifecycle, AutomationRunSummary, AutomationState, ChatInputAnswer, ChatInputRequest, ChatInputResponseKind, ChatInteractivity, ChatOrigin, ConfirmationOption, ContentRef, Customization, CustomizationEnablement, ErrorInfo, McpAuthRequirement, McpServerState, ModelSelection, ResponsePart, SessionActiveClient, SessionInputRequest, SideChatSelection, TerminalClaim, TerminalInfo, TextRange, ToolCallContributor, ToolCallResult, ToolCallRiskAssessment, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolInput, ToolResultContent, UsageInfo, Message, PendingMessageKind, Turn, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, Changeset, ChatSummary};');
+  lines.push('use crate::state::{AgentInfo, AgentSelection, Annotation, AnnotationEntry, AnnotationOrigin, AutomationDefinition, AutomationDefinitionPatch, AutomationRunLifecycle, AutomationRunSummary, AutomationState, ChatInputAnswer, ChatInputRequest, ChatInputResponseKind, ChatInteractivity, ChatOrigin, ConfirmationOption, ContentRef, Customization, CustomizationEnablement, ErrorInfo, McpAuthRequirement, McpServerState, ModelSelection, ResponsePart, SessionActiveClient, SessionInputRequest, SideChatSelection, TerminalClaim, TerminalInfo, TextRange, ToolCallContributor, ToolCallResult, ToolCallRiskAssessment, ToolCallConfirmationReason, ToolCallCancellationReason, ToolDefinition, ToolInput, ToolResultContent, UsageInfo, Message, PendingMessageKind, Turn, ChangesetStatus, ChangesetFile, ChangesetOperation, ChangesetOperationStatus, Changeset, ChatSummary};');
   lines.push('');
 
   // ActionType enum
@@ -1532,7 +1548,7 @@ const COMMAND_STRUCTS: { name: string; omitDiscriminants?: boolean; rustName?: s
   { name: 'ReconnectReplayResult', omitDiscriminants: true },
   { name: 'ReconnectSnapshotResult', omitDiscriminants: true },
   { name: 'SubscribeParams' }, { name: 'SubscribeView' }, { name: 'SubscriptionDeliveryOptions' }, { name: 'SubscribeResult' },
-  { name: 'SessionForkSource' }, { name: 'CreateSessionParams' },
+  { name: 'CreateSessionParams' },
   { name: 'DisposeSessionParams' },
   { name: 'ForkChatSource', omitDiscriminants: true }, { name: 'SideChatSource', omitDiscriminants: true }, { name: 'CreateChatParams' },
   { name: 'DisposeChatParams' },
@@ -2033,6 +2049,7 @@ function checkExhaustiveness(project: Project): void {
     'McpServerState',              // MCP_SERVER_STATUS_UNION discriminated union
     'ToolCallContributor',          // TOOL_CALL_CONTRIBUTOR_UNION discriminated union
     'ToolCallRiskAssessment',       // TOOL_CALL_RISK_ASSESSMENT_UNION discriminated union
+    'TerminalLifecycleState',       // TERMINAL_LIFECYCLE_STATE_UNION discriminated union
     'SessionInputRequest',          // SESSION_INPUT_REQUEST_UNION discriminated union
     'ToolCallConfirmationState',    // TOOL_CALL_CONFIRMATION_STATE_UNION discriminated union
     'ReconnectResult',

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -618,7 +618,8 @@ const STATE_ENUMS = [
   'ToolCallRiskAssessmentStatus',
   'ToolCallCancellationReason', 'ConfirmationOptionKind',
   'ToolCallContributorKind',
-  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus', 'TerminalClaimKind',
+  'ToolResultContentType', 'CustomizationType', 'CustomizationEnablementKind', 'CustomizationLoadStatus',
+  'TerminalClaimKind', 'TerminalLifecycleStatus',
   'McpServerStatus', 'McpAuthRequiredReason',
   'ChangesetStatus', 'ChangesetOperationStatus', 'ChangesetOperationScope', 'ResourceChangeType',
   'SessionOriginKind',
@@ -672,11 +673,12 @@ const STATE_STRUCTS = [
   'McpServerErrorState', 'McpServerStoppedState', 'McpOAuthClient', 'McpAuthRequirement',
   'ToolCallClientContributor', 'ToolCallMcpContributor',
   'FileEdit', 'TerminalCommandResult', 'TerminalInfo',
-  'TerminalClientClaim', 'TerminalSessionClaim', 'TerminalState',
+  'TerminalClientClaim', 'TerminalSessionClaim',
+  'TerminalRunningLifecycleState', 'TerminalExitedLifecycleState', 'TerminalState',
   'TerminalUnclassifiedPart', 'TerminalCommandPart',
   'UsageInfo', 'ErrorInfo', 'Snapshot',
   'Changeset', 'ChangesetCapabilities', 'ChangesetState', 'ChangesetFile', 'ChangesetOperation',
-  'AnnotationsSummary', 'AnnotationsState', 'Annotation', 'AnnotationEntry',
+  'AnnotationsSummary', 'AnnotationsState', 'AnnotationOrigin', 'Annotation', 'AnnotationEntry',
   'TelemetryCapabilities',
   'ResourceWatchState', 'ResourceChange',
   'AutomationSessionOrigin', 'AutomationSchedule',
@@ -887,6 +889,15 @@ const TOOL_CALL_RISK_ASSESSMENT_UNION: UnionConfig = {
   variants: [
     { caseName: 'loading', structName: 'ToolCallRiskAssessmentLoadingState', discriminantValue: 'loading' },
     { caseName: 'complete', structName: 'ToolCallRiskAssessmentCompleteState', discriminantValue: 'complete' },
+  ],
+};
+
+const TERMINAL_LIFECYCLE_STATE_UNION: UnionConfig = {
+  name: 'TerminalLifecycleState',
+  discriminantField: 'status',
+  variants: [
+    { caseName: 'running', structName: 'TerminalRunningLifecycleState', discriminantValue: 'running' },
+    { caseName: 'exited', structName: 'TerminalExitedLifecycleState', discriminantValue: 'exited' },
   ],
 };
 
@@ -1265,6 +1276,8 @@ function generateStateFile(project: Project): string {
   lines.push('');
   lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
   lines.push('');
+  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
+  lines.push('');
   lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
   lines.push('');
   lines.push(generateDiscriminatedUnion(SESSION_ORIGIN_UNION));
@@ -1558,7 +1571,7 @@ const COMMAND_STRUCTS = [
   'Implementation',
   'ReconnectParams', 'ReconnectReplayResult', 'ReconnectSnapshotResult',
   'SubscribeParams', 'SubscribeView', 'SubscriptionDeliveryOptions', 'SubscribeResult',
-  'SessionForkSource', 'CreateSessionParams', 'DisposeSessionParams',
+  'CreateSessionParams', 'DisposeSessionParams',
   'CreateChatParams', 'DisposeChatParams',
   'ListSessionsParams', 'ListSessionsResult',
   'ResourceReadParams', 'ResourceReadResult',
@@ -2292,6 +2305,7 @@ function checkExhaustiveness(project: Project): void {
     'McpServerState',              // MCP_SERVER_STATUS_UNION discriminated union
     'ToolCallContributor',          // TOOL_CALL_CONTRIBUTOR_UNION discriminated union
     'ToolCallRiskAssessment',       // TOOL_CALL_RISK_ASSESSMENT_UNION discriminated union
+    'TerminalLifecycleState',       // TERMINAL_LIFECYCLE_STATE_UNION discriminated union
     'SessionInputRequest',          // SESSION_INPUT_REQUEST_UNION discriminated union
     'ToolCallConfirmationState',    // TOOL_CALL_CONFIRMATION_STATE_UNION discriminated union
     'AuthRequiredErrorData',        // emitted by generateErrorsFile()

--- a/scripts/public-api.test.ts
+++ b/scripts/public-api.test.ts
@@ -15,6 +15,7 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 /** Declarations deliberately withheld from the entry point. */
 const INTENTIONALLY_INTERNAL: ReadonlySet<string> = new Set([
+  'addMillisecondsToTimestamp', // deterministic reducer timestamp helper
   'softAssertNever', // reducer-internal exhaustiveness helper
 ]);
 

--- a/types/channels-annotations/actions.ts
+++ b/types/channels-annotations/actions.ts
@@ -16,7 +16,7 @@
 
 import { ActionType } from '../common/actions.js';
 import type { URI, TextRange } from '../common/state.js';
-import type { AnnotationEntry, Annotation } from './state.js';
+import type { AnnotationEntry, Annotation, AnnotationOrigin } from './state.js';
 
 // ─── Annotations Actions ─────────────────────────────────────────────────────
 
@@ -70,12 +70,8 @@ export interface AnnotationsUpdatedAction {
   type: ActionType.AnnotationsUpdated;
   /** The {@link Annotation.id} of the annotation to update. */
   annotationId: string;
-  /**
-   * Re-anchors the annotation to the file versions this turn produced.
-   * Matches a {@link Turn.id} on the owning session. Omit to leave the
-   * current {@link Annotation.turnId} unchanged.
-   */
-  turnId?: string;
+  /** Replaces the annotation's provenance. Omit to leave it unchanged. */
+  origin?: AnnotationOrigin;
   /**
    * Re-anchors the annotation to this file. Omit to leave the current
    * {@link Annotation.resource} unchanged.

--- a/types/channels-annotations/reducer.ts
+++ b/types/channels-annotations/reducer.ts
@@ -43,8 +43,8 @@ export function annotationsReducer(state: AnnotationsState, action: AnnotationsA
       }
       const annotation = state.annotations[idx];
       const updated: Annotation = { ...annotation };
-      if (action.turnId !== undefined) {
-        updated.turnId = action.turnId;
+      if (action.origin !== undefined) {
+        updated.origin = action.origin;
       }
       if (action.resource !== undefined) {
         updated.resource = action.resource;

--- a/types/channels-annotations/state.ts
+++ b/types/channels-annotations/state.ts
@@ -47,17 +47,29 @@ export interface AnnotationsState {
   annotations: Annotation[];
 }
 
+/**
+ * Provenance of the content an annotation is anchored to.
+ *
+ * @category Annotations
+ */
+export interface AnnotationOrigin {
+  /** Owning session URI. */
+  session: URI;
+  /** Owning chat URI, when the annotation is scoped to a chat. */
+  chat?: URI;
+  /** Turn identifier within {@link chat}, when the annotation is scoped to a turn. */
+  turnId?: string;
+}
+
 // ─── Annotation ──────────────────────────────────────────────────────────────
 
 /**
- * A conversation anchored to a specific file produced by a specific turn,
- * optionally narrowed to a range within that file.
+ * A conversation anchored to a specific file in a session, optionally scoped
+ * to a chat and turn and narrowed to a range within that file.
  *
- * {@link turnId} anchors the annotation to the file versions that turn
- * produced, so a later turn that rewrites the same file does not silently
- * invalidate the annotation's anchor — clients can resolve {@link resource}
- * and {@link range} against the turn's changeset. When {@link range} is
- * omitted the annotation is anchored to the entire file.
+ * {@link origin} identifies the owning session and, when available, the chat
+ * and turn that produced the file version. When {@link range} is omitted the
+ * annotation is anchored to the entire file.
  *
  * Every annotation MUST contain at least one {@link AnnotationEntry}. An
  * {@link AnnotationsSetAction} that creates an annotation therefore carries
@@ -73,11 +85,8 @@ export interface Annotation {
    * that dispatches the creating {@link AnnotationsSetAction}.
    */
   id: string;
-  /**
-   * Turn that produced the file versions this annotation is anchored to.
-   * Matches a {@link Turn.id} on the owning session.
-   */
-  turnId: string;
+  /** Provenance of the content this annotation is anchored to. */
+  origin: AnnotationOrigin;
   /** The file the annotation is anchored to. */
   resource: URI;
   /**

--- a/types/channels-changeset/actions.ts
+++ b/types/channels-changeset/actions.ts
@@ -110,8 +110,6 @@ export interface ChangesetContentChangedAction {
   files: ChangesetFile[];
   /** Full replacement operation list. Omit when operations are unchanged. */
   operations?: ChangesetOperation[];
-  /** Error information, if the changeset content change failed. */
-  error?: ErrorInfo;
 }
 
 /**

--- a/types/channels-changeset/reducer.ts
+++ b/types/channels-changeset/reducer.ts
@@ -66,14 +66,9 @@ export function changesetReducer(state: ChangesetState, action: ChangesetAction,
     }
 
     case ActionType.ChangesetContentChanged: {
-      const next = action.operations === undefined
+      return action.operations === undefined
         ? { ...state, files: action.files }
         : { ...state, files: action.files, operations: action.operations };
-      if (action.error === undefined) {
-        const { error: _ignored, ...rest } = next;
-        return rest;
-      }
-      return { ...next, error: action.error };
     }
 
     case ActionType.ChangesetOperationsChanged: {

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -29,6 +29,7 @@ import {
 import { SessionStatus } from '../channels-session/state.js';
 import type { ChatAction } from '../action-origin.generated.js';
 import { softAssertNever } from '../common/reducer-helpers.js';
+import { addMillisecondsToTimestamp } from '../common/timestamps.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -215,7 +216,7 @@ function endTurn(
     ...state,
     turns: [...state.turns, turn],
     activeTurn: undefined,
-    modifiedAt: new Date(Date.now()).toISOString(),
+    modifiedAt: addMillisecondsToTimestamp(active.startedAt, turn.duration ?? 0),
   };
   return {
     ...next,
@@ -250,7 +251,7 @@ function upsertInputRequestPart(state: ChatState, request: InputRequestResponseP
       responseParts,
     },
   };
-  return { ...next, status: withStatusFlag(summaryStatus(next), SessionStatus.IsRead, false), modifiedAt: new Date(Date.now()).toISOString() };
+  return { ...next, status: withStatusFlag(summaryStatus(next), SessionStatus.IsRead, false) };
 }
 
 /**
@@ -356,7 +357,7 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
       next = {
         ...next,
         status: withStatusFlag(summaryStatus(next), SessionStatus.IsRead, false),
-        modifiedAt: new Date(Date.now()).toISOString(),
+        modifiedAt: action.startedAt,
       };
 
       // If this turn was auto-started from a pending message, remove it
@@ -720,7 +721,6 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
         ...state,
         turns,
         activeTurn: undefined,
-        modifiedAt: new Date(Date.now()).toISOString(),
       };
       if (action.turnId === undefined) {
         delete next.turnsNextCursor;
@@ -776,7 +776,6 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
           ...activeTurn,
           responseParts,
         },
-        modifiedAt: new Date(Date.now()).toISOString(),
       };
     }
 
@@ -809,7 +808,6 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
       return {
         ...next,
         status: summaryStatus(next),
-        modifiedAt: new Date(Date.now()).toISOString(),
       };
     }
 

--- a/types/channels-session/commands.ts
+++ b/types/channels-session/commands.ts
@@ -47,20 +47,6 @@ import type {
  * { "jsonrpc": "2.0", "id": 2, "error": { "code": -32003, "message": "Session already exists" } }
  * ```
  */
-/**
- * Identifies a source session and turn to fork from.
- *
- * When provided in `createSession`, the server populates the new session with
- * content from the source session up to and including the response of the
- * specified turn.
- */
-export interface SessionForkSource {
-  /** URI of the existing session to fork from */
-  session: URI;
-  /** Turn ID in the source session; content up to and including this turn's response is copied */
-  turnId: string;
-}
-
 export interface CreateSessionParams extends BaseParams {
   /** Session URI (client-chosen, e.g. `ahp-session:/<uuid>`) */
   channel: URI;
@@ -81,15 +67,8 @@ export interface CreateSessionParams extends BaseParams {
    * and ignores the rest. Dispatch working-directory actions to change the set
    * after the session has started.
    *
-   * Ignored for forked sessions — a fork inherits its working directories
-   * from the source session identified by `fork`.
    */
   workingDirectories?: URI[];
-  /**
-   * Fork from an existing session. The new session is populated with content
-   * from the source session up to and including the specified turn's response.
-   */
-  fork?: SessionForkSource;
   /**
    * Agent-specific configuration values collected via `resolveSessionConfig`.
    * Keys and values correspond to the schema returned by the server.

--- a/types/channels-session/reducer.ts
+++ b/types/channels-session/reducer.ts
@@ -151,7 +151,7 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
     case ActionType.SessionCreationFailed:
       return {
         ...state,
-        lifecycle: SessionLifecycle.CreationFailed,
+        lifecycle: SessionLifecycle.Failed,
         creationError: action.error,
       };
 

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -34,7 +34,7 @@ import type {
 export const enum SessionLifecycle {
   Creating = 'creating',
   Ready = 'ready',
-  CreationFailed = 'creationFailed',
+  Failed = 'failed',
 }
 
 /**

--- a/types/channels-terminal/reducer.ts
+++ b/types/channels-terminal/reducer.ts
@@ -6,6 +6,7 @@
 
 import { ActionType } from '../common/actions.js';
 import type { TerminalState, TerminalContentPart } from './state.js';
+import { TerminalLifecycleStatus } from './state.js';
 import type { TerminalAction } from '../action-origin.generated.js';
 import { softAssertNever } from '../common/reducer-helpers.js';
 
@@ -45,7 +46,13 @@ export function terminalReducer(state: TerminalState, action: TerminalAction, lo
       return { ...state, cwd: action.cwd };
 
     case ActionType.TerminalExited:
-      return { ...state, exitCode: action.exitCode };
+      return {
+        ...state,
+        lifecycle: {
+          status: TerminalLifecycleStatus.Exited,
+          exitCode: action.exitCode,
+        },
+      };
 
     case ActionType.TerminalCleared:
       return { ...state, content: [] };

--- a/types/channels-terminal/state.ts
+++ b/types/channels-terminal/state.ts
@@ -21,9 +21,48 @@ export interface TerminalInfo {
   title: string;
   /** Who currently holds this terminal */
   claim: TerminalClaim;
-  /** Process exit code, if the terminal process has exited */
+  /** Current terminal process lifecycle. */
+  lifecycle: TerminalLifecycleState;
+}
+
+/**
+ * Lifecycle status of a terminal process.
+ *
+ * @category Terminal Types
+ */
+export const enum TerminalLifecycleStatus {
+  Running = 'running',
+  Exited = 'exited',
+}
+
+/**
+ * A terminal process that is still running.
+ *
+ * @category Terminal Types
+ */
+export interface TerminalRunningLifecycleState {
+  status: TerminalLifecycleStatus.Running;
+}
+
+/**
+ * A terminal process that has exited.
+ *
+ * @category Terminal Types
+ */
+export interface TerminalExitedLifecycleState {
+  status: TerminalLifecycleStatus.Exited;
+  /** Process exit code, if the runtime reported one. */
   exitCode?: number;
 }
+
+/**
+ * Current lifecycle of a terminal process.
+ *
+ * @category Terminal Types
+ */
+export type TerminalLifecycleState =
+  | TerminalRunningLifecycleState
+  | TerminalExitedLifecycleState;
 
 /**
  * Discriminant for terminal claim kinds.
@@ -57,7 +96,9 @@ export interface TerminalSessionClaim {
   kind: TerminalClaimKind.Session;
   /** Session URI that claimed the terminal */
   session: URI;
-  /** Optional turn identifier within the session */
+  /** Chat URI that claimed the terminal. */
+  chat: URI;
+  /** Optional turn identifier within the chat. */
   turnId?: string;
   /** Optional tool call identifier within the turn */
   toolCallId?: string;
@@ -94,8 +135,8 @@ export interface TerminalState {
    * Consumers that need command boundaries can filter by part type.
    */
   content: TerminalContentPart[];
-  /** Process exit code, set when the terminal process exits */
-  exitCode?: number;
+  /** Current terminal process lifecycle. */
+  lifecycle: TerminalLifecycleState;
   /** Who currently holds this terminal */
   claim: TerminalClaim;
   /**

--- a/types/common/timestamps.ts
+++ b/types/common/timestamps.ts
@@ -1,0 +1,7 @@
+/**
+ * Adds a duration to an ISO 8601 timestamp and returns the result in canonical
+ * ISO 8601 form.
+ */
+export function addMillisecondsToTimestamp(timestamp: string, duration: number): string {
+  return new Date(Date.parse(timestamp) + duration).toISOString();
+}

--- a/types/reducers.test.ts
+++ b/types/reducers.test.ts
@@ -11,7 +11,7 @@
  * Run: npx tsx --test types/reducers.test.ts
  */
 
-import { describe, it, beforeEach, afterEach } from 'node:test';
+import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -110,24 +110,7 @@ const fixtures: Fixture[] = fixtureFiles.map(f => {
 
 // ─── Fixture-Driven Reducer Tests ────────────────────────────────────────────
 
-/**
- * The reducers call Date.now() for modifiedAt timestamps.
- * We mock it to a fixed value (9999) matching what was used during
- * fixture generation, so expected values match exactly.
- */
-const MOCK_NOW = 9999;
-let originalDateNow: typeof Date.now;
-
 describe('reducer fixtures', () => {
-  beforeEach(() => {
-    originalDateNow = Date.now;
-    Date.now = () => MOCK_NOW;
-  });
-
-  afterEach(() => {
-    Date.now = originalDateNow;
-  });
-
   for (const fixture of fixtures) {
     it(fixture.description, () => {
       let state = fixture.initial;

--- a/types/test-cases/reducers/004-session-creationfailed.json
+++ b/types/test-cases/reducers/004-session-creationfailed.json
@@ -22,7 +22,7 @@
     "provider": "copilot",
     "title": "Test Session",
     "status": 1,
-    "lifecycle": "creationFailed",
+    "lifecycle": "failed",
     "creationError": {
       "errorType": "init",
       "message": "Failed to start"

--- a/types/test-cases/reducers/005-session-turnstarted.json
+++ b/types/test-cases/reducers/005-session-turnstarted.json
@@ -38,6 +38,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/006-turnstarted-with-queuedmessageid-removes-from-queuedmessages.json
+++ b/types/test-cases/reducers/006-turnstarted-with-queuedmessageid-removes-from-queuedmessages.json
@@ -70,6 +70,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/007-turnstarted-with-queuedmessageid-removes-last-queued-message.json
+++ b/types/test-cases/reducers/007-turnstarted-with-queuedmessageid-removes-last-queued-message.json
@@ -51,6 +51,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/008-turnstarted-with-queuedmessageid-removes-matching-steering-message.json
+++ b/types/test-cases/reducers/008-turnstarted-with-queuedmessageid-removes-matching-steering-message.json
@@ -49,6 +49,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/009-turnstarted-without-queuedmessageid-does-not-touch-pending-messages.json
+++ b/types/test-cases/reducers/009-turnstarted-without-queuedmessageid-does-not-touch-pending-messages.json
@@ -78,6 +78,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/063-session-truncated-keeps-turns-up-to-turnid.json
+++ b/types/test-cases/reducers/063-session-truncated-keeps-turns-up-to-turnid.json
@@ -82,6 +82,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/064-session-truncated-keeps-all-when-turnid-is-last.json
+++ b/types/test-cases/reducers/064-session-truncated-keeps-all-when-turnid-is-last.json
@@ -70,6 +70,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/065-session-truncated-keeps-only-first-when-turnid-is-first.json
+++ b/types/test-cases/reducers/065-session-truncated-keeps-only-first-when-turnid-is-first.json
@@ -70,6 +70,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/066-session-truncated-clears-all-when-turnid-omitted.json
+++ b/types/test-cases/reducers/066-session-truncated-clears-all-when-turnid-omitted.json
@@ -56,6 +56,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/067-session-truncated-drops-active-turn.json
+++ b/types/test-cases/reducers/067-session-truncated-drops-active-turn.json
@@ -70,6 +70,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
   }
 }

--- a/types/test-cases/reducers/068-session-truncated-drops-active-turn-even-when-clearing-all.json
+++ b/types/test-cases/reducers/068-session-truncated-drops-active-turn-even-when-clearing-all.json
@@ -31,6 +31,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
   }
 }

--- a/types/test-cases/reducers/071-root-terminalschanged.json
+++ b/types/test-cases/reducers/071-root-terminalschanged.json
@@ -14,6 +14,9 @@
           "claim": {
             "kind": "client",
             "clientId": "c1"
+          },
+          "lifecycle": {
+            "status": "running"
           }
         },
         {
@@ -21,7 +24,11 @@
           "title": "zsh",
           "claim": {
             "kind": "session",
-            "session": "copilot:/s1"
+            "session": "copilot:/s1",
+            "chat": "ahp-chat:/test-chat"
+          },
+          "lifecycle": {
+            "status": "running"
           }
         }
       ]
@@ -36,6 +43,9 @@
         "claim": {
           "kind": "client",
           "clientId": "c1"
+        },
+        "lifecycle": {
+          "status": "running"
         }
       },
       {
@@ -43,7 +53,11 @@
         "title": "zsh",
         "claim": {
           "kind": "session",
-          "session": "copilot:/s1"
+          "session": "copilot:/s1",
+          "chat": "ahp-chat:/test-chat"
+        },
+        "lifecycle": {
+          "status": "running"
         }
       }
     ]

--- a/types/test-cases/reducers/072-terminal-data-appends.json
+++ b/types/test-cases/reducers/072-terminal-data-appends.json
@@ -12,6 +12,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -35,6 +38,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/073-terminal-input-noop.json
+++ b/types/test-cases/reducers/073-terminal-input-noop.json
@@ -12,6 +12,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -31,6 +34,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/074-terminal-resized.json
+++ b/types/test-cases/reducers/074-terminal-resized.json
@@ -9,6 +9,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -26,6 +29,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/075-terminal-claimed-client.json
+++ b/types/test-cases/reducers/075-terminal-claimed-client.json
@@ -6,7 +6,11 @@
     "content": [],
     "claim": {
       "kind": "session",
-      "session": "copilot:/s1"
+      "session": "copilot:/s1",
+      "chat": "ahp-chat:/test-chat"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -24,6 +28,9 @@
     "claim": {
       "kind": "client",
       "clientId": "vscode-1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/075-turnstarted-clears-isread.json
+++ b/types/test-cases/reducers/075-turnstarted-clears-isread.json
@@ -38,6 +38,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/076-terminal-claimed-session.json
+++ b/types/test-cases/reducers/076-terminal-claimed-session.json
@@ -7,6 +7,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -16,7 +19,8 @@
         "kind": "session",
         "session": "copilot:/session-1",
         "turnId": "turn-1",
-        "toolCallId": "tc-1"
+        "toolCallId": "tc-1",
+        "chat": "ahp-chat:/test-chat"
       }
     }
   ],
@@ -27,7 +31,11 @@
       "kind": "session",
       "session": "copilot:/session-1",
       "turnId": "turn-1",
-      "toolCallId": "tc-1"
+      "toolCallId": "tc-1",
+      "chat": "ahp-chat:/test-chat"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/077-terminal-claimed-release.json
+++ b/types/test-cases/reducers/077-terminal-claimed-release.json
@@ -8,7 +8,11 @@
       "kind": "session",
       "session": "copilot:/s1",
       "turnId": "t1",
-      "toolCallId": "tc1"
+      "toolCallId": "tc1",
+      "chat": "ahp-chat:/test-chat"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -16,7 +20,8 @@
       "type": "terminal/claimed",
       "claim": {
         "kind": "session",
-        "session": "copilot:/s1"
+        "session": "copilot:/s1",
+        "chat": "ahp-chat:/test-chat"
       }
     }
   ],
@@ -25,7 +30,11 @@
     "content": [],
     "claim": {
       "kind": "session",
-      "session": "copilot:/s1"
+      "session": "copilot:/s1",
+      "chat": "ahp-chat:/test-chat"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/078-terminal-titlechanged.json
+++ b/types/test-cases/reducers/078-terminal-titlechanged.json
@@ -7,6 +7,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -21,6 +24,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/079-terminal-cwdchanged.json
+++ b/types/test-cases/reducers/079-terminal-cwdchanged.json
@@ -8,6 +8,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -23,6 +26,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/081-terminal-exited.json
+++ b/types/test-cases/reducers/081-terminal-exited.json
@@ -13,6 +13,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -34,6 +37,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "exitCode": 0
+    "lifecycle": {
+      "status": "exited",
+      "exitCode": 0
+    }
   }
 }

--- a/types/test-cases/reducers/082-terminal-cleared.json
+++ b/types/test-cases/reducers/082-terminal-cleared.json
@@ -12,6 +12,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -25,6 +28,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/083-terminal-full-lifecycle.json
+++ b/types/test-cases/reducers/083-terminal-full-lifecycle.json
@@ -7,6 +7,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -25,7 +28,8 @@
         "kind": "session",
         "session": "copilot:/s1",
         "turnId": "t1",
-        "toolCallId": "tc1"
+        "toolCallId": "tc1",
+        "chat": "ahp-chat:/test-chat"
       }
     },
     {
@@ -36,7 +40,8 @@
       "type": "terminal/claimed",
       "claim": {
         "kind": "session",
-        "session": "copilot:/s1"
+        "session": "copilot:/s1",
+        "chat": "ahp-chat:/test-chat"
       }
     },
     {
@@ -57,8 +62,12 @@
     ],
     "claim": {
       "kind": "session",
-      "session": "copilot:/s1"
+      "session": "copilot:/s1",
+      "chat": "ahp-chat:/test-chat"
     },
-    "exitCode": 0
+    "lifecycle": {
+      "status": "exited",
+      "exitCode": 0
+    }
   }
 }

--- a/types/test-cases/reducers/089-terminal-unknown-action-type-is-no-op.json
+++ b/types/test-cases/reducers/089-terminal-unknown-action-type-is-no-op.json
@@ -9,6 +9,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -24,6 +27,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   }
 }

--- a/types/test-cases/reducers/105-session-input-full-draft-and-complete-flow.json
+++ b/types/test-cases/reducers/105-session-input-full-draft-and-complete-flow.json
@@ -143,6 +143,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/106-session-input-requested-with-drafts-status.json
+++ b/types/test-cases/reducers/106-session-input-requested-with-drafts-status.json
@@ -89,6 +89,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
   }
 }

--- a/types/test-cases/reducers/108-session-input-upsert-and-clear-answer.json
+++ b/types/test-cases/reducers/108-session-input-upsert-and-clear-answer.json
@@ -89,6 +89,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 24,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
   }
 }

--- a/types/test-cases/reducers/110-session-input-completion-and-truncation-filtering.json
+++ b/types/test-cases/reducers/110-session-input-completion-and-truncation-filtering.json
@@ -91,6 +91,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
   }
 }

--- a/types/test-cases/reducers/119-terminal-commandexecuted-appends-part.json
+++ b/types/test-cases/reducers/119-terminal-commandexecuted-appends-part.json
@@ -7,6 +7,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -33,6 +36,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   }
 }

--- a/types/test-cases/reducers/120-terminal-data-appends-to-command-output.json
+++ b/types/test-cases/reducers/120-terminal-data-appends-to-command-output.json
@@ -17,7 +17,10 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   },
   "actions": [
     {
@@ -45,6 +48,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   }
 }

--- a/types/test-cases/reducers/121-terminal-commandfinished-completes-part.json
+++ b/types/test-cases/reducers/121-terminal-commandfinished-completes-part.json
@@ -17,7 +17,10 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   },
   "actions": [
     {
@@ -45,6 +48,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   }
 }

--- a/types/test-cases/reducers/122-terminal-data-after-complete-creates-unclassified.json
+++ b/types/test-cases/reducers/122-terminal-data-after-complete-creates-unclassified.json
@@ -19,7 +19,10 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   },
   "actions": [
     {
@@ -49,6 +52,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   }
 }

--- a/types/test-cases/reducers/123-terminal-command-full-lifecycle.json
+++ b/types/test-cases/reducers/123-terminal-command-full-lifecycle.json
@@ -7,6 +7,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -87,6 +90,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   }
 }

--- a/types/test-cases/reducers/124-terminal-cleared-resets-content-parts.json
+++ b/types/test-cases/reducers/124-terminal-cleared-resets-content-parts.json
@@ -23,7 +23,10 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   },
   "actions": [
     {
@@ -37,6 +40,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   }
 }

--- a/types/test-cases/reducers/125-terminal-commanddetectionavailable.json
+++ b/types/test-cases/reducers/125-terminal-commanddetectionavailable.json
@@ -7,6 +7,9 @@
     "claim": {
       "kind": "client",
       "clientId": "c1"
+    },
+    "lifecycle": {
+      "status": "running"
     }
   },
   "actions": [
@@ -21,6 +24,9 @@
       "kind": "client",
       "clientId": "c1"
     },
-    "supportsCommandDetection": true
+    "supportsCommandDetection": true,
+    "lifecycle": {
+      "status": "running"
+    }
   }
 }

--- a/types/test-cases/reducers/159-changeset-contentchanged-updates-error.json
+++ b/types/test-cases/reducers/159-changeset-contentchanged-updates-error.json
@@ -1,5 +1,5 @@
 {
-  "description": "changeset/contentChanged updates error information",
+  "description": "changeset/contentChanged preserves lifecycle error information",
   "reducer": "changeset",
   "initial": {
     "status": "error",
@@ -52,18 +52,14 @@
             }
           }
         }
-      ],
-      "error": {
-        "errorType": "git",
-        "message": "new error"
-      }
+      ]
     }
   ],
   "expected": {
     "status": "error",
     "error": {
       "errorType": "git",
-      "message": "new error"
+      "message": "old error"
     },
     "files": [
       {

--- a/types/test-cases/reducers/210-annotations-set-appends-new-annotation.json
+++ b/types/test-cases/reducers/210-annotations-set-appends-new-annotation.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -26,7 +30,11 @@
       "type": "annotations/set",
       "annotation": {
         "id": "t-2",
-        "turnId": "turn-2",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-2"
+        },
         "resource": "file:///src/b.ts",
         "resolved": false,
         "entries": [
@@ -42,7 +50,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -58,7 +70,11 @@
       },
       {
         "id": "t-2",
-        "turnId": "turn-2",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-2"
+        },
         "resource": "file:///src/b.ts",
         "resolved": false,
         "entries": [

--- a/types/test-cases/reducers/211-annotations-set-replaces-existing-annotation.json
+++ b/types/test-cases/reducers/211-annotations-set-replaces-existing-annotation.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -23,7 +27,11 @@
       "type": "annotations/set",
       "annotation": {
         "id": "t-1",
-        "turnId": "turn-2",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-2"
+        },
         "resource": "file:///src/a.ts",
         "resolved": true,
         "entries": [
@@ -37,7 +45,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-2",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-2"
+        },
         "resource": "file:///src/a.ts",
         "resolved": true,
         "entries": [

--- a/types/test-cases/reducers/212-annotations-removed-drops-matching-annotation.json
+++ b/types/test-cases/reducers/212-annotations-removed-drops-matching-annotation.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -18,7 +22,11 @@
       },
       {
         "id": "t-2",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/b.ts",
         "range": {
           "start": { "line": 2, "character": 0 },
@@ -39,7 +47,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },

--- a/types/test-cases/reducers/213-annotations-entryset-appends-and-replaces.json
+++ b/types/test-cases/reducers/213-annotations-entryset-appends-and-replaces.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -34,7 +38,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },

--- a/types/test-cases/reducers/214-annotations-entryset-unknown-annotation-is-no-op.json
+++ b/types/test-cases/reducers/214-annotations-entryset-unknown-annotation-is-no-op.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -29,7 +33,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },

--- a/types/test-cases/reducers/215-annotations-entryremoved-drops-matching-entry.json
+++ b/types/test-cases/reducers/215-annotations-entryremoved-drops-matching-entry.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -29,7 +33,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },

--- a/types/test-cases/reducers/216-annotations-updated-resolves-and-preserves-entries.json
+++ b/types/test-cases/reducers/216-annotations-updated-resolves-and-preserves-entries.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -31,7 +35,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },

--- a/types/test-cases/reducers/217-annotations-unknown-action-type-is-no-op.json
+++ b/types/test-cases/reducers/217-annotations-unknown-action-type-is-no-op.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -25,7 +29,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },

--- a/types/test-cases/reducers/218-annotations-updated-reanchors-turn-and-range.json
+++ b/types/test-cases/reducers/218-annotations-updated-reanchors-turn-and-range.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "range": {
           "start": { "line": 0, "character": 0 },
@@ -22,7 +26,11 @@
     {
       "type": "annotations/updated",
       "annotationId": "t-1",
-      "turnId": "turn-2",
+      "origin": {
+        "session": "ahp-session:/test-session",
+        "chat": "ahp-chat:/test-chat",
+        "turnId": "turn-2"
+      },
       "resource": "file:///src/b.ts",
       "range": {
         "start": { "line": 3, "character": 2 },
@@ -34,7 +42,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-2",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-2"
+        },
         "resource": "file:///src/b.ts",
         "range": {
           "start": { "line": 3, "character": 2 },

--- a/types/test-cases/reducers/219-annotations-updated-unknown-annotation-is-no-op.json
+++ b/types/test-cases/reducers/219-annotations-updated-unknown-annotation-is-no-op.json
@@ -5,7 +5,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "resolved": false,
         "entries": [
@@ -25,7 +29,11 @@
     "annotations": [
       {
         "id": "t-1",
-        "turnId": "turn-1",
+        "origin": {
+          "session": "ahp-session:/test-session",
+          "chat": "ahp-chat:/test-chat",
+          "turnId": "turn-1"
+        },
         "resource": "file:///src/a.ts",
         "resolved": false,
         "entries": [

--- a/types/test-cases/reducers/234-chat-truncated-clears-turns-next-cursor-when-clearing-all.json
+++ b/types/test-cases/reducers/234-chat-truncated-clears-turns-next-cursor-when-clearing-all.json
@@ -33,6 +33,6 @@
     "resource": "ahp-chat:/c1",
     "title": "Chat 1",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/235-session-input-completion-records-declined-request-in-turn.json
+++ b/types/test-cases/reducers/235-session-input-completion-records-declined-request-in-turn.json
@@ -106,6 +106,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 8,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.000Z"
   }
 }

--- a/types/test-cases/reducers/240-turn-duration-is-clamped-to-zero.json
+++ b/types/test-cases/reducers/240-turn-duration-is-clamped-to-zero.json
@@ -49,6 +49,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:10.000Z"
   }
 }

--- a/types/test-cases/reducers/250-turncomplete-force-cancels-auth-required-tool-call.json
+++ b/types/test-cases/reducers/250-turncomplete-force-cancels-auth-required-tool-call.json
@@ -102,6 +102,6 @@
     "resource": "copilot:/test-session",
     "title": "Test Session",
     "status": 1,
-    "modifiedAt": "1970-01-01T00:00:09.999Z"
+    "modifiedAt": "1970-01-01T00:00:01.500Z"
   }
 }

--- a/types/test-cases/reducers/271-turn-end-normalizes-offset-and-rollover.json
+++ b/types/test-cases/reducers/271-turn-end-normalizes-offset-and-rollover.json
@@ -1,0 +1,54 @@
+{
+  "description": "turn end normalizes timezone offsets across leap-day rollover",
+  "reducer": "chat",
+  "initial": {
+    "resource": "ahp-chat:/timestamp-rollover",
+    "title": "Timestamp rollover",
+    "status": 8,
+    "modifiedAt": "2024-02-29T23:59:59.750-05:00",
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "startedAt": "2024-02-29T23:59:59.750-05:00",
+      "message": {
+        "text": "Test rollover",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [],
+      "usage": null
+    }
+  },
+  "actions": [
+    {
+      "type": "chat/turnComplete",
+      "turnId": "turn-1",
+      "duration": 500
+    }
+  ],
+  "expected": {
+    "resource": "ahp-chat:/timestamp-rollover",
+    "title": "Timestamp rollover",
+    "status": 1,
+    "modifiedAt": "2024-03-01T05:00:00.250Z",
+    "turns": [
+      {
+        "id": "turn-1",
+        "startedAt": "2024-02-29T23:59:59.750-05:00",
+        "duration": 500,
+        "message": {
+          "text": "Test rollover",
+          "origin": {
+            "kind": "user"
+          }
+        },
+        "responseParts": [],
+        "usage": null,
+        "state": "complete",
+        "error": null
+      }
+    ],
+    "activeTurn": null
+  }
+}


### PR DESCRIPTION
## Summary

- make chat reducer timestamps deterministic and ban wall-clock `Date` usage in reducers
- add explicit terminal `running`/`exited` lifecycle state and require chat provenance on session claims
- normalize annotation provenance and remove obsolete session-level forking
- rename the failed session lifecycle value and make changeset errors lifecycle-owned
- regenerate schemas, docs, fixtures, and all five language clients
- use Jiff for Rust timestamp arithmetic and return typed invalid reducer outcomes instead of panicking

## Why

This tightens structural and naming consistency before the 1.0 protocol surface is finalized, while preserving deterministic replay and durable terminal outcomes.

## Validation

- `npm run generate`
- `npm test`
- TypeScript client typecheck and tests
- Go client tests
- Rust workspace and doc tests
- Kotlin client tests

Swift compilation reaches the changed reducer code on Windows, but the full test run remains blocked by the existing CoreFoundation symbol/import issue in `AnyCodable.swift`.
