### PR TITLE
Remove unused AutomationCreateRequestedAction import

### DIFF
--- a/types/channels-automation/state.ts
+++ b/types/channels-automation/state.ts
@@ -17,7 +17,6 @@ import type { AgentInfo, ModelSelection, SessionModelInfo } from '../channels-ro
 import type { CreateSessionParams } from '../channels-session/commands.js';
 import type { AgentSelection } from '../channels-session/state.js';
 import type {
-  AutomationCreateRequestedAction,
   AutomationRemovedAction,
   AutomationSetAction,
   AutomationUpdateRequestedAction,


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/pull/331796#discussion_r3834882384

The type is imported in channels-automation/state.ts but never referenced. It compiles here because the types project does not enable noUnusedLocals, but vs code rejects the dead import.