### PR TITLE
types: define enum compatibility contracts

### DIFF
--- a/.github/instructions/general-instructions.instructions.md
+++ b/.github/instructions/general-instructions.instructions.md
@@ -36,6 +36,11 @@ applyTo: 'types/**/*.ts'
   ```
 
 - `number` types are assumed to be 64-bit integers. If a floating point values are reasonable for a field, you MUST annotate its jsdoc with `@format float`
+- Every protocol `enum` declaration MUST carry exactly one JSDoc compatibility
+  annotation: use `@nonexhaustive` when later protocol versions may add wire
+  values (clients preserve unknown raw values), and `@exhaustive` only when an
+  unknown value is invalid and clients must reject it. The generators validate
+  this contract and use it for both raw enums and discriminated unions.
 - For actions or commands that could be implemented by returning an array `T[]` directly, still prefer to wrap it in `{ items: T[] }` for forward compatibility. This allows adding additional fields later without breaking the shape.
 - Naming discriminants for discriminated unions:
   - Lifecycle / state-machine unions: name the union `Foo*State` and its discriminant enum `Foo*Status`. Variant interfaces are `Foo*State` (e.g. `ToolCallState` + `ToolCallStatus` + `ToolCallStreamingState`; `McpServerState` + `McpServerStatus` + `McpServerStartingState`; `CustomizationLoadState` + `CustomizationLoadStatus`).

--- a/clients/go/ahptypes/actions.generated.go
+++ b/clients/go/ahptypes/actions.generated.go
@@ -247,7 +247,7 @@ type ChatTurnStartedAction struct {
 // Streaming text chunk from the assistant, appended to a specific response part.
 //
 // The server MUST first emit a `chat/responsePart` to create the target
-// part (markdown or reasoning), then use this action to append text to it.
+// markdown part, then use this action to append text to it.
 type ChatDeltaAction struct {
 	Type ActionType `json:"type"`
 	// Turn identifier

--- a/clients/go/ahptypes/ahptypes_test.go
+++ b/clients/go/ahptypes/ahptypes_test.go
@@ -72,6 +72,7 @@ func TestStateActionUnknownVariant(t *testing.T) {
 	if err := json.Unmarshal([]byte(wire), &a); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+
 	unk, ok := a.Value.(*StateActionUnknown)
 	if !ok {
 		t.Fatalf("variant = %T, want *StateActionUnknown", a.Value)
@@ -82,6 +83,42 @@ func TestStateActionUnknownVariant(t *testing.T) {
 	}
 	if string(out) != string(unk.Raw) {
 		t.Errorf("round-trip mismatch:\nwant %s\ngot  %s", wire, out)
+	}
+}
+
+// TestNonexhaustiveEnumAndUnionRoundTrip verifies that both an open raw enum
+// and the union it discriminates preserve newer wire values.
+func TestNonexhaustiveEnumAndUnionRoundTrip(t *testing.T) {
+	const rawEnum = `"futurePart"`
+	var kind ResponsePartKind
+	if err := json.Unmarshal([]byte(rawEnum), &kind); err != nil {
+		t.Fatalf("unmarshal enum: %v", err)
+	}
+	if kind != ResponsePartKind("futurePart") {
+		t.Fatalf("enum = %q, want futurePart", kind)
+	}
+	enumOut, err := json.Marshal(kind)
+	if err != nil {
+		t.Fatalf("marshal enum: %v", err)
+	}
+	if string(enumOut) != rawEnum {
+		t.Errorf("enum round-trip: want %s got %s", rawEnum, enumOut)
+	}
+
+	const rawUnion = `{"kind":"futurePart","payload":{"preserve":true}}`
+	var part ResponsePart
+	if err := json.Unmarshal([]byte(rawUnion), &part); err != nil {
+		t.Fatalf("unmarshal union: %v", err)
+	}
+	if _, ok := part.Value.(*ResponsePartUnknown); !ok {
+		t.Fatalf("union variant = %T, want *ResponsePartUnknown", part.Value)
+	}
+	unionOut, err := json.Marshal(part)
+	if err != nil {
+		t.Fatalf("marshal union: %v", err)
+	}
+	if string(unionOut) != rawUnion {
+		t.Errorf("union round-trip: want %s got %s", rawUnion, unionOut)
 	}
 }
 

--- a/clients/go/ahptypes/chat_source_test.go
+++ b/clients/go/ahptypes/chat_source_test.go
@@ -1,8 +1,8 @@
 package ahptypes
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"testing"
 )
 
@@ -39,19 +39,25 @@ func TestChatSourceRoutesByKind(t *testing.T) {
 	})
 }
 
-func TestChatSourceRejectsMissingOrUnknownKind(t *testing.T) {
+func TestChatSourcePreservesMissingOrUnknownKind(t *testing.T) {
 	for name, raw := range map[string]string{
 		"missing kind": `{"chat":"ahp-chat:/main","turnId":"turn-12"}`,
 		"unknown kind": `{"kind":"future","chat":"ahp-chat:/main","turnId":"turn-12"}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			var value ChatSource
-			err := json.Unmarshal([]byte(raw), &value)
-			if err == nil {
-				t.Fatalf("expected decode failure for %s", name)
+			if err := json.Unmarshal([]byte(raw), &value); err != nil {
+				t.Fatalf("decode %s: %v", name, err)
 			}
-			if got := fmt.Sprint(err); got == "" {
-				t.Fatalf("expected printable error for %s", name)
+			if _, ok := value.Value.(*ChatSourceUnknown); !ok {
+				t.Fatalf("expected unknown variant for %s, got %T", name, value.Value)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				t.Fatalf("encode %s: %v", name, err)
+			}
+			if !bytes.Equal(encoded, []byte(raw)) {
+				t.Fatalf("round trip %s: got %s, want %s", name, encoded, raw)
 			}
 		})
 	}

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -103,7 +103,8 @@ type InitializeParams struct {
 	//
 	// The server selects one entry and returns it as `InitializeResult.protocolVersion`.
 	// If the server cannot speak any of the offered versions, it MUST return
-	// error code `-32005` (`UnsupportedProtocolVersion`).
+	// error code `-32005` (`UnsupportedProtocolVersion`) with required
+	// `UnsupportedProtocolVersionErrorData` containing `supportedVersions`.
 	ProtocolVersions []string `json:"protocolVersions"`
 	// Unique client identifier
 	ClientId string `json:"clientId"`
@@ -133,7 +134,8 @@ type InitializeParams struct {
 // `protocolVersions` list. The client and server MUST use this version for
 // the rest of the connection. If the server cannot speak any of the offered
 // versions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)
-// instead of a result.
+// with required `UnsupportedProtocolVersionErrorData` containing
+// `supportedVersions`, instead of a result.
 type InitializeResult struct {
 	// Protocol version selected by the server. MUST be one of the entries in
 	// `InitializeParams.protocolVersions`. Formatted as a [SemVer](https://semver.org)
@@ -1363,14 +1365,18 @@ type isChatSource interface{ isChatSource() }
 func (*ForkChatSource) isChatSource() {}
 func (*SideChatSource) isChatSource() {}
 
+// ChatSourceUnknown carries an unrecognized ChatSource variant — typically a discriminator value introduced by a newer protocol version. The original JSON object is preserved verbatim so that re-encoding round-trips faithfully.
+type ChatSourceUnknown struct {
+	Raw json.RawMessage
+}
+
+func (*ChatSourceUnknown) isChatSource() {}
+
 // UnmarshalJSON decodes the variant indicated by the "kind" discriminator.
 func (u *ChatSource) UnmarshalJSON(data []byte) error {
-	disc, ok, err := readDiscriminator(data, "kind")
+	disc, _, err := readDiscriminator(data, "kind")
 	if err != nil {
 		return err
-	}
-	if !ok {
-		return missingDiscriminatorError("ChatSource", "kind")
 	}
 	switch disc {
 	case "fork":
@@ -1386,13 +1392,21 @@ func (u *ChatSource) UnmarshalJSON(data []byte) error {
 		}
 		u.Value = &value
 	default:
-		return unknownDiscriminatorError("ChatSource", "kind", disc)
+		raw := make(json.RawMessage, len(data))
+		copy(raw, data)
+		u.Value = &ChatSourceUnknown{Raw: raw}
 	}
 	return nil
 }
 
 // MarshalJSON encodes the active variant back to JSON.
 func (u ChatSource) MarshalJSON() ([]byte, error) {
+	if unk, ok := u.Value.(*ChatSourceUnknown); ok {
+		if len(unk.Raw) == 0 {
+			return []byte("null"), nil
+		}
+		return unk.Raw, nil
+	}
 	if u.Value == nil {
 		return []byte("null"), nil
 	}

--- a/clients/go/ahptypes/errors.generated.go
+++ b/clients/go/ahptypes/errors.generated.go
@@ -31,11 +31,11 @@ const (
 	ErrorCodeSessionAlreadyExists       int32 = -32003
 	ErrorCodeTurnInProgress             int32 = -32004
 	ErrorCodeUnsupportedProtocolVersion int32 = -32005
-	ErrorCodeContentNotFound            int32 = -32006
-	ErrorCodeAuthRequired               int32 = -32007
-	ErrorCodeNotFound                   int32 = -32008
-	ErrorCodePermissionDenied           int32 = -32009
-	ErrorCodeAlreadyExists              int32 = -32010
+	// -32006 is intentionally reserved and unassigned.
+	ErrorCodeAuthRequired     int32 = -32007
+	ErrorCodeNotFound         int32 = -32008
+	ErrorCodePermissionDenied int32 = -32009
+	ErrorCodeAlreadyExists    int32 = -32010
 )
 
 // AhpErrorCode is the type alias used by AHP application error codes.

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -281,6 +281,7 @@ const (
 	ConfirmationOptionKindDeny    ConfirmationOptionKind = "deny"
 )
 
+// Identifies the source of a tool call's implementation.
 type ToolCallContributorKind string
 
 const (
@@ -1061,9 +1062,8 @@ type SessionToolClientExecutionRequest struct {
 	// tool call's client {@link ToolCallContributor}.
 	ClientId string `json:"clientId"`
 	// The running tool call the session wants the owning client to execute. The
-	// host only ever populates this with a {@link ToolCallRunningState} (i.e. a
-	// {@link ToolCallState} in `running` status).
-	ToolCall ToolCallState `json:"toolCall"`
+	// host only ever populates this with a {@link ToolCallRunningState}.
+	ToolCall ToolCallRunningState `json:"toolCall"`
 }
 
 // A tool call blocked on MCP authentication mid-execution, surfaced at the
@@ -4439,18 +4439,14 @@ type isTerminalClaim interface{ isTerminalClaim() }
 func (*TerminalClientClaim) isTerminalClaim()  {}
 func (*TerminalSessionClaim) isTerminalClaim() {}
 
-// TerminalClaimUnknown carries an unrecognized TerminalClaim variant — typically a discriminator value introduced by a newer protocol version. The original JSON object is preserved verbatim so that re-encoding round-trips faithfully.
-type TerminalClaimUnknown struct {
-	Raw json.RawMessage
-}
-
-func (*TerminalClaimUnknown) isTerminalClaim() {}
-
 // UnmarshalJSON decodes the variant indicated by the "kind" discriminator.
 func (u *TerminalClaim) UnmarshalJSON(data []byte) error {
-	disc, _, err := readDiscriminator(data, "kind")
+	disc, ok, err := readDiscriminator(data, "kind")
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return missingDiscriminatorError("TerminalClaim", "kind")
 	}
 	switch disc {
 	case "client":
@@ -4466,21 +4462,13 @@ func (u *TerminalClaim) UnmarshalJSON(data []byte) error {
 		}
 		u.Value = &value
 	default:
-		raw := make(json.RawMessage, len(data))
-		copy(raw, data)
-		u.Value = &TerminalClaimUnknown{Raw: raw}
+		return unknownDiscriminatorError("TerminalClaim", "kind", disc)
 	}
 	return nil
 }
 
 // MarshalJSON encodes the active variant back to JSON.
 func (u TerminalClaim) MarshalJSON() ([]byte, error) {
-	if unk, ok := u.Value.(*TerminalClaimUnknown); ok {
-		if len(unk.Raw) == 0 {
-			return []byte("null"), nil
-		}
-		return unk.Raw, nil
-	}
 	if u.Value == nil {
 		return []byte("null"), nil
 	}
@@ -4727,18 +4715,14 @@ type isChatInputAnswer interface{ isChatInputAnswer() }
 func (*ChatInputAnswered) isChatInputAnswer() {}
 func (*ChatInputSkipped) isChatInputAnswer()  {}
 
-// ChatInputAnswerUnknown carries an unrecognized ChatInputAnswer variant — typically a discriminator value introduced by a newer protocol version. The original JSON object is preserved verbatim so that re-encoding round-trips faithfully.
-type ChatInputAnswerUnknown struct {
-	Raw json.RawMessage
-}
-
-func (*ChatInputAnswerUnknown) isChatInputAnswer() {}
-
 // UnmarshalJSON decodes the variant indicated by the "state" discriminator.
 func (u *ChatInputAnswer) UnmarshalJSON(data []byte) error {
-	disc, _, err := readDiscriminator(data, "state")
+	disc, ok, err := readDiscriminator(data, "state")
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return missingDiscriminatorError("ChatInputAnswer", "state")
 	}
 	switch disc {
 	case "draft":
@@ -4760,21 +4744,13 @@ func (u *ChatInputAnswer) UnmarshalJSON(data []byte) error {
 		}
 		u.Value = &value
 	default:
-		raw := make(json.RawMessage, len(data))
-		copy(raw, data)
-		u.Value = &ChatInputAnswerUnknown{Raw: raw}
+		return unknownDiscriminatorError("ChatInputAnswer", "state", disc)
 	}
 	return nil
 }
 
 // MarshalJSON encodes the active variant back to JSON.
 func (u ChatInputAnswer) MarshalJSON() ([]byte, error) {
-	if unk, ok := u.Value.(*ChatInputAnswerUnknown); ok {
-		if len(unk.Raw) == 0 {
-			return []byte("null"), nil
-		}
-		return unk.Raw, nil
-	}
 	if u.Value == nil {
 		return []byte("null"), nil
 	}
@@ -5119,18 +5095,14 @@ func (*CustomizationLoadedState) isCustomizationLoadState()   {}
 func (*CustomizationDegradedState) isCustomizationLoadState() {}
 func (*CustomizationErrorState) isCustomizationLoadState()    {}
 
-// CustomizationLoadStateUnknown carries an unrecognized CustomizationLoadState variant — typically a discriminator value introduced by a newer protocol version. The original JSON object is preserved verbatim so that re-encoding round-trips faithfully.
-type CustomizationLoadStateUnknown struct {
-	Raw json.RawMessage
-}
-
-func (*CustomizationLoadStateUnknown) isCustomizationLoadState() {}
-
 // UnmarshalJSON decodes the variant indicated by the "kind" discriminator.
 func (u *CustomizationLoadState) UnmarshalJSON(data []byte) error {
-	disc, _, err := readDiscriminator(data, "kind")
+	disc, ok, err := readDiscriminator(data, "kind")
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return missingDiscriminatorError("CustomizationLoadState", "kind")
 	}
 	switch disc {
 	case "loading":
@@ -5158,21 +5130,13 @@ func (u *CustomizationLoadState) UnmarshalJSON(data []byte) error {
 		}
 		u.Value = &value
 	default:
-		raw := make(json.RawMessage, len(data))
-		copy(raw, data)
-		u.Value = &CustomizationLoadStateUnknown{Raw: raw}
+		return unknownDiscriminatorError("CustomizationLoadState", "kind", disc)
 	}
 	return nil
 }
 
 // MarshalJSON encodes the active variant back to JSON.
 func (u CustomizationLoadState) MarshalJSON() ([]byte, error) {
-	if unk, ok := u.Value.(*CustomizationLoadStateUnknown); ok {
-		if len(unk.Raw) == 0 {
-			return []byte("null"), nil
-		}
-		return unk.Raw, nil
-	}
 	if u.Value == nil {
 		return []byte("null"), nil
 	}
@@ -5513,14 +5477,18 @@ type isSessionOrigin interface{ isSessionOrigin() }
 
 func (*AutomationSessionOrigin) isSessionOrigin() {}
 
+// SessionOriginUnknown carries an unrecognized SessionOrigin variant — typically a discriminator value introduced by a newer protocol version. The original JSON object is preserved verbatim so that re-encoding round-trips faithfully.
+type SessionOriginUnknown struct {
+	Raw json.RawMessage
+}
+
+func (*SessionOriginUnknown) isSessionOrigin() {}
+
 // UnmarshalJSON decodes the variant indicated by the "kind" discriminator.
 func (u *SessionOrigin) UnmarshalJSON(data []byte) error {
-	disc, ok, err := readDiscriminator(data, "kind")
+	disc, _, err := readDiscriminator(data, "kind")
 	if err != nil {
 		return err
-	}
-	if !ok {
-		return missingDiscriminatorError("SessionOrigin", "kind")
 	}
 	switch disc {
 	case "automation":
@@ -5530,13 +5498,21 @@ func (u *SessionOrigin) UnmarshalJSON(data []byte) error {
 		}
 		u.Value = &value
 	default:
-		return unknownDiscriminatorError("SessionOrigin", "kind", disc)
+		raw := make(json.RawMessage, len(data))
+		copy(raw, data)
+		u.Value = &SessionOriginUnknown{Raw: raw}
 	}
 	return nil
 }
 
 // MarshalJSON encodes the active variant back to JSON.
 func (u SessionOrigin) MarshalJSON() ([]byte, error) {
+	if unk, ok := u.Value.(*SessionOriginUnknown); ok {
+		if len(unk.Raw) == 0 {
+			return []byte("null"), nil
+		}
+		return unk.Raw, nil
+	}
 	if u.Value == nil {
 		return []byte("null"), nil
 	}

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Actions.generated.kt
@@ -25,198 +25,116 @@ import kotlinx.serialization.json.contentOrNull
 /**
  * Discriminant values for all state actions.
  */
-@Serializable
-enum class ActionType {
-    @SerialName("root/agentsChanged")
-    ROOT_AGENTS_CHANGED,
-    @SerialName("root/activeSessionsChanged")
-    ROOT_ACTIVE_SESSIONS_CHANGED,
-    @SerialName("session/ready")
-    SESSION_READY,
-    @SerialName("session/creationFailed")
-    SESSION_CREATION_FAILED,
-    @SerialName("session/chatAdded")
-    SESSION_CHAT_ADDED,
-    @SerialName("session/chatRemoved")
-    SESSION_CHAT_REMOVED,
-    @SerialName("session/chatUpdated")
-    SESSION_CHAT_UPDATED,
-    @SerialName("session/defaultChatChanged")
-    SESSION_DEFAULT_CHAT_CHANGED,
-    @SerialName("chat/turnStarted")
-    CHAT_TURN_STARTED,
-    @SerialName("chat/delta")
-    CHAT_DELTA,
-    @SerialName("chat/responsePart")
-    CHAT_RESPONSE_PART,
-    @SerialName("chat/toolCallStart")
-    CHAT_TOOL_CALL_START,
-    @SerialName("chat/toolCallDelta")
-    CHAT_TOOL_CALL_DELTA,
-    @SerialName("chat/toolCallReady")
-    CHAT_TOOL_CALL_READY,
-    @SerialName("chat/toolCallConfirmed")
-    CHAT_TOOL_CALL_CONFIRMED,
-    @SerialName("chat/toolCallComplete")
-    CHAT_TOOL_CALL_COMPLETE,
-    @SerialName("chat/toolCallResultConfirmed")
-    CHAT_TOOL_CALL_RESULT_CONFIRMED,
-    @SerialName("chat/toolCallContentChanged")
-    CHAT_TOOL_CALL_CONTENT_CHANGED,
-    @SerialName("chat/toolCallAuthRequired")
-    CHAT_TOOL_CALL_AUTH_REQUIRED,
-    @SerialName("chat/toolCallAuthResolved")
-    CHAT_TOOL_CALL_AUTH_RESOLVED,
-    @SerialName("chat/turnComplete")
-    CHAT_TURN_COMPLETE,
-    @SerialName("chat/turnCancelled")
-    CHAT_TURN_CANCELLED,
-    @SerialName("chat/error")
-    CHAT_ERROR,
-    @SerialName("chat/activityChanged")
-    CHAT_ACTIVITY_CHANGED,
-    @SerialName("chat/workingDirectorySet")
-    CHAT_WORKING_DIRECTORY_SET,
-    @SerialName("chat/workingDirectoryRemoved")
-    CHAT_WORKING_DIRECTORY_REMOVED,
-    @SerialName("session/titleChanged")
-    SESSION_TITLE_CHANGED,
-    @SerialName("chat/usage")
-    CHAT_USAGE,
-    @SerialName("chat/reasoning")
-    CHAT_REASONING,
-    @SerialName("session/serverToolsChanged")
-    SESSION_SERVER_TOOLS_CHANGED,
-    @SerialName("session/activeClientSet")
-    SESSION_ACTIVE_CLIENT_SET,
-    @SerialName("session/activeClientRemoved")
-    SESSION_ACTIVE_CLIENT_REMOVED,
-    @SerialName("session/workingDirectorySet")
-    SESSION_WORKING_DIRECTORY_SET,
-    @SerialName("session/workingDirectoryRemoved")
-    SESSION_WORKING_DIRECTORY_REMOVED,
-    @SerialName("session/workingDirectoryReplaced")
-    SESSION_WORKING_DIRECTORY_REPLACED,
-    @SerialName("session/inputNeededSet")
-    SESSION_INPUT_NEEDED_SET,
-    @SerialName("session/inputNeededRemoved")
-    SESSION_INPUT_NEEDED_REMOVED,
-    @SerialName("chat/pendingMessageSet")
-    CHAT_PENDING_MESSAGE_SET,
-    @SerialName("chat/pendingMessageRemoved")
-    CHAT_PENDING_MESSAGE_REMOVED,
-    @SerialName("chat/queuedMessagesReordered")
-    CHAT_QUEUED_MESSAGES_REORDERED,
-    @SerialName("chat/draftChanged")
-    CHAT_DRAFT_CHANGED,
-    @SerialName("chat/inputRequested")
-    CHAT_INPUT_REQUESTED,
-    @SerialName("chat/inputAnswerChanged")
-    CHAT_INPUT_ANSWER_CHANGED,
-    @SerialName("chat/inputCompleted")
-    CHAT_INPUT_COMPLETED,
-    @SerialName("session/customizationsChanged")
-    SESSION_CUSTOMIZATIONS_CHANGED,
-    @SerialName("session/customizationToggled")
-    SESSION_CUSTOMIZATION_TOGGLED,
-    @SerialName("session/customizationUpdated")
-    SESSION_CUSTOMIZATION_UPDATED,
-    @SerialName("session/customizationRemoved")
-    SESSION_CUSTOMIZATION_REMOVED,
-    @SerialName("session/mcpServerStateChanged")
-    SESSION_MCP_SERVER_STATE_CHANGED,
-    @SerialName("session/mcpServerStartRequested")
-    SESSION_MCP_SERVER_START_REQUESTED,
-    @SerialName("session/mcpServerStopRequested")
-    SESSION_MCP_SERVER_STOP_REQUESTED,
-    @SerialName("chat/truncated")
-    CHAT_TRUNCATED,
-    @SerialName("chat/turnsLoaded")
-    CHAT_TURNS_LOADED,
-    @SerialName("session/isReadChanged")
-    SESSION_IS_READ_CHANGED,
-    @SerialName("session/isArchivedChanged")
-    SESSION_IS_ARCHIVED_CHANGED,
-    @SerialName("session/activityChanged")
-    SESSION_ACTIVITY_CHANGED,
-    @SerialName("session/changesetsChanged")
-    SESSION_CHANGESETS_CHANGED,
-    @SerialName("session/configChanged")
-    SESSION_CONFIG_CHANGED,
-    @SerialName("session/metaChanged")
-    SESSION_META_CHANGED,
-    @SerialName("changeset/statusChanged")
-    CHANGESET_STATUS_CHANGED,
-    @SerialName("changeset/fileSet")
-    CHANGESET_FILE_SET,
-    @SerialName("changeset/fileRemoved")
-    CHANGESET_FILE_REMOVED,
-    @SerialName("changeset/filesReviewChanged")
-    CHANGESET_FILES_REVIEW_CHANGED,
-    @SerialName("changeset/contentChanged")
-    CHANGESET_CONTENT_CHANGED,
-    @SerialName("changeset/operationsChanged")
-    CHANGESET_OPERATIONS_CHANGED,
-    @SerialName("changeset/operationStatusChanged")
-    CHANGESET_OPERATION_STATUS_CHANGED,
-    @SerialName("changeset/cleared")
-    CHANGESET_CLEARED,
-    @SerialName("annotations/set")
-    ANNOTATIONS_SET,
-    @SerialName("annotations/updated")
-    ANNOTATIONS_UPDATED,
-    @SerialName("annotations/removed")
-    ANNOTATIONS_REMOVED,
-    @SerialName("annotations/entrySet")
-    ANNOTATIONS_ENTRY_SET,
-    @SerialName("annotations/entryRemoved")
-    ANNOTATIONS_ENTRY_REMOVED,
-    @SerialName("root/terminalsChanged")
-    ROOT_TERMINALS_CHANGED,
-    @SerialName("root/configChanged")
-    ROOT_CONFIG_CHANGED,
-    @SerialName("terminal/data")
-    TERMINAL_DATA,
-    @SerialName("terminal/input")
-    TERMINAL_INPUT,
-    @SerialName("terminal/resized")
-    TERMINAL_RESIZED,
-    @SerialName("terminal/claimed")
-    TERMINAL_CLAIMED,
-    @SerialName("terminal/titleChanged")
-    TERMINAL_TITLE_CHANGED,
-    @SerialName("terminal/cwdChanged")
-    TERMINAL_CWD_CHANGED,
-    @SerialName("terminal/exited")
-    TERMINAL_EXITED,
-    @SerialName("terminal/cleared")
-    TERMINAL_CLEARED,
-    @SerialName("terminal/commandDetectionAvailable")
-    TERMINAL_COMMAND_DETECTION_AVAILABLE,
-    @SerialName("terminal/commandExecuted")
-    TERMINAL_COMMAND_EXECUTED,
-    @SerialName("terminal/commandFinished")
-    TERMINAL_COMMAND_FINISHED,
-    @SerialName("resourceWatch/changed")
-    RESOURCE_WATCH_CHANGED,
-    @SerialName("automation/createRequested")
-    AUTOMATION_CREATE_REQUESTED,
-    @SerialName("automation/updateRequested")
-    AUTOMATION_UPDATE_REQUESTED,
-    @SerialName("automation/set")
-    AUTOMATION_SET,
-    @SerialName("automation/removed")
-    AUTOMATION_REMOVED,
-    @SerialName("automationRun/lifecycleChanged")
-    AUTOMATION_RUN_LIFECYCLE_CHANGED,
-    @SerialName("automationRun/sessionSet")
-    AUTOMATION_RUN_SESSION_SET,
-    @SerialName("automationRun/sessionRemoved")
-    AUTOMATION_RUN_SESSION_REMOVED,
-    @SerialName("automationRun/primarySessionChanged")
-    AUTOMATION_RUN_PRIMARY_SESSION_CHANGED,
-    @SerialName("automationRun/cancelRequested")
-    AUTOMATION_RUN_CANCEL_REQUESTED
+@Serializable(with = ActionTypeSerializer::class)
+@JvmInline
+value class ActionType(val rawValue: String) {
+    companion object {
+        val ROOT_AGENTS_CHANGED: ActionType = ActionType("root/agentsChanged")
+        val ROOT_ACTIVE_SESSIONS_CHANGED: ActionType = ActionType("root/activeSessionsChanged")
+        val SESSION_READY: ActionType = ActionType("session/ready")
+        val SESSION_CREATION_FAILED: ActionType = ActionType("session/creationFailed")
+        val SESSION_CHAT_ADDED: ActionType = ActionType("session/chatAdded")
+        val SESSION_CHAT_REMOVED: ActionType = ActionType("session/chatRemoved")
+        val SESSION_CHAT_UPDATED: ActionType = ActionType("session/chatUpdated")
+        val SESSION_DEFAULT_CHAT_CHANGED: ActionType = ActionType("session/defaultChatChanged")
+        val CHAT_TURN_STARTED: ActionType = ActionType("chat/turnStarted")
+        val CHAT_DELTA: ActionType = ActionType("chat/delta")
+        val CHAT_RESPONSE_PART: ActionType = ActionType("chat/responsePart")
+        val CHAT_TOOL_CALL_START: ActionType = ActionType("chat/toolCallStart")
+        val CHAT_TOOL_CALL_DELTA: ActionType = ActionType("chat/toolCallDelta")
+        val CHAT_TOOL_CALL_READY: ActionType = ActionType("chat/toolCallReady")
+        val CHAT_TOOL_CALL_CONFIRMED: ActionType = ActionType("chat/toolCallConfirmed")
+        val CHAT_TOOL_CALL_COMPLETE: ActionType = ActionType("chat/toolCallComplete")
+        val CHAT_TOOL_CALL_RESULT_CONFIRMED: ActionType = ActionType("chat/toolCallResultConfirmed")
+        val CHAT_TOOL_CALL_CONTENT_CHANGED: ActionType = ActionType("chat/toolCallContentChanged")
+        val CHAT_TOOL_CALL_AUTH_REQUIRED: ActionType = ActionType("chat/toolCallAuthRequired")
+        val CHAT_TOOL_CALL_AUTH_RESOLVED: ActionType = ActionType("chat/toolCallAuthResolved")
+        val CHAT_TURN_COMPLETE: ActionType = ActionType("chat/turnComplete")
+        val CHAT_TURN_CANCELLED: ActionType = ActionType("chat/turnCancelled")
+        val CHAT_ERROR: ActionType = ActionType("chat/error")
+        val CHAT_ACTIVITY_CHANGED: ActionType = ActionType("chat/activityChanged")
+        val CHAT_WORKING_DIRECTORY_SET: ActionType = ActionType("chat/workingDirectorySet")
+        val CHAT_WORKING_DIRECTORY_REMOVED: ActionType = ActionType("chat/workingDirectoryRemoved")
+        val SESSION_TITLE_CHANGED: ActionType = ActionType("session/titleChanged")
+        val CHAT_USAGE: ActionType = ActionType("chat/usage")
+        val CHAT_REASONING: ActionType = ActionType("chat/reasoning")
+        val SESSION_SERVER_TOOLS_CHANGED: ActionType = ActionType("session/serverToolsChanged")
+        val SESSION_ACTIVE_CLIENT_SET: ActionType = ActionType("session/activeClientSet")
+        val SESSION_ACTIVE_CLIENT_REMOVED: ActionType = ActionType("session/activeClientRemoved")
+        val SESSION_WORKING_DIRECTORY_SET: ActionType = ActionType("session/workingDirectorySet")
+        val SESSION_WORKING_DIRECTORY_REMOVED: ActionType = ActionType("session/workingDirectoryRemoved")
+        val SESSION_WORKING_DIRECTORY_REPLACED: ActionType = ActionType("session/workingDirectoryReplaced")
+        val SESSION_INPUT_NEEDED_SET: ActionType = ActionType("session/inputNeededSet")
+        val SESSION_INPUT_NEEDED_REMOVED: ActionType = ActionType("session/inputNeededRemoved")
+        val CHAT_PENDING_MESSAGE_SET: ActionType = ActionType("chat/pendingMessageSet")
+        val CHAT_PENDING_MESSAGE_REMOVED: ActionType = ActionType("chat/pendingMessageRemoved")
+        val CHAT_QUEUED_MESSAGES_REORDERED: ActionType = ActionType("chat/queuedMessagesReordered")
+        val CHAT_DRAFT_CHANGED: ActionType = ActionType("chat/draftChanged")
+        val CHAT_INPUT_REQUESTED: ActionType = ActionType("chat/inputRequested")
+        val CHAT_INPUT_ANSWER_CHANGED: ActionType = ActionType("chat/inputAnswerChanged")
+        val CHAT_INPUT_COMPLETED: ActionType = ActionType("chat/inputCompleted")
+        val SESSION_CUSTOMIZATIONS_CHANGED: ActionType = ActionType("session/customizationsChanged")
+        val SESSION_CUSTOMIZATION_TOGGLED: ActionType = ActionType("session/customizationToggled")
+        val SESSION_CUSTOMIZATION_UPDATED: ActionType = ActionType("session/customizationUpdated")
+        val SESSION_CUSTOMIZATION_REMOVED: ActionType = ActionType("session/customizationRemoved")
+        val SESSION_MCP_SERVER_STATE_CHANGED: ActionType = ActionType("session/mcpServerStateChanged")
+        val SESSION_MCP_SERVER_START_REQUESTED: ActionType = ActionType("session/mcpServerStartRequested")
+        val SESSION_MCP_SERVER_STOP_REQUESTED: ActionType = ActionType("session/mcpServerStopRequested")
+        val CHAT_TRUNCATED: ActionType = ActionType("chat/truncated")
+        val CHAT_TURNS_LOADED: ActionType = ActionType("chat/turnsLoaded")
+        val SESSION_IS_READ_CHANGED: ActionType = ActionType("session/isReadChanged")
+        val SESSION_IS_ARCHIVED_CHANGED: ActionType = ActionType("session/isArchivedChanged")
+        val SESSION_ACTIVITY_CHANGED: ActionType = ActionType("session/activityChanged")
+        val SESSION_CHANGESETS_CHANGED: ActionType = ActionType("session/changesetsChanged")
+        val SESSION_CONFIG_CHANGED: ActionType = ActionType("session/configChanged")
+        val SESSION_META_CHANGED: ActionType = ActionType("session/metaChanged")
+        val CHANGESET_STATUS_CHANGED: ActionType = ActionType("changeset/statusChanged")
+        val CHANGESET_FILE_SET: ActionType = ActionType("changeset/fileSet")
+        val CHANGESET_FILE_REMOVED: ActionType = ActionType("changeset/fileRemoved")
+        val CHANGESET_FILES_REVIEW_CHANGED: ActionType = ActionType("changeset/filesReviewChanged")
+        val CHANGESET_CONTENT_CHANGED: ActionType = ActionType("changeset/contentChanged")
+        val CHANGESET_OPERATIONS_CHANGED: ActionType = ActionType("changeset/operationsChanged")
+        val CHANGESET_OPERATION_STATUS_CHANGED: ActionType = ActionType("changeset/operationStatusChanged")
+        val CHANGESET_CLEARED: ActionType = ActionType("changeset/cleared")
+        val ANNOTATIONS_SET: ActionType = ActionType("annotations/set")
+        val ANNOTATIONS_UPDATED: ActionType = ActionType("annotations/updated")
+        val ANNOTATIONS_REMOVED: ActionType = ActionType("annotations/removed")
+        val ANNOTATIONS_ENTRY_SET: ActionType = ActionType("annotations/entrySet")
+        val ANNOTATIONS_ENTRY_REMOVED: ActionType = ActionType("annotations/entryRemoved")
+        val ROOT_TERMINALS_CHANGED: ActionType = ActionType("root/terminalsChanged")
+        val ROOT_CONFIG_CHANGED: ActionType = ActionType("root/configChanged")
+        val TERMINAL_DATA: ActionType = ActionType("terminal/data")
+        val TERMINAL_INPUT: ActionType = ActionType("terminal/input")
+        val TERMINAL_RESIZED: ActionType = ActionType("terminal/resized")
+        val TERMINAL_CLAIMED: ActionType = ActionType("terminal/claimed")
+        val TERMINAL_TITLE_CHANGED: ActionType = ActionType("terminal/titleChanged")
+        val TERMINAL_CWD_CHANGED: ActionType = ActionType("terminal/cwdChanged")
+        val TERMINAL_EXITED: ActionType = ActionType("terminal/exited")
+        val TERMINAL_CLEARED: ActionType = ActionType("terminal/cleared")
+        val TERMINAL_COMMAND_DETECTION_AVAILABLE: ActionType = ActionType("terminal/commandDetectionAvailable")
+        val TERMINAL_COMMAND_EXECUTED: ActionType = ActionType("terminal/commandExecuted")
+        val TERMINAL_COMMAND_FINISHED: ActionType = ActionType("terminal/commandFinished")
+        val RESOURCE_WATCH_CHANGED: ActionType = ActionType("resourceWatch/changed")
+        val AUTOMATION_CREATE_REQUESTED: ActionType = ActionType("automation/createRequested")
+        val AUTOMATION_UPDATE_REQUESTED: ActionType = ActionType("automation/updateRequested")
+        val AUTOMATION_SET: ActionType = ActionType("automation/set")
+        val AUTOMATION_REMOVED: ActionType = ActionType("automation/removed")
+        val AUTOMATION_RUN_LIFECYCLE_CHANGED: ActionType = ActionType("automationRun/lifecycleChanged")
+        val AUTOMATION_RUN_SESSION_SET: ActionType = ActionType("automationRun/sessionSet")
+        val AUTOMATION_RUN_SESSION_REMOVED: ActionType = ActionType("automationRun/sessionRemoved")
+        val AUTOMATION_RUN_PRIMARY_SESSION_CHANGED: ActionType = ActionType("automationRun/primarySessionChanged")
+        val AUTOMATION_RUN_CANCEL_REQUESTED: ActionType = ActionType("automationRun/cancelRequested")
+    }
+}
+
+internal object ActionTypeSerializer : KSerializer<ActionType> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ActionType", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ActionType) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ActionType =
+        ActionType(decoder.decodeString())
 }
 
 // ─── Action Infrastructure ──────────────────────────────────────────────────

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -36,18 +36,29 @@ enum class ReconnectResultType {
 /**
  * How a new chat uses its source chat and turn.
  */
-@Serializable
-enum class ChatSourceKind {
-    /**
-     * Copy source history through the referenced turn into the new chat.
-     */
-    @SerialName("fork")
-    FORK,
-    /**
-     * Supply source context without copying it into the new chat's visible history.
-     */
-    @SerialName("sideChat")
-    SIDE_CHAT
+@Serializable(with = ChatSourceKindSerializer::class)
+@JvmInline
+value class ChatSourceKind(val rawValue: String) {
+    companion object {
+        /**
+         * Copy source history through the referenced turn into the new chat.
+         */
+        val FORK: ChatSourceKind = ChatSourceKind("fork")
+        /**
+         * Supply source context without copying it into the new chat's visible history.
+         */
+        val SIDE_CHAT: ChatSourceKind = ChatSourceKind("sideChat")
+    }
+}
+
+internal object ChatSourceKindSerializer : KSerializer<ChatSourceKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ChatSourceKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ChatSourceKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ChatSourceKind =
+        ChatSourceKind(decoder.decodeString())
 }
 
 /**
@@ -64,28 +75,50 @@ enum class ContentEncoding {
 /**
  * The kind of completion items being requested.
  */
-@Serializable
-enum class CompletionItemKind {
-    /**
-     * Completions for the text of a {@link Message} the user is composing.
-     * Each returned item carries an attachment that gets associated with the
-     * message when accepted.
-     */
-    @SerialName("userMessage")
-    USER_MESSAGE
+@Serializable(with = CompletionItemKindSerializer::class)
+@JvmInline
+value class CompletionItemKind(val rawValue: String) {
+    companion object {
+        /**
+         * Completions for the text of a {@link Message} the user is composing.
+         * Each returned item carries an attachment that gets associated with the
+         * message when accepted.
+         */
+        val USER_MESSAGE: CompletionItemKind = CompletionItemKind("userMessage")
+    }
+}
+
+internal object CompletionItemKindSerializer : KSerializer<CompletionItemKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("CompletionItemKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: CompletionItemKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): CompletionItemKind =
+        CompletionItemKind(decoder.decodeString())
 }
 
 /**
  * Discriminant for {@link ResourceResolveResult.type}.
  */
-@Serializable
-enum class ResourceType {
-    @SerialName("file")
-    FILE,
-    @SerialName("directory")
-    DIRECTORY,
-    @SerialName("symlink")
-    SYMLINK
+@Serializable(with = ResourceTypeSerializer::class)
+@JvmInline
+value class ResourceType(val rawValue: String) {
+    companion object {
+        val FILE: ResourceType = ResourceType("file")
+        val DIRECTORY: ResourceType = ResourceType("directory")
+        val SYMLINK: ResourceType = ResourceType("symlink")
+    }
+}
+
+internal object ResourceTypeSerializer : KSerializer<ResourceType> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ResourceType", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ResourceType) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ResourceType =
+        ResourceType(decoder.decodeString())
 }
 
 /**
@@ -256,7 +289,8 @@ data class InitializeParams(
      *
      * The server selects one entry and returns it as `InitializeResult.protocolVersion`.
      * If the server cannot speak any of the offered versions, it MUST return
-     * error code `-32005` (`UnsupportedProtocolVersion`).
+     * error code `-32005` (`UnsupportedProtocolVersion`) with required
+     * `UnsupportedProtocolVersionErrorData` containing `supportedVersions`.
      */
     val protocolVersions: List<String>,
     /**
@@ -1625,6 +1659,16 @@ sealed interface ChatSource
 value class ChatSourceFork(val value: ForkChatSource) : ChatSource
 @JvmInline
 value class ChatSourceSideChat(val value: SideChatSource) : ChatSource
+/**
+ * Forward-compat catch-all for unknown ChatSource discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
+ */
+@JvmInline
+value class ChatSourceUnknown(val raw: JsonObject) : ChatSource
 
 internal object ChatSourceSerializer : KSerializer<ChatSource> {
     override val descriptor: SerialDescriptor =
@@ -1637,11 +1681,11 @@ internal object ChatSourceSerializer : KSerializer<ChatSource> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for ChatSource")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: error("Missing kind discriminator on ChatSource")
+            ?: return ChatSourceUnknown(obj)
         return when (discriminant) {
             "fork" -> ChatSourceFork(input.json.decodeFromJsonElement(ForkChatSource.serializer(), element))
             "sideChat" -> ChatSourceSideChat(input.json.decodeFromJsonElement(SideChatSource.serializer(), element))
-            else -> error("Unknown ChatSource discriminator: $discriminant")
+            else -> ChatSourceUnknown(obj)
         }
     }
 
@@ -1651,6 +1695,7 @@ internal object ChatSourceSerializer : KSerializer<ChatSource> {
         val element: JsonElement = when (value) {
             is ChatSourceFork -> output.json.encodeToJsonElement(ForkChatSource.serializer(), value.value)
             is ChatSourceSideChat -> output.json.encodeToJsonElement(SideChatSource.serializer(), value.value)
+            is ChatSourceUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Errors.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Errors.generated.kt
@@ -48,8 +48,7 @@ object AhpErrorCodes {
     const val TURN_IN_PROGRESS: Int = -32004
     /** The server cannot speak any of the protocol versions offered by the client */
     const val UNSUPPORTED_PROTOCOL_VERSION: Int = -32005
-    /** The requested content URI does not exist */
-    const val CONTENT_NOT_FOUND: Int = -32006
+    // -32006 is intentionally reserved and unassigned.
     /** Authentication required for a protected resource */
     const val AUTH_REQUIRED: Int = -32007
     /** The requested file, folder, or URI does not exist */

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Notifications.generated.kt
@@ -25,18 +25,29 @@ import kotlinx.serialization.json.contentOrNull
 /**
  * Reason why authentication is required.
  */
-@Serializable
-enum class AuthRequiredReason {
-    /**
-     * The client has not yet authenticated for the resource
-     */
-    @SerialName("required")
-    REQUIRED,
-    /**
-     * A previously valid token has expired or been revoked
-     */
-    @SerialName("expired")
-    EXPIRED
+@Serializable(with = AuthRequiredReasonSerializer::class)
+@JvmInline
+value class AuthRequiredReason(val rawValue: String) {
+    companion object {
+        /**
+         * The client has not yet authenticated for the resource
+         */
+        val REQUIRED: AuthRequiredReason = AuthRequiredReason("required")
+        /**
+         * A previously valid token has expired or been revoked
+         */
+        val EXPIRED: AuthRequiredReason = AuthRequiredReason("expired")
+    }
+}
+
+internal object AuthRequiredReasonSerializer : KSerializer<AuthRequiredReason> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("AuthRequiredReason", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: AuthRequiredReason) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): AuthRequiredReason =
+        AuthRequiredReason(decoder.decodeString())
 }
 
 // ─── Notification Types ─────────────────────────────────────────────────────

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -105,14 +105,24 @@ enum class PendingMessageKind {
 /**
  * Session initialization state.
  */
-@Serializable
-enum class SessionLifecycle {
-    @SerialName("creating")
-    CREATING,
-    @SerialName("ready")
-    READY,
-    @SerialName("failed")
-    FAILED
+@Serializable(with = SessionLifecycleSerializer::class)
+@JvmInline
+value class SessionLifecycle(val rawValue: String) {
+    companion object {
+        val CREATING: SessionLifecycle = SessionLifecycle("creating")
+        val READY: SessionLifecycle = SessionLifecycle("ready")
+        val FAILED: SessionLifecycle = SessionLifecycle("failed")
+    }
+}
+
+internal object SessionLifecycleSerializer : KSerializer<SessionLifecycle> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("SessionLifecycle", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: SessionLifecycle) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): SessionLifecycle =
+        SessionLifecycle(decoder.decodeString())
 }
 
 /**
@@ -172,28 +182,37 @@ internal object SessionStatusSerializer : KSerializer<SessionStatus> {
 /**
  * Discriminant for {@link ChatOrigin} — how a chat came into existence.
  */
-@Serializable
-enum class ChatOriginKind {
-    /**
-     * User created the chat explicitly (e.g. via the host UI).
-     */
-    @SerialName("user")
-    USER,
-    /**
-     * Forked from an existing chat at a specific turn.
-     */
-    @SerialName("fork")
-    FORK,
-    /**
-     * Created as an independent side conversation from a specific turn.
-     */
-    @SerialName("sideChat")
-    SIDE_CHAT,
-    /**
-     * Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
-     */
-    @SerialName("tool")
-    TOOL
+@Serializable(with = ChatOriginKindSerializer::class)
+@JvmInline
+value class ChatOriginKind(val rawValue: String) {
+    companion object {
+        /**
+         * User created the chat explicitly (e.g. via the host UI).
+         */
+        val USER: ChatOriginKind = ChatOriginKind("user")
+        /**
+         * Forked from an existing chat at a specific turn.
+         */
+        val FORK: ChatOriginKind = ChatOriginKind("fork")
+        /**
+         * Created as an independent side conversation from a specific turn.
+         */
+        val SIDE_CHAT: ChatOriginKind = ChatOriginKind("sideChat")
+        /**
+         * Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
+         */
+        val TOOL: ChatOriginKind = ChatOriginKind("tool")
+    }
+}
+
+internal object ChatOriginKindSerializer : KSerializer<ChatOriginKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ChatOriginKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ChatOriginKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ChatOriginKind =
+        ChatOriginKind(decoder.decodeString())
 }
 
 /**
@@ -243,37 +262,52 @@ enum class ChatInputAnswerState {
 /**
  * Answer value kind.
  */
-@Serializable
-enum class ChatInputAnswerValueKind {
-    @SerialName("text")
-    TEXT,
-    @SerialName("number")
-    NUMBER,
-    @SerialName("boolean")
-    BOOLEAN,
-    @SerialName("selected")
-    SELECTED,
-    @SerialName("selected-many")
-    SELECTED_MANY
+@Serializable(with = ChatInputAnswerValueKindSerializer::class)
+@JvmInline
+value class ChatInputAnswerValueKind(val rawValue: String) {
+    companion object {
+        val TEXT: ChatInputAnswerValueKind = ChatInputAnswerValueKind("text")
+        val NUMBER: ChatInputAnswerValueKind = ChatInputAnswerValueKind("number")
+        val BOOLEAN: ChatInputAnswerValueKind = ChatInputAnswerValueKind("boolean")
+        val SELECTED: ChatInputAnswerValueKind = ChatInputAnswerValueKind("selected")
+        val SELECTED_MANY: ChatInputAnswerValueKind = ChatInputAnswerValueKind("selected-many")
+    }
+}
+
+internal object ChatInputAnswerValueKindSerializer : KSerializer<ChatInputAnswerValueKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ChatInputAnswerValueKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ChatInputAnswerValueKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ChatInputAnswerValueKind =
+        ChatInputAnswerValueKind(decoder.decodeString())
 }
 
 /**
  * Question/input control kind.
  */
-@Serializable
-enum class ChatInputQuestionKind {
-    @SerialName("text")
-    TEXT,
-    @SerialName("number")
-    NUMBER,
-    @SerialName("integer")
-    INTEGER,
-    @SerialName("boolean")
-    BOOLEAN,
-    @SerialName("single-select")
-    SINGLE_SELECT,
-    @SerialName("multi-select")
-    MULTI_SELECT
+@Serializable(with = ChatInputQuestionKindSerializer::class)
+@JvmInline
+value class ChatInputQuestionKind(val rawValue: String) {
+    companion object {
+        val TEXT: ChatInputQuestionKind = ChatInputQuestionKind("text")
+        val NUMBER: ChatInputQuestionKind = ChatInputQuestionKind("number")
+        val INTEGER: ChatInputQuestionKind = ChatInputQuestionKind("integer")
+        val BOOLEAN: ChatInputQuestionKind = ChatInputQuestionKind("boolean")
+        val SINGLE_SELECT: ChatInputQuestionKind = ChatInputQuestionKind("single-select")
+        val MULTI_SELECT: ChatInputQuestionKind = ChatInputQuestionKind("multi-select")
+    }
+}
+
+internal object ChatInputQuestionKindSerializer : KSerializer<ChatInputQuestionKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ChatInputQuestionKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ChatInputQuestionKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ChatInputQuestionKind =
+        ChatInputQuestionKind(decoder.decodeString())
 }
 
 /**
@@ -296,28 +330,37 @@ enum class ChatInputResponseKind {
  * This is a general/typological union (not a lifecycle), so the discriminant is
  * a `*Kind`.
  */
-@Serializable
-enum class SessionInputRequestKind {
-    /**
-     * A user-facing elicitation mirrored from an unresolved chat response part.
-     */
-    @SerialName("chatInput")
-    CHAT_INPUT,
-    /**
-     * A tool call awaiting parameter- or result-confirmation.
-     */
-    @SerialName("toolConfirmation")
-    TOOL_CONFIRMATION,
-    /**
-     * A running tool the session wants an active client to execute.
-     */
-    @SerialName("toolClientExecution")
-    TOOL_CLIENT_EXECUTION,
-    /**
-     * A tool call blocked on MCP authentication mid-execution.
-     */
-    @SerialName("toolAuthentication")
-    TOOL_AUTHENTICATION
+@Serializable(with = SessionInputRequestKindSerializer::class)
+@JvmInline
+value class SessionInputRequestKind(val rawValue: String) {
+    companion object {
+        /**
+         * A user-facing elicitation mirrored from an unresolved chat response part.
+         */
+        val CHAT_INPUT: SessionInputRequestKind = SessionInputRequestKind("chatInput")
+        /**
+         * A tool call awaiting parameter- or result-confirmation.
+         */
+        val TOOL_CONFIRMATION: SessionInputRequestKind = SessionInputRequestKind("toolConfirmation")
+        /**
+         * A running tool the session wants an active client to execute.
+         */
+        val TOOL_CLIENT_EXECUTION: SessionInputRequestKind = SessionInputRequestKind("toolClientExecution")
+        /**
+         * A tool call blocked on MCP authentication mid-execution.
+         */
+        val TOOL_AUTHENTICATION: SessionInputRequestKind = SessionInputRequestKind("toolAuthentication")
+    }
+}
+
+internal object SessionInputRequestKindSerializer : KSerializer<SessionInputRequestKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("SessionInputRequestKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: SessionInputRequestKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): SessionInputRequestKind =
+        SessionInputRequestKind(decoder.decodeString())
 }
 
 /**
@@ -336,112 +379,141 @@ enum class TurnState {
 /**
  * Discriminant for {@link MessageOrigin} — identifies who produced a message.
  */
-@Serializable
-enum class MessageKind {
-    /**
-     * Sent directly by the user.
-     */
-    @SerialName("user")
-    USER,
-    /**
-     * Produced by the agent itself rather than the user — for example, an agent
-     * that seeds the first message of a chat it spawned.
-     */
-    @SerialName("agent")
-    AGENT,
-    /**
-     * Produced by a tool rather than the user — for example, a tool that spawns a
-     * worker chat whose first message carries a seed prompt.
-     */
-    @SerialName("tool")
-    TOOL,
-    /**
-     * Emitted automatically when an automation run starts a session.
-     */
-    @SerialName("automation")
-    AUTOMATION,
-    /**
-     * A system-generated notification rather than a direct user message.
-     */
-    @SerialName("systemNotification")
-    SYSTEM_NOTIFICATION
+@Serializable(with = MessageKindSerializer::class)
+@JvmInline
+value class MessageKind(val rawValue: String) {
+    companion object {
+        /**
+         * Sent directly by the user.
+         */
+        val USER: MessageKind = MessageKind("user")
+        /**
+         * Produced by the agent itself rather than the user — for example, an agent
+         * that seeds the first message of a chat it spawned.
+         */
+        val AGENT: MessageKind = MessageKind("agent")
+        /**
+         * Produced by a tool rather than the user — for example, a tool that spawns a
+         * worker chat whose first message carries a seed prompt.
+         */
+        val TOOL: MessageKind = MessageKind("tool")
+        /**
+         * Emitted automatically when an automation run starts a session.
+         */
+        val AUTOMATION: MessageKind = MessageKind("automation")
+        /**
+         * A system-generated notification rather than a direct user message.
+         */
+        val SYSTEM_NOTIFICATION: MessageKind = MessageKind("systemNotification")
+    }
+}
+
+internal object MessageKindSerializer : KSerializer<MessageKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("MessageKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: MessageKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): MessageKind =
+        MessageKind(decoder.decodeString())
 }
 
 /**
  * Discriminant for {@link MessageAttachment} variants.
  */
-@Serializable
-enum class MessageAttachmentKind {
-    /**
-     * A simple, opaque attachment whose representation is described by the producer.
-     */
-    @SerialName("simple")
-    SIMPLE,
-    /**
-     * An attachment whose data is embedded inline as a base64 string.
-     */
-    @SerialName("embeddedResource")
-    EMBEDDED_RESOURCE,
-    /**
-     * An attachment that references a resource by URI.
-     */
-    @SerialName("resource")
-    RESOURCE,
-    /**
-     * An attachment that references annotations on an annotations channel.
-     */
-    @SerialName("annotations")
-    ANNOTATIONS,
-    /**
-     * An attachment that references a bounded transcript from another chat.
-     */
-    @SerialName("chat")
-    CHAT
+@Serializable(with = MessageAttachmentKindSerializer::class)
+@JvmInline
+value class MessageAttachmentKind(val rawValue: String) {
+    companion object {
+        /**
+         * A simple, opaque attachment whose representation is described by the producer.
+         */
+        val SIMPLE: MessageAttachmentKind = MessageAttachmentKind("simple")
+        /**
+         * An attachment whose data is embedded inline as a base64 string.
+         */
+        val EMBEDDED_RESOURCE: MessageAttachmentKind = MessageAttachmentKind("embeddedResource")
+        /**
+         * An attachment that references a resource by URI.
+         */
+        val RESOURCE: MessageAttachmentKind = MessageAttachmentKind("resource")
+        /**
+         * An attachment that references annotations on an annotations channel.
+         */
+        val ANNOTATIONS: MessageAttachmentKind = MessageAttachmentKind("annotations")
+        /**
+         * An attachment that references a bounded transcript from another chat.
+         */
+        val CHAT: MessageAttachmentKind = MessageAttachmentKind("chat")
+    }
+}
+
+internal object MessageAttachmentKindSerializer : KSerializer<MessageAttachmentKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("MessageAttachmentKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: MessageAttachmentKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): MessageAttachmentKind =
+        MessageAttachmentKind(decoder.decodeString())
 }
 
 /**
  * Discriminant for response part types.
  */
-@Serializable
-enum class ResponsePartKind {
-    @SerialName("markdown")
-    MARKDOWN,
-    @SerialName("contentRef")
-    CONTENT_REF,
-    @SerialName("toolCall")
-    TOOL_CALL,
-    @SerialName("reasoning")
-    REASONING,
-    @SerialName("systemNotification")
-    SYSTEM_NOTIFICATION,
-    @SerialName("inputRequest")
-    INPUT_REQUEST
+@Serializable(with = ResponsePartKindSerializer::class)
+@JvmInline
+value class ResponsePartKind(val rawValue: String) {
+    companion object {
+        val MARKDOWN: ResponsePartKind = ResponsePartKind("markdown")
+        val CONTENT_REF: ResponsePartKind = ResponsePartKind("contentRef")
+        val TOOL_CALL: ResponsePartKind = ResponsePartKind("toolCall")
+        val REASONING: ResponsePartKind = ResponsePartKind("reasoning")
+        val SYSTEM_NOTIFICATION: ResponsePartKind = ResponsePartKind("systemNotification")
+        val INPUT_REQUEST: ResponsePartKind = ResponsePartKind("inputRequest")
+    }
+}
+
+internal object ResponsePartKindSerializer : KSerializer<ResponsePartKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ResponsePartKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ResponsePartKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ResponsePartKind =
+        ResponsePartKind(decoder.decodeString())
 }
 
 /**
  * Status of a tool call in the lifecycle state machine.
  */
-@Serializable
-enum class ToolCallStatus {
-    @SerialName("streaming")
-    STREAMING,
-    @SerialName("pending-confirmation")
-    PENDING_CONFIRMATION,
-    @SerialName("running")
-    RUNNING,
-    /**
-     * Running paused because the MCP server backing this call needs
-     * authentication (typically step-up auth for insufficient scope,
-     * surfacing mid-execution). See {@link ToolCallAuthRequiredState}.
-     */
-    @SerialName("auth-required")
-    AUTH_REQUIRED,
-    @SerialName("pending-result-confirmation")
-    PENDING_RESULT_CONFIRMATION,
-    @SerialName("completed")
-    COMPLETED,
-    @SerialName("cancelled")
-    CANCELLED
+@Serializable(with = ToolCallStatusSerializer::class)
+@JvmInline
+value class ToolCallStatus(val rawValue: String) {
+    companion object {
+        val STREAMING: ToolCallStatus = ToolCallStatus("streaming")
+        val PENDING_CONFIRMATION: ToolCallStatus = ToolCallStatus("pending-confirmation")
+        val RUNNING: ToolCallStatus = ToolCallStatus("running")
+        /**
+         * Running paused because the MCP server backing this call needs
+         * authentication (typically step-up auth for insufficient scope,
+         * surfacing mid-execution). See {@link ToolCallAuthRequiredState}.
+         */
+        val AUTH_REQUIRED: ToolCallStatus = ToolCallStatus("auth-required")
+        val PENDING_RESULT_CONFIRMATION: ToolCallStatus = ToolCallStatus("pending-result-confirmation")
+        val COMPLETED: ToolCallStatus = ToolCallStatus("completed")
+        val CANCELLED: ToolCallStatus = ToolCallStatus("cancelled")
+    }
+}
+
+internal object ToolCallStatusSerializer : KSerializer<ToolCallStatus> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ToolCallStatus", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ToolCallStatus) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ToolCallStatus =
+        ToolCallStatus(decoder.decodeString())
 }
 
 /**
@@ -451,34 +523,67 @@ enum class ToolCallStatus {
  * - `UserAction` — User explicitly approved
  * - `Setting` — Approved by a persistent user setting
  */
-@Serializable
-enum class ToolCallConfirmationReason {
-    @SerialName("not-needed")
-    NOT_NEEDED,
-    @SerialName("user-action")
-    USER_ACTION,
-    @SerialName("setting")
-    SETTING
+@Serializable(with = ToolCallConfirmationReasonSerializer::class)
+@JvmInline
+value class ToolCallConfirmationReason(val rawValue: String) {
+    companion object {
+        val NOT_NEEDED: ToolCallConfirmationReason = ToolCallConfirmationReason("not-needed")
+        val USER_ACTION: ToolCallConfirmationReason = ToolCallConfirmationReason("user-action")
+        val SETTING: ToolCallConfirmationReason = ToolCallConfirmationReason("setting")
+    }
+}
+
+internal object ToolCallConfirmationReasonSerializer : KSerializer<ToolCallConfirmationReason> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ToolCallConfirmationReason", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ToolCallConfirmationReason) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ToolCallConfirmationReason =
+        ToolCallConfirmationReason(decoder.decodeString())
 }
 
 /**
  * Identifies a model judge as the source of a confirmation requirement.
  */
-@Serializable
-enum class ToolCallRiskAssessmentKind {
-    @SerialName("judge")
-    JUDGE
+@Serializable(with = ToolCallRiskAssessmentKindSerializer::class)
+@JvmInline
+value class ToolCallRiskAssessmentKind(val rawValue: String) {
+    companion object {
+        val JUDGE: ToolCallRiskAssessmentKind = ToolCallRiskAssessmentKind("judge")
+    }
+}
+
+internal object ToolCallRiskAssessmentKindSerializer : KSerializer<ToolCallRiskAssessmentKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ToolCallRiskAssessmentKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ToolCallRiskAssessmentKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ToolCallRiskAssessmentKind =
+        ToolCallRiskAssessmentKind(decoder.decodeString())
 }
 
 /**
  * Lifecycle status of an asynchronous model-judge confirmation decision.
  */
-@Serializable
-enum class ToolCallRiskAssessmentStatus {
-    @SerialName("loading")
-    LOADING,
-    @SerialName("complete")
-    COMPLETE
+@Serializable(with = ToolCallRiskAssessmentStatusSerializer::class)
+@JvmInline
+value class ToolCallRiskAssessmentStatus(val rawValue: String) {
+    companion object {
+        val LOADING: ToolCallRiskAssessmentStatus = ToolCallRiskAssessmentStatus("loading")
+        val COMPLETE: ToolCallRiskAssessmentStatus = ToolCallRiskAssessmentStatus("complete")
+    }
+}
+
+internal object ToolCallRiskAssessmentStatusSerializer : KSerializer<ToolCallRiskAssessmentStatus> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ToolCallRiskAssessmentStatus", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ToolCallRiskAssessmentStatus) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ToolCallRiskAssessmentStatus =
+        ToolCallRiskAssessmentStatus(decoder.decodeString())
 }
 
 /**
@@ -497,39 +602,71 @@ enum class ToolCallCancellationReason {
 /**
  * Whether a confirmation option represents an approval or denial action.
  */
-@Serializable
-enum class ConfirmationOptionKind {
-    @SerialName("approve")
-    APPROVE,
-    @SerialName("deny")
-    DENY
+@Serializable(with = ConfirmationOptionKindSerializer::class)
+@JvmInline
+value class ConfirmationOptionKind(val rawValue: String) {
+    companion object {
+        val APPROVE: ConfirmationOptionKind = ConfirmationOptionKind("approve")
+        val DENY: ConfirmationOptionKind = ConfirmationOptionKind("deny")
+    }
 }
 
-@Serializable
-enum class ToolCallContributorKind {
-    @SerialName("client")
-    CLIENT,
-    @SerialName("mcp")
-    MCP
+internal object ConfirmationOptionKindSerializer : KSerializer<ConfirmationOptionKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ConfirmationOptionKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ConfirmationOptionKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ConfirmationOptionKind =
+        ConfirmationOptionKind(decoder.decodeString())
+}
+
+/**
+ * Identifies the source of a tool call's implementation.
+ */
+@Serializable(with = ToolCallContributorKindSerializer::class)
+@JvmInline
+value class ToolCallContributorKind(val rawValue: String) {
+    companion object {
+        val CLIENT: ToolCallContributorKind = ToolCallContributorKind("client")
+        val MCP: ToolCallContributorKind = ToolCallContributorKind("mcp")
+    }
+}
+
+internal object ToolCallContributorKindSerializer : KSerializer<ToolCallContributorKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ToolCallContributorKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ToolCallContributorKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ToolCallContributorKind =
+        ToolCallContributorKind(decoder.decodeString())
 }
 
 /**
  * Discriminant for tool result content types.
  */
-@Serializable
-enum class ToolResultContentType {
-    @SerialName("text")
-    TEXT,
-    @SerialName("embeddedResource")
-    EMBEDDED_RESOURCE,
-    @SerialName("resource")
-    RESOURCE,
-    @SerialName("fileEdit")
-    FILE_EDIT,
-    @SerialName("terminal")
-    TERMINAL,
-    @SerialName("subagent")
-    SUBAGENT
+@Serializable(with = ToolResultContentTypeSerializer::class)
+@JvmInline
+value class ToolResultContentType(val rawValue: String) {
+    companion object {
+        val TEXT: ToolResultContentType = ToolResultContentType("text")
+        val EMBEDDED_RESOURCE: ToolResultContentType = ToolResultContentType("embeddedResource")
+        val RESOURCE: ToolResultContentType = ToolResultContentType("resource")
+        val FILE_EDIT: ToolResultContentType = ToolResultContentType("fileEdit")
+        val TERMINAL: ToolResultContentType = ToolResultContentType("terminal")
+        val SUBAGENT: ToolResultContentType = ToolResultContentType("subagent")
+    }
+}
+
+internal object ToolResultContentTypeSerializer : KSerializer<ToolResultContentType> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ToolResultContentType", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ToolResultContentType) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ToolResultContentType =
+        ToolResultContentType(decoder.decodeString())
 }
 
 /**
@@ -543,37 +680,52 @@ enum class ToolResultContentType {
  * directly by the host. The remaining types appear only as children of
  * a container.
  */
-@Serializable
-enum class CustomizationType {
-    @SerialName("plugin")
-    PLUGIN,
-    @SerialName("directory")
-    DIRECTORY,
-    @SerialName("agent")
-    AGENT,
-    @SerialName("skill")
-    SKILL,
-    @SerialName("prompt")
-    PROMPT,
-    @SerialName("rule")
-    RULE,
-    @SerialName("hook")
-    HOOK,
-    @SerialName("mcpServer")
-    MCP_SERVER
+@Serializable(with = CustomizationTypeSerializer::class)
+@JvmInline
+value class CustomizationType(val rawValue: String) {
+    companion object {
+        val PLUGIN: CustomizationType = CustomizationType("plugin")
+        val DIRECTORY: CustomizationType = CustomizationType("directory")
+        val AGENT: CustomizationType = CustomizationType("agent")
+        val SKILL: CustomizationType = CustomizationType("skill")
+        val PROMPT: CustomizationType = CustomizationType("prompt")
+        val RULE: CustomizationType = CustomizationType("rule")
+        val HOOK: CustomizationType = CustomizationType("hook")
+        val MCP_SERVER: CustomizationType = CustomizationType("mcpServer")
+    }
+}
+
+internal object CustomizationTypeSerializer : KSerializer<CustomizationType> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("CustomizationType", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: CustomizationType) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): CustomizationType =
+        CustomizationType(decoder.decodeString())
 }
 
 /**
  * Scope at which customization enablement is decided.
  */
-@Serializable
-enum class CustomizationEnablementKind {
-    @SerialName("global")
-    GLOBAL,
-    @SerialName("workspace")
-    WORKSPACE,
-    @SerialName("session")
-    SESSION
+@Serializable(with = CustomizationEnablementKindSerializer::class)
+@JvmInline
+value class CustomizationEnablementKind(val rawValue: String) {
+    companion object {
+        val GLOBAL: CustomizationEnablementKind = CustomizationEnablementKind("global")
+        val WORKSPACE: CustomizationEnablementKind = CustomizationEnablementKind("workspace")
+        val SESSION: CustomizationEnablementKind = CustomizationEnablementKind("session")
+    }
+}
+
+internal object CustomizationEnablementKindSerializer : KSerializer<CustomizationEnablementKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("CustomizationEnablementKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: CustomizationEnablementKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): CustomizationEnablementKind =
+        CustomizationEnablementKind(decoder.decodeString())
 }
 
 /**
@@ -616,37 +768,45 @@ enum class TerminalLifecycleStatus {
 /**
  * Discriminant for the {@link McpServerState} union.
  */
-@Serializable
-enum class McpServerStatus {
-    /**
-     * Server has been registered but is not yet running.
-     */
-    @SerialName("starting")
-    STARTING,
-    /**
-     * Server is running and serving requests.
-     */
-    @SerialName("ready")
-    READY,
-    /**
-     * Server is reachable but requires additional authentication before it
-     * can start, or before it can serve a particular request. Carries the
-     * RFC 9728 Protected Resource Metadata the client needs to obtain a
-     * token; the client then pushes the token via the existing
-     * `authenticate` command.
-     */
-    @SerialName("authRequired")
-    AUTH_REQUIRED,
-    /**
-     * Server failed to start, crashed, or otherwise transitioned to a fatal error.
-     */
-    @SerialName("error")
-    ERROR,
-    /**
-     * Server has been shut down.
-     */
-    @SerialName("stopped")
-    STOPPED
+@Serializable(with = McpServerStatusSerializer::class)
+@JvmInline
+value class McpServerStatus(val rawValue: String) {
+    companion object {
+        /**
+         * Server has been registered but is not yet running.
+         */
+        val STARTING: McpServerStatus = McpServerStatus("starting")
+        /**
+         * Server is running and serving requests.
+         */
+        val READY: McpServerStatus = McpServerStatus("ready")
+        /**
+         * Server is reachable but requires additional authentication before it
+         * can start, or before it can serve a particular request. Carries the
+         * RFC 9728 Protected Resource Metadata the client needs to obtain a
+         * token; the client then pushes the token via the existing
+         * `authenticate` command.
+         */
+        val AUTH_REQUIRED: McpServerStatus = McpServerStatus("authRequired")
+        /**
+         * Server failed to start, crashed, or otherwise transitioned to a fatal error.
+         */
+        val ERROR: McpServerStatus = McpServerStatus("error")
+        /**
+         * Server has been shut down.
+         */
+        val STOPPED: McpServerStatus = McpServerStatus("stopped")
+    }
+}
+
+internal object McpServerStatusSerializer : KSerializer<McpServerStatus> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("McpServerStatus", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: McpServerStatus) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): McpServerStatus =
+        McpServerStatus(decoder.decodeString())
 }
 
 /**
@@ -654,61 +814,81 @@ enum class McpServerStatus {
  * state. Mirrors the three failure modes defined by the
  * [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md).
  */
-@Serializable
-enum class McpAuthRequiredReason {
-    /**
-     * No token has been provided yet (HTTP 401, no prior token).
-     */
-    @SerialName("required")
-    REQUIRED,
-    /**
-     * A previously valid token expired or was revoked (HTTP 401).
-     */
-    @SerialName("expired")
-    EXPIRED,
-    /**
-     * Step-up auth: a token is present but its scopes are insufficient for
-     * the requested operation (HTTP 403 with
-     * `WWW-Authenticate: Bearer error="insufficient_scope"`).
-     *
-     * Unlike {@link Required} and {@link Expired} — which typically surface
-     * before any tool work is in flight — `InsufficientScope` is almost
-     * always triggered by an MCP request issued mid-turn (a `tools/call`,
-     * `resources/read`, etc.). The host SHOULD pair the
-     * {@link McpServerAuthRequiredState} transition with
-     * {@link SessionStatus.InputNeeded} on
-     * {@link SessionSummary.status | the session} so the activity becomes
-     * visible at the session-summary level, and clients SHOULD watch for
-     * this kind on any
-     * {@link McpServerCustomization | MCP server} backing a running tool
-     * call so they can present an explicit "grant more access" affordance
-     * tied to the blocked tool call.
-     */
-    @SerialName("insufficientScope")
-    INSUFFICIENT_SCOPE
+@Serializable(with = McpAuthRequiredReasonSerializer::class)
+@JvmInline
+value class McpAuthRequiredReason(val rawValue: String) {
+    companion object {
+        /**
+         * No token has been provided yet (HTTP 401, no prior token).
+         */
+        val REQUIRED: McpAuthRequiredReason = McpAuthRequiredReason("required")
+        /**
+         * A previously valid token expired or was revoked (HTTP 401).
+         */
+        val EXPIRED: McpAuthRequiredReason = McpAuthRequiredReason("expired")
+        /**
+         * Step-up auth: a token is present but its scopes are insufficient for
+         * the requested operation (HTTP 403 with
+         * `WWW-Authenticate: Bearer error="insufficient_scope"`).
+         *
+         * Unlike {@link Required} and {@link Expired} — which typically surface
+         * before any tool work is in flight — `InsufficientScope` is almost
+         * always triggered by an MCP request issued mid-turn (a `tools/call`,
+         * `resources/read`, etc.). The host SHOULD pair the
+         * {@link McpServerAuthRequiredState} transition with
+         * {@link SessionStatus.InputNeeded} on
+         * {@link SessionSummary.status | the session} so the activity becomes
+         * visible at the session-summary level, and clients SHOULD watch for
+         * this kind on any
+         * {@link McpServerCustomization | MCP server} backing a running tool
+         * call so they can present an explicit "grant more access" affordance
+         * tied to the blocked tool call.
+         */
+        val INSUFFICIENT_SCOPE: McpAuthRequiredReason = McpAuthRequiredReason("insufficientScope")
+    }
+}
+
+internal object McpAuthRequiredReasonSerializer : KSerializer<McpAuthRequiredReason> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("McpAuthRequiredReason", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: McpAuthRequiredReason) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): McpAuthRequiredReason =
+        McpAuthRequiredReason(decoder.decodeString())
 }
 
 /**
  * Computation lifecycle of a {@link ChangesetState}.
  */
-@Serializable
-enum class ChangesetStatus {
-    /**
-     * The server is still computing the contents of this changeset.
-     */
-    @SerialName("computing")
-    COMPUTING,
-    /**
-     * The changeset has been fully computed and is up-to-date.
-     */
-    @SerialName("ready")
-    READY,
-    /**
-     * Computation failed. The cause is described by
-     * {@link ChangesetState.error}.
-     */
-    @SerialName("error")
-    ERROR
+@Serializable(with = ChangesetStatusSerializer::class)
+@JvmInline
+value class ChangesetStatus(val rawValue: String) {
+    companion object {
+        /**
+         * The server is still computing the contents of this changeset.
+         */
+        val COMPUTING: ChangesetStatus = ChangesetStatus("computing")
+        /**
+         * The changeset has been fully computed and is up-to-date.
+         */
+        val READY: ChangesetStatus = ChangesetStatus("ready")
+        /**
+         * Computation failed. The cause is described by
+         * {@link ChangesetState.error}.
+         */
+        val ERROR: ChangesetStatus = ChangesetStatus("error")
+    }
+}
+
+internal object ChangesetStatusSerializer : KSerializer<ChangesetStatus> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ChangesetStatus", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ChangesetStatus) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ChangesetStatus =
+        ChangesetStatus(decoder.decodeString())
 }
 
 /**
@@ -719,52 +899,71 @@ enum class ChangesetStatus {
  * every subscriber observes a consistent view (e.g. a spinner on a "Create
  * Pull Request" button, or an inline error after a failed "revert").
  */
-@Serializable
-enum class ChangesetOperationStatus {
-    /**
-     * The operation is ready to be invoked. This is the default when
-     * {@link ChangesetOperation.status} is omitted.
-     */
-    @SerialName("idle")
-    IDLE,
-    /**
-     * An invocation of this operation is currently in flight.
-     */
-    @SerialName("running")
-    RUNNING,
-    /**
-     * The most recent invocation failed. The cause is described by
-     * {@link ChangesetOperation.error}.
-     */
-    @SerialName("error")
-    ERROR,
-    /**
-     * The operation is currently disabled and cannot be invoked.
-     */
-    @SerialName("disabled")
-    DISABLED
+@Serializable(with = ChangesetOperationStatusSerializer::class)
+@JvmInline
+value class ChangesetOperationStatus(val rawValue: String) {
+    companion object {
+        /**
+         * The operation is ready to be invoked. This is the default when
+         * {@link ChangesetOperation.status} is omitted.
+         */
+        val IDLE: ChangesetOperationStatus = ChangesetOperationStatus("idle")
+        /**
+         * An invocation of this operation is currently in flight.
+         */
+        val RUNNING: ChangesetOperationStatus = ChangesetOperationStatus("running")
+        /**
+         * The most recent invocation failed. The cause is described by
+         * {@link ChangesetOperation.error}.
+         */
+        val ERROR: ChangesetOperationStatus = ChangesetOperationStatus("error")
+        /**
+         * The operation is currently disabled and cannot be invoked.
+         */
+        val DISABLED: ChangesetOperationStatus = ChangesetOperationStatus("disabled")
+    }
+}
+
+internal object ChangesetOperationStatusSerializer : KSerializer<ChangesetOperationStatus> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ChangesetOperationStatus", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ChangesetOperationStatus) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ChangesetOperationStatus =
+        ChangesetOperationStatus(decoder.decodeString())
 }
 
 /**
  * Where a {@link ChangesetOperation} can be invoked.
  */
-@Serializable
-enum class ChangesetOperationScope {
-    /**
-     * Applies to the whole changeset.
-     */
-    @SerialName("changeset")
-    CHANGESET,
-    /**
-     * Applies to a single file within the changeset.
-     */
-    @SerialName("resource")
-    RESOURCE,
-    /**
-     * Applies to a line range within a single file.
-     */
-    @SerialName("range")
-    RANGE
+@Serializable(with = ChangesetOperationScopeSerializer::class)
+@JvmInline
+value class ChangesetOperationScope(val rawValue: String) {
+    companion object {
+        /**
+         * Applies to the whole changeset.
+         */
+        val CHANGESET: ChangesetOperationScope = ChangesetOperationScope("changeset")
+        /**
+         * Applies to a single file within the changeset.
+         */
+        val RESOURCE: ChangesetOperationScope = ChangesetOperationScope("resource")
+        /**
+         * Applies to a line range within a single file.
+         */
+        val RANGE: ChangesetOperationScope = ChangesetOperationScope("range")
+    }
+}
+
+internal object ChangesetOperationScopeSerializer : KSerializer<ChangesetOperationScope> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ChangesetOperationScope", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ChangesetOperationScope) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): ChangesetOperationScope =
+        ChangesetOperationScope(decoder.decodeString())
 }
 
 /**
@@ -783,13 +982,25 @@ enum class ResourceChangeType {
 /**
  * Discriminant describing the durable provenance of a session.
  */
-@Serializable
-enum class SessionOriginKind {
-    /**
-     * The session was created as part of an automation run.
-     */
-    @SerialName("automation")
-    AUTOMATION
+@Serializable(with = SessionOriginKindSerializer::class)
+@JvmInline
+value class SessionOriginKind(val rawValue: String) {
+    companion object {
+        /**
+         * The session was created as part of an automation run.
+         */
+        val AUTOMATION: SessionOriginKind = SessionOriginKind("automation")
+    }
+}
+
+internal object SessionOriginKindSerializer : KSerializer<SessionOriginKind> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("SessionOriginKind", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: SessionOriginKind) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): SessionOriginKind =
+        SessionOriginKind(decoder.decodeString())
 }
 
 /**
@@ -800,42 +1011,63 @@ enum class SessionOriginKind {
  * capabilities describe what the host implementation can support, while
  * operations describe what is allowed for this particular automation now.
  */
-@Serializable
-enum class AutomationOperation {
-    /**
-     * Replace editable fields using {@link AutomationUpdateRequestedAction | `automation/updateRequested`}.
-     */
-    @SerialName("update")
-    UPDATE,
-    /**
-     * Permanently remove the automation using {@link AutomationRemovedAction | `automation/removed`}.
-     */
-    @SerialName("remove")
-    REMOVE,
-    /**
-     * Start a manual run using {@link RunAutomationParams | runAutomation}.
-     */
-    @SerialName("run")
-    RUN
+@Serializable(with = AutomationOperationSerializer::class)
+@JvmInline
+value class AutomationOperation(val rawValue: String) {
+    companion object {
+        /**
+         * Replace editable fields using {@link AutomationUpdateRequestedAction | `automation/updateRequested`}.
+         */
+        val UPDATE: AutomationOperation = AutomationOperation("update")
+        /**
+         * Permanently remove the automation using {@link AutomationRemovedAction | `automation/removed`}.
+         */
+        val REMOVE: AutomationOperation = AutomationOperation("remove")
+        /**
+         * Start a manual run using {@link RunAutomationParams | runAutomation}.
+         */
+        val RUN: AutomationOperation = AutomationOperation("run")
+    }
+}
+
+internal object AutomationOperationSerializer : KSerializer<AutomationOperation> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("AutomationOperation", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: AutomationOperation) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): AutomationOperation =
+        AutomationOperation(decoder.decodeString())
 }
 
 /**
  * How a host handles schedule occurrences missed while automatic execution was
  * unavailable.
  */
-@Serializable
-enum class AutomationMisfirePolicy {
-    /**
-     * Discard missed occurrences and wait for the next future occurrence.
-     */
-    @SerialName("skip")
-    SKIP,
-    /**
-     * Start at most one catch-up run when execution becomes available, regardless
-     * of how many occurrences were missed.
-     */
-    @SerialName("runOnce")
-    RUN_ONCE
+@Serializable(with = AutomationMisfirePolicySerializer::class)
+@JvmInline
+value class AutomationMisfirePolicy(val rawValue: String) {
+    companion object {
+        /**
+         * Discard missed occurrences and wait for the next future occurrence.
+         */
+        val SKIP: AutomationMisfirePolicy = AutomationMisfirePolicy("skip")
+        /**
+         * Start at most one catch-up run when execution becomes available, regardless
+         * of how many occurrences were missed.
+         */
+        val RUN_ONCE: AutomationMisfirePolicy = AutomationMisfirePolicy("runOnce")
+    }
+}
+
+internal object AutomationMisfirePolicySerializer : KSerializer<AutomationMisfirePolicy> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("AutomationMisfirePolicy", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: AutomationMisfirePolicy) {
+        encoder.encodeString(value.rawValue)
+    }
+    override fun deserialize(decoder: Decoder): AutomationMisfirePolicy =
+        AutomationMisfirePolicy(decoder.decodeString())
 }
 
 /**
@@ -1736,10 +1968,9 @@ data class SessionToolClientExecutionRequest(
     val clientId: String,
     /**
      * The running tool call the session wants the owning client to execute. The
-     * host only ever populates this with a {@link ToolCallRunningState} (i.e. a
-     * {@link ToolCallState} in `running` status).
+     * host only ever populates this with a {@link ToolCallRunningState}.
      */
-    val toolCall: ToolCallState
+    val toolCall: ToolCallRunningState
 )
 
 @Serializable
@@ -5728,16 +5959,6 @@ sealed interface TerminalClaim
 value class TerminalClaimClient(val value: TerminalClientClaim) : TerminalClaim
 @JvmInline
 value class TerminalClaimSession(val value: TerminalSessionClaim) : TerminalClaim
-/**
- * Forward-compat catch-all for unknown TerminalClaim discriminators.
- *
- * Older clients may receive newer wire variants they don't recognise; capturing
- * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers handle this variant conservatively on a per-union basis (typically
- * as a no-op, but see `Reducers.kt` for the exact treatment).
- */
-@JvmInline
-value class TerminalClaimUnknown(val raw: JsonObject) : TerminalClaim
 
 internal object TerminalClaimSerializer : KSerializer<TerminalClaim> {
     override val descriptor: SerialDescriptor =
@@ -5750,11 +5971,11 @@ internal object TerminalClaimSerializer : KSerializer<TerminalClaim> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for TerminalClaim")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: return TerminalClaimUnknown(obj)
+            ?: error("Missing kind discriminator on TerminalClaim")
         return when (discriminant) {
             "client" -> TerminalClaimClient(input.json.decodeFromJsonElement(TerminalClientClaim.serializer(), element))
             "session" -> TerminalClaimSession(input.json.decodeFromJsonElement(TerminalSessionClaim.serializer(), element))
-            else -> TerminalClaimUnknown(obj)
+            else -> error("Unknown TerminalClaim discriminator: $discriminant")
         }
     }
 
@@ -5764,7 +5985,6 @@ internal object TerminalClaimSerializer : KSerializer<TerminalClaim> {
         val element: JsonElement = when (value) {
             is TerminalClaimClient -> output.json.encodeToJsonElement(TerminalClientClaim.serializer(), value.value)
             is TerminalClaimSession -> output.json.encodeToJsonElement(TerminalSessionClaim.serializer(), value.value)
-            is TerminalClaimUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -5949,16 +6169,6 @@ sealed interface ChatInputAnswer
 value class ChatInputAnswerDraft(val value: ChatInputAnswered) : ChatInputAnswer
 @JvmInline
 value class ChatInputAnswerSkipped(val value: ChatInputSkipped) : ChatInputAnswer
-/**
- * Forward-compat catch-all for unknown ChatInputAnswer discriminators.
- *
- * Older clients may receive newer wire variants they don't recognise; capturing
- * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers handle this variant conservatively on a per-union basis (typically
- * as a no-op, but see `Reducers.kt` for the exact treatment).
- */
-@JvmInline
-value class ChatInputAnswerUnknown(val raw: JsonObject) : ChatInputAnswer
 
 internal object ChatInputAnswerSerializer : KSerializer<ChatInputAnswer> {
     override val descriptor: SerialDescriptor =
@@ -5971,12 +6181,12 @@ internal object ChatInputAnswerSerializer : KSerializer<ChatInputAnswer> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for ChatInputAnswer")
         val discriminant = (obj["state"] as? JsonPrimitive)?.content
-            ?: return ChatInputAnswerUnknown(obj)
+            ?: error("Missing state discriminator on ChatInputAnswer")
         return when (discriminant) {
             "draft" -> ChatInputAnswerDraft(input.json.decodeFromJsonElement(ChatInputAnswered.serializer(), element))
             "submitted" -> ChatInputAnswerDraft(input.json.decodeFromJsonElement(ChatInputAnswered.serializer(), element))
             "skipped" -> ChatInputAnswerSkipped(input.json.decodeFromJsonElement(ChatInputSkipped.serializer(), element))
-            else -> ChatInputAnswerUnknown(obj)
+            else -> error("Unknown ChatInputAnswer discriminator: $discriminant")
         }
     }
 
@@ -5986,7 +6196,6 @@ internal object ChatInputAnswerSerializer : KSerializer<ChatInputAnswer> {
         val element: JsonElement = when (value) {
             is ChatInputAnswerDraft -> output.json.encodeToJsonElement(ChatInputAnswered.serializer(), value.value)
             is ChatInputAnswerSkipped -> output.json.encodeToJsonElement(ChatInputSkipped.serializer(), value.value)
-            is ChatInputAnswerUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -6182,16 +6391,6 @@ value class CustomizationLoadStateLoaded(val value: CustomizationLoadedState) : 
 value class CustomizationLoadStateDegraded(val value: CustomizationDegradedState) : CustomizationLoadState
 @JvmInline
 value class CustomizationLoadStateError(val value: CustomizationErrorState) : CustomizationLoadState
-/**
- * Forward-compat catch-all for unknown CustomizationLoadState discriminators.
- *
- * Older clients may receive newer wire variants they don't recognise; capturing
- * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
- * Reducers handle this variant conservatively on a per-union basis (typically
- * as a no-op, but see `Reducers.kt` for the exact treatment).
- */
-@JvmInline
-value class CustomizationLoadStateUnknown(val raw: JsonObject) : CustomizationLoadState
 
 internal object CustomizationLoadStateSerializer : KSerializer<CustomizationLoadState> {
     override val descriptor: SerialDescriptor =
@@ -6204,13 +6403,13 @@ internal object CustomizationLoadStateSerializer : KSerializer<CustomizationLoad
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for CustomizationLoadState")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: return CustomizationLoadStateUnknown(obj)
+            ?: error("Missing kind discriminator on CustomizationLoadState")
         return when (discriminant) {
             "loading" -> CustomizationLoadStateLoading(input.json.decodeFromJsonElement(CustomizationLoadingState.serializer(), element))
             "loaded" -> CustomizationLoadStateLoaded(input.json.decodeFromJsonElement(CustomizationLoadedState.serializer(), element))
             "degraded" -> CustomizationLoadStateDegraded(input.json.decodeFromJsonElement(CustomizationDegradedState.serializer(), element))
             "error" -> CustomizationLoadStateError(input.json.decodeFromJsonElement(CustomizationErrorState.serializer(), element))
-            else -> CustomizationLoadStateUnknown(obj)
+            else -> error("Unknown CustomizationLoadState discriminator: $discriminant")
         }
     }
 
@@ -6222,7 +6421,6 @@ internal object CustomizationLoadStateSerializer : KSerializer<CustomizationLoad
             is CustomizationLoadStateLoaded -> output.json.encodeToJsonElement(CustomizationLoadedState.serializer(), value.value)
             is CustomizationLoadStateDegraded -> output.json.encodeToJsonElement(CustomizationDegradedState.serializer(), value.value)
             is CustomizationLoadStateError -> output.json.encodeToJsonElement(CustomizationErrorState.serializer(), value.value)
-            is CustomizationLoadStateUnknown -> value.raw
         }
         output.encodeJsonElement(element)
     }
@@ -6487,6 +6685,16 @@ sealed interface SessionOrigin
 
 @JvmInline
 value class SessionOriginAutomation(val value: AutomationSessionOrigin) : SessionOrigin
+/**
+ * Forward-compat catch-all for unknown SessionOrigin discriminators.
+ *
+ * Older clients may receive newer wire variants they don't recognise; capturing
+ * the raw `JsonObject` lets such payloads round-trip through the client unchanged.
+ * Reducers handle this variant conservatively on a per-union basis (typically
+ * as a no-op, but see `Reducers.kt` for the exact treatment).
+ */
+@JvmInline
+value class SessionOriginUnknown(val raw: JsonObject) : SessionOrigin
 
 internal object SessionOriginSerializer : KSerializer<SessionOrigin> {
     override val descriptor: SerialDescriptor =
@@ -6499,10 +6707,10 @@ internal object SessionOriginSerializer : KSerializer<SessionOrigin> {
         val obj = element as? JsonObject
             ?: error("Expected JsonObject for SessionOrigin")
         val discriminant = (obj["kind"] as? JsonPrimitive)?.content
-            ?: error("Missing kind discriminator on SessionOrigin")
+            ?: return SessionOriginUnknown(obj)
         return when (discriminant) {
             "automation" -> SessionOriginAutomation(input.json.decodeFromJsonElement(AutomationSessionOrigin.serializer(), element))
-            else -> error("Unknown SessionOrigin discriminator: $discriminant")
+            else -> SessionOriginUnknown(obj)
         }
     }
 
@@ -6511,10 +6719,12 @@ internal object SessionOriginSerializer : KSerializer<SessionOrigin> {
             ?: error("SessionOrigin can only be serialized to JSON")
         val element: JsonElement = when (value) {
             is SessionOriginAutomation -> output.json.encodeToJsonElement(AutomationSessionOrigin.serializer(), value.value)
+            is SessionOriginUnknown -> value.raw
         }
         val encodedObject = element.jsonObject.toMutableMap()
         val discriminant = when (value) {
             is SessionOriginAutomation -> "automation"
+            is SessionOriginUnknown -> null
         }
         if (discriminant != null) encodedObject["kind"] = JsonPrimitive(discriminant)
         output.encodeJsonElement(JsonObject(encodedObject))

--- a/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/DiscriminatedUnionTest.kt
+++ b/clients/kotlin/src/test/kotlin/com/microsoft/agenthostprotocol/DiscriminatedUnionTest.kt
@@ -22,6 +22,7 @@ import com.microsoft.agenthostprotocol.generated.ChatSource
 import com.microsoft.agenthostprotocol.generated.ChatSourceFork
 import com.microsoft.agenthostprotocol.generated.ChatSourceKind
 import com.microsoft.agenthostprotocol.generated.ChatSourceSideChat
+import com.microsoft.agenthostprotocol.generated.ChatSourceUnknown
 import com.microsoft.agenthostprotocol.generated.ForkChatSource
 import com.microsoft.agenthostprotocol.generated.SideChatSource
 import com.microsoft.agenthostprotocol.generated.SideChatSelection
@@ -80,6 +81,21 @@ class DiscriminatedUnionTest {
 
         val decoded = json.decodeFromString(ResponsePart.serializer(), encoded)
         assertIs<ResponsePartReasoning>(decoded)
+    }
+
+    @Test
+    fun `nonexhaustive enum and union preserve future values`() {
+        val kind = json.decodeFromString(ResponsePartKind.serializer(), "\"futurePart\"")
+        assertEquals("futurePart", kind.rawValue)
+        assertEquals("\"futurePart\"", json.encodeToString(ResponsePartKind.serializer(), kind))
+
+        val raw = """{"kind":"futurePart","payload":{"preserve":true}}"""
+        val part = json.decodeFromString(ResponsePart.serializer(), raw)
+        assertIs<ResponsePartUnknown>(part)
+        assertEquals(
+            json.parseToJsonElement(raw),
+            json.parseToJsonElement(json.encodeToString(ResponsePart.serializer(), part)),
+        )
     }
 
     @Test
@@ -191,16 +207,21 @@ class DiscriminatedUnionTest {
     }
 
     @Test
-    fun `ChatSource rejects missing or unknown kind`() {
+    fun `ChatSource preserves missing or unknown kind`() {
         val missingKind = """{"chat":"ahp-chat:/main","turnId":"turn-12"}"""
         val unknownKind = """{"kind":"future","chat":"ahp-chat:/main","turnId":"turn-12"}"""
 
-        assertFailsWith<IllegalStateException> {
-            json.decodeFromString(ChatSource.serializer(), missingKind)
-        }
-        assertFailsWith<IllegalStateException> {
-            json.decodeFromString(ChatSource.serializer(), unknownKind)
-        }
+        val missing = assertIs<ChatSourceUnknown>(
+            json.decodeFromString(ChatSource.serializer(), missingKind),
+        )
+        val unknown = assertIs<ChatSourceUnknown>(
+            json.decodeFromString(ChatSource.serializer(), unknownKind),
+        )
+
+        assertEquals(json.parseToJsonElement(missingKind), missing.raw)
+        assertEquals(json.parseToJsonElement(unknownKind), unknown.raw)
+        assertEquals(missingKind, json.encodeToString(ChatSource.serializer(), missing))
+        assertEquals(unknownKind, json.encodeToString(ChatSource.serializer(), unknown))
     }
 
     @Test

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -13,6 +13,10 @@ rust-version = "1.75"
 license = "MIT"
 repository = "https://github.com/microsoft/agent-host-protocol"
 
+[workspace.lints.clippy]
+panic = "deny"
+unwrap_used = "deny"
+
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/clients/rust/crates/ahp-types/Cargo.toml
+++ b/clients/rust/crates/ahp-types/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["api-bindings", "encoding", "data-structures"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/clients/rust/crates/ahp-types/src/actions.rs
+++ b/clients/rust/crates/ahp-types/src/actions.rs
@@ -28,198 +28,378 @@ use crate::state::{
 // ─── ActionType ──────────────────────────────────────────────────────
 
 /// Discriminant values for all state actions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ActionType {
-    #[serde(rename = "root/agentsChanged")]
     RootAgentsChanged,
-    #[serde(rename = "root/activeSessionsChanged")]
     RootActiveSessionsChanged,
-    #[serde(rename = "session/ready")]
     SessionReady,
-    #[serde(rename = "session/creationFailed")]
     SessionCreationFailed,
-    #[serde(rename = "session/chatAdded")]
     SessionChatAdded,
-    #[serde(rename = "session/chatRemoved")]
     SessionChatRemoved,
-    #[serde(rename = "session/chatUpdated")]
     SessionChatUpdated,
-    #[serde(rename = "session/defaultChatChanged")]
     SessionDefaultChatChanged,
-    #[serde(rename = "chat/turnStarted")]
     ChatTurnStarted,
-    #[serde(rename = "chat/delta")]
     ChatDelta,
-    #[serde(rename = "chat/responsePart")]
     ChatResponsePart,
-    #[serde(rename = "chat/toolCallStart")]
     ChatToolCallStart,
-    #[serde(rename = "chat/toolCallDelta")]
     ChatToolCallDelta,
-    #[serde(rename = "chat/toolCallReady")]
     ChatToolCallReady,
-    #[serde(rename = "chat/toolCallConfirmed")]
     ChatToolCallConfirmed,
-    #[serde(rename = "chat/toolCallComplete")]
     ChatToolCallComplete,
-    #[serde(rename = "chat/toolCallResultConfirmed")]
     ChatToolCallResultConfirmed,
-    #[serde(rename = "chat/toolCallContentChanged")]
     ChatToolCallContentChanged,
-    #[serde(rename = "chat/toolCallAuthRequired")]
     ChatToolCallAuthRequired,
-    #[serde(rename = "chat/toolCallAuthResolved")]
     ChatToolCallAuthResolved,
-    #[serde(rename = "chat/turnComplete")]
     ChatTurnComplete,
-    #[serde(rename = "chat/turnCancelled")]
     ChatTurnCancelled,
-    #[serde(rename = "chat/error")]
     ChatError,
-    #[serde(rename = "chat/activityChanged")]
     ChatActivityChanged,
-    #[serde(rename = "chat/workingDirectorySet")]
     ChatWorkingDirectorySet,
-    #[serde(rename = "chat/workingDirectoryRemoved")]
     ChatWorkingDirectoryRemoved,
-    #[serde(rename = "session/titleChanged")]
     SessionTitleChanged,
-    #[serde(rename = "chat/usage")]
     ChatUsage,
-    #[serde(rename = "chat/reasoning")]
     ChatReasoning,
-    #[serde(rename = "session/serverToolsChanged")]
     SessionServerToolsChanged,
-    #[serde(rename = "session/activeClientSet")]
     SessionActiveClientSet,
-    #[serde(rename = "session/activeClientRemoved")]
     SessionActiveClientRemoved,
-    #[serde(rename = "session/workingDirectorySet")]
     SessionWorkingDirectorySet,
-    #[serde(rename = "session/workingDirectoryRemoved")]
     SessionWorkingDirectoryRemoved,
-    #[serde(rename = "session/workingDirectoryReplaced")]
     SessionWorkingDirectoryReplaced,
-    #[serde(rename = "session/inputNeededSet")]
     SessionInputNeededSet,
-    #[serde(rename = "session/inputNeededRemoved")]
     SessionInputNeededRemoved,
-    #[serde(rename = "chat/pendingMessageSet")]
     ChatPendingMessageSet,
-    #[serde(rename = "chat/pendingMessageRemoved")]
     ChatPendingMessageRemoved,
-    #[serde(rename = "chat/queuedMessagesReordered")]
     ChatQueuedMessagesReordered,
-    #[serde(rename = "chat/draftChanged")]
     ChatDraftChanged,
-    #[serde(rename = "chat/inputRequested")]
     ChatInputRequested,
-    #[serde(rename = "chat/inputAnswerChanged")]
     ChatInputAnswerChanged,
-    #[serde(rename = "chat/inputCompleted")]
     ChatInputCompleted,
-    #[serde(rename = "session/customizationsChanged")]
     SessionCustomizationsChanged,
-    #[serde(rename = "session/customizationToggled")]
     SessionCustomizationToggled,
-    #[serde(rename = "session/customizationUpdated")]
     SessionCustomizationUpdated,
-    #[serde(rename = "session/customizationRemoved")]
     SessionCustomizationRemoved,
-    #[serde(rename = "session/mcpServerStateChanged")]
     SessionMcpServerStateChanged,
-    #[serde(rename = "session/mcpServerStartRequested")]
     SessionMcpServerStartRequested,
-    #[serde(rename = "session/mcpServerStopRequested")]
     SessionMcpServerStopRequested,
-    #[serde(rename = "chat/truncated")]
     ChatTruncated,
-    #[serde(rename = "chat/turnsLoaded")]
     ChatTurnsLoaded,
-    #[serde(rename = "session/isReadChanged")]
     SessionIsReadChanged,
-    #[serde(rename = "session/isArchivedChanged")]
     SessionIsArchivedChanged,
-    #[serde(rename = "session/activityChanged")]
     SessionActivityChanged,
-    #[serde(rename = "session/changesetsChanged")]
     SessionChangesetsChanged,
-    #[serde(rename = "session/configChanged")]
     SessionConfigChanged,
-    #[serde(rename = "session/metaChanged")]
     SessionMetaChanged,
-    #[serde(rename = "changeset/statusChanged")]
     ChangesetStatusChanged,
-    #[serde(rename = "changeset/fileSet")]
     ChangesetFileSet,
-    #[serde(rename = "changeset/fileRemoved")]
     ChangesetFileRemoved,
-    #[serde(rename = "changeset/filesReviewChanged")]
     ChangesetFilesReviewChanged,
-    #[serde(rename = "changeset/contentChanged")]
     ChangesetContentChanged,
-    #[serde(rename = "changeset/operationsChanged")]
     ChangesetOperationsChanged,
-    #[serde(rename = "changeset/operationStatusChanged")]
     ChangesetOperationStatusChanged,
-    #[serde(rename = "changeset/cleared")]
     ChangesetCleared,
-    #[serde(rename = "annotations/set")]
     AnnotationsSet,
-    #[serde(rename = "annotations/updated")]
     AnnotationsUpdated,
-    #[serde(rename = "annotations/removed")]
     AnnotationsRemoved,
-    #[serde(rename = "annotations/entrySet")]
     AnnotationsEntrySet,
-    #[serde(rename = "annotations/entryRemoved")]
     AnnotationsEntryRemoved,
-    #[serde(rename = "root/terminalsChanged")]
     RootTerminalsChanged,
-    #[serde(rename = "root/configChanged")]
     RootConfigChanged,
-    #[serde(rename = "terminal/data")]
     TerminalData,
-    #[serde(rename = "terminal/input")]
     TerminalInput,
-    #[serde(rename = "terminal/resized")]
     TerminalResized,
-    #[serde(rename = "terminal/claimed")]
     TerminalClaimed,
-    #[serde(rename = "terminal/titleChanged")]
     TerminalTitleChanged,
-    #[serde(rename = "terminal/cwdChanged")]
     TerminalCwdChanged,
-    #[serde(rename = "terminal/exited")]
     TerminalExited,
-    #[serde(rename = "terminal/cleared")]
     TerminalCleared,
-    #[serde(rename = "terminal/commandDetectionAvailable")]
     TerminalCommandDetectionAvailable,
-    #[serde(rename = "terminal/commandExecuted")]
     TerminalCommandExecuted,
-    #[serde(rename = "terminal/commandFinished")]
     TerminalCommandFinished,
-    #[serde(rename = "resourceWatch/changed")]
     ResourceWatchChanged,
-    #[serde(rename = "automation/createRequested")]
     AutomationCreateRequested,
-    #[serde(rename = "automation/updateRequested")]
     AutomationUpdateRequested,
-    #[serde(rename = "automation/set")]
     AutomationSet,
-    #[serde(rename = "automation/removed")]
     AutomationRemoved,
-    #[serde(rename = "automationRun/lifecycleChanged")]
     AutomationRunLifecycleChanged,
-    #[serde(rename = "automationRun/sessionSet")]
     AutomationRunSessionSet,
-    #[serde(rename = "automationRun/sessionRemoved")]
     AutomationRunSessionRemoved,
-    #[serde(rename = "automationRun/primarySessionChanged")]
     AutomationRunPrimarySessionChanged,
-    #[serde(rename = "automationRun/cancelRequested")]
     AutomationRunCancelRequested,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ActionType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::RootAgentsChanged => serializer.serialize_str("root/agentsChanged"),
+            Self::RootActiveSessionsChanged => {
+                serializer.serialize_str("root/activeSessionsChanged")
+            }
+            Self::SessionReady => serializer.serialize_str("session/ready"),
+            Self::SessionCreationFailed => serializer.serialize_str("session/creationFailed"),
+            Self::SessionChatAdded => serializer.serialize_str("session/chatAdded"),
+            Self::SessionChatRemoved => serializer.serialize_str("session/chatRemoved"),
+            Self::SessionChatUpdated => serializer.serialize_str("session/chatUpdated"),
+            Self::SessionDefaultChatChanged => {
+                serializer.serialize_str("session/defaultChatChanged")
+            }
+            Self::ChatTurnStarted => serializer.serialize_str("chat/turnStarted"),
+            Self::ChatDelta => serializer.serialize_str("chat/delta"),
+            Self::ChatResponsePart => serializer.serialize_str("chat/responsePart"),
+            Self::ChatToolCallStart => serializer.serialize_str("chat/toolCallStart"),
+            Self::ChatToolCallDelta => serializer.serialize_str("chat/toolCallDelta"),
+            Self::ChatToolCallReady => serializer.serialize_str("chat/toolCallReady"),
+            Self::ChatToolCallConfirmed => serializer.serialize_str("chat/toolCallConfirmed"),
+            Self::ChatToolCallComplete => serializer.serialize_str("chat/toolCallComplete"),
+            Self::ChatToolCallResultConfirmed => {
+                serializer.serialize_str("chat/toolCallResultConfirmed")
+            }
+            Self::ChatToolCallContentChanged => {
+                serializer.serialize_str("chat/toolCallContentChanged")
+            }
+            Self::ChatToolCallAuthRequired => serializer.serialize_str("chat/toolCallAuthRequired"),
+            Self::ChatToolCallAuthResolved => serializer.serialize_str("chat/toolCallAuthResolved"),
+            Self::ChatTurnComplete => serializer.serialize_str("chat/turnComplete"),
+            Self::ChatTurnCancelled => serializer.serialize_str("chat/turnCancelled"),
+            Self::ChatError => serializer.serialize_str("chat/error"),
+            Self::ChatActivityChanged => serializer.serialize_str("chat/activityChanged"),
+            Self::ChatWorkingDirectorySet => serializer.serialize_str("chat/workingDirectorySet"),
+            Self::ChatWorkingDirectoryRemoved => {
+                serializer.serialize_str("chat/workingDirectoryRemoved")
+            }
+            Self::SessionTitleChanged => serializer.serialize_str("session/titleChanged"),
+            Self::ChatUsage => serializer.serialize_str("chat/usage"),
+            Self::ChatReasoning => serializer.serialize_str("chat/reasoning"),
+            Self::SessionServerToolsChanged => {
+                serializer.serialize_str("session/serverToolsChanged")
+            }
+            Self::SessionActiveClientSet => serializer.serialize_str("session/activeClientSet"),
+            Self::SessionActiveClientRemoved => {
+                serializer.serialize_str("session/activeClientRemoved")
+            }
+            Self::SessionWorkingDirectorySet => {
+                serializer.serialize_str("session/workingDirectorySet")
+            }
+            Self::SessionWorkingDirectoryRemoved => {
+                serializer.serialize_str("session/workingDirectoryRemoved")
+            }
+            Self::SessionWorkingDirectoryReplaced => {
+                serializer.serialize_str("session/workingDirectoryReplaced")
+            }
+            Self::SessionInputNeededSet => serializer.serialize_str("session/inputNeededSet"),
+            Self::SessionInputNeededRemoved => {
+                serializer.serialize_str("session/inputNeededRemoved")
+            }
+            Self::ChatPendingMessageSet => serializer.serialize_str("chat/pendingMessageSet"),
+            Self::ChatPendingMessageRemoved => {
+                serializer.serialize_str("chat/pendingMessageRemoved")
+            }
+            Self::ChatQueuedMessagesReordered => {
+                serializer.serialize_str("chat/queuedMessagesReordered")
+            }
+            Self::ChatDraftChanged => serializer.serialize_str("chat/draftChanged"),
+            Self::ChatInputRequested => serializer.serialize_str("chat/inputRequested"),
+            Self::ChatInputAnswerChanged => serializer.serialize_str("chat/inputAnswerChanged"),
+            Self::ChatInputCompleted => serializer.serialize_str("chat/inputCompleted"),
+            Self::SessionCustomizationsChanged => {
+                serializer.serialize_str("session/customizationsChanged")
+            }
+            Self::SessionCustomizationToggled => {
+                serializer.serialize_str("session/customizationToggled")
+            }
+            Self::SessionCustomizationUpdated => {
+                serializer.serialize_str("session/customizationUpdated")
+            }
+            Self::SessionCustomizationRemoved => {
+                serializer.serialize_str("session/customizationRemoved")
+            }
+            Self::SessionMcpServerStateChanged => {
+                serializer.serialize_str("session/mcpServerStateChanged")
+            }
+            Self::SessionMcpServerStartRequested => {
+                serializer.serialize_str("session/mcpServerStartRequested")
+            }
+            Self::SessionMcpServerStopRequested => {
+                serializer.serialize_str("session/mcpServerStopRequested")
+            }
+            Self::ChatTruncated => serializer.serialize_str("chat/truncated"),
+            Self::ChatTurnsLoaded => serializer.serialize_str("chat/turnsLoaded"),
+            Self::SessionIsReadChanged => serializer.serialize_str("session/isReadChanged"),
+            Self::SessionIsArchivedChanged => serializer.serialize_str("session/isArchivedChanged"),
+            Self::SessionActivityChanged => serializer.serialize_str("session/activityChanged"),
+            Self::SessionChangesetsChanged => serializer.serialize_str("session/changesetsChanged"),
+            Self::SessionConfigChanged => serializer.serialize_str("session/configChanged"),
+            Self::SessionMetaChanged => serializer.serialize_str("session/metaChanged"),
+            Self::ChangesetStatusChanged => serializer.serialize_str("changeset/statusChanged"),
+            Self::ChangesetFileSet => serializer.serialize_str("changeset/fileSet"),
+            Self::ChangesetFileRemoved => serializer.serialize_str("changeset/fileRemoved"),
+            Self::ChangesetFilesReviewChanged => {
+                serializer.serialize_str("changeset/filesReviewChanged")
+            }
+            Self::ChangesetContentChanged => serializer.serialize_str("changeset/contentChanged"),
+            Self::ChangesetOperationsChanged => {
+                serializer.serialize_str("changeset/operationsChanged")
+            }
+            Self::ChangesetOperationStatusChanged => {
+                serializer.serialize_str("changeset/operationStatusChanged")
+            }
+            Self::ChangesetCleared => serializer.serialize_str("changeset/cleared"),
+            Self::AnnotationsSet => serializer.serialize_str("annotations/set"),
+            Self::AnnotationsUpdated => serializer.serialize_str("annotations/updated"),
+            Self::AnnotationsRemoved => serializer.serialize_str("annotations/removed"),
+            Self::AnnotationsEntrySet => serializer.serialize_str("annotations/entrySet"),
+            Self::AnnotationsEntryRemoved => serializer.serialize_str("annotations/entryRemoved"),
+            Self::RootTerminalsChanged => serializer.serialize_str("root/terminalsChanged"),
+            Self::RootConfigChanged => serializer.serialize_str("root/configChanged"),
+            Self::TerminalData => serializer.serialize_str("terminal/data"),
+            Self::TerminalInput => serializer.serialize_str("terminal/input"),
+            Self::TerminalResized => serializer.serialize_str("terminal/resized"),
+            Self::TerminalClaimed => serializer.serialize_str("terminal/claimed"),
+            Self::TerminalTitleChanged => serializer.serialize_str("terminal/titleChanged"),
+            Self::TerminalCwdChanged => serializer.serialize_str("terminal/cwdChanged"),
+            Self::TerminalExited => serializer.serialize_str("terminal/exited"),
+            Self::TerminalCleared => serializer.serialize_str("terminal/cleared"),
+            Self::TerminalCommandDetectionAvailable => {
+                serializer.serialize_str("terminal/commandDetectionAvailable")
+            }
+            Self::TerminalCommandExecuted => serializer.serialize_str("terminal/commandExecuted"),
+            Self::TerminalCommandFinished => serializer.serialize_str("terminal/commandFinished"),
+            Self::ResourceWatchChanged => serializer.serialize_str("resourceWatch/changed"),
+            Self::AutomationCreateRequested => {
+                serializer.serialize_str("automation/createRequested")
+            }
+            Self::AutomationUpdateRequested => {
+                serializer.serialize_str("automation/updateRequested")
+            }
+            Self::AutomationSet => serializer.serialize_str("automation/set"),
+            Self::AutomationRemoved => serializer.serialize_str("automation/removed"),
+            Self::AutomationRunLifecycleChanged => {
+                serializer.serialize_str("automationRun/lifecycleChanged")
+            }
+            Self::AutomationRunSessionSet => serializer.serialize_str("automationRun/sessionSet"),
+            Self::AutomationRunSessionRemoved => {
+                serializer.serialize_str("automationRun/sessionRemoved")
+            }
+            Self::AutomationRunPrimarySessionChanged => {
+                serializer.serialize_str("automationRun/primarySessionChanged")
+            }
+            Self::AutomationRunCancelRequested => {
+                serializer.serialize_str("automationRun/cancelRequested")
+            }
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ActionType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "root/agentsChanged" => Self::RootAgentsChanged,
+            "root/activeSessionsChanged" => Self::RootActiveSessionsChanged,
+            "session/ready" => Self::SessionReady,
+            "session/creationFailed" => Self::SessionCreationFailed,
+            "session/chatAdded" => Self::SessionChatAdded,
+            "session/chatRemoved" => Self::SessionChatRemoved,
+            "session/chatUpdated" => Self::SessionChatUpdated,
+            "session/defaultChatChanged" => Self::SessionDefaultChatChanged,
+            "chat/turnStarted" => Self::ChatTurnStarted,
+            "chat/delta" => Self::ChatDelta,
+            "chat/responsePart" => Self::ChatResponsePart,
+            "chat/toolCallStart" => Self::ChatToolCallStart,
+            "chat/toolCallDelta" => Self::ChatToolCallDelta,
+            "chat/toolCallReady" => Self::ChatToolCallReady,
+            "chat/toolCallConfirmed" => Self::ChatToolCallConfirmed,
+            "chat/toolCallComplete" => Self::ChatToolCallComplete,
+            "chat/toolCallResultConfirmed" => Self::ChatToolCallResultConfirmed,
+            "chat/toolCallContentChanged" => Self::ChatToolCallContentChanged,
+            "chat/toolCallAuthRequired" => Self::ChatToolCallAuthRequired,
+            "chat/toolCallAuthResolved" => Self::ChatToolCallAuthResolved,
+            "chat/turnComplete" => Self::ChatTurnComplete,
+            "chat/turnCancelled" => Self::ChatTurnCancelled,
+            "chat/error" => Self::ChatError,
+            "chat/activityChanged" => Self::ChatActivityChanged,
+            "chat/workingDirectorySet" => Self::ChatWorkingDirectorySet,
+            "chat/workingDirectoryRemoved" => Self::ChatWorkingDirectoryRemoved,
+            "session/titleChanged" => Self::SessionTitleChanged,
+            "chat/usage" => Self::ChatUsage,
+            "chat/reasoning" => Self::ChatReasoning,
+            "session/serverToolsChanged" => Self::SessionServerToolsChanged,
+            "session/activeClientSet" => Self::SessionActiveClientSet,
+            "session/activeClientRemoved" => Self::SessionActiveClientRemoved,
+            "session/workingDirectorySet" => Self::SessionWorkingDirectorySet,
+            "session/workingDirectoryRemoved" => Self::SessionWorkingDirectoryRemoved,
+            "session/workingDirectoryReplaced" => Self::SessionWorkingDirectoryReplaced,
+            "session/inputNeededSet" => Self::SessionInputNeededSet,
+            "session/inputNeededRemoved" => Self::SessionInputNeededRemoved,
+            "chat/pendingMessageSet" => Self::ChatPendingMessageSet,
+            "chat/pendingMessageRemoved" => Self::ChatPendingMessageRemoved,
+            "chat/queuedMessagesReordered" => Self::ChatQueuedMessagesReordered,
+            "chat/draftChanged" => Self::ChatDraftChanged,
+            "chat/inputRequested" => Self::ChatInputRequested,
+            "chat/inputAnswerChanged" => Self::ChatInputAnswerChanged,
+            "chat/inputCompleted" => Self::ChatInputCompleted,
+            "session/customizationsChanged" => Self::SessionCustomizationsChanged,
+            "session/customizationToggled" => Self::SessionCustomizationToggled,
+            "session/customizationUpdated" => Self::SessionCustomizationUpdated,
+            "session/customizationRemoved" => Self::SessionCustomizationRemoved,
+            "session/mcpServerStateChanged" => Self::SessionMcpServerStateChanged,
+            "session/mcpServerStartRequested" => Self::SessionMcpServerStartRequested,
+            "session/mcpServerStopRequested" => Self::SessionMcpServerStopRequested,
+            "chat/truncated" => Self::ChatTruncated,
+            "chat/turnsLoaded" => Self::ChatTurnsLoaded,
+            "session/isReadChanged" => Self::SessionIsReadChanged,
+            "session/isArchivedChanged" => Self::SessionIsArchivedChanged,
+            "session/activityChanged" => Self::SessionActivityChanged,
+            "session/changesetsChanged" => Self::SessionChangesetsChanged,
+            "session/configChanged" => Self::SessionConfigChanged,
+            "session/metaChanged" => Self::SessionMetaChanged,
+            "changeset/statusChanged" => Self::ChangesetStatusChanged,
+            "changeset/fileSet" => Self::ChangesetFileSet,
+            "changeset/fileRemoved" => Self::ChangesetFileRemoved,
+            "changeset/filesReviewChanged" => Self::ChangesetFilesReviewChanged,
+            "changeset/contentChanged" => Self::ChangesetContentChanged,
+            "changeset/operationsChanged" => Self::ChangesetOperationsChanged,
+            "changeset/operationStatusChanged" => Self::ChangesetOperationStatusChanged,
+            "changeset/cleared" => Self::ChangesetCleared,
+            "annotations/set" => Self::AnnotationsSet,
+            "annotations/updated" => Self::AnnotationsUpdated,
+            "annotations/removed" => Self::AnnotationsRemoved,
+            "annotations/entrySet" => Self::AnnotationsEntrySet,
+            "annotations/entryRemoved" => Self::AnnotationsEntryRemoved,
+            "root/terminalsChanged" => Self::RootTerminalsChanged,
+            "root/configChanged" => Self::RootConfigChanged,
+            "terminal/data" => Self::TerminalData,
+            "terminal/input" => Self::TerminalInput,
+            "terminal/resized" => Self::TerminalResized,
+            "terminal/claimed" => Self::TerminalClaimed,
+            "terminal/titleChanged" => Self::TerminalTitleChanged,
+            "terminal/cwdChanged" => Self::TerminalCwdChanged,
+            "terminal/exited" => Self::TerminalExited,
+            "terminal/cleared" => Self::TerminalCleared,
+            "terminal/commandDetectionAvailable" => Self::TerminalCommandDetectionAvailable,
+            "terminal/commandExecuted" => Self::TerminalCommandExecuted,
+            "terminal/commandFinished" => Self::TerminalCommandFinished,
+            "resourceWatch/changed" => Self::ResourceWatchChanged,
+            "automation/createRequested" => Self::AutomationCreateRequested,
+            "automation/updateRequested" => Self::AutomationUpdateRequested,
+            "automation/set" => Self::AutomationSet,
+            "automation/removed" => Self::AutomationRemoved,
+            "automationRun/lifecycleChanged" => Self::AutomationRunLifecycleChanged,
+            "automationRun/sessionSet" => Self::AutomationRunSessionSet,
+            "automationRun/sessionRemoved" => Self::AutomationRunSessionRemoved,
+            "automationRun/primarySessionChanged" => Self::AutomationRunPrimarySessionChanged,
+            "automationRun/cancelRequested" => Self::AutomationRunCancelRequested,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 // ─── Action Envelope ─────────────────────────────────────────────────
@@ -377,7 +557,7 @@ pub struct ChatTurnStartedAction {
 /// Streaming text chunk from the assistant, appended to a specific response part.
 ///
 /// The server MUST first emit a `chat/responsePart` to create the target
-/// part (markdown or reasoning), then use this action to append text to it.
+/// markdown part, then use this action to append text to it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatDeltaAction {

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -33,14 +33,41 @@ pub enum ReconnectResultType {
 }
 
 /// How a new chat uses its source chat and turn.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChatSourceKind {
     /// Copy source history through the referenced turn into the new chat.
-    #[serde(rename = "fork")]
     Fork,
     /// Supply source context without copying it into the new chat's visible history.
-    #[serde(rename = "sideChat")]
     SideChat,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ChatSourceKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Fork => serializer.serialize_str("fork"),
+            Self::SideChat => serializer.serialize_str("sideChat"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ChatSourceKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "fork" => Self::Fork,
+            "sideChat" => Self::SideChat,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Encoding of fetched content data.
@@ -53,24 +80,78 @@ pub enum ContentEncoding {
 }
 
 /// The kind of completion items being requested.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CompletionItemKind {
     /// Completions for the text of a {@link Message} the user is composing.
     /// Each returned item carries an attachment that gets associated with the
     /// message when accepted.
-    #[serde(rename = "userMessage")]
     UserMessage,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for CompletionItemKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::UserMessage => serializer.serialize_str("userMessage"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CompletionItemKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "userMessage" => Self::UserMessage,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant for {@link ResourceResolveResult.type}.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ResourceType {
-    #[serde(rename = "file")]
     File,
-    #[serde(rename = "directory")]
     Directory,
-    #[serde(rename = "symlink")]
     Symlink,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ResourceType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::File => serializer.serialize_str("file"),
+            Self::Directory => serializer.serialize_str("directory"),
+            Self::Symlink => serializer.serialize_str("symlink"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ResourceType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "file" => Self::File,
+            "directory" => Self::Directory,
+            "symlink" => Self::Symlink,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// How {@link ResourceWriteParams.data} is placed within the target file.
@@ -121,7 +202,8 @@ pub struct InitializeParams {
     ///
     /// The server selects one entry and returns it as `InitializeResult.protocolVersion`.
     /// If the server cannot speak any of the offered versions, it MUST return
-    /// error code `-32005` (`UnsupportedProtocolVersion`).
+    /// error code `-32005` (`UnsupportedProtocolVersion`) with required
+    /// `UnsupportedProtocolVersionErrorData` containing `supportedVersions`.
     pub protocol_versions: Vec<String>,
     /// Unique client identifier
     pub client_id: String,
@@ -155,7 +237,8 @@ pub struct InitializeParams {
 /// `protocolVersions` list. The client and server MUST use this version for
 /// the rest of the connection. If the server cannot speak any of the offered
 /// versions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)
-/// instead of a result.
+/// with required `UnsupportedProtocolVersionErrorData` containing
+/// `supportedVersions`, instead of a result.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResult {
@@ -1582,6 +1665,10 @@ pub enum ChatSource {
     Fork(ForkChatSource),
     #[serde(rename = "sideChat")]
     SideChat(SideChatSource),
+    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
+    /// Reducers treat this as a no-op.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 // ─── ReconnectResult Union ────────────────────────────────────────────
@@ -1615,4 +1702,6 @@ pub enum ChangesetOperationTarget {
         side: Option<String>,
         range: TextRange,
     },
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }

--- a/clients/rust/crates/ahp-types/src/errors.rs
+++ b/clients/rust/crates/ahp-types/src/errors.rs
@@ -41,10 +41,10 @@ pub mod ahp_error_codes {
     /// The operation requires no active turn, but one is in progress.
     pub const TURN_IN_PROGRESS: i32 = -32004;
     /// The server cannot speak any of the protocol versions offered by the
-    /// client in `InitializeParams.protocolVersions`.
+    /// client in `InitializeParams.protocolVersions`; its required data
+    /// payload advertises supported versions.
     pub const UNSUPPORTED_PROTOCOL_VERSION: i32 = -32005;
-    /// The requested content URI does not exist.
-    pub const CONTENT_NOT_FOUND: i32 = -32006;
+    // -32006 is intentionally reserved and unassigned.
     /// Authentication required for a protected resource.
     pub const AUTH_REQUIRED: i32 = -32007;
     /// The requested file, folder, or URI does not exist.

--- a/clients/rust/crates/ahp-types/src/notifications.rs
+++ b/clients/rust/crates/ahp-types/src/notifications.rs
@@ -20,14 +20,41 @@ use crate::state::{
 // ─── Enums ────────────────────────────────────────────────────────────
 
 /// Reason why authentication is required.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AuthRequiredReason {
     /// The client has not yet authenticated for the resource
-    #[serde(rename = "required")]
     Required,
     /// A previously valid token has expired or been revoked
-    #[serde(rename = "expired")]
     Expired,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for AuthRequiredReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Required => serializer.serialize_str("required"),
+            Self::Expired => serializer.serialize_str("expired"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AuthRequiredReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "required" => Self::Required,
+            "expired" => Self::Expired,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 // ─── Notification Payloads ────────────────────────────────────────────

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -36,14 +36,42 @@ pub enum PendingMessageKind {
 }
 
 /// Session initialization state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SessionLifecycle {
-    #[serde(rename = "creating")]
     Creating,
-    #[serde(rename = "ready")]
     Ready,
-    #[serde(rename = "failed")]
     Failed,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for SessionLifecycle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Creating => serializer.serialize_str("creating"),
+            Self::Ready => serializer.serialize_str("ready"),
+            Self::Failed => serializer.serialize_str("failed"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SessionLifecycle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "creating" => Self::Creating,
+            "ready" => Self::Ready,
+            "failed" => Self::Failed,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Bitset of summary-level session status flags.
@@ -138,20 +166,49 @@ impl std::ops::Not for SessionStatus {
 }
 
 /// Discriminant for {@link ChatOrigin} — how a chat came into existence.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChatOriginKind {
     /// User created the chat explicitly (e.g. via the host UI).
-    #[serde(rename = "user")]
     User,
     /// Forked from an existing chat at a specific turn.
-    #[serde(rename = "fork")]
     Fork,
     /// Created as an independent side conversation from a specific turn.
-    #[serde(rename = "sideChat")]
     SideChat,
     /// Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
-    #[serde(rename = "tool")]
     Tool,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ChatOriginKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::User => serializer.serialize_str("user"),
+            Self::Fork => serializer.serialize_str("fork"),
+            Self::SideChat => serializer.serialize_str("sideChat"),
+            Self::Tool => serializer.serialize_str("tool"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ChatOriginKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "user" => Self::User,
+            "fork" => Self::Fork,
+            "sideChat" => Self::SideChat,
+            "tool" => Self::Tool,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// How a user can interact with a chat.
@@ -189,35 +246,96 @@ pub enum ChatInputAnswerState {
 }
 
 /// Answer value kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChatInputAnswerValueKind {
-    #[serde(rename = "text")]
     Text,
-    #[serde(rename = "number")]
     Number,
-    #[serde(rename = "boolean")]
     Boolean,
-    #[serde(rename = "selected")]
     Selected,
-    #[serde(rename = "selected-many")]
     SelectedMany,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ChatInputAnswerValueKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Text => serializer.serialize_str("text"),
+            Self::Number => serializer.serialize_str("number"),
+            Self::Boolean => serializer.serialize_str("boolean"),
+            Self::Selected => serializer.serialize_str("selected"),
+            Self::SelectedMany => serializer.serialize_str("selected-many"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ChatInputAnswerValueKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "text" => Self::Text,
+            "number" => Self::Number,
+            "boolean" => Self::Boolean,
+            "selected" => Self::Selected,
+            "selected-many" => Self::SelectedMany,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Question/input control kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChatInputQuestionKind {
-    #[serde(rename = "text")]
     Text,
-    #[serde(rename = "number")]
     Number,
-    #[serde(rename = "integer")]
     Integer,
-    #[serde(rename = "boolean")]
     Boolean,
-    #[serde(rename = "single-select")]
     SingleSelect,
-    #[serde(rename = "multi-select")]
     MultiSelect,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ChatInputQuestionKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Text => serializer.serialize_str("text"),
+            Self::Number => serializer.serialize_str("number"),
+            Self::Integer => serializer.serialize_str("integer"),
+            Self::Boolean => serializer.serialize_str("boolean"),
+            Self::SingleSelect => serializer.serialize_str("single-select"),
+            Self::MultiSelect => serializer.serialize_str("multi-select"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ChatInputQuestionKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "text" => Self::Text,
+            "number" => Self::Number,
+            "integer" => Self::Integer,
+            "boolean" => Self::Boolean,
+            "single-select" => Self::SingleSelect,
+            "multi-select" => Self::MultiSelect,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// How a client completed an input request.
@@ -236,20 +354,49 @@ pub enum ChatInputResponseKind {
 ///
 /// This is a general/typological union (not a lifecycle), so the discriminant is
 /// a `*Kind`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SessionInputRequestKind {
     /// A user-facing elicitation mirrored from an unresolved chat response part.
-    #[serde(rename = "chatInput")]
     ChatInput,
     /// A tool call awaiting parameter- or result-confirmation.
-    #[serde(rename = "toolConfirmation")]
     ToolConfirmation,
     /// A running tool the session wants an active client to execute.
-    #[serde(rename = "toolClientExecution")]
     ToolClientExecution,
     /// A tool call blocked on MCP authentication mid-execution.
-    #[serde(rename = "toolAuthentication")]
     ToolAuthentication,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for SessionInputRequestKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::ChatInput => serializer.serialize_str("chatInput"),
+            Self::ToolConfirmation => serializer.serialize_str("toolConfirmation"),
+            Self::ToolClientExecution => serializer.serialize_str("toolClientExecution"),
+            Self::ToolAuthentication => serializer.serialize_str("toolAuthentication"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SessionInputRequestKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "chatInput" => Self::ChatInput,
+            "toolConfirmation" => Self::ToolConfirmation,
+            "toolClientExecution" => Self::ToolClientExecution,
+            "toolAuthentication" => Self::ToolAuthentication,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// How a turn ended.
@@ -264,84 +411,209 @@ pub enum TurnState {
 }
 
 /// Discriminant for {@link MessageOrigin} — identifies who produced a message.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MessageKind {
     /// Sent directly by the user.
-    #[serde(rename = "user")]
     User,
     /// Produced by the agent itself rather than the user — for example, an agent
     /// that seeds the first message of a chat it spawned.
-    #[serde(rename = "agent")]
     Agent,
     /// Produced by a tool rather than the user — for example, a tool that spawns a
     /// worker chat whose first message carries a seed prompt.
-    #[serde(rename = "tool")]
     Tool,
     /// Emitted automatically when an automation run starts a session.
-    #[serde(rename = "automation")]
     Automation,
     /// A system-generated notification rather than a direct user message.
-    #[serde(rename = "systemNotification")]
     SystemNotification,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for MessageKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::User => serializer.serialize_str("user"),
+            Self::Agent => serializer.serialize_str("agent"),
+            Self::Tool => serializer.serialize_str("tool"),
+            Self::Automation => serializer.serialize_str("automation"),
+            Self::SystemNotification => serializer.serialize_str("systemNotification"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for MessageKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "user" => Self::User,
+            "agent" => Self::Agent,
+            "tool" => Self::Tool,
+            "automation" => Self::Automation,
+            "systemNotification" => Self::SystemNotification,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant for {@link MessageAttachment} variants.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MessageAttachmentKind {
     /// A simple, opaque attachment whose representation is described by the producer.
-    #[serde(rename = "simple")]
     Simple,
     /// An attachment whose data is embedded inline as a base64 string.
-    #[serde(rename = "embeddedResource")]
     EmbeddedResource,
     /// An attachment that references a resource by URI.
-    #[serde(rename = "resource")]
     Resource,
     /// An attachment that references annotations on an annotations channel.
-    #[serde(rename = "annotations")]
     Annotations,
     /// An attachment that references a bounded transcript from another chat.
-    #[serde(rename = "chat")]
     Chat,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for MessageAttachmentKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Simple => serializer.serialize_str("simple"),
+            Self::EmbeddedResource => serializer.serialize_str("embeddedResource"),
+            Self::Resource => serializer.serialize_str("resource"),
+            Self::Annotations => serializer.serialize_str("annotations"),
+            Self::Chat => serializer.serialize_str("chat"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for MessageAttachmentKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "simple" => Self::Simple,
+            "embeddedResource" => Self::EmbeddedResource,
+            "resource" => Self::Resource,
+            "annotations" => Self::Annotations,
+            "chat" => Self::Chat,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant for response part types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ResponsePartKind {
-    #[serde(rename = "markdown")]
     Markdown,
-    #[serde(rename = "contentRef")]
     ContentRef,
-    #[serde(rename = "toolCall")]
     ToolCall,
-    #[serde(rename = "reasoning")]
     Reasoning,
-    #[serde(rename = "systemNotification")]
     SystemNotification,
-    #[serde(rename = "inputRequest")]
     InputRequest,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ResponsePartKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Markdown => serializer.serialize_str("markdown"),
+            Self::ContentRef => serializer.serialize_str("contentRef"),
+            Self::ToolCall => serializer.serialize_str("toolCall"),
+            Self::Reasoning => serializer.serialize_str("reasoning"),
+            Self::SystemNotification => serializer.serialize_str("systemNotification"),
+            Self::InputRequest => serializer.serialize_str("inputRequest"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ResponsePartKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "markdown" => Self::Markdown,
+            "contentRef" => Self::ContentRef,
+            "toolCall" => Self::ToolCall,
+            "reasoning" => Self::Reasoning,
+            "systemNotification" => Self::SystemNotification,
+            "inputRequest" => Self::InputRequest,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Status of a tool call in the lifecycle state machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ToolCallStatus {
-    #[serde(rename = "streaming")]
     Streaming,
-    #[serde(rename = "pending-confirmation")]
     PendingConfirmation,
-    #[serde(rename = "running")]
     Running,
     /// Running paused because the MCP server backing this call needs
     /// authentication (typically step-up auth for insufficient scope,
     /// surfacing mid-execution). See {@link ToolCallAuthRequiredState}.
-    #[serde(rename = "auth-required")]
     AuthRequired,
-    #[serde(rename = "pending-result-confirmation")]
     PendingResultConfirmation,
-    #[serde(rename = "completed")]
     Completed,
-    #[serde(rename = "cancelled")]
     Cancelled,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ToolCallStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Streaming => serializer.serialize_str("streaming"),
+            Self::PendingConfirmation => serializer.serialize_str("pending-confirmation"),
+            Self::Running => serializer.serialize_str("running"),
+            Self::AuthRequired => serializer.serialize_str("auth-required"),
+            Self::PendingResultConfirmation => {
+                serializer.serialize_str("pending-result-confirmation")
+            }
+            Self::Completed => serializer.serialize_str("completed"),
+            Self::Cancelled => serializer.serialize_str("cancelled"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolCallStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "streaming" => Self::Streaming,
+            "pending-confirmation" => Self::PendingConfirmation,
+            "running" => Self::Running,
+            "auth-required" => Self::AuthRequired,
+            "pending-result-confirmation" => Self::PendingResultConfirmation,
+            "completed" => Self::Completed,
+            "cancelled" => Self::Cancelled,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// How a tool call was confirmed for execution.
@@ -349,30 +621,111 @@ pub enum ToolCallStatus {
 /// - `NotNeeded` — No confirmation required (auto-approved)
 /// - `UserAction` — User explicitly approved
 /// - `Setting` — Approved by a persistent user setting
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ToolCallConfirmationReason {
-    #[serde(rename = "not-needed")]
     NotNeeded,
-    #[serde(rename = "user-action")]
     UserAction,
-    #[serde(rename = "setting")]
     Setting,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ToolCallConfirmationReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::NotNeeded => serializer.serialize_str("not-needed"),
+            Self::UserAction => serializer.serialize_str("user-action"),
+            Self::Setting => serializer.serialize_str("setting"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolCallConfirmationReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "not-needed" => Self::NotNeeded,
+            "user-action" => Self::UserAction,
+            "setting" => Self::Setting,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Identifies a model judge as the source of a confirmation requirement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ToolCallRiskAssessmentKind {
-    #[serde(rename = "judge")]
     Judge,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ToolCallRiskAssessmentKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Judge => serializer.serialize_str("judge"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolCallRiskAssessmentKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "judge" => Self::Judge,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Lifecycle status of an asynchronous model-judge confirmation decision.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ToolCallRiskAssessmentStatus {
-    #[serde(rename = "loading")]
     Loading,
-    #[serde(rename = "complete")]
     Complete,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ToolCallRiskAssessmentStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Loading => serializer.serialize_str("loading"),
+            Self::Complete => serializer.serialize_str("complete"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolCallRiskAssessmentStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "loading" => Self::Loading,
+            "complete" => Self::Complete,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Why a tool call was cancelled.
@@ -387,37 +740,123 @@ pub enum ToolCallCancellationReason {
 }
 
 /// Whether a confirmation option represents an approval or denial action.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ConfirmationOptionKind {
-    #[serde(rename = "approve")]
     Approve,
-    #[serde(rename = "deny")]
     Deny,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+impl serde::Serialize for ConfirmationOptionKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Approve => serializer.serialize_str("approve"),
+            Self::Deny => serializer.serialize_str("deny"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ConfirmationOptionKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "approve" => Self::Approve,
+            "deny" => Self::Deny,
+            _ => Self::Unknown(raw),
+        })
+    }
+}
+
+/// Identifies the source of a tool call's implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ToolCallContributorKind {
-    #[serde(rename = "client")]
     Client,
-    #[serde(rename = "mcp")]
     MCP,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ToolCallContributorKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Client => serializer.serialize_str("client"),
+            Self::MCP => serializer.serialize_str("mcp"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolCallContributorKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "client" => Self::Client,
+            "mcp" => Self::MCP,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant for tool result content types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ToolResultContentType {
-    #[serde(rename = "text")]
     Text,
-    #[serde(rename = "embeddedResource")]
     EmbeddedResource,
-    #[serde(rename = "resource")]
     Resource,
-    #[serde(rename = "fileEdit")]
     FileEdit,
-    #[serde(rename = "terminal")]
     Terminal,
-    #[serde(rename = "subagent")]
     Subagent,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ToolResultContentType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Text => serializer.serialize_str("text"),
+            Self::EmbeddedResource => serializer.serialize_str("embeddedResource"),
+            Self::Resource => serializer.serialize_str("resource"),
+            Self::FileEdit => serializer.serialize_str("fileEdit"),
+            Self::Terminal => serializer.serialize_str("terminal"),
+            Self::Subagent => serializer.serialize_str("subagent"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolResultContentType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "text" => Self::Text,
+            "embeddedResource" => Self::EmbeddedResource,
+            "resource" => Self::Resource,
+            "fileEdit" => Self::FileEdit,
+            "terminal" => Self::Terminal,
+            "subagent" => Self::Subagent,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant for the kind of customization.
@@ -429,35 +868,96 @@ pub enum ToolResultContentType {
 /// {@link CustomizationType.McpServer | `McpServer`} entries surfaced
 /// directly by the host. The remaining types appear only as children of
 /// a container.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CustomizationType {
-    #[serde(rename = "plugin")]
     Plugin,
-    #[serde(rename = "directory")]
     Directory,
-    #[serde(rename = "agent")]
     Agent,
-    #[serde(rename = "skill")]
     Skill,
-    #[serde(rename = "prompt")]
     Prompt,
-    #[serde(rename = "rule")]
     Rule,
-    #[serde(rename = "hook")]
     Hook,
-    #[serde(rename = "mcpServer")]
     McpServer,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for CustomizationType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Plugin => serializer.serialize_str("plugin"),
+            Self::Directory => serializer.serialize_str("directory"),
+            Self::Agent => serializer.serialize_str("agent"),
+            Self::Skill => serializer.serialize_str("skill"),
+            Self::Prompt => serializer.serialize_str("prompt"),
+            Self::Rule => serializer.serialize_str("rule"),
+            Self::Hook => serializer.serialize_str("hook"),
+            Self::McpServer => serializer.serialize_str("mcpServer"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CustomizationType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "plugin" => Self::Plugin,
+            "directory" => Self::Directory,
+            "agent" => Self::Agent,
+            "skill" => Self::Skill,
+            "prompt" => Self::Prompt,
+            "rule" => Self::Rule,
+            "hook" => Self::Hook,
+            "mcpServer" => Self::McpServer,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Scope at which customization enablement is decided.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CustomizationEnablementKind {
-    #[serde(rename = "global")]
     Global,
-    #[serde(rename = "workspace")]
     Workspace,
-    #[serde(rename = "session")]
     Session,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for CustomizationEnablementKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Global => serializer.serialize_str("global"),
+            Self::Workspace => serializer.serialize_str("workspace"),
+            Self::Session => serializer.serialize_str("session"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CustomizationEnablementKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "global" => Self::Global,
+            "workspace" => Self::Workspace,
+            "session" => Self::Session,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant values for {@link CustomizationLoadState}.
@@ -492,39 +992,67 @@ pub enum TerminalLifecycleStatus {
 }
 
 /// Discriminant for the {@link McpServerState} union.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum McpServerStatus {
     /// Server has been registered but is not yet running.
-    #[serde(rename = "starting")]
     Starting,
     /// Server is running and serving requests.
-    #[serde(rename = "ready")]
     Ready,
     /// Server is reachable but requires additional authentication before it
     /// can start, or before it can serve a particular request. Carries the
     /// RFC 9728 Protected Resource Metadata the client needs to obtain a
     /// token; the client then pushes the token via the existing
     /// `authenticate` command.
-    #[serde(rename = "authRequired")]
     AuthRequired,
     /// Server failed to start, crashed, or otherwise transitioned to a fatal error.
-    #[serde(rename = "error")]
     Error,
     /// Server has been shut down.
-    #[serde(rename = "stopped")]
     Stopped,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for McpServerStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Starting => serializer.serialize_str("starting"),
+            Self::Ready => serializer.serialize_str("ready"),
+            Self::AuthRequired => serializer.serialize_str("authRequired"),
+            Self::Error => serializer.serialize_str("error"),
+            Self::Stopped => serializer.serialize_str("stopped"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for McpServerStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "starting" => Self::Starting,
+            "ready" => Self::Ready,
+            "authRequired" => Self::AuthRequired,
+            "error" => Self::Error,
+            "stopped" => Self::Stopped,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Why an MCP server is currently in the {@link McpServerStatus.AuthRequired}
 /// state. Mirrors the three failure modes defined by the
 /// [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum McpAuthRequiredReason {
     /// No token has been provided yet (HTTP 401, no prior token).
-    #[serde(rename = "required")]
     Required,
     /// A previously valid token expired or was revoked (HTTP 401).
-    #[serde(rename = "expired")]
     Expired,
     /// Step-up auth: a token is present but its scopes are insufficient for
     /// the requested operation (HTTP 403 with
@@ -542,23 +1070,81 @@ pub enum McpAuthRequiredReason {
     /// {@link McpServerCustomization | MCP server} backing a running tool
     /// call so they can present an explicit "grant more access" affordance
     /// tied to the blocked tool call.
-    #[serde(rename = "insufficientScope")]
     InsufficientScope,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for McpAuthRequiredReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Required => serializer.serialize_str("required"),
+            Self::Expired => serializer.serialize_str("expired"),
+            Self::InsufficientScope => serializer.serialize_str("insufficientScope"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for McpAuthRequiredReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "required" => Self::Required,
+            "expired" => Self::Expired,
+            "insufficientScope" => Self::InsufficientScope,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Computation lifecycle of a {@link ChangesetState}.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChangesetStatus {
     /// The server is still computing the contents of this changeset.
-    #[serde(rename = "computing")]
     Computing,
     /// The changeset has been fully computed and is up-to-date.
-    #[serde(rename = "ready")]
     Ready,
     /// Computation failed. The cause is described by
     /// {@link ChangesetState.error}.
-    #[serde(rename = "error")]
     Error,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ChangesetStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Computing => serializer.serialize_str("computing"),
+            Self::Ready => serializer.serialize_str("ready"),
+            Self::Error => serializer.serialize_str("error"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ChangesetStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "computing" => Self::Computing,
+            "ready" => Self::Ready,
+            "error" => Self::Error,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Execution lifecycle of a {@link ChangesetOperation}.
@@ -567,36 +1153,93 @@ pub enum ChangesetStatus {
 /// its progress and outcome are reflected back into changeset state so that
 /// every subscriber observes a consistent view (e.g. a spinner on a "Create
 /// Pull Request" button, or an inline error after a failed "revert").
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChangesetOperationStatus {
     /// The operation is ready to be invoked. This is the default when
     /// {@link ChangesetOperation.status} is omitted.
-    #[serde(rename = "idle")]
     Idle,
     /// An invocation of this operation is currently in flight.
-    #[serde(rename = "running")]
     Running,
     /// The most recent invocation failed. The cause is described by
     /// {@link ChangesetOperation.error}.
-    #[serde(rename = "error")]
     Error,
     /// The operation is currently disabled and cannot be invoked.
-    #[serde(rename = "disabled")]
     Disabled,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ChangesetOperationStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Idle => serializer.serialize_str("idle"),
+            Self::Running => serializer.serialize_str("running"),
+            Self::Error => serializer.serialize_str("error"),
+            Self::Disabled => serializer.serialize_str("disabled"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ChangesetOperationStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "idle" => Self::Idle,
+            "running" => Self::Running,
+            "error" => Self::Error,
+            "disabled" => Self::Disabled,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Where a {@link ChangesetOperation} can be invoked.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChangesetOperationScope {
     /// Applies to the whole changeset.
-    #[serde(rename = "changeset")]
     Changeset,
     /// Applies to a single file within the changeset.
-    #[serde(rename = "resource")]
     Resource,
     /// Applies to a line range within a single file.
-    #[serde(rename = "range")]
     Range,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for ChangesetOperationScope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Changeset => serializer.serialize_str("changeset"),
+            Self::Resource => serializer.serialize_str("resource"),
+            Self::Range => serializer.serialize_str("range"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ChangesetOperationScope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "changeset" => Self::Changeset,
+            "resource" => Self::Resource,
+            "range" => Self::Range,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant for {@link ResourceChange.type}.
@@ -611,11 +1254,37 @@ pub enum ResourceChangeType {
 }
 
 /// Discriminant describing the durable provenance of a session.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SessionOriginKind {
     /// The session was created as part of an automation run.
-    #[serde(rename = "automation")]
     Automation,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for SessionOriginKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Automation => serializer.serialize_str("automation"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SessionOriginKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "automation" => Self::Automation,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Operations the host currently permits for an automation.
@@ -624,30 +1293,85 @@ pub enum SessionOriginKind {
 /// change over time. Clients MUST NOT infer permission from capabilities alone:
 /// capabilities describe what the host implementation can support, while
 /// operations describe what is allowed for this particular automation now.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AutomationOperation {
     /// Replace editable fields using {@link AutomationUpdateRequestedAction | `automation/updateRequested`}.
-    #[serde(rename = "update")]
     Update,
     /// Permanently remove the automation using {@link AutomationRemovedAction | `automation/removed`}.
-    #[serde(rename = "remove")]
     Remove,
     /// Start a manual run using {@link RunAutomationParams | runAutomation}.
-    #[serde(rename = "run")]
     Run,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for AutomationOperation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Update => serializer.serialize_str("update"),
+            Self::Remove => serializer.serialize_str("remove"),
+            Self::Run => serializer.serialize_str("run"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AutomationOperation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "update" => Self::Update,
+            "remove" => Self::Remove,
+            "run" => Self::Run,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// How a host handles schedule occurrences missed while automatic execution was
 /// unavailable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AutomationMisfirePolicy {
     /// Discard missed occurrences and wait for the next future occurrence.
-    #[serde(rename = "skip")]
     Skip,
     /// Start at most one catch-up run when execution becomes available, regardless
     /// of how many occurrences were missed.
-    #[serde(rename = "runOnce")]
     RunOnce,
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    Unknown(String),
+}
+
+impl serde::Serialize for AutomationMisfirePolicy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Skip => serializer.serialize_str("skip"),
+            Self::RunOnce => serializer.serialize_str("runOnce"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AutomationMisfirePolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "skip" => Self::Skip,
+            "runOnce" => Self::RunOnce,
+            _ => Self::Unknown(raw),
+        })
+    }
 }
 
 /// Discriminant for automatic trigger definitions.
@@ -1496,9 +2220,45 @@ pub struct SessionToolClientExecutionRequest {
     /// tool call's client {@link ToolCallContributor}.
     pub client_id: String,
     /// The running tool call the session wants the owning client to execute. The
-    /// host only ever populates this with a {@link ToolCallRunningState} (i.e. a
-    /// {@link ToolCallState} in `running` status).
-    pub tool_call: ToolCallState,
+    /// host only ever populates this with a {@link ToolCallRunningState}.
+    #[serde(
+        serialize_with = "serialize_running_tool_call",
+        deserialize_with = "deserialize_running_tool_call"
+    )]
+    pub tool_call: ToolCallRunningState,
+}
+
+fn serialize_running_tool_call<S>(
+    value: &ToolCallRunningState,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut raw = serde_json::to_value(value).map_err(serde::ser::Error::custom)?;
+    let serde_json::Value::Object(object) = &mut raw else {
+        return Err(serde::ser::Error::custom(
+            "running tool call must serialize to an object",
+        ));
+    };
+    object.insert(
+        "status".to_owned(),
+        serde_json::Value::String("running".to_owned()),
+    );
+    serde::Serialize::serialize(&raw, serializer)
+}
+
+fn deserialize_running_tool_call<'de, D>(deserializer: D) -> Result<ToolCallRunningState, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    if raw.get("status").and_then(serde_json::Value::as_str) != Some("running") {
+        return Err(serde::de::Error::custom(
+            "expected running tool-call status",
+        ));
+    }
+    serde_json::from_value(raw).map_err(serde::de::Error::custom)
 }
 
 /// A tool call blocked on MCP authentication mid-execution, surfaced at the
@@ -4881,6 +5641,8 @@ pub enum CustomizationEnablement {
     Workspace { uri: Uri, enabled: bool },
     #[serde(rename = "session")]
     Session { enabled: bool },
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 /// Raw tool input represented inline or by content reference.
@@ -5004,10 +5766,6 @@ pub enum TerminalClaim {
     Client(TerminalClientClaim),
     #[serde(rename = "session")]
     Session(TerminalSessionClaim),
-    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
-    /// Reducers treat this as a no-op.
-    #[serde(untagged)]
-    Unknown(serde_json::Value),
 }
 
 /// A content part within terminal output.
@@ -5076,10 +5834,6 @@ pub enum ChatInputAnswer {
     Submitted(ChatInputAnswered),
     #[serde(rename = "skipped")]
     Skipped(ChatInputSkipped),
-    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
-    /// Reducers treat this as a no-op.
-    #[serde(untagged)]
-    Unknown(serde_json::Value),
 }
 
 /// Content block in a tool result.
@@ -5174,10 +5928,6 @@ pub enum CustomizationLoadState {
     Degraded(CustomizationDegradedState),
     #[serde(rename = "error")]
     Error(CustomizationErrorState),
-    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
-    /// Reducers treat this as a no-op.
-    #[serde(untagged)]
-    Unknown(serde_json::Value),
 }
 
 /// Discriminated lifecycle status of an MCP server customization.
@@ -5249,7 +5999,7 @@ pub enum SessionInputRequest {
     #[serde(rename = "toolClientExecution")]
     ToolClientExecution(SessionToolClientExecutionRequest),
     #[serde(rename = "toolAuthentication")]
-    ToolAuthentication(SessionToolAuthenticationRequest),
+    ToolAuthentication(Box<SessionToolAuthenticationRequest>),
     /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
     /// Reducers treat this as a no-op.
     #[serde(untagged)]
@@ -5262,6 +6012,10 @@ pub enum SessionInputRequest {
 pub enum SessionOrigin {
     #[serde(rename = "automation")]
     Automation(AutomationSessionOrigin),
+    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
+    /// Reducers treat this as a no-op.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 /// Automatic trigger for an automation.

--- a/clients/rust/crates/ahp-types/tests/chat_source.rs
+++ b/clients/rust/crates/ahp-types/tests/chat_source.rs
@@ -1,4 +1,9 @@
-use ahp_types::commands::ChatSource;
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use ahp_types::{
+    commands::ChatSource,
+    state::{ResponsePart, ResponsePartKind},
+};
 
 #[test]
 fn chat_source_routes_by_kind() {
@@ -32,14 +37,35 @@ fn chat_source_routes_by_kind() {
 }
 
 #[test]
-fn chat_source_rejects_missing_or_unknown_kind() {
+fn chat_source_preserves_missing_or_unknown_kind() {
     for raw in [
         r#"{"chat":"ahp-chat:/main","turnId":"turn-12"}"#,
         r#"{"kind":"future","chat":"ahp-chat:/main","turnId":"turn-12"}"#,
     ] {
-        assert!(
-            serde_json::from_str::<ChatSource>(raw).is_err(),
-            "expected decode failure for {raw}"
+        let source = serde_json::from_str::<ChatSource>(raw).expect("decode unknown chat source");
+        assert!(matches!(source, ChatSource::Unknown(_)));
+        assert_eq!(
+            serde_json::to_value(&source).expect("encode unknown chat source"),
+            serde_json::from_str::<serde_json::Value>(raw).expect("decode expected JSON")
         );
     }
+}
+
+#[test]
+fn nonexhaustive_enum_and_union_preserve_future_values() {
+    let kind = serde_json::from_str::<ResponsePartKind>(r#""futurePart""#)
+        .expect("decode unknown response-part kind");
+    assert!(matches!(&kind, ResponsePartKind::Unknown(value) if value == "futurePart"));
+    assert_eq!(
+        serde_json::to_string(&kind).expect("encode unknown response-part kind"),
+        r#""futurePart""#
+    );
+
+    let raw = r#"{"kind":"futurePart","payload":{"preserve":true}}"#;
+    let part = serde_json::from_str::<ResponsePart>(raw).expect("decode unknown response part");
+    assert!(matches!(part, ResponsePart::Unknown(_)));
+    assert_eq!(
+        serde_json::to_string(&part).expect("encode unknown response part"),
+        raw
+    );
 }

--- a/clients/rust/crates/ahp-types/tests/roundtrip_corpus.rs
+++ b/clients/rust/crates/ahp-types/tests/roundtrip_corpus.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic, clippy::unwrap_used)]
+
 // roundtrip_corpus.rs — data-driven wire round-trip parity for the Rust client.
 //
 // Loads the SHARED, language-agnostic round-trip corpus under

--- a/clients/rust/crates/ahp-ws/Cargo.toml
+++ b/clients/rust/crates/ahp-ws/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["api-bindings", "asynchronous", "network-programming"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints]
+workspace = true
+
 [features]
 # Default to rustls with roots loaded from the OS trust store: a pure-Rust
 # TLS stack (no OpenSSL on Linux) that still validates against the platform

--- a/clients/rust/crates/ahp/Cargo.toml
+++ b/clients/rust/crates/ahp/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["api-bindings", "asynchronous", "network-programming"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints]
+workspace = true
+
 [dependencies]
 ahp-types = { workspace = true }
 serde = { workspace = true }

--- a/clients/rust/crates/ahp/src/hosts/client_id_store.rs
+++ b/clients/rust/crates/ahp/src/hosts/client_id_store.rs
@@ -325,6 +325,7 @@ fn atomic_write(final_path: &Path, content: &[u8]) -> io::Result<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -354,7 +354,9 @@ fn end_turn(
         Ok(timestamp) => timestamp,
         Err(error) => return ReduceOutcome::Invalid(error),
     };
-    let active = state.active_turn.take().unwrap();
+    let Some(active) = state.active_turn.take() else {
+        return ReduceOutcome::NoOp;
+    };
 
     let response_parts: Vec<ResponsePart> = active
         .response_parts
@@ -504,6 +506,7 @@ fn effective_enablement(enablement: &[CustomizationEnablement]) -> bool {
         Some(CustomizationEnablement::Global { enabled }) => *enabled,
         Some(CustomizationEnablement::Workspace { enabled, .. }) => *enabled,
         Some(CustomizationEnablement::Session { enabled }) => *enabled,
+        Some(CustomizationEnablement::Unknown(_)) => false,
         None => true,
     }
 }
@@ -1216,7 +1219,7 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
                 id: a.id.clone(),
                 message: a.message.clone(),
             };
-            match a.kind {
+            match &a.kind {
                 PendingMessageKind::Steering => {
                     state.steering_message = Some(entry);
                 }
@@ -1345,7 +1348,7 @@ fn apply_tool_call_ready(state: &mut ChatState, a: &ChatToolCallReadyAction) -> 
             ToolCallState::Streaming(_)
             | ToolCallState::Running(_)
             | ToolCallState::PendingConfirmation(_) => {
-                if let Some(confirmed) = a.confirmed {
+                if let Some(confirmed) = a.confirmed.clone() {
                     ToolCallState::Running(ToolCallRunningState {
                         tool_call_id: base.tool_call_id,
                         tool_name: base.tool_name,
@@ -1436,7 +1439,10 @@ fn apply_tool_call_confirmed(
                 contributor,
                 meta,
                 invocation_message,
-                confirmed: a.confirmed.unwrap_or(ToolCallConfirmationReason::NotNeeded),
+                confirmed: match a.confirmed.clone() {
+                    Some(confirmed) => confirmed,
+                    None => ToolCallConfirmationReason::NotNeeded,
+                },
                 selected_option,
                 content: None,
             })
@@ -1450,7 +1456,10 @@ fn apply_tool_call_confirmed(
                 contributor,
                 meta,
                 invocation_message,
-                reason: a.reason.unwrap_or(ToolCallCancellationReason::Denied),
+                reason: match a.reason {
+                    Some(reason) => reason,
+                    None => ToolCallCancellationReason::Denied,
+                },
                 reason_message: a.reason_message.clone(),
                 user_suggestion: a.user_suggestion.clone(),
                 selected_option,
@@ -1834,10 +1843,10 @@ pub fn apply_action_to_changeset(
             // Carry `error` only when the new status is `Error` so we don't
             // leave a stale error sitting on a recovered changeset.
             if a.status == ChangesetStatus::Error {
-                state.status = a.status;
+                state.status = a.status.clone();
                 state.error = a.error.clone();
             } else {
-                state.status = a.status;
+                state.status = a.status.clone();
                 state.error = None;
             }
             ReduceOutcome::Applied
@@ -1894,10 +1903,10 @@ pub fn apply_action_to_changeset(
             // Carry `error` only when the new status is `Error` so we don't
             // leave a stale error on an operation that recovered or started running.
             if a.status == ChangesetOperationStatus::Error {
-                ops[idx].status = a.status;
+                ops[idx].status = a.status.clone();
                 ops[idx].error = a.error.clone();
             } else {
-                ops[idx].status = a.status;
+                ops[idx].status = a.status.clone();
                 ops[idx].error = None;
             }
             ReduceOutcome::Applied
@@ -2099,6 +2108,7 @@ pub fn apply_action_to_automation_run(
 }
 
 #[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use ahp_types::state::{

--- a/clients/rust/crates/ahp/tests/client_roundtrip.rs
+++ b/clients/rust/crates/ahp/tests/client_roundtrip.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic, clippy::unwrap_used, clippy::useless_conversion)]
+
 //! Integration test: round-trip a JSON-RPC request and a broadcast
 //! action through an in-memory transport pair.
 //!

--- a/clients/rust/crates/ahp/tests/file_client_id_store.rs
+++ b/clients/rust/crates/ahp/tests/file_client_id_store.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic, clippy::unwrap_used)]
+
 //! Tests for [`ahp::hosts::FileClientIdStore`].
 //!
 //! Cover round-trips, restart simulation (fresh instances see prior

--- a/clients/rust/crates/ahp/tests/hosts.rs
+++ b/clients/rust/crates/ahp/tests/hosts.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic, clippy::unwrap_used)]
+
 //! Integration tests for the multi-host SDK (`ahp::hosts`).
 //!
 //! Uses an in-memory transport pair (mirroring `client_roundtrip.rs`)

--- a/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
+++ b/clients/rust/crates/ahp/tests/multi_host_state_mirror.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic, clippy::unwrap_used)]
+
 //! Tests for [`ahp::MultiHostStateMirror`] — the host-aware reducer
 //! façade.
 //!

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Actions.generated.swift
@@ -5,102 +5,309 @@ import Foundation
 // MARK: - ActionType
 
 /// Discriminant values for all state actions.
-public enum ActionType: String, Codable, Sendable {
-    case rootAgentsChanged = "root/agentsChanged"
-    case rootActiveSessionsChanged = "root/activeSessionsChanged"
-    case sessionReady = "session/ready"
-    case sessionCreationFailed = "session/creationFailed"
-    case sessionChatAdded = "session/chatAdded"
-    case sessionChatRemoved = "session/chatRemoved"
-    case sessionChatUpdated = "session/chatUpdated"
-    case sessionDefaultChatChanged = "session/defaultChatChanged"
-    case chatTurnStarted = "chat/turnStarted"
-    case chatDelta = "chat/delta"
-    case chatResponsePart = "chat/responsePart"
-    case chatToolCallStart = "chat/toolCallStart"
-    case chatToolCallDelta = "chat/toolCallDelta"
-    case chatToolCallReady = "chat/toolCallReady"
-    case chatToolCallConfirmed = "chat/toolCallConfirmed"
-    case chatToolCallComplete = "chat/toolCallComplete"
-    case chatToolCallResultConfirmed = "chat/toolCallResultConfirmed"
-    case chatToolCallContentChanged = "chat/toolCallContentChanged"
-    case chatToolCallAuthRequired = "chat/toolCallAuthRequired"
-    case chatToolCallAuthResolved = "chat/toolCallAuthResolved"
-    case chatTurnComplete = "chat/turnComplete"
-    case chatTurnCancelled = "chat/turnCancelled"
-    case chatError = "chat/error"
-    case chatActivityChanged = "chat/activityChanged"
-    case chatWorkingDirectorySet = "chat/workingDirectorySet"
-    case chatWorkingDirectoryRemoved = "chat/workingDirectoryRemoved"
-    case sessionTitleChanged = "session/titleChanged"
-    case chatUsage = "chat/usage"
-    case chatReasoning = "chat/reasoning"
-    case sessionServerToolsChanged = "session/serverToolsChanged"
-    case sessionActiveClientSet = "session/activeClientSet"
-    case sessionActiveClientRemoved = "session/activeClientRemoved"
-    case sessionWorkingDirectorySet = "session/workingDirectorySet"
-    case sessionWorkingDirectoryRemoved = "session/workingDirectoryRemoved"
-    case sessionWorkingDirectoryReplaced = "session/workingDirectoryReplaced"
-    case sessionInputNeededSet = "session/inputNeededSet"
-    case sessionInputNeededRemoved = "session/inputNeededRemoved"
-    case chatPendingMessageSet = "chat/pendingMessageSet"
-    case chatPendingMessageRemoved = "chat/pendingMessageRemoved"
-    case chatQueuedMessagesReordered = "chat/queuedMessagesReordered"
-    case chatDraftChanged = "chat/draftChanged"
-    case chatInputRequested = "chat/inputRequested"
-    case chatInputAnswerChanged = "chat/inputAnswerChanged"
-    case chatInputCompleted = "chat/inputCompleted"
-    case sessionCustomizationsChanged = "session/customizationsChanged"
-    case sessionCustomizationToggled = "session/customizationToggled"
-    case sessionCustomizationUpdated = "session/customizationUpdated"
-    case sessionCustomizationRemoved = "session/customizationRemoved"
-    case sessionMcpServerStateChanged = "session/mcpServerStateChanged"
-    case sessionMcpServerStartRequested = "session/mcpServerStartRequested"
-    case sessionMcpServerStopRequested = "session/mcpServerStopRequested"
-    case chatTruncated = "chat/truncated"
-    case chatTurnsLoaded = "chat/turnsLoaded"
-    case sessionIsReadChanged = "session/isReadChanged"
-    case sessionIsArchivedChanged = "session/isArchivedChanged"
-    case sessionActivityChanged = "session/activityChanged"
-    case sessionChangesetsChanged = "session/changesetsChanged"
-    case sessionConfigChanged = "session/configChanged"
-    case sessionMetaChanged = "session/metaChanged"
-    case changesetStatusChanged = "changeset/statusChanged"
-    case changesetFileSet = "changeset/fileSet"
-    case changesetFileRemoved = "changeset/fileRemoved"
-    case changesetFilesReviewChanged = "changeset/filesReviewChanged"
-    case changesetContentChanged = "changeset/contentChanged"
-    case changesetOperationsChanged = "changeset/operationsChanged"
-    case changesetOperationStatusChanged = "changeset/operationStatusChanged"
-    case changesetCleared = "changeset/cleared"
-    case annotationsSet = "annotations/set"
-    case annotationsUpdated = "annotations/updated"
-    case annotationsRemoved = "annotations/removed"
-    case annotationsEntrySet = "annotations/entrySet"
-    case annotationsEntryRemoved = "annotations/entryRemoved"
-    case rootTerminalsChanged = "root/terminalsChanged"
-    case rootConfigChanged = "root/configChanged"
-    case terminalData = "terminal/data"
-    case terminalInput = "terminal/input"
-    case terminalResized = "terminal/resized"
-    case terminalClaimed = "terminal/claimed"
-    case terminalTitleChanged = "terminal/titleChanged"
-    case terminalCwdChanged = "terminal/cwdChanged"
-    case terminalExited = "terminal/exited"
-    case terminalCleared = "terminal/cleared"
-    case terminalCommandDetectionAvailable = "terminal/commandDetectionAvailable"
-    case terminalCommandExecuted = "terminal/commandExecuted"
-    case terminalCommandFinished = "terminal/commandFinished"
-    case resourceWatchChanged = "resourceWatch/changed"
-    case automationCreateRequested = "automation/createRequested"
-    case automationUpdateRequested = "automation/updateRequested"
-    case automationSet = "automation/set"
-    case automationRemoved = "automation/removed"
-    case automationRunLifecycleChanged = "automationRun/lifecycleChanged"
-    case automationRunSessionSet = "automationRun/sessionSet"
-    case automationRunSessionRemoved = "automationRun/sessionRemoved"
-    case automationRunPrimarySessionChanged = "automationRun/primarySessionChanged"
-    case automationRunCancelRequested = "automationRun/cancelRequested"
+public enum ActionType: Codable, Sendable, Equatable {
+    case rootAgentsChanged
+    case rootActiveSessionsChanged
+    case sessionReady
+    case sessionCreationFailed
+    case sessionChatAdded
+    case sessionChatRemoved
+    case sessionChatUpdated
+    case sessionDefaultChatChanged
+    case chatTurnStarted
+    case chatDelta
+    case chatResponsePart
+    case chatToolCallStart
+    case chatToolCallDelta
+    case chatToolCallReady
+    case chatToolCallConfirmed
+    case chatToolCallComplete
+    case chatToolCallResultConfirmed
+    case chatToolCallContentChanged
+    case chatToolCallAuthRequired
+    case chatToolCallAuthResolved
+    case chatTurnComplete
+    case chatTurnCancelled
+    case chatError
+    case chatActivityChanged
+    case chatWorkingDirectorySet
+    case chatWorkingDirectoryRemoved
+    case sessionTitleChanged
+    case chatUsage
+    case chatReasoning
+    case sessionServerToolsChanged
+    case sessionActiveClientSet
+    case sessionActiveClientRemoved
+    case sessionWorkingDirectorySet
+    case sessionWorkingDirectoryRemoved
+    case sessionWorkingDirectoryReplaced
+    case sessionInputNeededSet
+    case sessionInputNeededRemoved
+    case chatPendingMessageSet
+    case chatPendingMessageRemoved
+    case chatQueuedMessagesReordered
+    case chatDraftChanged
+    case chatInputRequested
+    case chatInputAnswerChanged
+    case chatInputCompleted
+    case sessionCustomizationsChanged
+    case sessionCustomizationToggled
+    case sessionCustomizationUpdated
+    case sessionCustomizationRemoved
+    case sessionMcpServerStateChanged
+    case sessionMcpServerStartRequested
+    case sessionMcpServerStopRequested
+    case chatTruncated
+    case chatTurnsLoaded
+    case sessionIsReadChanged
+    case sessionIsArchivedChanged
+    case sessionActivityChanged
+    case sessionChangesetsChanged
+    case sessionConfigChanged
+    case sessionMetaChanged
+    case changesetStatusChanged
+    case changesetFileSet
+    case changesetFileRemoved
+    case changesetFilesReviewChanged
+    case changesetContentChanged
+    case changesetOperationsChanged
+    case changesetOperationStatusChanged
+    case changesetCleared
+    case annotationsSet
+    case annotationsUpdated
+    case annotationsRemoved
+    case annotationsEntrySet
+    case annotationsEntryRemoved
+    case rootTerminalsChanged
+    case rootConfigChanged
+    case terminalData
+    case terminalInput
+    case terminalResized
+    case terminalClaimed
+    case terminalTitleChanged
+    case terminalCwdChanged
+    case terminalExited
+    case terminalCleared
+    case terminalCommandDetectionAvailable
+    case terminalCommandExecuted
+    case terminalCommandFinished
+    case resourceWatchChanged
+    case automationCreateRequested
+    case automationUpdateRequested
+    case automationSet
+    case automationRemoved
+    case automationRunLifecycleChanged
+    case automationRunSessionSet
+    case automationRunSessionRemoved
+    case automationRunPrimarySessionChanged
+    case automationRunCancelRequested
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "root/agentsChanged": self = .rootAgentsChanged
+        case "root/activeSessionsChanged": self = .rootActiveSessionsChanged
+        case "session/ready": self = .sessionReady
+        case "session/creationFailed": self = .sessionCreationFailed
+        case "session/chatAdded": self = .sessionChatAdded
+        case "session/chatRemoved": self = .sessionChatRemoved
+        case "session/chatUpdated": self = .sessionChatUpdated
+        case "session/defaultChatChanged": self = .sessionDefaultChatChanged
+        case "chat/turnStarted": self = .chatTurnStarted
+        case "chat/delta": self = .chatDelta
+        case "chat/responsePart": self = .chatResponsePart
+        case "chat/toolCallStart": self = .chatToolCallStart
+        case "chat/toolCallDelta": self = .chatToolCallDelta
+        case "chat/toolCallReady": self = .chatToolCallReady
+        case "chat/toolCallConfirmed": self = .chatToolCallConfirmed
+        case "chat/toolCallComplete": self = .chatToolCallComplete
+        case "chat/toolCallResultConfirmed": self = .chatToolCallResultConfirmed
+        case "chat/toolCallContentChanged": self = .chatToolCallContentChanged
+        case "chat/toolCallAuthRequired": self = .chatToolCallAuthRequired
+        case "chat/toolCallAuthResolved": self = .chatToolCallAuthResolved
+        case "chat/turnComplete": self = .chatTurnComplete
+        case "chat/turnCancelled": self = .chatTurnCancelled
+        case "chat/error": self = .chatError
+        case "chat/activityChanged": self = .chatActivityChanged
+        case "chat/workingDirectorySet": self = .chatWorkingDirectorySet
+        case "chat/workingDirectoryRemoved": self = .chatWorkingDirectoryRemoved
+        case "session/titleChanged": self = .sessionTitleChanged
+        case "chat/usage": self = .chatUsage
+        case "chat/reasoning": self = .chatReasoning
+        case "session/serverToolsChanged": self = .sessionServerToolsChanged
+        case "session/activeClientSet": self = .sessionActiveClientSet
+        case "session/activeClientRemoved": self = .sessionActiveClientRemoved
+        case "session/workingDirectorySet": self = .sessionWorkingDirectorySet
+        case "session/workingDirectoryRemoved": self = .sessionWorkingDirectoryRemoved
+        case "session/workingDirectoryReplaced": self = .sessionWorkingDirectoryReplaced
+        case "session/inputNeededSet": self = .sessionInputNeededSet
+        case "session/inputNeededRemoved": self = .sessionInputNeededRemoved
+        case "chat/pendingMessageSet": self = .chatPendingMessageSet
+        case "chat/pendingMessageRemoved": self = .chatPendingMessageRemoved
+        case "chat/queuedMessagesReordered": self = .chatQueuedMessagesReordered
+        case "chat/draftChanged": self = .chatDraftChanged
+        case "chat/inputRequested": self = .chatInputRequested
+        case "chat/inputAnswerChanged": self = .chatInputAnswerChanged
+        case "chat/inputCompleted": self = .chatInputCompleted
+        case "session/customizationsChanged": self = .sessionCustomizationsChanged
+        case "session/customizationToggled": self = .sessionCustomizationToggled
+        case "session/customizationUpdated": self = .sessionCustomizationUpdated
+        case "session/customizationRemoved": self = .sessionCustomizationRemoved
+        case "session/mcpServerStateChanged": self = .sessionMcpServerStateChanged
+        case "session/mcpServerStartRequested": self = .sessionMcpServerStartRequested
+        case "session/mcpServerStopRequested": self = .sessionMcpServerStopRequested
+        case "chat/truncated": self = .chatTruncated
+        case "chat/turnsLoaded": self = .chatTurnsLoaded
+        case "session/isReadChanged": self = .sessionIsReadChanged
+        case "session/isArchivedChanged": self = .sessionIsArchivedChanged
+        case "session/activityChanged": self = .sessionActivityChanged
+        case "session/changesetsChanged": self = .sessionChangesetsChanged
+        case "session/configChanged": self = .sessionConfigChanged
+        case "session/metaChanged": self = .sessionMetaChanged
+        case "changeset/statusChanged": self = .changesetStatusChanged
+        case "changeset/fileSet": self = .changesetFileSet
+        case "changeset/fileRemoved": self = .changesetFileRemoved
+        case "changeset/filesReviewChanged": self = .changesetFilesReviewChanged
+        case "changeset/contentChanged": self = .changesetContentChanged
+        case "changeset/operationsChanged": self = .changesetOperationsChanged
+        case "changeset/operationStatusChanged": self = .changesetOperationStatusChanged
+        case "changeset/cleared": self = .changesetCleared
+        case "annotations/set": self = .annotationsSet
+        case "annotations/updated": self = .annotationsUpdated
+        case "annotations/removed": self = .annotationsRemoved
+        case "annotations/entrySet": self = .annotationsEntrySet
+        case "annotations/entryRemoved": self = .annotationsEntryRemoved
+        case "root/terminalsChanged": self = .rootTerminalsChanged
+        case "root/configChanged": self = .rootConfigChanged
+        case "terminal/data": self = .terminalData
+        case "terminal/input": self = .terminalInput
+        case "terminal/resized": self = .terminalResized
+        case "terminal/claimed": self = .terminalClaimed
+        case "terminal/titleChanged": self = .terminalTitleChanged
+        case "terminal/cwdChanged": self = .terminalCwdChanged
+        case "terminal/exited": self = .terminalExited
+        case "terminal/cleared": self = .terminalCleared
+        case "terminal/commandDetectionAvailable": self = .terminalCommandDetectionAvailable
+        case "terminal/commandExecuted": self = .terminalCommandExecuted
+        case "terminal/commandFinished": self = .terminalCommandFinished
+        case "resourceWatch/changed": self = .resourceWatchChanged
+        case "automation/createRequested": self = .automationCreateRequested
+        case "automation/updateRequested": self = .automationUpdateRequested
+        case "automation/set": self = .automationSet
+        case "automation/removed": self = .automationRemoved
+        case "automationRun/lifecycleChanged": self = .automationRunLifecycleChanged
+        case "automationRun/sessionSet": self = .automationRunSessionSet
+        case "automationRun/sessionRemoved": self = .automationRunSessionRemoved
+        case "automationRun/primarySessionChanged": self = .automationRunPrimarySessionChanged
+        case "automationRun/cancelRequested": self = .automationRunCancelRequested
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .rootAgentsChanged: try container.encode("root/agentsChanged")
+        case .rootActiveSessionsChanged: try container.encode("root/activeSessionsChanged")
+        case .sessionReady: try container.encode("session/ready")
+        case .sessionCreationFailed: try container.encode("session/creationFailed")
+        case .sessionChatAdded: try container.encode("session/chatAdded")
+        case .sessionChatRemoved: try container.encode("session/chatRemoved")
+        case .sessionChatUpdated: try container.encode("session/chatUpdated")
+        case .sessionDefaultChatChanged: try container.encode("session/defaultChatChanged")
+        case .chatTurnStarted: try container.encode("chat/turnStarted")
+        case .chatDelta: try container.encode("chat/delta")
+        case .chatResponsePart: try container.encode("chat/responsePart")
+        case .chatToolCallStart: try container.encode("chat/toolCallStart")
+        case .chatToolCallDelta: try container.encode("chat/toolCallDelta")
+        case .chatToolCallReady: try container.encode("chat/toolCallReady")
+        case .chatToolCallConfirmed: try container.encode("chat/toolCallConfirmed")
+        case .chatToolCallComplete: try container.encode("chat/toolCallComplete")
+        case .chatToolCallResultConfirmed: try container.encode("chat/toolCallResultConfirmed")
+        case .chatToolCallContentChanged: try container.encode("chat/toolCallContentChanged")
+        case .chatToolCallAuthRequired: try container.encode("chat/toolCallAuthRequired")
+        case .chatToolCallAuthResolved: try container.encode("chat/toolCallAuthResolved")
+        case .chatTurnComplete: try container.encode("chat/turnComplete")
+        case .chatTurnCancelled: try container.encode("chat/turnCancelled")
+        case .chatError: try container.encode("chat/error")
+        case .chatActivityChanged: try container.encode("chat/activityChanged")
+        case .chatWorkingDirectorySet: try container.encode("chat/workingDirectorySet")
+        case .chatWorkingDirectoryRemoved: try container.encode("chat/workingDirectoryRemoved")
+        case .sessionTitleChanged: try container.encode("session/titleChanged")
+        case .chatUsage: try container.encode("chat/usage")
+        case .chatReasoning: try container.encode("chat/reasoning")
+        case .sessionServerToolsChanged: try container.encode("session/serverToolsChanged")
+        case .sessionActiveClientSet: try container.encode("session/activeClientSet")
+        case .sessionActiveClientRemoved: try container.encode("session/activeClientRemoved")
+        case .sessionWorkingDirectorySet: try container.encode("session/workingDirectorySet")
+        case .sessionWorkingDirectoryRemoved: try container.encode("session/workingDirectoryRemoved")
+        case .sessionWorkingDirectoryReplaced: try container.encode("session/workingDirectoryReplaced")
+        case .sessionInputNeededSet: try container.encode("session/inputNeededSet")
+        case .sessionInputNeededRemoved: try container.encode("session/inputNeededRemoved")
+        case .chatPendingMessageSet: try container.encode("chat/pendingMessageSet")
+        case .chatPendingMessageRemoved: try container.encode("chat/pendingMessageRemoved")
+        case .chatQueuedMessagesReordered: try container.encode("chat/queuedMessagesReordered")
+        case .chatDraftChanged: try container.encode("chat/draftChanged")
+        case .chatInputRequested: try container.encode("chat/inputRequested")
+        case .chatInputAnswerChanged: try container.encode("chat/inputAnswerChanged")
+        case .chatInputCompleted: try container.encode("chat/inputCompleted")
+        case .sessionCustomizationsChanged: try container.encode("session/customizationsChanged")
+        case .sessionCustomizationToggled: try container.encode("session/customizationToggled")
+        case .sessionCustomizationUpdated: try container.encode("session/customizationUpdated")
+        case .sessionCustomizationRemoved: try container.encode("session/customizationRemoved")
+        case .sessionMcpServerStateChanged: try container.encode("session/mcpServerStateChanged")
+        case .sessionMcpServerStartRequested: try container.encode("session/mcpServerStartRequested")
+        case .sessionMcpServerStopRequested: try container.encode("session/mcpServerStopRequested")
+        case .chatTruncated: try container.encode("chat/truncated")
+        case .chatTurnsLoaded: try container.encode("chat/turnsLoaded")
+        case .sessionIsReadChanged: try container.encode("session/isReadChanged")
+        case .sessionIsArchivedChanged: try container.encode("session/isArchivedChanged")
+        case .sessionActivityChanged: try container.encode("session/activityChanged")
+        case .sessionChangesetsChanged: try container.encode("session/changesetsChanged")
+        case .sessionConfigChanged: try container.encode("session/configChanged")
+        case .sessionMetaChanged: try container.encode("session/metaChanged")
+        case .changesetStatusChanged: try container.encode("changeset/statusChanged")
+        case .changesetFileSet: try container.encode("changeset/fileSet")
+        case .changesetFileRemoved: try container.encode("changeset/fileRemoved")
+        case .changesetFilesReviewChanged: try container.encode("changeset/filesReviewChanged")
+        case .changesetContentChanged: try container.encode("changeset/contentChanged")
+        case .changesetOperationsChanged: try container.encode("changeset/operationsChanged")
+        case .changesetOperationStatusChanged: try container.encode("changeset/operationStatusChanged")
+        case .changesetCleared: try container.encode("changeset/cleared")
+        case .annotationsSet: try container.encode("annotations/set")
+        case .annotationsUpdated: try container.encode("annotations/updated")
+        case .annotationsRemoved: try container.encode("annotations/removed")
+        case .annotationsEntrySet: try container.encode("annotations/entrySet")
+        case .annotationsEntryRemoved: try container.encode("annotations/entryRemoved")
+        case .rootTerminalsChanged: try container.encode("root/terminalsChanged")
+        case .rootConfigChanged: try container.encode("root/configChanged")
+        case .terminalData: try container.encode("terminal/data")
+        case .terminalInput: try container.encode("terminal/input")
+        case .terminalResized: try container.encode("terminal/resized")
+        case .terminalClaimed: try container.encode("terminal/claimed")
+        case .terminalTitleChanged: try container.encode("terminal/titleChanged")
+        case .terminalCwdChanged: try container.encode("terminal/cwdChanged")
+        case .terminalExited: try container.encode("terminal/exited")
+        case .terminalCleared: try container.encode("terminal/cleared")
+        case .terminalCommandDetectionAvailable: try container.encode("terminal/commandDetectionAvailable")
+        case .terminalCommandExecuted: try container.encode("terminal/commandExecuted")
+        case .terminalCommandFinished: try container.encode("terminal/commandFinished")
+        case .resourceWatchChanged: try container.encode("resourceWatch/changed")
+        case .automationCreateRequested: try container.encode("automation/createRequested")
+        case .automationUpdateRequested: try container.encode("automation/updateRequested")
+        case .automationSet: try container.encode("automation/set")
+        case .automationRemoved: try container.encode("automation/removed")
+        case .automationRunLifecycleChanged: try container.encode("automationRun/lifecycleChanged")
+        case .automationRunSessionSet: try container.encode("automationRun/sessionSet")
+        case .automationRunSessionRemoved: try container.encode("automationRun/sessionRemoved")
+        case .automationRunPrimarySessionChanged: try container.encode("automationRun/primarySessionChanged")
+        case .automationRunCancelRequested: try container.encode("automationRun/cancelRequested")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 // MARK: - Action Infrastructure

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -2068,7 +2068,10 @@ public enum ChatSource: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "fork":
             self = .fork(try ForkChatSource(from: decoder))

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -11,11 +11,32 @@ public enum ReconnectResultType: String, Codable, Sendable {
 }
 
 /// How a new chat uses its source chat and turn.
-public enum ChatSourceKind: String, Codable, Sendable {
+public enum ChatSourceKind: Codable, Sendable, Equatable {
     /// Copy source history through the referenced turn into the new chat.
-    case fork = "fork"
+    case fork
     /// Supply source context without copying it into the new chat's visible history.
-    case sideChat = "sideChat"
+    case sideChat
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "fork": self = .fork
+        case "sideChat": self = .sideChat
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .fork: try container.encode("fork")
+        case .sideChat: try container.encode("sideChat")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Encoding of fetched content data.
@@ -25,18 +46,60 @@ public enum ContentEncoding: String, Codable, Sendable {
 }
 
 /// The kind of completion items being requested.
-public enum CompletionItemKind: String, Codable, Sendable {
+public enum CompletionItemKind: Codable, Sendable, Equatable {
     /// Completions for the text of a {@link Message} the user is composing.
     /// Each returned item carries an attachment that gets associated with the
     /// message when accepted.
-    case userMessage = "userMessage"
+    case userMessage
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "userMessage": self = .userMessage
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .userMessage: try container.encode("userMessage")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant for {@link ResourceResolveResult.type}.
-public enum ResourceType: String, Codable, Sendable {
-    case file = "file"
-    case directory = "directory"
-    case symlink = "symlink"
+public enum ResourceType: Codable, Sendable, Equatable {
+    case file
+    case directory
+    case symlink
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "file": self = .file
+        case "directory": self = .directory
+        case "symlink": self = .symlink
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .file: try container.encode("file")
+        case .directory: try container.encode("directory")
+        case .symlink: try container.encode("symlink")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// How {@link ResourceWriteParams.data} is placed within the target file.
@@ -178,7 +241,8 @@ public struct InitializeParams: Codable, Sendable {
     ///
     /// The server selects one entry and returns it as `InitializeResult.protocolVersion`.
     /// If the server cannot speak any of the offered versions, it MUST return
-    /// error code `-32005` (`UnsupportedProtocolVersion`).
+    /// error code `-32005` (`UnsupportedProtocolVersion`) with required
+    /// `UnsupportedProtocolVersionErrorData` containing `supportedVersions`.
     public var protocolVersions: [String]
     /// Unique client identifier
     public var clientId: String
@@ -1994,6 +2058,9 @@ public struct FetchAutomationRunsResult: Codable, Sendable {
 public enum ChatSource: Codable, Sendable {
     case fork(ForkChatSource)
     case sideChat(SideChatSource)
+    /// Unknown or future discriminant; the raw payload is preserved
+    /// and re-encoded verbatim for forward-compatibility.
+    case unknown(AnyCodable)
 
     private enum DiscriminantKey: String, CodingKey {
         case discriminant = "kind"
@@ -2008,7 +2075,7 @@ public enum ChatSource: Codable, Sendable {
         case "sideChat":
             self = .sideChat(try SideChatSource(from: decoder))
         default:
-            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ChatSource discriminant: \(discriminant)")
+            self = .unknown(try AnyCodable(from: decoder))
         }
     }
 
@@ -2016,6 +2083,7 @@ public enum ChatSource: Codable, Sendable {
         switch self {
         case .fork(let value): try value.encode(to: encoder)
         case .sideChat(let value): try value.encode(to: encoder)
+        case .unknown(let value): try value.encode(to: encoder)
         }
     }
 }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Errors.generated.swift
@@ -30,8 +30,7 @@ public enum AhpErrorCodes {
     public static let turnInProgress = -32004
     /// The server cannot speak any of the protocol versions offered by the client in `InitializeParams.protocolVersions`
     public static let unsupportedProtocolVersion = -32005
-    /// The requested content URI does not exist
-    public static let contentNotFound = -32006
+    // -32006 is intentionally reserved and unassigned.
     /// Authentication required for a protected resource
     public static let authRequired = -32007
     /// The requested file, folder, or URI does not exist

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Notifications.generated.swift
@@ -5,11 +5,32 @@ import Foundation
 // MARK: - Notification Enums
 
 /// Reason why authentication is required.
-public enum AuthRequiredReason: String, Codable, Sendable {
+public enum AuthRequiredReason: Codable, Sendable, Equatable {
     /// The client has not yet authenticated for the resource
-    case required = "required"
+    case required
     /// A previously valid token has expired or been revoked
-    case expired = "expired"
+    case expired
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "required": self = .required
+        case "expired": self = .expired
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .required: try container.encode("required")
+        case .expired: try container.encode("expired")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 // MARK: - Notification Types

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -56,10 +56,33 @@ public enum PendingMessageKind: String, Codable, Sendable {
 }
 
 /// Session initialization state.
-public enum SessionLifecycle: String, Codable, Sendable {
-    case creating = "creating"
-    case ready = "ready"
-    case failed = "failed"
+public enum SessionLifecycle: Codable, Sendable, Equatable {
+    case creating
+    case ready
+    case failed
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "creating": self = .creating
+        case "ready": self = .ready
+        case "failed": self = .failed
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .creating: try container.encode("creating")
+        case .ready: try container.encode("ready")
+        case .failed: try container.encode("failed")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Bitset of summary-level session status flags.
@@ -86,15 +109,40 @@ public struct SessionStatus: OptionSet, Codable, Sendable, Hashable {
 }
 
 /// Discriminant for {@link ChatOrigin} — how a chat came into existence.
-public enum ChatOriginKind: String, Codable, Sendable {
+public enum ChatOriginKind: Codable, Sendable, Equatable {
     /// User created the chat explicitly (e.g. via the host UI).
-    case user = "user"
+    case user
     /// Forked from an existing chat at a specific turn.
-    case fork = "fork"
+    case fork
     /// Created as an independent side conversation from a specific turn.
-    case sideChat = "sideChat"
+    case sideChat
     /// Spawned by a tool call running in another chat (e.g. a sub-agent delegation).
-    case tool = "tool"
+    case tool
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "user": self = .user
+        case "fork": self = .fork
+        case "sideChat": self = .sideChat
+        case "tool": self = .tool
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .user: try container.encode("user")
+        case .fork: try container.encode("fork")
+        case .sideChat: try container.encode("sideChat")
+        case .tool: try container.encode("tool")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// How a user can interact with a chat.
@@ -124,22 +172,78 @@ public enum ChatInputAnswerState: String, Codable, Sendable {
 }
 
 /// Answer value kind.
-public enum ChatInputAnswerValueKind: String, Codable, Sendable {
-    case text = "text"
-    case number = "number"
-    case boolean = "boolean"
-    case selected = "selected"
-    case selectedMany = "selected-many"
+public enum ChatInputAnswerValueKind: Codable, Sendable, Equatable {
+    case text
+    case number
+    case boolean
+    case selected
+    case selectedMany
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "text": self = .text
+        case "number": self = .number
+        case "boolean": self = .boolean
+        case "selected": self = .selected
+        case "selected-many": self = .selectedMany
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text: try container.encode("text")
+        case .number: try container.encode("number")
+        case .boolean: try container.encode("boolean")
+        case .selected: try container.encode("selected")
+        case .selectedMany: try container.encode("selected-many")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Question/input control kind.
-public enum ChatInputQuestionKind: String, Codable, Sendable {
-    case text = "text"
-    case number = "number"
-    case integer = "integer"
-    case boolean = "boolean"
-    case singleSelect = "single-select"
-    case multiSelect = "multi-select"
+public enum ChatInputQuestionKind: Codable, Sendable, Equatable {
+    case text
+    case number
+    case integer
+    case boolean
+    case singleSelect
+    case multiSelect
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "text": self = .text
+        case "number": self = .number
+        case "integer": self = .integer
+        case "boolean": self = .boolean
+        case "single-select": self = .singleSelect
+        case "multi-select": self = .multiSelect
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text: try container.encode("text")
+        case .number: try container.encode("number")
+        case .integer: try container.encode("integer")
+        case .boolean: try container.encode("boolean")
+        case .singleSelect: try container.encode("single-select")
+        case .multiSelect: try container.encode("multi-select")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// How a client completed an input request.
@@ -154,15 +258,40 @@ public enum ChatInputResponseKind: String, Codable, Sendable {
 ///
 /// This is a general/typological union (not a lifecycle), so the discriminant is
 /// a `*Kind`.
-public enum SessionInputRequestKind: String, Codable, Sendable {
+public enum SessionInputRequestKind: Codable, Sendable, Equatable {
     /// A user-facing elicitation mirrored from an unresolved chat response part.
-    case chatInput = "chatInput"
+    case chatInput
     /// A tool call awaiting parameter- or result-confirmation.
-    case toolConfirmation = "toolConfirmation"
+    case toolConfirmation
     /// A running tool the session wants an active client to execute.
-    case toolClientExecution = "toolClientExecution"
+    case toolClientExecution
     /// A tool call blocked on MCP authentication mid-execution.
-    case toolAuthentication = "toolAuthentication"
+    case toolAuthentication
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "chatInput": self = .chatInput
+        case "toolConfirmation": self = .toolConfirmation
+        case "toolClientExecution": self = .toolClientExecution
+        case "toolAuthentication": self = .toolAuthentication
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .chatInput: try container.encode("chatInput")
+        case .toolConfirmation: try container.encode("toolConfirmation")
+        case .toolClientExecution: try container.encode("toolClientExecution")
+        case .toolAuthentication: try container.encode("toolAuthentication")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// How a turn ended.
@@ -173,57 +302,171 @@ public enum TurnState: String, Codable, Sendable {
 }
 
 /// Discriminant for {@link MessageOrigin} — identifies who produced a message.
-public enum MessageKind: String, Codable, Sendable {
+public enum MessageKind: Codable, Sendable, Equatable {
     /// Sent directly by the user.
-    case user = "user"
+    case user
     /// Produced by the agent itself rather than the user — for example, an agent
     /// that seeds the first message of a chat it spawned.
-    case agent = "agent"
+    case agent
     /// Produced by a tool rather than the user — for example, a tool that spawns a
     /// worker chat whose first message carries a seed prompt.
-    case tool = "tool"
+    case tool
     /// Emitted automatically when an automation run starts a session.
-    case automation = "automation"
+    case automation
     /// A system-generated notification rather than a direct user message.
-    case systemNotification = "systemNotification"
+    case systemNotification
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "user": self = .user
+        case "agent": self = .agent
+        case "tool": self = .tool
+        case "automation": self = .automation
+        case "systemNotification": self = .systemNotification
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .user: try container.encode("user")
+        case .agent: try container.encode("agent")
+        case .tool: try container.encode("tool")
+        case .automation: try container.encode("automation")
+        case .systemNotification: try container.encode("systemNotification")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant for {@link MessageAttachment} variants.
-public enum MessageAttachmentKind: String, Codable, Sendable {
+public enum MessageAttachmentKind: Codable, Sendable, Equatable {
     /// A simple, opaque attachment whose representation is described by the producer.
-    case simple = "simple"
+    case simple
     /// An attachment whose data is embedded inline as a base64 string.
-    case embeddedResource = "embeddedResource"
+    case embeddedResource
     /// An attachment that references a resource by URI.
-    case resource = "resource"
+    case resource
     /// An attachment that references annotations on an annotations channel.
-    case annotations = "annotations"
+    case annotations
     /// An attachment that references a bounded transcript from another chat.
-    case chat = "chat"
+    case chat
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "simple": self = .simple
+        case "embeddedResource": self = .embeddedResource
+        case "resource": self = .resource
+        case "annotations": self = .annotations
+        case "chat": self = .chat
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .simple: try container.encode("simple")
+        case .embeddedResource: try container.encode("embeddedResource")
+        case .resource: try container.encode("resource")
+        case .annotations: try container.encode("annotations")
+        case .chat: try container.encode("chat")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant for response part types.
-public enum ResponsePartKind: String, Codable, Sendable {
-    case markdown = "markdown"
-    case contentRef = "contentRef"
-    case toolCall = "toolCall"
-    case reasoning = "reasoning"
-    case systemNotification = "systemNotification"
-    case inputRequest = "inputRequest"
+public enum ResponsePartKind: Codable, Sendable, Equatable {
+    case markdown
+    case contentRef
+    case toolCall
+    case reasoning
+    case systemNotification
+    case inputRequest
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "markdown": self = .markdown
+        case "contentRef": self = .contentRef
+        case "toolCall": self = .toolCall
+        case "reasoning": self = .reasoning
+        case "systemNotification": self = .systemNotification
+        case "inputRequest": self = .inputRequest
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .markdown: try container.encode("markdown")
+        case .contentRef: try container.encode("contentRef")
+        case .toolCall: try container.encode("toolCall")
+        case .reasoning: try container.encode("reasoning")
+        case .systemNotification: try container.encode("systemNotification")
+        case .inputRequest: try container.encode("inputRequest")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Status of a tool call in the lifecycle state machine.
-public enum ToolCallStatus: String, Codable, Sendable {
-    case streaming = "streaming"
-    case pendingConfirmation = "pending-confirmation"
-    case running = "running"
+public enum ToolCallStatus: Codable, Sendable, Equatable {
+    case streaming
+    case pendingConfirmation
+    case running
     /// Running paused because the MCP server backing this call needs
     /// authentication (typically step-up auth for insufficient scope,
     /// surfacing mid-execution). See {@link ToolCallAuthRequiredState}.
-    case authRequired = "auth-required"
-    case pendingResultConfirmation = "pending-result-confirmation"
-    case completed = "completed"
-    case cancelled = "cancelled"
+    case authRequired
+    case pendingResultConfirmation
+    case completed
+    case cancelled
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "streaming": self = .streaming
+        case "pending-confirmation": self = .pendingConfirmation
+        case "running": self = .running
+        case "auth-required": self = .authRequired
+        case "pending-result-confirmation": self = .pendingResultConfirmation
+        case "completed": self = .completed
+        case "cancelled": self = .cancelled
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .streaming: try container.encode("streaming")
+        case .pendingConfirmation: try container.encode("pending-confirmation")
+        case .running: try container.encode("running")
+        case .authRequired: try container.encode("auth-required")
+        case .pendingResultConfirmation: try container.encode("pending-result-confirmation")
+        case .completed: try container.encode("completed")
+        case .cancelled: try container.encode("cancelled")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// How a tool call was confirmed for execution.
@@ -231,21 +474,84 @@ public enum ToolCallStatus: String, Codable, Sendable {
 /// - `NotNeeded` — No confirmation required (auto-approved)
 /// - `UserAction` — User explicitly approved
 /// - `Setting` — Approved by a persistent user setting
-public enum ToolCallConfirmationReason: String, Codable, Sendable {
-    case notNeeded = "not-needed"
-    case userAction = "user-action"
-    case setting = "setting"
+public enum ToolCallConfirmationReason: Codable, Sendable, Equatable {
+    case notNeeded
+    case userAction
+    case setting
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "not-needed": self = .notNeeded
+        case "user-action": self = .userAction
+        case "setting": self = .setting
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .notNeeded: try container.encode("not-needed")
+        case .userAction: try container.encode("user-action")
+        case .setting: try container.encode("setting")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Identifies a model judge as the source of a confirmation requirement.
-public enum ToolCallRiskAssessmentKind: String, Codable, Sendable {
-    case judge = "judge"
+public enum ToolCallRiskAssessmentKind: Codable, Sendable, Equatable {
+    case judge
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "judge": self = .judge
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .judge: try container.encode("judge")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Lifecycle status of an asynchronous model-judge confirmation decision.
-public enum ToolCallRiskAssessmentStatus: String, Codable, Sendable {
-    case loading = "loading"
-    case complete = "complete"
+public enum ToolCallRiskAssessmentStatus: Codable, Sendable, Equatable {
+    case loading
+    case complete
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "loading": self = .loading
+        case "complete": self = .complete
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .loading: try container.encode("loading")
+        case .complete: try container.encode("complete")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Why a tool call was cancelled.
@@ -256,24 +562,96 @@ public enum ToolCallCancellationReason: String, Codable, Sendable {
 }
 
 /// Whether a confirmation option represents an approval or denial action.
-public enum ConfirmationOptionKind: String, Codable, Sendable {
-    case approve = "approve"
-    case deny = "deny"
+public enum ConfirmationOptionKind: Codable, Sendable, Equatable {
+    case approve
+    case deny
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "approve": self = .approve
+        case "deny": self = .deny
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .approve: try container.encode("approve")
+        case .deny: try container.encode("deny")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
-public enum ToolCallContributorKind: String, Codable, Sendable {
-    case client = "client"
-    case mCP = "mcp"
+/// Identifies the source of a tool call's implementation.
+public enum ToolCallContributorKind: Codable, Sendable, Equatable {
+    case client
+    case mCP
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "client": self = .client
+        case "mcp": self = .mCP
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .client: try container.encode("client")
+        case .mCP: try container.encode("mcp")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant for tool result content types.
-public enum ToolResultContentType: String, Codable, Sendable {
-    case text = "text"
-    case embeddedResource = "embeddedResource"
-    case resource = "resource"
-    case fileEdit = "fileEdit"
-    case terminal = "terminal"
-    case subagent = "subagent"
+public enum ToolResultContentType: Codable, Sendable, Equatable {
+    case text
+    case embeddedResource
+    case resource
+    case fileEdit
+    case terminal
+    case subagent
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "text": self = .text
+        case "embeddedResource": self = .embeddedResource
+        case "resource": self = .resource
+        case "fileEdit": self = .fileEdit
+        case "terminal": self = .terminal
+        case "subagent": self = .subagent
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text: try container.encode("text")
+        case .embeddedResource: try container.encode("embeddedResource")
+        case .resource: try container.encode("resource")
+        case .fileEdit: try container.encode("fileEdit")
+        case .terminal: try container.encode("terminal")
+        case .subagent: try container.encode("subagent")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant for the kind of customization.
@@ -285,22 +663,78 @@ public enum ToolResultContentType: String, Codable, Sendable {
 /// {@link CustomizationType.McpServer | `McpServer`} entries surfaced
 /// directly by the host. The remaining types appear only as children of
 /// a container.
-public enum CustomizationType: String, Codable, Sendable {
-    case plugin = "plugin"
-    case directory = "directory"
-    case agent = "agent"
-    case skill = "skill"
-    case prompt = "prompt"
-    case rule = "rule"
-    case hook = "hook"
-    case mcpServer = "mcpServer"
+public enum CustomizationType: Codable, Sendable, Equatable {
+    case plugin
+    case directory
+    case agent
+    case skill
+    case prompt
+    case rule
+    case hook
+    case mcpServer
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "plugin": self = .plugin
+        case "directory": self = .directory
+        case "agent": self = .agent
+        case "skill": self = .skill
+        case "prompt": self = .prompt
+        case "rule": self = .rule
+        case "hook": self = .hook
+        case "mcpServer": self = .mcpServer
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .plugin: try container.encode("plugin")
+        case .directory: try container.encode("directory")
+        case .agent: try container.encode("agent")
+        case .skill: try container.encode("skill")
+        case .prompt: try container.encode("prompt")
+        case .rule: try container.encode("rule")
+        case .hook: try container.encode("hook")
+        case .mcpServer: try container.encode("mcpServer")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Scope at which customization enablement is decided.
-public enum CustomizationEnablementKind: String, Codable, Sendable {
-    case global = "global"
-    case workspace = "workspace"
-    case session = "session"
+public enum CustomizationEnablementKind: Codable, Sendable, Equatable {
+    case global
+    case workspace
+    case session
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "global": self = .global
+        case "workspace": self = .workspace
+        case "session": self = .session
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .global: try container.encode("global")
+        case .workspace: try container.encode("workspace")
+        case .session: try container.encode("session")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant values for {@link CustomizationLoadState}.
@@ -324,31 +758,58 @@ public enum TerminalLifecycleStatus: String, Codable, Sendable {
 }
 
 /// Discriminant for the {@link McpServerState} union.
-public enum McpServerStatus: String, Codable, Sendable {
+public enum McpServerStatus: Codable, Sendable, Equatable {
     /// Server has been registered but is not yet running.
-    case starting = "starting"
+    case starting
     /// Server is running and serving requests.
-    case ready = "ready"
+    case ready
     /// Server is reachable but requires additional authentication before it
     /// can start, or before it can serve a particular request. Carries the
     /// RFC 9728 Protected Resource Metadata the client needs to obtain a
     /// token; the client then pushes the token via the existing
     /// `authenticate` command.
-    case authRequired = "authRequired"
+    case authRequired
     /// Server failed to start, crashed, or otherwise transitioned to a fatal error.
-    case error = "error"
+    case error
     /// Server has been shut down.
-    case stopped = "stopped"
+    case stopped
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "starting": self = .starting
+        case "ready": self = .ready
+        case "authRequired": self = .authRequired
+        case "error": self = .error
+        case "stopped": self = .stopped
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .starting: try container.encode("starting")
+        case .ready: try container.encode("ready")
+        case .authRequired: try container.encode("authRequired")
+        case .error: try container.encode("error")
+        case .stopped: try container.encode("stopped")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Why an MCP server is currently in the {@link McpServerStatus.AuthRequired}
 /// state. Mirrors the three failure modes defined by the
 /// [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md).
-public enum McpAuthRequiredReason: String, Codable, Sendable {
+public enum McpAuthRequiredReason: Codable, Sendable, Equatable {
     /// No token has been provided yet (HTTP 401, no prior token).
-    case required = "required"
+    case required
     /// A previously valid token expired or was revoked (HTTP 401).
-    case expired = "expired"
+    case expired
     /// Step-up auth: a token is present but its scopes are insufficient for
     /// the requested operation (HTTP 403 with
     /// `WWW-Authenticate: Bearer error="insufficient_scope"`).
@@ -365,18 +826,64 @@ public enum McpAuthRequiredReason: String, Codable, Sendable {
     /// {@link McpServerCustomization | MCP server} backing a running tool
     /// call so they can present an explicit "grant more access" affordance
     /// tied to the blocked tool call.
-    case insufficientScope = "insufficientScope"
+    case insufficientScope
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "required": self = .required
+        case "expired": self = .expired
+        case "insufficientScope": self = .insufficientScope
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .required: try container.encode("required")
+        case .expired: try container.encode("expired")
+        case .insufficientScope: try container.encode("insufficientScope")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Computation lifecycle of a {@link ChangesetState}.
-public enum ChangesetStatus: String, Codable, Sendable {
+public enum ChangesetStatus: Codable, Sendable, Equatable {
     /// The server is still computing the contents of this changeset.
-    case computing = "computing"
+    case computing
     /// The changeset has been fully computed and is up-to-date.
-    case ready = "ready"
+    case ready
     /// Computation failed. The cause is described by
     /// {@link ChangesetState.error}.
-    case error = "error"
+    case error
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "computing": self = .computing
+        case "ready": self = .ready
+        case "error": self = .error
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .computing: try container.encode("computing")
+        case .ready: try container.encode("ready")
+        case .error: try container.encode("error")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Execution lifecycle of a {@link ChangesetOperation}.
@@ -385,27 +892,75 @@ public enum ChangesetStatus: String, Codable, Sendable {
 /// its progress and outcome are reflected back into changeset state so that
 /// every subscriber observes a consistent view (e.g. a spinner on a "Create
 /// Pull Request" button, or an inline error after a failed "revert").
-public enum ChangesetOperationStatus: String, Codable, Sendable {
+public enum ChangesetOperationStatus: Codable, Sendable, Equatable {
     /// The operation is ready to be invoked. This is the default when
     /// {@link ChangesetOperation.status} is omitted.
-    case idle = "idle"
+    case idle
     /// An invocation of this operation is currently in flight.
-    case running = "running"
+    case running
     /// The most recent invocation failed. The cause is described by
     /// {@link ChangesetOperation.error}.
-    case error = "error"
+    case error
     /// The operation is currently disabled and cannot be invoked.
-    case disabled = "disabled"
+    case disabled
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "idle": self = .idle
+        case "running": self = .running
+        case "error": self = .error
+        case "disabled": self = .disabled
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .idle: try container.encode("idle")
+        case .running: try container.encode("running")
+        case .error: try container.encode("error")
+        case .disabled: try container.encode("disabled")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Where a {@link ChangesetOperation} can be invoked.
-public enum ChangesetOperationScope: String, Codable, Sendable {
+public enum ChangesetOperationScope: Codable, Sendable, Equatable {
     /// Applies to the whole changeset.
-    case changeset = "changeset"
+    case changeset
     /// Applies to a single file within the changeset.
-    case resource = "resource"
+    case resource
     /// Applies to a line range within a single file.
-    case range = "range"
+    case range
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "changeset": self = .changeset
+        case "resource": self = .resource
+        case "range": self = .range
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .changeset: try container.encode("changeset")
+        case .resource: try container.encode("resource")
+        case .range: try container.encode("range")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant for {@link ResourceChange.type}.
@@ -416,9 +971,28 @@ public enum ResourceChangeType: String, Codable, Sendable {
 }
 
 /// Discriminant describing the durable provenance of a session.
-public enum SessionOriginKind: String, Codable, Sendable {
+public enum SessionOriginKind: Codable, Sendable, Equatable {
     /// The session was created as part of an automation run.
-    case automation = "automation"
+    case automation
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "automation": self = .automation
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .automation: try container.encode("automation")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Operations the host currently permits for an automation.
@@ -427,23 +1001,67 @@ public enum SessionOriginKind: String, Codable, Sendable {
 /// change over time. Clients MUST NOT infer permission from capabilities alone:
 /// capabilities describe what the host implementation can support, while
 /// operations describe what is allowed for this particular automation now.
-public enum AutomationOperation: String, Codable, Sendable {
+public enum AutomationOperation: Codable, Sendable, Equatable {
     /// Replace editable fields using {@link AutomationUpdateRequestedAction | `automation/updateRequested`}.
-    case update = "update"
+    case update
     /// Permanently remove the automation using {@link AutomationRemovedAction | `automation/removed`}.
-    case remove = "remove"
+    case remove
     /// Start a manual run using {@link RunAutomationParams | runAutomation}.
-    case run = "run"
+    case run
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "update": self = .update
+        case "remove": self = .remove
+        case "run": self = .run
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .update: try container.encode("update")
+        case .remove: try container.encode("remove")
+        case .run: try container.encode("run")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// How a host handles schedule occurrences missed while automatic execution was
 /// unavailable.
-public enum AutomationMisfirePolicy: String, Codable, Sendable {
+public enum AutomationMisfirePolicy: Codable, Sendable, Equatable {
     /// Discard missed occurrences and wait for the next future occurrence.
-    case skip = "skip"
+    case skip
     /// Start at most one catch-up run when execution becomes available, regardless
     /// of how many occurrences were missed.
-    case runOnce = "runOnce"
+    case runOnce
+    /// Unknown raw value from a newer protocol version, preserved verbatim.
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        switch raw {
+        case "skip": self = .skip
+        case "runOnce": self = .runOnce
+        default: self = .unknown(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .skip: try container.encode("skip")
+        case .runOnce: try container.encode("runOnce")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
 }
 
 /// Discriminant for automatic trigger definitions.
@@ -1442,9 +2060,8 @@ public struct SessionToolClientExecutionRequest: Codable, Sendable {
     /// tool call's client {@link ToolCallContributor}.
     public var clientId: String
     /// The running tool call the session wants the owning client to execute. The
-    /// host only ever populates this with a {@link ToolCallRunningState} (i.e. a
-    /// {@link ToolCallState} in `running` status).
-    public var toolCall: ToolCallState
+    /// host only ever populates this with a {@link ToolCallRunningState}.
+    public var toolCall: ToolCallRunningState
 
     public init(
         id: String,
@@ -1452,7 +2069,7 @@ public struct SessionToolClientExecutionRequest: Codable, Sendable {
         kind: SessionInputRequestKind,
         turnId: String,
         clientId: String,
-        toolCall: ToolCallState
+        toolCall: ToolCallRunningState
     ) {
         self.id = id
         self.chat = chat
@@ -6298,9 +6915,6 @@ public enum ToolCallConfirmationState: Codable, Sendable {
 public enum TerminalClaim: Codable, Sendable {
     case client(TerminalClientClaim)
     case session(TerminalSessionClaim)
-    /// Unknown or future discriminant; the raw payload is preserved
-    /// and re-encoded verbatim for forward-compatibility.
-    case unknown(AnyCodable)
 
     private enum DiscriminantKey: String, CodingKey {
         case discriminant = "kind"
@@ -6315,7 +6929,7 @@ public enum TerminalClaim: Codable, Sendable {
         case "session":
             self = .session(try TerminalSessionClaim(from: decoder))
         default:
-            self = .unknown(try AnyCodable(from: decoder))
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown TerminalClaim discriminant: \(discriminant)")
         }
     }
 
@@ -6323,7 +6937,6 @@ public enum TerminalClaim: Codable, Sendable {
         switch self {
         case .client(let value): try value.encode(to: encoder)
         case .session(let value): try value.encode(to: encoder)
-        case .unknown(let value): try value.encode(to: encoder)
         }
     }
 }
@@ -6459,9 +7072,6 @@ public enum ChatInputAnswer: Codable, Sendable {
     case draft(ChatInputAnswered)
     case submitted(ChatInputAnswered)
     case skipped(ChatInputSkipped)
-    /// Unknown or future discriminant; the raw payload is preserved
-    /// and re-encoded verbatim for forward-compatibility.
-    case unknown(AnyCodable)
 
     private enum DiscriminantKey: String, CodingKey {
         case discriminant = "state"
@@ -6478,7 +7088,7 @@ public enum ChatInputAnswer: Codable, Sendable {
         case "skipped":
             self = .skipped(try ChatInputSkipped(from: decoder))
         default:
-            self = .unknown(try AnyCodable(from: decoder))
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ChatInputAnswer discriminant: \(discriminant)")
         }
     }
 
@@ -6487,7 +7097,6 @@ public enum ChatInputAnswer: Codable, Sendable {
         case .draft(let value): try value.encode(to: encoder)
         case .submitted(let value): try value.encode(to: encoder)
         case .skipped(let value): try value.encode(to: encoder)
-        case .unknown(let value): try value.encode(to: encoder)
         }
     }
 }
@@ -6628,9 +7237,6 @@ public enum CustomizationLoadState: Codable, Sendable {
     case loaded(CustomizationLoadedState)
     case degraded(CustomizationDegradedState)
     case error(CustomizationErrorState)
-    /// Unknown or future discriminant; the raw payload is preserved
-    /// and re-encoded verbatim for forward-compatibility.
-    case unknown(AnyCodable)
 
     private enum DiscriminantKey: String, CodingKey {
         case discriminant = "kind"
@@ -6649,7 +7255,7 @@ public enum CustomizationLoadState: Codable, Sendable {
         case "error":
             self = .error(try CustomizationErrorState(from: decoder))
         default:
-            self = .unknown(try AnyCodable(from: decoder))
+            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown CustomizationLoadState discriminant: \(discriminant)")
         }
     }
 
@@ -6659,7 +7265,6 @@ public enum CustomizationLoadState: Codable, Sendable {
         case .loaded(let value): try value.encode(to: encoder)
         case .degraded(let value): try value.encode(to: encoder)
         case .error(let value): try value.encode(to: encoder)
-        case .unknown(let value): try value.encode(to: encoder)
         }
     }
 }
@@ -6670,6 +7275,9 @@ public enum McpServerState: Codable, Sendable {
     case authRequired(McpServerAuthRequiredState)
     case error(McpServerErrorState)
     case stopped(McpServerStoppedState)
+    /// Unknown or future discriminant; the raw payload is preserved
+    /// and re-encoded verbatim for forward-compatibility.
+    case unknown(AnyCodable)
 
     private enum DiscriminantKey: String, CodingKey {
         case discriminant = "kind"
@@ -6690,7 +7298,7 @@ public enum McpServerState: Codable, Sendable {
         case "stopped":
             self = .stopped(try McpServerStoppedState(from: decoder))
         default:
-            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown McpServerState discriminant: \(discriminant)")
+            self = .unknown(try AnyCodable(from: decoder))
         }
     }
 
@@ -6701,6 +7309,7 @@ public enum McpServerState: Codable, Sendable {
         case .authRequired(let value): try value.encode(to: encoder)
         case .error(let value): try value.encode(to: encoder)
         case .stopped(let value): try value.encode(to: encoder)
+        case .unknown(let value): try value.encode(to: encoder)
         }
     }
 }
@@ -6708,6 +7317,9 @@ public enum McpServerState: Codable, Sendable {
 public enum ToolCallContributor: Codable, Sendable {
     case client(ToolCallClientContributor)
     case mcp(ToolCallMcpContributor)
+    /// Unknown or future discriminant; the raw payload is preserved
+    /// and re-encoded verbatim for forward-compatibility.
+    case unknown(AnyCodable)
 
     private enum DiscriminantKey: String, CodingKey {
         case discriminant = "kind"
@@ -6722,7 +7334,7 @@ public enum ToolCallContributor: Codable, Sendable {
         case "mcp":
             self = .mcp(try ToolCallMcpContributor(from: decoder))
         default:
-            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ToolCallContributor discriminant: \(discriminant)")
+            self = .unknown(try AnyCodable(from: decoder))
         }
     }
 
@@ -6730,6 +7342,7 @@ public enum ToolCallContributor: Codable, Sendable {
         switch self {
         case .client(let value): try value.encode(to: encoder)
         case .mcp(let value): try value.encode(to: encoder)
+        case .unknown(let value): try value.encode(to: encoder)
         }
     }
 }
@@ -6839,6 +7452,9 @@ public enum SessionInputRequest: Codable, Sendable {
 
 public enum SessionOrigin: Codable, Sendable {
     case automation(AutomationSessionOrigin)
+    /// Unknown or future discriminant; the raw payload is preserved
+    /// and re-encoded verbatim for forward-compatibility.
+    case unknown(AnyCodable)
 
     private enum DiscriminantKey: String, CodingKey {
         case discriminant = "kind"
@@ -6851,7 +7467,7 @@ public enum SessionOrigin: Codable, Sendable {
         case "automation":
             self = .automation(try AutomationSessionOrigin(from: decoder))
         default:
-            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown SessionOrigin discriminant: \(discriminant)")
+            self = .unknown(try AnyCodable(from: decoder))
         }
     }
 
@@ -6860,6 +7476,7 @@ public enum SessionOrigin: Codable, Sendable {
         case .automation(var value):
             value.kind = .automation
             try value.encode(to: encoder)
+        case .unknown(let value): try value.encode(to: encoder)
         }
     }
 }

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -6794,7 +6794,10 @@ public enum ResponsePart: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "markdown":
             self = .markdown(try MarkdownResponsePart(from: decoder))
@@ -6844,7 +6847,10 @@ public enum ToolCallState: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "streaming":
             self = .streaming(try ToolCallStreamingState(from: decoder))
@@ -6892,7 +6898,10 @@ public enum ToolCallConfirmationState: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "pending-confirmation":
             self = .pendingConfirmation(try ToolCallPendingConfirmationState(from: decoder))
@@ -6954,7 +6963,10 @@ public enum TerminalContentPart: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "unclassified":
             self = .unclassified(try TerminalUnclassifiedPart(from: decoder))
@@ -6991,7 +7003,10 @@ public enum ChatInputQuestion: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "text":
             self = .text(try ChatInputTextQuestion(from: decoder))
@@ -7039,7 +7054,10 @@ public enum ChatInputAnswerValue: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "text":
             self = .text(try ChatInputTextAnswerValue(from: decoder))
@@ -7117,7 +7135,10 @@ public enum MessageAttachment: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "simple":
             self = .simple(try SimpleMessageAttachment(from: decoder))
@@ -7160,7 +7181,10 @@ public enum Customization: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "plugin":
             self = .plugin(try PluginCustomization(from: decoder))
@@ -7200,7 +7224,10 @@ public enum ChildCustomization: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "agent":
             self = .agent(try AgentCustomization(from: decoder))
@@ -7285,7 +7312,10 @@ public enum McpServerState: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "starting":
             self = .starting(try McpServerStartingState(from: decoder))
@@ -7327,7 +7357,10 @@ public enum ToolCallContributor: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "client":
             self = .client(try ToolCallClientContributor(from: decoder))
@@ -7360,7 +7393,10 @@ public enum ToolCallRiskAssessment: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "loading":
             self = .loading(try ToolCallRiskAssessmentLoadingState(from: decoder))
@@ -7424,7 +7460,10 @@ public enum SessionInputRequest: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "chatInput":
             self = .chatInput(try SessionChatInputRequest(from: decoder))
@@ -7462,7 +7501,10 @@ public enum SessionOrigin: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DiscriminantKey.self)
-        let discriminant = try container.decode(String.self, forKey: .discriminant)
+        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {
+            self = .unknown(try AnyCodable(from: decoder))
+            return
+        }
         switch discriminant {
         case "automation":
             self = .automation(try AutomationSessionOrigin(from: decoder))

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/ChatSourceTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/ChatSourceTests.swift
@@ -34,21 +34,25 @@ final class ChatSourceTests: XCTestCase {
         }
     }
 
-    func testChatSourceRejectsMissingOrUnknownKind() {
+    func testChatSourcePreservesMissingOrUnknownKind() throws {
         let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        let payloads = [
+            #"{"chat":"ahp-chat:/main","turnId":"turn-12"}"#,
+            #"{"kind":"future","chat":"ahp-chat:/main","turnId":"turn-12"}"#,
+        ]
 
-        XCTAssertThrowsError(
-            try decoder.decode(
-                ChatSource.self,
-                from: Data(#"{"chat":"ahp-chat:/main","turnId":"turn-12"}"#.utf8)
+        for payload in payloads {
+            let source = try decoder.decode(ChatSource.self, from: Data(payload.utf8))
+            guard case .unknown = source else {
+                return XCTFail("Expected unknown ChatSource for \(payload)")
+            }
+            let encoded = try encoder.encode(source)
+            XCTAssertEqual(
+                try JSONSerialization.jsonObject(with: encoded) as? NSDictionary,
+                try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? NSDictionary
             )
-        )
-        XCTAssertThrowsError(
-            try decoder.decode(
-                ChatSource.self,
-                from: Data(#"{"kind":"future","chat":"ahp-chat:/main","turnId":"turn-12"}"#.utf8)
-            )
-        )
+        }
     }
 
     func testChatSourceBranchesEncodeFixedKinds() throws {

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/EnumCompatibilityTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/EnumCompatibilityTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+import AgentHostProtocol
+
+final class EnumCompatibilityTests: XCTestCase {
+    func testNonexhaustiveEnumAndUnionRoundTripUnknownValues() throws {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+
+        let kind = try decoder.decode(ResponsePartKind.self, from: Data(#""futurePart""#.utf8))
+        guard case .unknown(let rawKind) = kind else {
+            return XCTFail("Expected unknown response-part kind")
+        }
+        XCTAssertEqual(rawKind, "futurePart")
+        XCTAssertEqual(String(data: try encoder.encode(kind), encoding: .utf8), #""futurePart""#)
+
+        let rawPart = #"{"kind":"futurePart","payload":{"preserve":true}}"#
+        let part = try decoder.decode(ResponsePart.self, from: Data(rawPart.utf8))
+        guard case .unknown = part else {
+            return XCTFail("Expected unknown response part")
+        }
+        XCTAssertEqual(String(data: try encoder.encode(part), encoding: .utf8), rawPart)
+    }
+}

--- a/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/EnumCompatibilityTests.swift
+++ b/clients/swift/AgentHostProtocol/Tests/AgentHostProtocolTests/EnumCompatibilityTests.swift
@@ -18,6 +18,9 @@ final class EnumCompatibilityTests: XCTestCase {
         guard case .unknown = part else {
             return XCTFail("Expected unknown response part")
         }
-        XCTAssertEqual(String(data: try encoder.encode(part), encoding: .utf8), rawPart)
+        XCTAssertEqual(
+            try JSONSerialization.jsonObject(with: encoder.encode(part)) as? NSDictionary,
+            try JSONSerialization.jsonObject(with: Data(rawPart.utf8)) as? NSDictionary
+        )
     }
 }

--- a/docs/.changes/20260821-enum-compatibility.json
+++ b/docs/.changes/20260821-enum-compatibility.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "Generated clients now preserve unknown values for nonexhaustive protocol enums and their discriminated unions."
+}

--- a/docs/.changes/20260821-error-code-corrections.json
+++ b/docs/.changes/20260821-error-code-corrections.json
@@ -1,0 +1,4 @@
+{
+  "type": "removed",
+  "message": "`ContentNotFound` is no longer an exported AHP error code; `-32006` remains reserved and unassigned."
+}

--- a/docs/.changes/20260821-running-tool-call-request.json
+++ b/docs/.changes/20260821-running-tool-call-request.json
@@ -1,0 +1,4 @@
+{
+  "type": "changed",
+  "message": "`SessionToolClientExecutionRequest.toolCall` is narrowed to a running tool-call state."
+}

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -348,7 +348,7 @@ InputRequestResponsePart {
 
 `SystemNotificationResponsePart._meta` carries provider-specific metadata describing what triggered the notification. A host MAY attach a machine-readable descriptor so clients can categorize, icon, group, filter, or localize the notification without parsing `content`. Clients MAY inspect well-known keys for enhanced UI, and MUST render coherently from `content` alone when `_meta` is absent or unrecognized.
 
-Text content uses a **create-then-append** pattern: the server first emits a `chat/responsePart` action to create a new markdown (or reasoning) part with an `id`, then streams text into it via `chat/delta` (or `chat/reasoning`) actions targeting that `partId`. This pattern is extensible to future streaming content types.
+Text content uses a **create-then-append** pattern: the server first emits a `chat/responsePart` action to create a new markdown or reasoning part with an `id`. `chat/delta` targets markdown parts only, while `chat/reasoning` targets reasoning parts only. This pattern is extensible to future streaming content types.
 
 Clients fetch `ContentRef` content separately via the `resourceRead(uri)` command. This keeps the state tree small and serializable.
 

--- a/docs/specification/lifecycle.md
+++ b/docs/specification/lifecycle.md
@@ -31,7 +31,7 @@ The client initiates the connection with an `initialize` **request**. The client
 }
 ```
 
-`protocolVersions` is ordered from most preferred to least preferred. The server picks one entry and returns it as `InitializeResult.protocolVersion`. If the server cannot speak any of the offered versions it MUST return [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) instead of a result. See [Versioning](/specification/versioning) for the negotiation rules.
+`protocolVersions` is ordered from most preferred to least preferred. The server picks one entry and returns it as `InitializeResult.protocolVersion`. If the server cannot speak any of the offered versions it MUST return [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) with required `data.supportedVersions` instead of a result. See [Versioning](/specification/versioning) for the negotiation rules.
 
 `initialSubscriptions` allows the client to subscribe to channels in the same round-trip as the handshake — typically `ahp-root://` plus any previously-open session URIs.
 

--- a/docs/specification/versioning.md
+++ b/docs/specification/versioning.md
@@ -12,7 +12,7 @@ Version selection happens once, during the [`initialize`](/specification/lifecyc
 
 1. The client sends `InitializeParams.protocolVersions`: an array of every protocol version it is willing to speak, ordered from most preferred to least preferred.
 2. The server picks one entry it can speak and returns it as `InitializeResult.protocolVersion`. Servers SHOULD honor the client's preference order when multiple offered versions are acceptable.
-3. If the server cannot speak any of the offered versions, it MUST respond with [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) instead of a result, and close the connection.
+3. If the server cannot speak any of the offered versions, it MUST respond with [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) and required `data.supportedVersions` instead of a result, and close the connection.
 
 Both peers MUST use the selected version for the rest of the connection. There is no per-message renegotiation.
 
@@ -41,7 +41,7 @@ As a result:
 
 - **Clients SHOULD offer a wide range of protocol versions** when feasible so that older hosts can still pick a version they understand. Clients then degrade features gracefully when the negotiated version lacks a capability they would otherwise use.
 - **Hosts SHOULD pick the highest offered version they implement.** Lower entries in the client's array are fallbacks for older hosts.
-- **Hosts MUST refuse incompatible clients** by returning [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) when no offered version is acceptable.
+- **Hosts MUST refuse incompatible clients** by returning [`UnsupportedProtocolVersion`](/reference/error-codes) (`-32005`) with required `data.supportedVersions` when no offered version is acceptable.
 
 ## Forward Compatibility
 
@@ -58,7 +58,7 @@ When a newer client connects to an older host:
 When an older client connects to a newer host:
 
 1. The client offers only the versions it knows.
-2. The host picks one of those (typically the newest the client offered) or returns `UnsupportedProtocolVersion` if it can no longer speak any of them.
+2. The host picks one of those (typically the newest the client offered) or returns `UnsupportedProtocolVersion` with required `data.supportedVersions` if it can no longer speak any of them.
 3. On a successful negotiation the host MUST NOT use newer-version-only behaviors on that connection unless gated behind a capability the client has acknowledged.
 
 ## Release Model

--- a/schema/actions.schema.json
+++ b/schema/actions.schema.json
@@ -734,7 +734,7 @@
     },
     "ChatDeltaAction": {
       "type": "object",
-      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
+      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\nmarkdown part, then use this action to append text to it.",
       "properties": {
         "type": {
           "const": "chat/delta"
@@ -3364,8 +3364,8 @@
           "description": "The `clientId` expected to execute the tool. Matches the `clientId` of the\ntool call's client {@link ToolCallContributor}."
         },
         "toolCall": {
-          "$ref": "#/$defs/ToolCallState",
-          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState} (i.e. a\n{@link ToolCallState} in `running` status)."
+          "$ref": "#/$defs/ToolCallRunningState",
+          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState}."
         }
       },
       "required": [

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -88,7 +88,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Protocol versions the client is willing to speak, ordered from most\npreferred to least preferred. Each entry is a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`).\n\nThe server selects one entry and returns it as `InitializeResult.protocolVersion`.\nIf the server cannot speak any of the offered versions, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`)."
+          "description": "Protocol versions the client is willing to speak, ordered from most\npreferred to least preferred. Each entry is a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`).\n\nThe server selects one entry and returns it as `InitializeResult.protocolVersion`.\nIf the server cannot speak any of the offered versions, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`) with required\n`UnsupportedProtocolVersionErrorData` containing `supportedVersions`."
         },
         "clientId": {
           "type": "string",
@@ -133,7 +133,7 @@
     },
     "InitializeResult": {
       "type": "object",
-      "description": "Result of the `initialize` command.\n\n`protocolVersion` is the version the server has selected from the client's\n`protocolVersions` list. The client and server MUST use this version for\nthe rest of the connection. If the server cannot speak any of the offered\nversions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)\ninstead of a result.",
+      "description": "Result of the `initialize` command.\n\n`protocolVersion` is the version the server has selected from the client's\n`protocolVersions` list. The client and server MUST use this version for\nthe rest of the connection. If the server cannot speak any of the offered\nversions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)\nwith required `UnsupportedProtocolVersionErrorData` containing\n`supportedVersions`, instead of a result.",
       "properties": {
         "protocolVersion": {
           "type": "string",
@@ -2618,8 +2618,8 @@
           "description": "The `clientId` expected to execute the tool. Matches the `clientId` of the\ntool call's client {@link ToolCallContributor}."
         },
         "toolCall": {
-          "$ref": "#/$defs/ToolCallState",
-          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState} (i.e. a\n{@link ToolCallState} in `running` status)."
+          "$ref": "#/$defs/ToolCallRunningState",
+          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState}."
         }
       },
       "required": [
@@ -7929,7 +7929,7 @@
     },
     "ChatDeltaAction": {
       "type": "object",
-      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
+      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\nmarkdown part, then use this action to append text to it.",
       "properties": {
         "type": {
           "const": "chat/delta"
@@ -10028,32 +10028,6 @@
       ],
       "description": "The two tool-call states that block on a client confirmation: parameter\nconfirmation before execution ({@link ToolCallPendingConfirmationState}) and\nresult confirmation after execution\n({@link ToolCallPendingResultConfirmationState}).\n\n{@link ToolCallAuthRequiredState} is intentionally **not** part of this\nunion: it doesn't block on a `chat/toolCallConfirmed`-style client\ndecision, it blocks on the client completing an OAuth flow and calling\n`authenticate`. See {@link SessionToolAuthenticationRequest} for its\nsession-level surfacing.\n\nSurfaced at the session level by {@link SessionToolConfirmationRequest}."
     },
-    "ToolCallState": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/ToolCallStreamingState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallPendingConfirmationState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallRunningState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallAuthRequiredState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallCompletedState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallCancelledState"
-        }
-      ],
-      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
-    },
     "CustomizationLoadState": {
       "oneOf": [
         {
@@ -10376,6 +10350,32 @@
       ],
       "type": "string",
       "description": "Discriminant for {@link MessageOrigin} — identifies who produced a message."
+    },
+    "ToolCallState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallStreamingState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallRunningState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallAuthRequiredState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCompletedState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCancelledState"
+        }
+      ],
+      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
     },
     "ChatInputResponseKind": {
       "enum": [

--- a/schema/errors.schema.json
+++ b/schema/errors.schema.json
@@ -25,11 +25,11 @@
         -32003,
         -32004,
         -32005,
-        -32006,
         -32007,
         -32008,
         -32009,
-        -32010
+        -32010,
+        -32011
       ]
     },
     "AuthRequiredErrorData": {
@@ -60,7 +60,7 @@
     },
     "UnsupportedProtocolVersionErrorData": {
       "type": "object",
-      "description": "Details carried in the `data` field of an `UnsupportedProtocolVersion`\n(-32005) error.",
+      "description": "Details carried in the `data` field of an `UnsupportedProtocolVersion`\n(-32005) error.\n\nThe data payload is required and always carries `supportedVersions`.",
       "properties": {
         "supportedVersions": {
           "type": "array",
@@ -1057,8 +1057,8 @@
           "description": "The `clientId` expected to execute the tool. Matches the `clientId` of the\ntool call's client {@link ToolCallContributor}."
         },
         "toolCall": {
-          "$ref": "#/$defs/ToolCallState",
-          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState} (i.e. a\n{@link ToolCallState} in `running` status)."
+          "$ref": "#/$defs/ToolCallRunningState",
+          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState}."
         }
       },
       "required": [
@@ -5722,7 +5722,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Protocol versions the client is willing to speak, ordered from most\npreferred to least preferred. Each entry is a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`).\n\nThe server selects one entry and returns it as `InitializeResult.protocolVersion`.\nIf the server cannot speak any of the offered versions, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`)."
+          "description": "Protocol versions the client is willing to speak, ordered from most\npreferred to least preferred. Each entry is a [SemVer](https://semver.org)\n`MAJOR.MINOR.PATCH` string (e.g. `\"0.1.0\"`).\n\nThe server selects one entry and returns it as `InitializeResult.protocolVersion`.\nIf the server cannot speak any of the offered versions, it MUST return\nerror code `-32005` (`UnsupportedProtocolVersion`) with required\n`UnsupportedProtocolVersionErrorData` containing `supportedVersions`."
         },
         "clientId": {
           "type": "string",
@@ -5767,7 +5767,7 @@
     },
     "InitializeResult": {
       "type": "object",
-      "description": "Result of the `initialize` command.\n\n`protocolVersion` is the version the server has selected from the client's\n`protocolVersions` list. The client and server MUST use this version for\nthe rest of the connection. If the server cannot speak any of the offered\nversions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)\ninstead of a result.",
+      "description": "Result of the `initialize` command.\n\n`protocolVersion` is the version the server has selected from the client's\n`protocolVersions` list. The client and server MUST use this version for\nthe rest of the connection. If the server cannot speak any of the offered\nversions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)\nwith required `UnsupportedProtocolVersionErrorData` containing\n`supportedVersions`, instead of a result.",
       "properties": {
         "protocolVersion": {
           "type": "string",
@@ -7386,32 +7386,6 @@
       ],
       "description": "The two tool-call states that block on a client confirmation: parameter\nconfirmation before execution ({@link ToolCallPendingConfirmationState}) and\nresult confirmation after execution\n({@link ToolCallPendingResultConfirmationState}).\n\n{@link ToolCallAuthRequiredState} is intentionally **not** part of this\nunion: it doesn't block on a `chat/toolCallConfirmed`-style client\ndecision, it blocks on the client completing an OAuth flow and calling\n`authenticate`. See {@link SessionToolAuthenticationRequest} for its\nsession-level surfacing.\n\nSurfaced at the session level by {@link SessionToolConfirmationRequest}."
     },
-    "ToolCallState": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/ToolCallStreamingState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallPendingConfirmationState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallRunningState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallAuthRequiredState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallCompletedState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallCancelledState"
-        }
-      ],
-      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
-    },
     "CustomizationLoadState": {
       "oneOf": [
         {
@@ -7754,6 +7728,32 @@
         }
       ],
       "description": "An attachment associated with a {@link Message}."
+    },
+    "ToolCallState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallStreamingState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallRunningState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallAuthRequiredState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCompletedState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCancelledState"
+        }
+      ],
+      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
     },
     "ChatInputResponseKind": {
       "enum": [
@@ -9092,7 +9092,7 @@
     },
     "ChatDeltaAction": {
       "type": "object",
-      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\npart (markdown or reasoning), then use this action to append text to it.",
+      "description": "Streaming text chunk from the assistant, appended to a specific response part.\n\nThe server MUST first emit a `chat/responsePart` to create the target\nmarkdown part, then use this action to append text to it.",
       "properties": {
         "type": {
           "const": "chat/delta"

--- a/schema/notifications.schema.json
+++ b/schema/notifications.schema.json
@@ -1224,8 +1224,8 @@
           "description": "The `clientId` expected to execute the tool. Matches the `clientId` of the\ntool call's client {@link ToolCallContributor}."
         },
         "toolCall": {
-          "$ref": "#/$defs/ToolCallState",
-          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState} (i.e. a\n{@link ToolCallState} in `running` status)."
+          "$ref": "#/$defs/ToolCallRunningState",
+          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState}."
         }
       },
       "required": [
@@ -5911,32 +5911,6 @@
       ],
       "description": "The two tool-call states that block on a client confirmation: parameter\nconfirmation before execution ({@link ToolCallPendingConfirmationState}) and\nresult confirmation after execution\n({@link ToolCallPendingResultConfirmationState}).\n\n{@link ToolCallAuthRequiredState} is intentionally **not** part of this\nunion: it doesn't block on a `chat/toolCallConfirmed`-style client\ndecision, it blocks on the client completing an OAuth flow and calling\n`authenticate`. See {@link SessionToolAuthenticationRequest} for its\nsession-level surfacing.\n\nSurfaced at the session level by {@link SessionToolConfirmationRequest}."
     },
-    "ToolCallState": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/ToolCallStreamingState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallPendingConfirmationState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallRunningState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallAuthRequiredState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallCompletedState"
-        },
-        {
-          "$ref": "#/$defs/ToolCallCancelledState"
-        }
-      ],
-      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
-    },
     "CustomizationLoadState": {
       "oneOf": [
         {
@@ -6279,6 +6253,32 @@
         }
       ],
       "description": "An attachment associated with a {@link Message}."
+    },
+    "ToolCallState": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ToolCallStreamingState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallRunningState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallAuthRequiredState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallPendingResultConfirmationState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCompletedState"
+        },
+        {
+          "$ref": "#/$defs/ToolCallCancelledState"
+        }
+      ],
+      "description": "Discriminated union of all tool call lifecycle states.\n\nSee the [state model guide](/guide/state-model.html#tool-call-lifecycle)\nfor the full state machine diagram."
     },
     "ChatInputResponseKind": {
       "enum": [

--- a/schema/state.schema.json
+++ b/schema/state.schema.json
@@ -968,8 +968,8 @@
           "description": "The `clientId` expected to execute the tool. Matches the `clientId` of the\ntool call's client {@link ToolCallContributor}."
         },
         "toolCall": {
-          "$ref": "#/$defs/ToolCallState",
-          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState} (i.e. a\n{@link ToolCallState} in `running` status)."
+          "$ref": "#/$defs/ToolCallRunningState",
+          "description": "The running tool call the session wants the owning client to execute. The\nhost only ever populates this with a {@link ToolCallRunningState}."
         }
       },
       "required": [

--- a/scripts/enum-compatibility.test.ts
+++ b/scripts/enum-compatibility.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Project } from 'ts-morph';
+import {
+  discriminatedUnionAllowsUnknown,
+  getEnumCompatibility,
+  validateEnumCompatibility,
+} from './enum-compatibility.js';
+
+function projectFor(source: string): Project {
+  const project = new Project({ useInMemoryFileSystem: true });
+  project.createSourceFile('/types/example.ts', source);
+  return project;
+}
+
+test('reads enum compatibility annotations', () => {
+  const project = projectFor('/** An open enum. @nonexhaustive */ export enum Open { Value = "value" }');
+  const enumDecl = project.getSourceFileOrThrow('/types/example.ts').getEnumOrThrow('Open');
+
+  assert.equal(getEnumCompatibility(enumDecl), 'nonexhaustive');
+});
+
+test('rejects unannotated and ambiguously annotated enums', () => {
+  assert.throws(
+    () => validateEnumCompatibility(projectFor('export enum Missing { Value = "value" }')),
+    /exactly one of @exhaustive or @nonexhaustive/,
+  );
+  assert.throws(
+    () => validateEnumCompatibility(projectFor('/** @exhaustive @nonexhaustive */ export enum Both { Value = "value" }')),
+    /exactly one of @exhaustive or @nonexhaustive/,
+  );
+});
+
+test('requires compatibility annotations in the main enum JSDoc block', () => {
+  assert.throws(
+    () => validateEnumCompatibility(projectFor(`
+      /** Describes the enum. */
+      /** @nonexhaustive */
+      export enum Detached { Value = "value" }
+    `)),
+    /substantive main enum JSDoc block/,
+  );
+  assert.throws(
+    () => validateEnumCompatibility(projectFor(`
+      /** @nonexhaustive */
+      export enum Undocumented { Value = "value" }
+    `)),
+    /substantive main enum JSDoc block/,
+  );
+  assert.doesNotThrow(() => validateEnumCompatibility(projectFor(`
+    /**
+     * Describes the enum.
+     *
+     * @nonexhaustive
+     */
+    export enum Attached { Value = "value" }
+  `)));
+});
+
+test('derives discriminated-union compatibility from its discriminator enum', () => {
+  const project = projectFor(`
+    /** A discriminator enum. @nonexhaustive */
+    export enum Kind { Known = "known" }
+    export interface Known { kind: Kind.Known }
+  `);
+
+  assert.equal(discriminatedUnionAllowsUnknown(project, 'kind', ['Known']), true);
+});

--- a/scripts/enum-compatibility.ts
+++ b/scripts/enum-compatibility.ts
@@ -1,0 +1,134 @@
+import { EnumDeclaration, Project } from 'ts-morph';
+
+export type EnumCompatibility = 'exhaustive' | 'nonexhaustive';
+
+const COMPATIBILITY_TAGS = new Set<EnumCompatibility>(['exhaustive', 'nonexhaustive']);
+
+/**
+ * Gets the compatibility contract declared on a protocol enum.
+ *
+ * A closed enum rejects unknown wire values. An open enum must preserve an
+ * unknown raw value so an older client can relay newer protocol data without
+ * corruption.
+ */
+export function getEnumCompatibility(enumDecl: EnumDeclaration): EnumCompatibility {
+  const jsDocs = enumDecl.getJsDocs();
+  const tags = jsDocs
+    .flatMap(doc => doc.getTags())
+    .map(tag => tag.getTagName())
+    .filter((tag): tag is EnumCompatibility => COMPATIBILITY_TAGS.has(tag as EnumCompatibility));
+
+  if (tags.length !== 1) {
+    const location = enumDecl.getSourceFile().getFilePath();
+    throw new Error(
+      `${location}: enum ${enumDecl.getName()} must declare exactly one of ` +
+      '@exhaustive or @nonexhaustive.',
+    );
+  }
+
+  const mainDoc = jsDocs[0];
+  if (
+    !mainDoc ||
+    !mainDoc.getDescription().trim() ||
+    !mainDoc.getTags().some(tag => tag.getTagName() === tags[0])
+  ) {
+    const location = enumDecl.getSourceFile().getFilePath();
+    throw new Error(
+      `${location}: enum ${enumDecl.getName()} must have a substantive main enum ` +
+      'JSDoc block containing its compatibility annotation.',
+    );
+  }
+
+  return tags[0];
+}
+
+export function isNonexhaustiveEnum(enumDecl: EnumDeclaration): boolean {
+  return getEnumCompatibility(enumDecl) === 'nonexhaustive';
+}
+
+/** Validates every enum declaration participating in the protocol project. */
+export function validateEnumCompatibility(project: Project): void {
+  for (const sourceFile of project.getSourceFiles()) {
+    for (const enumDecl of sourceFile.getEnums()) {
+      getEnumCompatibility(enumDecl);
+    }
+  }
+}
+
+function propertyInHierarchy(
+  project: Project,
+  interfaceName: string,
+  propertyName: string,
+) {
+  for (const sourceFile of project.getSourceFiles()) {
+    const interfaceDecl = sourceFile.getInterface(interfaceName);
+    if (!interfaceDecl) continue;
+
+    const direct = interfaceDecl.getProperty(propertyName);
+    if (direct) return direct;
+
+    for (const base of interfaceDecl.getExtends()) {
+      const inherited = propertyInHierarchy(project, base.getExpression().getText(), propertyName);
+      if (inherited) return inherited;
+    }
+  }
+  return undefined;
+}
+
+function enumByName(project: Project, name: string): EnumDeclaration | undefined {
+  for (const sourceFile of project.getSourceFiles()) {
+    const enumDecl = sourceFile.getEnum(name);
+    if (enumDecl) return enumDecl;
+  }
+  return undefined;
+}
+
+/**
+ * Determines whether a discriminated union must preserve an unknown payload
+ * from the compatibility annotation of its discriminator enum. Configurations
+ * list only their wire variants; this avoids separately maintained open-union
+ * lists drifting from the protocol declaration.
+ */
+export function discriminatedUnionAllowsUnknown(
+  project: Project,
+  discriminatorField: string,
+  variantInterfaceNames: readonly string[],
+  fallback = false,
+  discriminatorEnumName?: string,
+): boolean {
+  if (discriminatorEnumName) {
+    const enumDecl = enumByName(project, discriminatorEnumName);
+    if (!enumDecl) throw new Error(`Cannot find discriminator enum ${discriminatorEnumName}.`);
+    return isNonexhaustiveEnum(enumDecl);
+  }
+
+  const enumNames = new Set<string>();
+  for (const interfaceName of variantInterfaceNames) {
+    const property = propertyInHierarchy(project, interfaceName, discriminatorField);
+    if (!property) {
+      throw new Error(
+        `Cannot find ${discriminatorField} discriminator on ${interfaceName} while determining union compatibility.`,
+      );
+    }
+
+    for (const [, enumName] of property.getTypeNodeOrThrow().getText().matchAll(/\b(\w+)\.\w+/g)) {
+      enumNames.add(enumName);
+    }
+  }
+
+  if (enumNames.size === 0) {
+    return fallback;
+  }
+  if (enumNames.size !== 1) {
+    throw new Error(
+      `Expected one discriminator enum for ${variantInterfaceNames.join(', ')}; found ${[...enumNames].join(', ') || 'none'}.`,
+    );
+  }
+
+  const enumName = [...enumNames][0];
+  const enumDecl = enumByName(project, enumName);
+  if (!enumDecl) {
+    throw new Error(`Cannot find discriminator enum ${enumName}.`);
+  }
+  return isNonexhaustiveEnum(enumDecl);
+}

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -41,6 +41,7 @@ import fs from 'fs';
 import path from 'path';
 import { findProtocolSourceFiles } from './find-protocol-sources.js';
 import { readProtocolVersions } from './read-protocol-versions.js';
+import { discriminatedUnionAllowsUnknown } from './enum-compatibility.js';
 
 const GENERATED_BANNER =
   '// Generated from types/*.ts — do not edit.\n' +
@@ -590,6 +591,8 @@ interface UnionConfig {
   variants: UnionVariant[];
   /** Emit an `XUnknown` variant for forward-compat. */
   unknown?: boolean;
+  /** Discriminator enum when a generated wrapper lacks the field itself. */
+  discriminatorEnum?: string;
   /**
    * For action-like unions where the inner-struct's own discriminator
    * type would not match the wrapper's wireValue (e.g. unique inner
@@ -599,7 +602,14 @@ interface UnionConfig {
   injectDiscriminantOnMarshal?: boolean;
 }
 
-function generateDiscriminatedUnion(cfg: UnionConfig): string {
+function generateDiscriminatedUnion(project: Project, cfg: UnionConfig): string {
+  const unknown = discriminatedUnionAllowsUnknown(
+    project,
+    cfg.discriminantField,
+    cfg.variants.map(variant => variant.innerType),
+    cfg.unknown,
+    cfg.discriminatorEnum,
+  );
   const lines: string[] = [];
   emitDocComment('', cfg.doc, lines);
   lines.push(`type ${cfg.name} struct {`);
@@ -617,7 +627,7 @@ function generateDiscriminatedUnion(cfg: UnionConfig): string {
     seenInner.add(v.innerType);
     lines.push(`func (*${v.innerType}) is${cfg.name}() {}`);
   }
-  if (cfg.unknown) {
+  if (unknown) {
     lines.push('');
     emitDocComment('', `${cfg.name}Unknown carries an unrecognized ${cfg.name} variant — typically a discriminator value introduced by a newer protocol version. The original JSON object is preserved verbatim so that re-encoding round-trips faithfully.`, lines);
     lines.push(`type ${cfg.name}Unknown struct {`);
@@ -632,12 +642,12 @@ function generateDiscriminatedUnion(cfg: UnionConfig): string {
   lines.push(`// UnmarshalJSON decodes the variant indicated by the ${JSON.stringify(cfg.discriminantField)} discriminator.`);
   lines.push(`func (u *${cfg.name}) UnmarshalJSON(data []byte) error {`);
   lines.push(
-    `\tdisc, ${cfg.unknown ? '_' : 'ok'}, err := readDiscriminator(data, ${JSON.stringify(cfg.discriminantField)})`,
+    `\tdisc, ${unknown ? '_' : 'ok'}, err := readDiscriminator(data, ${JSON.stringify(cfg.discriminantField)})`,
   );
   lines.push('\tif err != nil {');
   lines.push('\t\treturn err');
   lines.push('\t}');
-  if (!cfg.unknown) {
+  if (!unknown) {
     lines.push('\tif !ok {');
     lines.push(
       `\t\treturn missingDiscriminatorError(${JSON.stringify(cfg.name)}, ${JSON.stringify(cfg.discriminantField)})`,
@@ -654,7 +664,7 @@ function generateDiscriminatedUnion(cfg: UnionConfig): string {
     lines.push('\t\tu.Value = &value');
   }
   lines.push('\tdefault:');
-  if (cfg.unknown) {
+  if (unknown) {
     lines.push('\t\traw := make(json.RawMessage, len(data))');
     lines.push('\t\tcopy(raw, data)');
     lines.push(`\t\tu.Value = &${cfg.name}Unknown{Raw: raw}`);
@@ -671,7 +681,7 @@ function generateDiscriminatedUnion(cfg: UnionConfig): string {
   // MarshalJSON
   lines.push(`// MarshalJSON encodes the active variant back to JSON.`);
   lines.push(`func (u ${cfg.name}) MarshalJSON() ([]byte, error) {`);
-  if (cfg.unknown) {
+  if (unknown) {
     lines.push(`\tif unk, ok := u.Value.(*${cfg.name}Unknown); ok {`);
     lines.push('\t\tif len(unk.Raw) == 0 {');
     lines.push('\t\t\treturn []byte("null"), nil');
@@ -1443,49 +1453,49 @@ function generateStateFile(project: Project): string {
   lines.push('');
 
   lines.push('// ─── Discriminated Unions ─────────────────────────────────────────────\n');
-  lines.push(generateDiscriminatedUnion(RESPONSE_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, RESPONSE_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONFIRMATION_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONFIRMATION_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CLAIM_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CLAIM_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CONTENT_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CONTENT_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHAT_INPUT_QUESTION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_QUESTION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHAT_INPUT_ANSWER_VALUE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_ANSWER_VALUE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHAT_INPUT_ANSWER_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_ANSWER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_RESULT_CONTENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_RESULT_CONTENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MESSAGE_ATTACHMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, MESSAGE_ATTACHMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHILD_CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHILD_CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_LOAD_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_LOAD_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MCP_SERVER_STATUS_UNION));
+  lines.push(generateDiscriminatedUnion(project, MCP_SERVER_STATUS_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONTRIBUTOR_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONTRIBUTOR_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_RISK_ASSESSMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_LIFECYCLE_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_REQUEST_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_TRIGGER_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_TRIGGER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_LIFECYCLE_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_LIFECYCLE_UNION));
   lines.push('');
   lines.push(generateChatOriginGo());
   lines.push('');
@@ -1638,7 +1648,7 @@ function generateActionTypeEnum(project: Project): string {
   return generateEnum(decl);
 }
 
-function generateActionsUnion(): string {
+function generateActionsUnion(project: Project): string {
   const cfg: UnionConfig = {
     name: 'StateAction',
     discriminantField: 'type',
@@ -1651,9 +1661,9 @@ function generateActionsUnion(): string {
           : stripIPrefix(v.tsInterface),
       wireValue: v.type,
     })),
-    unknown: true,
+    discriminatorEnum: 'ActionType',
   };
-  return generateDiscriminatedUnion(cfg);
+  return generateDiscriminatedUnion(project, cfg);
 }
 
 function generateActionsFile(project: Project): string {
@@ -1690,7 +1700,7 @@ function generateActionsFile(project: Project): string {
   }
 
   lines.push('// ─── StateAction Union ───────────────────────────────────────────────\n');
-  lines.push(generateActionsUnion());
+  lines.push(generateActionsUnion(project));
   lines.push('');
 
   return lines.join('\n');
@@ -1928,11 +1938,11 @@ function generateCommandsFile(project: Project): string {
   lines.push('');
 
   lines.push('// ─── ChatSource Union ─────────────────────────────────────────────────\n');
-  lines.push(generateDiscriminatedUnion(CHAT_SOURCE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_SOURCE_UNION));
   lines.push('');
 
   lines.push('// ─── ReconnectResult Union ────────────────────────────────────────────\n');
-  lines.push(generateDiscriminatedUnion(RECONNECT_RESULT_UNION));
+  lines.push(generateDiscriminatedUnion(project, RECONNECT_RESULT_UNION));
   lines.push('');
 
   lines.push('// ─── Changeset Operation Unions ───────────────────────────────────────\n');
@@ -2034,7 +2044,7 @@ const (
 \tErrorCodeSessionAlreadyExists        int32 = -32003
 \tErrorCodeTurnInProgress              int32 = -32004
 \tErrorCodeUnsupportedProtocolVersion  int32 = -32005
-\tErrorCodeContentNotFound             int32 = -32006
+\t// -32006 is intentionally reserved and unassigned.
 \tErrorCodeAuthRequired                int32 = -32007
 \tErrorCodeNotFound                    int32 = -32008
 \tErrorCodePermissionDenied            int32 = -32009

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -580,7 +580,7 @@ function generateErrorsSchema(project: Project): JsonSchema {
       AhpErrorCode: {
         description: 'AHP application-specific error codes.',
         type: 'number',
-        enum: [-32001, -32002, -32003, -32004, -32005, -32006, -32007, -32008, -32009, -32010],
+        enum: [-32001, -32002, -32003, -32004, -32005, -32007, -32008, -32009, -32010, -32011],
       },
     },
   };

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -35,6 +35,10 @@ import fs from 'fs';
 import path from 'path';
 import { findProtocolSourceFiles } from './find-protocol-sources.js';
 import { readProtocolVersions } from './read-protocol-versions.js';
+import {
+  discriminatedUnionAllowsUnknown,
+  getEnumCompatibility,
+} from './enum-compatibility.js';
 
 const GENERATED_HEADER =
   '// Generated from types/*.ts — do not edit\n\n' +
@@ -350,6 +354,7 @@ function generateKotlinEnum(enumDecl: EnumDeclaration): string {
   const desc = enumDecl.getJsDocs()[0]?.getDescription().trim();
   const values = enumDecl.getMembers().map(m => m.getValue());
   const isNumeric = values.every(v => typeof v === 'number');
+  const isNonexhaustive = getEnumCompatibility(enumDecl) === 'nonexhaustive';
 
   // Bitset enums (JSDoc convention "Bitset of …") → `value class` so OR'd
   // combinations with unknown bits decode/encode losslessly.
@@ -404,6 +409,38 @@ function generateKotlinEnum(enumDecl: EnumDeclaration): string {
     lines.push('    }');
     lines.push(`    override fun deserialize(decoder: Decoder): ${name} =`);
     lines.push(`        ${name}(decoder.decodeLong().toUInt())`);
+    lines.push('}');
+    return lines.join('\n');
+  }
+
+  if (isNonexhaustive) {
+    const rawType = isNumeric ? 'Long' : 'String';
+    const primitiveKind = isNumeric ? 'PrimitiveKind.LONG' : 'PrimitiveKind.STRING';
+    const encode = isNumeric ? 'encoder.encodeLong(value.rawValue)' : 'encoder.encodeString(value.rawValue)';
+    const decode = isNumeric ? 'decoder.decodeLong()' : 'decoder.decodeString()';
+    lines.push(`@Serializable(with = ${name}Serializer::class)`);
+    lines.push('@JvmInline');
+    lines.push(`value class ${name}(val rawValue: ${rawType}) {`);
+    lines.push('    companion object {');
+    for (const member of enumDecl.getMembers()) {
+      const memberName = toScreamingSnake(member.getName());
+      const memberDoc = member.getJsDocs()[0]?.getDescription().trim();
+      if (memberDoc) {
+        lines.push(...emitKDoc(memberDoc, '        '));
+      }
+      lines.push(`        val ${memberName}: ${name} = ${name}(${JSON.stringify(member.getValue())})`);
+    }
+    lines.push('    }');
+    lines.push('}');
+    lines.push('');
+    lines.push(`internal object ${name}Serializer : KSerializer<${name}> {`);
+    lines.push(`    override val descriptor: SerialDescriptor =`);
+    lines.push(`        PrimitiveSerialDescriptor("${name}", ${primitiveKind})`);
+    lines.push(`    override fun serialize(encoder: Encoder, value: ${name}) {`);
+    lines.push(`        ${encode}`);
+    lines.push('    }');
+    lines.push(`    override fun deserialize(decoder: Decoder): ${name} =`);
+    lines.push(`        ${name}(${decode})`);
     lines.push('}');
     return lines.join('\n');
   }
@@ -485,6 +522,8 @@ interface UnionConfig {
    * on the same set of state-channel unions.
    */
   unknown?: boolean;
+  /** Discriminator enum when a generated wrapper lacks the field itself. */
+  discriminatorEnum?: string;
   /** Force the sealed case's discriminator when serializing its payload. */
   injectDiscriminantOnSerialize?: boolean;
 }
@@ -500,7 +539,14 @@ interface UnionConfig {
  * `structName` for the sealed-interface declaration but preserve every entry
  * in the deserializer switch.
  */
-function generateDiscriminatedUnion(config: UnionConfig): string {
+function generateDiscriminatedUnion(project: Project, config: UnionConfig): string {
+  const unknown = discriminatedUnionAllowsUnknown(
+    project,
+    config.discriminantField,
+    config.variants.map(variant => variant.structName),
+    config.unknown,
+    config.discriminatorEnum,
+  );
   const lines: string[] = [];
 
   lines.push(`@Serializable(with = ${config.name}Serializer::class)`);
@@ -518,7 +564,7 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
     lines.push(`@JvmInline`);
     lines.push(`value class ${config.name}${v.caseName}(val value: ${v.structName}) : ${config.name}`);
   }
-  if (config.unknown) {
+  if (unknown) {
     lines.push(`/**`);
     lines.push(` * Forward-compat catch-all for unknown ${config.name} discriminators.`);
     lines.push(' *');
@@ -544,7 +590,7 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
   lines.push('        val obj = element as? JsonObject');
   lines.push(`            ?: error("Expected JsonObject for ${config.name}")`);
   lines.push(`        val discriminant = (obj[${JSON.stringify(config.discriminantField)}] as? JsonPrimitive)?.content`);
-  if (config.unknown) {
+  if (unknown) {
     lines.push(`            ?: return ${config.name}Unknown(obj)`);
   } else {
     lines.push(`            ?: error("Missing ${config.discriminantField} discriminator on ${config.name}")`);
@@ -554,7 +600,7 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
     const variantClass = `${config.name}${(byStruct.get(v.structName) ?? v).caseName}`;
     lines.push(`            ${JSON.stringify(v.discriminantValue)} -> ${variantClass}(input.json.decodeFromJsonElement(${v.structName}.serializer(), element))`);
   }
-  if (config.unknown) {
+  if (unknown) {
     lines.push(`            else -> ${config.name}Unknown(obj)`);
   } else {
     lines.push(`            else -> error("Unknown ${config.name} discriminator: $discriminant")`);
@@ -570,7 +616,7 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
     const variantClass = `${config.name}${v.caseName}`;
     lines.push(`            is ${variantClass} -> output.json.encodeToJsonElement(${v.structName}.serializer(), value.value)`);
   }
-  if (config.unknown) {
+  if (unknown) {
     lines.push(`            is ${config.name}Unknown -> value.raw`);
   }
   lines.push('        }');
@@ -580,7 +626,7 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
     for (const v of byStruct.values()) {
       lines.push(`            is ${config.name}${v.caseName} -> ${JSON.stringify(v.discriminantValue)}`);
     }
-    if (config.unknown) {
+    if (unknown) {
       lines.push(`            is ${config.name}Unknown -> null`);
     }
     lines.push('        }');
@@ -1364,47 +1410,47 @@ function generateStateFile(project: Project): string {
   lines.push('');
   lines.push(generateChatOriginKotlin());
   lines.push('');
-  lines.push(generateDiscriminatedUnion(RESPONSE_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, RESPONSE_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONFIRMATION_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONFIRMATION_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CLAIM_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CLAIM_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CONTENT_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CONTENT_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_QUESTION_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_QUESTION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_ANSWER_VALUE_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_ANSWER_VALUE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_ANSWER_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_ANSWER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MESSAGE_ATTACHMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, MESSAGE_ATTACHMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHILD_CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHILD_CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_LOAD_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_LOAD_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MCP_SERVER_STATUS_UNION));
+  lines.push(generateDiscriminatedUnion(project, MCP_SERVER_STATUS_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONTRIBUTOR_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONTRIBUTOR_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_RISK_ASSESSMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_LIFECYCLE_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_REQUEST_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_TRIGGER_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_TRIGGER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_LIFECYCLE_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_LIFECYCLE_UNION));
   lines.push('');
   lines.push(generateToolResultContentUnion());
   lines.push('');
@@ -1914,12 +1960,12 @@ function generateCommandsFile(project: Project): string {
 
   lines.push('// ─── ChatSource Union ───────────────────────────────────────────────────────');
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHAT_SOURCE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_SOURCE_UNION));
   lines.push('');
 
   lines.push('// ─── ReconnectResult Union ──────────────────────────────────────────────────');
   lines.push('');
-  lines.push(generateDiscriminatedUnion(RECONNECT_RESULT_UNION));
+  lines.push(generateDiscriminatedUnion(project, RECONNECT_RESULT_UNION));
   lines.push('');
 
   lines.push('// ─── Changeset Operation Unions ─────────────────────────────────────────────');
@@ -2032,8 +2078,7 @@ function generateErrorsFile(project: Project): string {
   lines.push('    const val TURN_IN_PROGRESS: Int = -32004');
   lines.push('    /** The server cannot speak any of the protocol versions offered by the client */');
   lines.push('    const val UNSUPPORTED_PROTOCOL_VERSION: Int = -32005');
-  lines.push('    /** The requested content URI does not exist */');
-  lines.push('    const val CONTENT_NOT_FOUND: Int = -32006');
+  lines.push('    // -32006 is intentionally reserved and unassigned.');
   lines.push('    /** Authentication required for a protected resource */');
   lines.push('    const val AUTH_REQUIRED: Int = -32007');
   lines.push('    /** The requested file, folder, or URI does not exist */');

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -22,6 +22,10 @@ import fs from 'fs';
 import path from 'path';
 import { findProtocolSourceFiles } from './find-protocol-sources.js';
 import { readProtocolVersions } from './read-protocol-versions.js';
+import {
+  discriminatedUnionAllowsUnknown,
+  getEnumCompatibility,
+} from './enum-compatibility.js';
 
 const GENERATED_BANNER = '// Generated from types/*.ts — do not edit.\n//\n// Regenerate with: npm run generate:rust\n\n#![allow(missing_docs)]\n';
 
@@ -472,6 +476,7 @@ function generateRustEnum(enumDecl: EnumDeclaration): string {
   const desc = enumDecl.getJsDocs()[0]?.getDescription().trim();
   const values = enumDecl.getMembers().map(m => m.getValue());
   const isNumeric = values.every(v => typeof v === 'number');
+  const isNonexhaustive = getEnumCompatibility(enumDecl) === 'nonexhaustive';
 
   if (desc) {
     for (const d of desc.split('\n')) {
@@ -479,7 +484,57 @@ function generateRustEnum(enumDecl: EnumDeclaration): string {
     }
   }
 
-  if (isNumeric) {
+  if (isNonexhaustive) {
+    const rawType = isNumeric ? 'i64' : 'String';
+    lines.push('#[derive(Debug, Clone, PartialEq, Eq, Hash)]');
+    lines.push(`pub enum ${name} {`);
+    for (const mem of enumDecl.getMembers()) {
+      const doc = mem.getJsDocs()[0]?.getDescription().trim();
+      if (doc) {
+        for (const d of doc.split('\n')) lines.push(`    /// ${d.trimEnd()}`);
+      }
+      lines.push(`    ${mem.getName()},`);
+    }
+    lines.push(`    /// Unknown raw value from a newer protocol version, preserved verbatim.`);
+    lines.push(`    Unknown(${rawType}),`);
+    lines.push('}');
+    lines.push('');
+    lines.push(`impl serde::Serialize for ${name} {`);
+    lines.push('    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>');
+    lines.push('    where S: serde::Serializer {');
+    lines.push('        match self {');
+    for (const mem of enumDecl.getMembers()) {
+      const value = mem.getValue();
+      const serialized = isNumeric ? `serializer.serialize_i64(${value})` : `serializer.serialize_str(${JSON.stringify(String(value))})`;
+      lines.push(`            Self::${mem.getName()} => ${serialized},`);
+    }
+    lines.push(`            Self::Unknown(value) => ${isNumeric ? 'serializer.serialize_i64(*value)' : 'serializer.serialize_str(value)'},`);
+    lines.push('        }');
+    lines.push('    }');
+    lines.push('}');
+    lines.push('');
+    lines.push(`impl<'de> serde::Deserialize<'de> for ${name} {`);
+    lines.push('    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>');
+    lines.push('    where D: serde::Deserializer<\'de> {');
+    lines.push(`        let raw = <${rawType} as serde::Deserialize>::deserialize(deserializer)?;`);
+    if (isNumeric) {
+      lines.push('        Ok(match raw {');
+      for (const mem of enumDecl.getMembers()) {
+        lines.push(`            ${mem.getValue()} => Self::${mem.getName()},`);
+      }
+      lines.push('            value => Self::Unknown(value),');
+      lines.push('        })');
+    } else {
+      lines.push('        Ok(match raw.as_str() {');
+      for (const mem of enumDecl.getMembers()) {
+        lines.push(`            ${JSON.stringify(String(mem.getValue()))} => Self::${mem.getName()},`);
+      }
+      lines.push('            _ => Self::Unknown(raw),');
+      lines.push('        })');
+    }
+    lines.push('    }');
+    lines.push('}');
+  } else if (isNumeric) {
     lines.push('#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]');
     lines.push('#[repr(u32)]');
     lines.push(`pub enum ${name} {`);
@@ -544,9 +599,14 @@ function generateRustStruct(rustName: string, props: RustProp[], opts: StructOpt
       attrs.push('default');
       attrs.push('skip_serializing_if = "Option::is_none"');
     }
+    if (rustName === 'SessionToolClientExecutionRequest' && p.rustName === 'tool_call') {
+      attrs.push('serialize_with = "serialize_running_tool_call"');
+      attrs.push('deserialize_with = "deserialize_running_tool_call"');
+    }
     if (attrs.length > 0) {
       lines.push(`    #[serde(${attrs.join(', ')})]`);
     }
+
     // Box self-referential fields to break infinite size cycles.
     let rustType = p.rustType;
     if (rustType.includes(rustName)) {
@@ -557,6 +617,34 @@ function generateRustStruct(rustName: string, props: RustProp[], opts: StructOpt
 
   lines.push('}');
   return lines.join('\n');
+}
+
+function generateRunningToolCallSerdeHelpers(): string {
+  return `fn serialize_running_tool_call<S>(
+    value: &ToolCallRunningState,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut raw = serde_json::to_value(value).map_err(serde::ser::Error::custom)?;
+    let serde_json::Value::Object(object) = &mut raw else {
+        return Err(serde::ser::Error::custom("running tool call must serialize to an object"));
+    };
+    object.insert("status".to_owned(), serde_json::Value::String("running".to_owned()));
+    serde::Serialize::serialize(&raw, serializer)
+}
+
+fn deserialize_running_tool_call<'de, D>(deserializer: D) -> Result<ToolCallRunningState, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    if raw.get("status").and_then(serde_json::Value::as_str) != Some("running") {
+        return Err(serde::de::Error::custom("expected running tool-call status"));
+    }
+    serde_json::from_value(raw).map_err(serde::de::Error::custom)
+}`;
 }
 
 // ─── Partial Struct Generation ───────────────────────────────────────────────
@@ -598,9 +686,18 @@ interface UnionConfig {
   variants: UnionVariant[];
   /** Extra variant for unknown/future values. */
   unknown?: boolean;
+  /** Discriminator enum when a generated wrapper lacks the field itself. */
+  discriminatorEnum?: string;
 }
 
-function generateDiscriminatedUnion(cfg: UnionConfig): string {
+function generateDiscriminatedUnion(project: Project, cfg: UnionConfig): string {
+  const unknown = discriminatedUnionAllowsUnknown(
+    project,
+    cfg.discriminantField,
+    cfg.variants.map(variant => variant.innerType),
+    cfg.unknown,
+    cfg.discriminatorEnum,
+  );
   const lines: string[] = [];
   if (cfg.doc) {
     for (const d of cfg.doc.split('\n')) lines.push(`/// ${d.trimEnd()}`);
@@ -622,7 +719,7 @@ function generateDiscriminatedUnion(cfg: UnionConfig): string {
     }
   }
 
-  if (cfg.unknown) {
+  if (unknown) {
     lines.push('    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.');
     lines.push('    /// Reducers treat this as a no-op.');
     lines.push('    #[serde(untagged)]');
@@ -1075,7 +1172,7 @@ const SESSION_INPUT_REQUEST_UNION: UnionConfig = {
     { variantName: 'ChatInput', innerType: 'SessionChatInputRequest', wireValue: 'chatInput' },
     { variantName: 'ToolConfirmation', innerType: 'SessionToolConfirmationRequest', wireValue: 'toolConfirmation' },
     { variantName: 'ToolClientExecution', innerType: 'SessionToolClientExecutionRequest', wireValue: 'toolClientExecution' },
-    { variantName: 'ToolAuthentication', innerType: 'SessionToolAuthenticationRequest', wireValue: 'toolAuthentication' },
+    { variantName: 'ToolAuthentication', innerType: 'SessionToolAuthenticationRequest', wireValue: 'toolAuthentication', boxed: true },
   ],
   unknown: true,
 };
@@ -1122,7 +1219,16 @@ const AUTOMATION_RUN_LIFECYCLE_UNION: UnionConfig = {
   ],
 };
 
-function generateChatOrigin(): string {
+function generateChatOrigin(project: Project): string {
+  const originKind = findEnum(project, 'ChatOriginKind');
+  if (!originKind) throw new Error('ChatOriginKind enum not found');
+  const unknownVariant = getEnumCompatibility(originKind) === 'nonexhaustive'
+    ? `    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
+    /// Reducers treat this as a no-op.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
+`
+    : '';
   return `/// How a chat came into existence.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
@@ -1160,11 +1266,7 @@ pub enum ChatOrigin {
         #[serde(rename = "toolCallId")]
         tool_call_id: String,
     },
-    /// Unknown or future variant — preserved as raw JSON for round-trip fidelity.
-    /// Reducers treat this as a no-op.
-    #[serde(untagged)]
-    Unknown(serde_json::Value),
-}`;
+${unknownVariant}}`;
 }
 
 function generateSnapshotState(): string {
@@ -1222,6 +1324,10 @@ function generateStateFile(project: Project): string {
       lines.push(generateStructFromInterface(project, entry.name, entry.rustName, {
         omitDiscriminants: entry.omitDiscriminants,
       }));
+      if (entry.name === 'SessionToolClientExecutionRequest') {
+        lines.push('');
+        lines.push(generateRunningToolCallSerdeHelpers());
+      }
       if (entry.name === 'SubscribeParams') {
         lines.push('');
         lines.push(generateSubscribeParamsImplRust());
@@ -1234,58 +1340,58 @@ function generateStateFile(project: Project): string {
   }
 
   lines.push('// ─── Customization Enablement Union ───────────────────────────────────────\n');
-  lines.push(generateCustomizationEnablementRust());
+  lines.push(generateCustomizationEnablementRust(project));
   lines.push('');
 
   lines.push(generateToolInput());
   lines.push('');
 
   lines.push('// ─── Discriminated Unions ─────────────────────────────────────────────\n');
-  lines.push(generateChatOrigin());
+  lines.push(generateChatOrigin(project));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(RESPONSE_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, RESPONSE_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONFIRMATION_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONFIRMATION_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CLAIM_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CLAIM_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CONTENT_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CONTENT_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHAT_INPUT_QUESTION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_QUESTION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHAT_INPUT_ANSWER_VALUE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_ANSWER_VALUE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHAT_INPUT_ANSWER_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_ANSWER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_RESULT_CONTENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_RESULT_CONTENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MESSAGE_ATTACHMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, MESSAGE_ATTACHMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHILD_CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHILD_CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_LOAD_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_LOAD_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MCP_SERVER_STATUS_UNION));
+  lines.push(generateDiscriminatedUnion(project, MCP_SERVER_STATUS_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONTRIBUTOR_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONTRIBUTOR_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_RISK_ASSESSMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_LIFECYCLE_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_REQUEST_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_TRIGGER_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_TRIGGER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_LIFECYCLE_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_LIFECYCLE_UNION));
   lines.push('');
   lines.push(generateSnapshotState());
   lines.push('');
@@ -1521,12 +1627,12 @@ pub struct ActionEnvelope {
     wireValue: v.type,
     boxed: v.boxed,
   }));
-  lines.push(generateDiscriminatedUnion({
+  lines.push(generateDiscriminatedUnion(project, {
     name: 'StateAction',
     discriminantField: 'type',
     doc: 'Discriminated union of every state action.',
     variants,
-    unknown: true,
+    discriminatorEnum: 'ActionType',
   }));
   lines.push('');
 
@@ -1637,21 +1743,28 @@ function generateCommandsFile(project: Project): string {
   }
 
   lines.push('// ─── ChatSource Union ─────────────────────────────────────────────────\n');
-  lines.push(generateDiscriminatedUnion(CHAT_SOURCE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_SOURCE_UNION));
   lines.push('');
 
   lines.push('// ─── ReconnectResult Union ────────────────────────────────────────────\n');
-  lines.push(generateDiscriminatedUnion(RECONNECT_RESULT_UNION));
+  lines.push(generateDiscriminatedUnion(project, RECONNECT_RESULT_UNION));
   lines.push('');
 
   lines.push('// ─── Changeset Operation Unions ───────────────────────────────────────\n');
-  lines.push(generateChangesetOperationTargetRust());
+  lines.push(generateChangesetOperationTargetRust(project));
   lines.push('');
 
   return lines.join('\n');
 }
 
-function generateCustomizationEnablementRust(): string {
+function generateCustomizationEnablementRust(project: Project): string {
+  const kind = findEnum(project, 'CustomizationEnablementKind');
+  if (!kind) throw new Error('CustomizationEnablementKind enum not found');
+  const unknownVariant = getEnumCompatibility(kind) === 'nonexhaustive'
+    ? `    #[serde(untagged)]
+    Unknown(serde_json::Value),
+`
+    : '';
   return `/// A single explicit customization enablement decision.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
@@ -1669,7 +1782,7 @@ pub enum CustomizationEnablement {
     Session {
         enabled: bool,
     },
-}`;
+${unknownVariant}}`;
 }
 
 function generateSubscribeParamsImplRust(): string {
@@ -1706,7 +1819,14 @@ function generateSubscribeParamsImplRust(): string {
 }`;
 }
 
-function generateChangesetOperationTargetRust(): string {
+function generateChangesetOperationTargetRust(project: Project): string {
+  const kind = findEnum(project, 'ChangesetOperationTargetKind');
+  if (!kind) throw new Error('ChangesetOperationTargetKind enum not found');
+  const unknownVariant = getEnumCompatibility(kind) === 'nonexhaustive'
+    ? `    #[serde(untagged)]
+    Unknown(serde_json::Value),
+`
+    : '';
   return `/// Identifies the file or range a \`ChangesetOperation\` should act on.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
@@ -1724,7 +1844,7 @@ pub enum ChangesetOperationTarget {
         side: Option<String>,
         range: TextRange,
     },
-}`;
+${unknownVariant}}`;
 }
 
 // ─── Notifications File Generator ────────────────────────────────────────────
@@ -1823,10 +1943,10 @@ pub mod ahp_error_codes {
     /// The operation requires no active turn, but one is in progress.
     pub const TURN_IN_PROGRESS: i32 = -32004;
     /// The server cannot speak any of the protocol versions offered by the
-    /// client in \`InitializeParams.protocolVersions\`.
+    /// client in \`InitializeParams.protocolVersions\`; its required data
+    /// payload advertises supported versions.
     pub const UNSUPPORTED_PROTOCOL_VERSION: i32 = -32005;
-    /// The requested content URI does not exist.
-    pub const CONTENT_NOT_FOUND: i32 = -32006;
+    // -32006 is intentionally reserved and unassigned.
     /// Authentication required for a protected resource.
     pub const AUTH_REQUIRED: i32 = -32007;
     /// The requested file, folder, or URI does not exist.

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -526,7 +526,14 @@ function generateDiscriminatedUnion(project: Project, config: UnionConfig): stri
   lines.push('');
   lines.push('    public init(from decoder: Decoder) throws {');
   lines.push('        let container = try decoder.container(keyedBy: DiscriminantKey.self)');
-  lines.push('        let discriminant = try container.decode(String.self, forKey: .discriminant)');
+  if (allowUnknown) {
+    lines.push('        guard let discriminant = try container.decodeIfPresent(String.self, forKey: .discriminant) else {');
+    lines.push('            self = .unknown(try AnyCodable(from: decoder))');
+    lines.push('            return');
+    lines.push('        }');
+  } else {
+    lines.push('        let discriminant = try container.decode(String.self, forKey: .discriminant)');
+  }
   lines.push('        switch discriminant {');
   for (const v of config.variants) {
     lines.push(`        case ${JSON.stringify(v.discriminantValue)}:`);

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -22,6 +22,10 @@ import fs from 'fs';
 import path from 'path';
 import { findProtocolSourceFiles } from './find-protocol-sources.js';
 import { readProtocolVersions } from './read-protocol-versions.js';
+import {
+  discriminatedUnionAllowsUnknown,
+  getEnumCompatibility,
+} from './enum-compatibility.js';
 
 const GENERATED_HEADER = '// Generated from types/*.ts — do not edit\n\nimport Foundation\n';
 
@@ -301,6 +305,7 @@ function generateSwiftEnum(enumDecl: EnumDeclaration): string {
   const desc = enumDecl.getJsDocs()[0]?.getDescription().trim();
   const values = enumDecl.getMembers().map(member => member.getValue());
   const rawType = values.every(value => typeof value === 'number') ? 'Int' : 'String';
+  const isNonexhaustive = getEnumCompatibility(enumDecl) === 'nonexhaustive';
 
   // Bitset enums (detected via JSDoc convention "Bitset of …") are emitted
   // as Swift `OptionSet` structs so OR'd combinations are representable and
@@ -330,6 +335,45 @@ function generateSwiftEnum(enumDecl: EnumDeclaration): string {
       }
       lines.push(`    public static let ${memberName} = ${name}(rawValue: ${value})`);
     }
+    lines.push('}');
+    return lines.join('\n');
+  }
+
+  if (isNonexhaustive) {
+    lines.push(`public enum ${name}: Codable, Sendable, Equatable {`);
+    for (const member of enumDecl.getMembers()) {
+      const memberName = swiftIdentifier(toCamelCase(member.getName()));
+      const memberDoc = member.getJsDocs()[0]?.getDescription().trim();
+      if (memberDoc) {
+        for (const docLine of memberDoc.split('\n')) {
+          lines.push(emitSwiftDocLine(docLine, '    '));
+        }
+      }
+      lines.push(`    case ${memberName}`);
+    }
+    lines.push(`    /// Unknown raw value from a newer protocol version, preserved verbatim.`);
+    lines.push(`    case unknown(${rawType})`);
+    lines.push('');
+    lines.push('    public init(from decoder: Decoder) throws {');
+    lines.push('        let container = try decoder.singleValueContainer()');
+    lines.push(`        let raw = try container.decode(${rawType}.self)`);
+    lines.push('        switch raw {');
+    for (const member of enumDecl.getMembers()) {
+      lines.push(`        case ${JSON.stringify(member.getValue())}: self = .${swiftIdentifier(toCamelCase(member.getName()))}`);
+    }
+    lines.push('        default: self = .unknown(raw)');
+    lines.push('        }');
+    lines.push('    }');
+    lines.push('');
+    lines.push('    public func encode(to encoder: Encoder) throws {');
+    lines.push('        var container = encoder.singleValueContainer()');
+    lines.push('        switch self {');
+    for (const member of enumDecl.getMembers()) {
+      lines.push(`        case .${swiftIdentifier(toCamelCase(member.getName()))}: try container.encode(${JSON.stringify(member.getValue())})`);
+    }
+    lines.push('        case .unknown(let raw): try container.encode(raw)');
+    lines.push('        }');
+    lines.push('    }');
     lines.push('}');
     return lines.join('\n');
   }
@@ -447,18 +491,27 @@ interface UnionConfig {
    * ChangesetOperationTarget, ReconnectResult).
    */
   allowUnknown?: boolean;
+  /** Discriminator enum when a generated wrapper lacks the field itself. */
+  discriminatorEnum?: string;
   /** Force the enum case's discriminator when encoding its payload. */
   injectDiscriminantOnEncode?: boolean;
 }
 
-function generateDiscriminatedUnion(config: UnionConfig): string {
+function generateDiscriminatedUnion(project: Project, config: UnionConfig): string {
+  const allowUnknown = discriminatedUnionAllowsUnknown(
+    project,
+    config.discriminantField,
+    config.variants.map(variant => variant.structName),
+    config.allowUnknown,
+    config.discriminatorEnum,
+  );
   const lines: string[] = [];
   lines.push(`public enum ${config.name}: Codable, Sendable {`);
 
   for (const v of config.variants) {
     lines.push(`    case ${v.caseName}(${v.structName})`);
   }
-  if (config.allowUnknown) {
+  if (allowUnknown) {
     lines.push('    /// Unknown or future discriminant; the raw payload is preserved');
     lines.push('    /// and re-encoded verbatim for forward-compatibility.');
     lines.push('    case unknown(AnyCodable)');
@@ -480,7 +533,7 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
     lines.push(`            self = .${v.caseName}(try ${v.structName}(from: decoder))`);
   }
   lines.push('        default:');
-  if (config.allowUnknown) {
+  if (allowUnknown) {
     lines.push('            self = .unknown(try AnyCodable(from: decoder))');
   } else {
     lines.push(`            throw DecodingError.dataCorruptedError(forKey: .discriminant, in: container, debugDescription: "Unknown ${config.name} discriminant: \\(discriminant)")`);
@@ -501,7 +554,7 @@ function generateDiscriminatedUnion(config: UnionConfig): string {
       lines.push(`        case .${v.caseName}(let value): try value.encode(to: encoder)`);
     }
   }
-  if (config.allowUnknown) {
+  if (allowUnknown) {
     lines.push('        case .unknown(let value): try value.encode(to: encoder)');
   }
   lines.push('        }');
@@ -1246,47 +1299,47 @@ function generateStateFile(project: Project): string {
   lines.push('// MARK: - Discriminated Unions\n');
   lines.push(generateChatOriginSwift());
   lines.push('');
-  lines.push(generateDiscriminatedUnion(RESPONSE_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, RESPONSE_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONFIRMATION_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONFIRMATION_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CLAIM_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CLAIM_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_CONTENT_PART_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_CONTENT_PART_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_QUESTION_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_QUESTION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_ANSWER_VALUE_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_ANSWER_VALUE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_ANSWER_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_ANSWER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MESSAGE_ATTACHMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, MESSAGE_ATTACHMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CHILD_CUSTOMIZATION_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHILD_CUSTOMIZATION_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(CUSTOMIZATION_LOAD_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_LOAD_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(MCP_SERVER_STATUS_UNION));
+  lines.push(generateDiscriminatedUnion(project, MCP_SERVER_STATUS_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_CONTRIBUTOR_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONTRIBUTOR_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TOOL_CALL_RISK_ASSESSMENT_UNION));
+  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_RISK_ASSESSMENT_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(TERMINAL_LIFECYCLE_STATE_UNION));
+  lines.push(generateDiscriminatedUnion(project, TERMINAL_LIFECYCLE_STATE_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_INPUT_REQUEST_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_REQUEST_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(SESSION_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, SESSION_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_TRIGGER_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_TRIGGER_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_ORIGIN_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_ORIGIN_UNION));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(AUTOMATION_RUN_LIFECYCLE_UNION));
+  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_LIFECYCLE_UNION));
   lines.push('');
   lines.push(generateToolResultContentUnion());
   lines.push('');
@@ -1660,11 +1713,11 @@ function generateCommandsFile(project: Project): string {
   }
 
   lines.push('// MARK: - Command Unions\n');
-  lines.push(generateDiscriminatedUnion(CHAT_SOURCE_UNION));
+  lines.push(generateDiscriminatedUnion(project, CHAT_SOURCE_UNION));
   lines.push('');
 
   lines.push('// MARK: - ReconnectResult Union\n');
-  lines.push(generateDiscriminatedUnion(RECONNECT_RESULT_UNION));
+  lines.push(generateDiscriminatedUnion(project, RECONNECT_RESULT_UNION));
   lines.push('');
 
   lines.push('// MARK: - Changeset Operation Unions\n');
@@ -1909,8 +1962,7 @@ function generateErrorsFile(project: Project): string {
   lines.push('    public static let turnInProgress = -32004');
   lines.push('    /// The server cannot speak any of the protocol versions offered by the client in `InitializeParams.protocolVersions`');
   lines.push('    public static let unsupportedProtocolVersion = -32005');
-  lines.push('    /// The requested content URI does not exist');
-  lines.push('    public static let contentNotFound = -32006');
+  lines.push('    // -32006 is intentionally reserved and unassigned.');
   lines.push('    /// Authentication required for a protected resource');
   lines.push('    public static let authRequired = -32007');
   lines.push('    /// The requested file, folder, or URI does not exist');

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -16,6 +16,7 @@ import { generateKotlinPackage } from './generate-kotlin.js';
 import { generateTypeScriptClient } from './generate-typescript.js';
 import { generateGoModule } from './generate-go.js';
 import { generateReleaseMetadata } from './generate-release-metadata.js';
+import { validateEnumCompatibility } from './enum-compatibility.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -55,6 +56,8 @@ const generateAll =
 const project = new Project({
   tsConfigFilePath: path.join(TYPES_DIR, 'tsconfig.json'),
 });
+
+validateEnumCompatibility(project);
 
 if (generateAll || docsOnly) {
   console.log('Generating documentation markdown...');

--- a/types/channels-automation-run/state.ts
+++ b/types/channels-automation-run/state.ts
@@ -22,6 +22,7 @@ import type { SessionState } from '../channels-session/state.js';
  * state is authoritative for those interactions.
  *
  * @category Automation Run State
+ * @exhaustive
  */
 export const enum AutomationRunStatus {
   /** The durable run record exists but execution has not started. */
@@ -40,6 +41,7 @@ export const enum AutomationRunStatus {
  * Discriminant describing what created an automation run.
  *
  * @category Automation Run State
+ * @exhaustive
  */
 export const enum AutomationRunOriginKind {
   /** A client explicitly invoked {@link RunAutomationParams | runAutomation}. */

--- a/types/channels-automation/state.ts
+++ b/types/channels-automation/state.ts
@@ -35,6 +35,7 @@ import type {
  * operations describe what is allowed for this particular automation now.
  *
  * @category Automation State
+ * @nonexhaustive
  */
 export const enum AutomationOperation {
   /** Replace editable fields using {@link AutomationUpdateRequestedAction | `automation/updateRequested`}. */
@@ -90,6 +91,7 @@ export interface AutomationSchedule {
  * unavailable.
  *
  * @category Automation State
+ * @nonexhaustive
  */
 export const enum AutomationMisfirePolicy {
   /** Discard missed occurrences and wait for the next future occurrence. */
@@ -105,6 +107,7 @@ export const enum AutomationMisfirePolicy {
  * Discriminant for automatic trigger definitions.
  *
  * @category Automation State
+ * @exhaustive
  */
 export const enum AutomationTriggerKind {
   /** A portable recurring {@link AutomationSchedule}. */

--- a/types/channels-changeset/commands.ts
+++ b/types/channels-changeset/commands.ts
@@ -15,6 +15,7 @@ import type { BaseParams } from '../common/commands.js';
  * `Changeset` scope has no target.
  *
  * @category Commands
+ * @nonexhaustive
  */
 export const enum ChangesetOperationTargetKind {
   /** Operation acts on a single file. */

--- a/types/channels-changeset/state.ts
+++ b/types/channels-changeset/state.ts
@@ -101,6 +101,7 @@ export interface ChangesetCapabilities {
  * Computation lifecycle of a {@link ChangesetState}.
  *
  * @category Changesets
+ * @nonexhaustive
  */
 export const enum ChangesetStatus {
   /** The server is still computing the contents of this changeset. */
@@ -190,6 +191,7 @@ export interface ChangesetFile {
  * Pull Request" button, or an inline error after a failed "revert").
  *
  * @category Changesets
+ * @nonexhaustive
  */
 export const enum ChangesetOperationStatus {
   /**
@@ -214,6 +216,7 @@ export const enum ChangesetOperationStatus {
  * Where a {@link ChangesetOperation} can be invoked.
  *
  * @category Changesets
+ * @nonexhaustive
  */
 export const enum ChangesetOperationScope {
   /** Applies to the whole changeset. */

--- a/types/channels-chat/actions.ts
+++ b/types/channels-chat/actions.ts
@@ -90,7 +90,7 @@ export interface ChatTurnStartedAction {
  * Streaming text chunk from the assistant, appended to a specific response part.
  *
  * The server MUST first emit a `chat/responsePart` to create the target
- * part (markdown or reasoning), then use this action to append text to it.
+ * markdown part, then use this action to append text to it.
  *
  * @category Chat Actions
  * @version 1

--- a/types/channels-chat/commands.ts
+++ b/types/channels-chat/commands.ts
@@ -12,6 +12,7 @@ import type { Message, SideChatSelection } from './state.js';
 
 /**
  * How a new chat uses its source chat and turn.
+ * @nonexhaustive
  */
 export const enum ChatSourceKind {
   /** Copy source history through the referenced turn into the new chat. */

--- a/types/channels-chat/state.ts
+++ b/types/channels-chat/state.ts
@@ -149,6 +149,7 @@ export interface ChatSummary {
  * Discriminant for {@link ChatOrigin} — how a chat came into existence.
  *
  * @category Chat State
+ * @nonexhaustive
  */
 export const enum ChatOriginKind {
   /** User created the chat explicitly (e.g. via the host UI). */
@@ -232,6 +233,7 @@ export type ChatOrigin =
  * the UI uses it to show appropriate controls.
  *
  * @category Chat State
+ * @exhaustive
  */
 export const enum ChatInteractivity {
   /** User can send messages and watch (default when absent) */
@@ -248,6 +250,7 @@ export const enum ChatInteractivity {
  * Discriminant for pending message kinds.
  *
  * @category Pending Message Types
+ * @exhaustive
  */
 export const enum PendingMessageKind {
   /** Injected into the current turn at a convenient point */
@@ -279,6 +282,7 @@ export interface PendingMessage {
  * How a client completed an input request.
  *
  * @category Chat Input Types
+ * @exhaustive
  */
 export const enum ChatInputResponseKind {
   Accept = 'accept',
@@ -290,6 +294,7 @@ export const enum ChatInputResponseKind {
  * Question/input control kind.
  *
  * @category Chat Input Types
+ * @nonexhaustive
  */
 export const enum ChatInputQuestionKind {
   Text = 'text',
@@ -426,6 +431,7 @@ export interface ChatInputRequest {
  * Answer value kind.
  *
  * @category Chat Input Types
+ * @nonexhaustive
  */
 export const enum ChatInputAnswerValueKind {
   Text = 'text',
@@ -494,6 +500,7 @@ export interface ChatInputSkipped {
  * Answer lifecycle state.
  *
  * @category Chat Input Types
+ * @exhaustive
  */
 export const enum ChatInputAnswerState {
   Draft = 'draft',
@@ -515,6 +522,7 @@ export type ChatInputAnswer = ChatInputAnswered | ChatInputSkipped;
  * How a turn ended.
  *
  * @category Turn Types
+ * @exhaustive
  */
 export const enum TurnState {
   Complete = 'complete',
@@ -526,6 +534,7 @@ export const enum TurnState {
  * Discriminant for {@link MessageAttachment} variants.
  *
  * @category Turn Types
+ * @nonexhaustive
  */
 export const enum MessageAttachmentKind {
   /** A simple, opaque attachment whose representation is described by the producer. */
@@ -595,6 +604,7 @@ export interface ActiveTurn {
  * Discriminant for {@link MessageOrigin} — identifies who produced a message.
  *
  * @category Turn Types
+ * @nonexhaustive
  */
 export enum MessageKind {
   /** Sent directly by the user. */
@@ -857,6 +867,7 @@ export type MessageAttachment =
  * Discriminant for response part types.
  *
  * @category Response Parts
+ * @nonexhaustive
  */
 export const enum ResponsePartKind {
   Markdown = 'markdown',
@@ -993,6 +1004,7 @@ export interface SystemNotificationResponsePart {
  * Status of a tool call in the lifecycle state machine.
  *
  * @category Tool Call Types
+ * @nonexhaustive
  */
 export const enum ToolCallStatus {
   Streaming = 'streaming',
@@ -1017,6 +1029,7 @@ export const enum ToolCallStatus {
  * - `Setting` — Approved by a persistent user setting
  *
  * @category Tool Call Types
+ * @nonexhaustive
  */
 export const enum ToolCallConfirmationReason {
   NotNeeded = 'not-needed',
@@ -1028,6 +1041,7 @@ export const enum ToolCallConfirmationReason {
  * Identifies a model judge as the source of a confirmation requirement.
  *
  * @category Tool Call Types
+ * @nonexhaustive
  */
 export const enum ToolCallRiskAssessmentKind {
   Judge = 'judge',
@@ -1037,6 +1051,7 @@ export const enum ToolCallRiskAssessmentKind {
  * Lifecycle status of an asynchronous model-judge confirmation decision.
  *
  * @category Tool Call Types
+ * @nonexhaustive
  */
 export const enum ToolCallRiskAssessmentStatus {
   Loading = 'loading',
@@ -1079,6 +1094,7 @@ export type ToolCallRiskAssessment =
  * Why a tool call was cancelled.
  *
  * @category Tool Call Types
+ * @exhaustive
  */
 export const enum ToolCallCancellationReason {
   Denied = 'denied',
@@ -1090,6 +1106,7 @@ export const enum ToolCallCancellationReason {
  * Whether a confirmation option represents an approval or denial action.
  *
  * @category Tool Call Types
+ * @nonexhaustive
  */
 export const enum ConfirmationOptionKind {
   Approve = 'approve',
@@ -1120,6 +1137,12 @@ export interface ConfirmationOption {
   group?: number;
 }
 
+/**
+ * Identifies the source of a tool call's implementation.
+ *
+ * @category Tool Call Types
+ * @nonexhaustive
+ */
 export const enum ToolCallContributorKind {
   Client = 'client',
   MCP = 'mcp',
@@ -1424,6 +1447,7 @@ export type ToolCallConfirmationState =
  * Discriminant for tool result content types.
  *
  * @category Tool Result Content
+ * @nonexhaustive
  */
 export const enum ToolResultContentType {
   Text = 'text',

--- a/types/channels-resource-watch/state.ts
+++ b/types/channels-resource-watch/state.ts
@@ -52,6 +52,7 @@ export interface ResourceWatchState {
  * Discriminant for {@link ResourceChange.type}.
  *
  * @category Resource Watch Types
+ * @exhaustive
  */
 export const enum ResourceChangeType {
   Added = 'added',

--- a/types/channels-root/state.ts
+++ b/types/channels-root/state.ts
@@ -18,6 +18,7 @@ import type { Customization } from '../channels-session/state.js';
  * Policy configuration state for a model.
  *
  * @category Root State
+ * @exhaustive
  */
 export const enum PolicyState {
   Enabled = 'enabled',

--- a/types/channels-session/commands.ts
+++ b/types/channels-session/commands.ts
@@ -166,6 +166,7 @@ export interface FetchTurnsResult {}
  * The kind of completion items being requested.
  *
  * @category Commands
+ * @nonexhaustive
  */
 export const enum CompletionItemKind {
   /**

--- a/types/channels-session/state.ts
+++ b/types/channels-session/state.ts
@@ -10,7 +10,7 @@ import type {
   ChatSummary,
   ChatInputRequest,
   ToolCallConfirmationState,
-  ToolCallState,
+  ToolCallRunningState,
   ToolCallAuthRequiredState,
 } from '../channels-chat/state.js';
 import type { AutomationRunState } from '../channels-automation-run/state.js';
@@ -30,6 +30,7 @@ import type {
  * Session initialization state.
  *
  * @category Session State
+ * @nonexhaustive
  */
 export const enum SessionLifecycle {
   Creating = 'creating',
@@ -45,6 +46,7 @@ export const enum SessionLifecycle {
  * and turns that are paused waiting for input.
  *
  * @category Session State
+ * @nonexhaustive
  */
 export const enum SessionStatus {
   /** Session is idle — no turn is active. */
@@ -65,6 +67,7 @@ export const enum SessionStatus {
  * Discriminant describing the durable provenance of a session.
  *
  * @category Session State
+ * @nonexhaustive
  */
 export const enum SessionOriginKind {
   /** The session was created as part of an automation run. */
@@ -281,6 +284,7 @@ export interface SessionActiveClient {
  * a `*Kind`.
  *
  * @category Session Input Types
+ * @nonexhaustive
  */
 export const enum SessionInputRequestKind {
   /** A user-facing elicitation mirrored from an unresolved chat response part. */
@@ -383,10 +387,9 @@ export interface SessionToolClientExecutionRequest extends SessionInputRequestBa
   clientId: string;
   /**
    * The running tool call the session wants the owning client to execute. The
-   * host only ever populates this with a {@link ToolCallRunningState} (i.e. a
-   * {@link ToolCallState} in `running` status).
+   * host only ever populates this with a {@link ToolCallRunningState}.
    */
-  toolCall: ToolCallState;
+  toolCall: ToolCallRunningState;
 }
 
 /**
@@ -672,6 +675,7 @@ export interface ToolAnnotations {
  * a container.
  *
  * @category Customization Types
+ * @nonexhaustive
  */
 export const enum CustomizationType {
   Plugin = 'plugin',
@@ -688,6 +692,7 @@ export const enum CustomizationType {
  * Scope at which customization enablement is decided.
  *
  * @category Customization Types
+ * @nonexhaustive
  */
 export const enum CustomizationEnablementKind {
   Global = 'global',
@@ -762,6 +767,7 @@ interface CustomizationBase {
  * Discriminant values for {@link CustomizationLoadState}.
  *
  * @category Customization Types
+ * @exhaustive
  */
 export const enum CustomizationLoadStatus {
   Loading = 'loading',
@@ -1253,6 +1259,7 @@ export type Customization =
  * Discriminant for the {@link McpServerState} union.
  *
  * @category MCP Server State
+ * @nonexhaustive
  */
 export const enum McpServerStatus {
   /** Server has been registered but is not yet running. */
@@ -1279,6 +1286,7 @@ export const enum McpServerStatus {
  * [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md).
  *
  * @category MCP Server State
+ * @nonexhaustive
  */
 export const enum McpAuthRequiredReason {
   /** No token has been provided yet (HTTP 401, no prior token). */

--- a/types/channels-terminal/state.ts
+++ b/types/channels-terminal/state.ts
@@ -29,6 +29,7 @@ export interface TerminalInfo {
  * Lifecycle status of a terminal process.
  *
  * @category Terminal Types
+ * @exhaustive
  */
 export const enum TerminalLifecycleStatus {
   Running = 'running',
@@ -68,6 +69,7 @@ export type TerminalLifecycleState =
  * Discriminant for terminal claim kinds.
  *
  * @category Terminal Types
+ * @exhaustive
  */
 export const enum TerminalClaimKind {
   Client = 'client',

--- a/types/common/actions.ts
+++ b/types/common/actions.ts
@@ -134,6 +134,7 @@ import type {
  * Discriminant values for all state actions.
  *
  * @category Actions
+ * @nonexhaustive
  */
 export const enum ActionType {
   RootAgentsChanged = 'root/agentsChanged',

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -163,7 +163,8 @@ export interface InitializeParams extends BaseParams {
    *
    * The server selects one entry and returns it as `InitializeResult.protocolVersion`.
    * If the server cannot speak any of the offered versions, it MUST return
-   * error code `-32005` (`UnsupportedProtocolVersion`).
+   * error code `-32005` (`UnsupportedProtocolVersion`) with required
+   * `UnsupportedProtocolVersionErrorData` containing `supportedVersions`.
    */
   protocolVersions: string[];
   /** Unique client identifier */
@@ -227,7 +228,8 @@ export interface ClientCapabilities {
  * `protocolVersions` list. The client and server MUST use this version for
  * the rest of the connection. If the server cannot speak any of the offered
  * versions it MUST return error code `-32005` (`UnsupportedProtocolVersion`)
- * instead of a result.
+ * with required `UnsupportedProtocolVersionErrorData` containing
+ * `supportedVersions`, instead of a result.
  */
 export interface InitializeResult {
   /**
@@ -380,6 +382,7 @@ export interface PingParams extends BaseParams {
  * Discriminant for reconnect result types.
  *
  * @category Commands
+ * @exhaustive
  */
 export const enum ReconnectResultType {
   Replay = 'replay',
@@ -569,6 +572,7 @@ export interface DispatchActionParams {
  * Encoding of fetched content data.
  *
  * @category Commands
+ * @exhaustive
  */
 export const enum ContentEncoding {
   Base64 = 'base64',
@@ -659,6 +663,7 @@ export interface ResourceReadResult {
  *   the file — use `truncate` to overwrite bytes in place.
  *
  * @category Commands
+ * @exhaustive
  */
 export const enum ResourceWriteMode {
   Truncate = 'truncate',
@@ -973,6 +978,7 @@ export interface ResourceMoveResult {
  * Discriminant for {@link ResourceResolveResult.type}.
  *
  * @category Commands
+ * @nonexhaustive
  */
 export const enum ResourceType {
   File = 'file',

--- a/types/common/errors.ts
+++ b/types/common/errors.ts
@@ -50,12 +50,10 @@ export const AhpErrorCodes = {
   /**
    * The server cannot speak any of the protocol versions offered by the
    * client in `InitializeParams.protocolVersions`. The `data` field of the
-   * JSON-RPC error MAY be an `UnsupportedProtocolVersionErrorData` advertising
-   * the protocol versions the server is willing to speak.
+   * JSON-RPC error MUST carry an `UnsupportedProtocolVersionErrorData`
+   * advertising the protocol versions the server is willing to speak.
    */
   UnsupportedProtocolVersion: -32005,
-  /** The requested content URI does not exist */
-  ContentNotFound: -32006,
   /**
    * A command failed because the client has not authenticated for a required
    * protected resource. The `data` field of the JSON-RPC error MUST be an
@@ -142,6 +140,8 @@ export interface PermissionDeniedErrorData {
 /**
  * Details carried in the `data` field of an `UnsupportedProtocolVersion`
  * (-32005) error.
+ *
+ * The data payload is required and always carries `supportedVersions`.
  *
  * @category Error Details
  * @version 1

--- a/types/common/notifications.ts
+++ b/types/common/notifications.ts
@@ -11,6 +11,7 @@ import type { ProtectedResourceMetadata, URI } from './state.js';
  * Reason why authentication is required.
  *
  * @category Protocol Notifications
+ * @nonexhaustive
  */
 export const enum AuthRequiredReason {
   /** The client has not yet authenticated for the resource */


### PR DESCRIPTION
## Summary

- **Define explicit enum compatibility contracts.** Every protocol enum now declares `@exhaustive` or `@nonexhaustive` in its primary documentation block, and generation fails when an enum is missing or ambiguously declares that contract. This makes the intended compatibility behavior reviewable at the source instead of relying on generator-specific allowlists.

- **Preserve unknown values consistently across generated clients.** Rust, Kotlin, Swift, and Go now derive raw-enum and discriminated-union handling from the annotations: nonexhaustive values round-trip without data loss, while exhaustive values remain closed. Cross-client tests cover both raw unknown enum values and unknown union payloads so future generator changes cannot silently diverge.

- **Narrow delegated client tool execution to the running state.** `SessionToolClientExecutionRequest.toolCall` now uses `ToolCallRunningState` rather than the full lifecycle union. This makes the existing protocol invariant structural and prevents clients from receiving impossible streaming, cancelled, or completed states in an execution request.

- **Clarify action and error contracts before 1.0.** The documentation now states that `chat/delta` targets markdown while `chat/reasoning` targets reasoning, and `UnsupportedProtocolVersion` requires its structured supported-version data. The obsolete `ContentNotFound` symbol was removed while `-32006` remains explicitly reserved, avoiding two competing not-found errors without reassigning a historic code.

- **Strengthen Rust correctness checks.** All Rust crates now inherit workspace-wide `clippy::panic` and `clippy::unwrap_used` denials, with production call sites refactored accordingly and narrowly scoped allowances limited to tests. This keeps malformed protocol input on typed error paths and prevents accidental panic-based handling from returning.

- **Regenerate and verify every published surface.** Schemas, reference output, and generated clients were refreshed from the canonical types, with atomic changelog fragments for each user-visible contract change. Hand-written reducers and compatibility tests were updated where revised enum annotations changed the expected open/closed behavior.

## Validation

- `npm run generate`
- enum compatibility tests
- `npm test`
- TypeScript client typecheck and tests
- Go tests
- Kotlin tests
- Rust `cargo fmt --check`
- Rust `cargo clippy --workspace --all-targets -- -D warnings`
- Rust workspace and doc tests

Swift's generated output and compatibility tests were updated, but the full Swift test command remains blocked on this Windows host by the existing CoreFoundation symbol issue in `AnyCodable.swift`.
