### PR TITLE
fix(dotnet): initialize generated literal discriminants

### DIFF
--- a/clients/dotnet/CHANGELOG.md
+++ b/clients/dotnet/CHANGELOG.md
@@ -11,18 +11,6 @@ this release negotiates.
 
 ## [Unreleased]
 
-### Fixed
-
-- Generated action, state and command records now initialize their literal
-  discriminant (`Type`/`Kind`/`Status`/`State`) to its own constant. Previously
-  the property was emitted with no initializer, so it fell back to
-  `default(ActionType)` — and because these are ordinary enums whose zero value
-  is a real member, an action constructed without explicitly setting `Type`
-  serialized with a valid but wrong discriminant (the first enum member,
-  `root/agentsChanged`). 94 records across `Actions`, `State` and `Commands`
-  were affected. The generator already computed the correct value and discarded
-  it.
-
 ### Added
 
 - **Multiroot working directories** (upstream

--- a/clients/dotnet/CHANGELOG.md
+++ b/clients/dotnet/CHANGELOG.md
@@ -11,6 +11,18 @@ this release negotiates.
 
 ## [Unreleased]
 
+### Fixed
+
+- Generated action, state and command records now initialize their literal
+  discriminant (`Type`/`Kind`/`Status`/`State`) to its own constant. Previously
+  the property was emitted with no initializer, so it fell back to
+  `default(ActionType)` — and because these are ordinary enums whose zero value
+  is a real member, an action constructed without explicitly setting `Type`
+  serialized with a valid but wrong discriminant (the first enum member,
+  `root/agentsChanged`). 94 records across `Actions`, `State` and `Commands`
+  were affected. The generator already computed the correct value and discarded
+  it.
+
 ### Added
 
 - **Multiroot working directories** (upstream

--- a/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Actions.generated.cs
+++ b/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Actions.generated.cs
@@ -1342,7 +1342,7 @@ public sealed record ChatToolCallReadyAction
 /// </summary>
 public sealed record ChatToolCallConfirmedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallConfirmed;
 
     public required string TurnId { get; init; }
 

--- a/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Actions.generated.cs
+++ b/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Actions.generated.cs
@@ -242,7 +242,7 @@ public sealed record ActionEnvelope
 /// <summary>Fired when available agent backends or their models change.</summary>
 public sealed record RootAgentsChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.RootAgentsChanged;
 
     /// <summary>Updated agent list</summary>
     public required List<AgentInfo> Agents { get; init; }
@@ -251,7 +251,7 @@ public sealed record RootAgentsChangedAction
 /// <summary>Fired when the number of active sessions changes.</summary>
 public sealed record RootActiveSessionsChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.RootActiveSessionsChanged;
 
     /// <summary>Current count of active sessions</summary>
     public long ActiveSessions { get; init; }
@@ -263,7 +263,7 @@ public sealed record RootActiveSessionsChangedAction
 /// Set `replace` to `true` to replace all values instead of merging.</summary>
 public sealed record RootConfigChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.RootConfigChanged;
 
     /// <summary>Updated config values</summary>
     public required Dictionary<string, JsonElement> Config { get; init; }
@@ -276,13 +276,13 @@ public sealed record RootConfigChangedAction
 /// <summary>Session backend initialized successfully.</summary>
 public sealed record SessionReadyAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionReady;
 }
 
 /// <summary>Session backend failed to initialize.</summary>
 public sealed record SessionCreationFailedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionCreationFailed;
 
     /// <summary>Error details</summary>
     public required ErrorInfo Error { get; init; }
@@ -602,7 +602,7 @@ public sealed record SessionToolCallConfirmedAction
 /// from conversation, or dispatched by a client to rename a session.</summary>
 public sealed record SessionTitleChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionTitleChanged;
 
     /// <summary>New title</summary>
     public required string Title { get; init; }
@@ -614,7 +614,7 @@ public sealed record SessionTitleChangedAction
 /// or unread (e.g. after new activity since the client last looked at it).</summary>
 public sealed record SessionIsReadChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionIsReadChanged;
 
     /// <summary>Whether the session has been read</summary>
     public bool IsRead { get; init; }
@@ -626,7 +626,7 @@ public sealed record SessionIsReadChangedAction
 /// complete) or to unarchive it.</summary>
 public sealed record SessionIsArchivedChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionIsArchivedChanged;
 
     /// <summary>Whether the session is archived</summary>
     public bool IsArchived { get; init; }
@@ -638,7 +638,7 @@ public sealed record SessionIsArchivedChangedAction
 /// (e.g. running a tool, thinking). Clear activity by setting it to `undefined`.</summary>
 public sealed record SessionActivityChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionActivityChanged;
 
     /// <summary>Human-readable description of current activity, or `undefined` to clear</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -657,7 +657,7 @@ public sealed record SessionActivityChangedAction
 /// stream they already follow for file-level updates.</summary>
 public sealed record SessionChangesetsChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionChangesetsChanged;
 
     /// <summary>New catalogue, or `undefined` to clear it</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -669,7 +669,7 @@ public sealed record SessionChangesetsChangedAction
 /// Full-replacement semantics: the `tools` array replaces the previous `serverTools` entirely.</summary>
 public sealed record SessionServerToolsChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionServerToolsChanged;
 
     /// <summary>Updated server tools list (full replacement)</summary>
     public required List<ToolDefinition> Tools { get; init; }
@@ -688,7 +688,7 @@ public sealed record SessionServerToolsChangedAction
 /// client disconnects.</summary>
 public sealed record SessionActiveClientSetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionActiveClientSet;
 
     /// <summary>The active client to add or update, matched by `clientId`.</summary>
     public required SessionActiveClient ActiveClient { get; init; }
@@ -711,7 +711,7 @@ public sealed record SessionActiveClientSetAction
 /// mechanism, and the call ends in `completed` status with a failed result.)</summary>
 public sealed record SessionActiveClientRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionActiveClientRemoved;
 
     /// <summary>The `clientId` of the active client to remove.</summary>
     public required string ClientId { get; init; }
@@ -726,7 +726,7 @@ public sealed record SessionActiveClientRemovedAction
 /// advertises {@link AgentCapabilities.multipleWorkingDirectories}.</summary>
 public sealed record SessionWorkingDirectorySetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionWorkingDirectorySet;
 
     /// <summary>The working directory to grant the session's agent tool access to.</summary>
     public required string Directory { get; init; }
@@ -746,7 +746,7 @@ public sealed record SessionWorkingDirectorySetAction
 /// reject such a removal, leaving the protected slot intact.</summary>
 public sealed record SessionWorkingDirectoryRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionWorkingDirectoryRemoved;
 
     /// <summary>The working directory to revoke the session's agent tool access to.</summary>
     public required string Directory { get; init; }
@@ -771,7 +771,7 @@ public sealed record SessionWorkingDirectoryRemovedAction
 /// backend side effect before broadcasting an accepted action, or reject it.</summary>
 public sealed record SessionWorkingDirectoryReplacedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionWorkingDirectoryReplaced;
 
     /// <summary>URI of the existing entry to replace.</summary>
     public required string Directory { get; init; }
@@ -794,7 +794,7 @@ public sealed record SessionWorkingDirectoryReplacedAction
 /// {@link SessionInputRequest}.</summary>
 public sealed record SessionInputNeededSetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionInputNeededSet;
 
     /// <summary>The input request to add or update, matched by `id`.</summary>
     public required SessionInputRequest Request { get; init; }
@@ -810,7 +810,7 @@ public sealed record SessionInputNeededSetAction
 /// reports its result).</summary>
 public sealed record SessionInputNeededRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionInputNeededRemoved;
 
     /// <summary>The `id` of the input request to remove.</summary>
     public required string Id { get; init; }
@@ -822,7 +822,7 @@ public sealed record SessionInputNeededRemovedAction
 /// previous `customizations` entirely.</summary>
 public sealed record SessionCustomizationsChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionCustomizationsChanged;
 
     /// <summary>Updated customization list (full replacement).</summary>
     public required List<Customization> Customizations { get; init; }
@@ -844,7 +844,7 @@ public sealed record SessionCustomizationsChangedAction
 /// changing one scope must include every decision it intends to preserve.</summary>
 public sealed record SessionCustomizationToggledAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionCustomizationToggled;
 
     /// <summary>The id of the container or child to update.</summary>
     public required string Id { get; init; }
@@ -863,7 +863,7 @@ public sealed record SessionCustomizationToggledAction
 /// - If not found, the entry is appended.</summary>
 public sealed record SessionCustomizationUpdatedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionCustomizationUpdated;
 
     /// <summary>The customization to upsert (matched by `customization.id`).</summary>
     public required Customization Customization { get; init; }
@@ -876,7 +876,7 @@ public sealed record SessionCustomizationUpdatedAction
 /// matching id is found.</summary>
 public sealed record SessionCustomizationRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionCustomizationRemoved;
 
     /// <summary>The id of the customization to remove.</summary>
     public required string Id { get; init; }
@@ -904,7 +904,7 @@ public sealed record SessionCustomizationRemovedAction
 /// {@link McpServerAuthRequiredState} for the rationale.</summary>
 public sealed record SessionMcpServerStateChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionMcpServerStateChanged;
 
     /// <summary>The id of the {@link McpServerCustomization} to update.</summary>
     public required string Id { get; init; }
@@ -933,7 +933,7 @@ public sealed record SessionMcpServerStateChangedAction
 /// rejected. Is a no-op when no matching `McpServerCustomization` is found.</summary>
 public sealed record SessionMcpServerStartRequestedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionMcpServerStartRequested;
 
     /// <summary>The id of the {@link McpServerCustomization} to start.</summary>
     public required string Id { get; init; }
@@ -957,7 +957,7 @@ public sealed record SessionMcpServerStartRequestedAction
 /// `McpServerCustomization` is found.</summary>
 public sealed record SessionMcpServerStopRequestedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionMcpServerStopRequested;
 
     /// <summary>The id of the {@link McpServerCustomization} to stop.</summary>
     public required string Id { get; init; }
@@ -988,7 +988,7 @@ public sealed record SessionTruncatedAction
 /// the new values into `state.config.values`.</summary>
 public sealed record SessionConfigChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionConfigChanged;
 
     /// <summary>Updated config values</summary>
     public required Dictionary<string, JsonElement> Config { get; init; }
@@ -1003,7 +1003,7 @@ public sealed record SessionConfigChangedAction
 /// keys they wish to preserve into the new value before dispatching.</summary>
 public sealed record SessionMetaChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionMetaChanged;
 
     /// <summary>New `_meta` payload, or `undefined` to clear it</summary>
     [JsonPropertyName("_meta")]
@@ -1052,7 +1052,7 @@ public sealed record SessionToolCallContentChangedAction
 /// Mirrors the root-channel `root/sessionAdded` notification.</summary>
 public sealed record SessionChatAddedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionChatAdded;
 
     /// <summary>The full summary of the newly added (or upserted) chat.</summary>
     public required ChatSummary Summary { get; init; }
@@ -1063,7 +1063,7 @@ public sealed record SessionChatAddedAction
 /// Mirrors the root-channel `root/sessionRemoved` notification.</summary>
 public sealed record SessionChatRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionChatRemoved;
 
     /// <summary>The URI of the chat to remove.</summary>
     public required string Chat { get; init; }
@@ -1079,7 +1079,7 @@ public sealed record SessionChatRemovedAction
 /// Mirrors the root-channel `root/sessionSummaryChanged` notification.</summary>
 public sealed record SessionChatUpdatedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionChatUpdated;
 
     /// <summary>The URI of the chat whose summary changed.</summary>
     public required string Chat { get; init; }
@@ -1094,7 +1094,7 @@ public sealed record SessionChatUpdatedAction
 /// <summary>The default chat input-routing hint for this session changed.</summary>
 public sealed record SessionDefaultChatChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.SessionDefaultChatChanged;
 
     /// <summary>New default chat URI, or `undefined` to clear the hint.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1106,7 +1106,7 @@ public sealed record SessionDefaultChatChangedAction
 /// A client is only allowed to send {@link MessageKind.User} messages.</summary>
 public sealed record ChatTurnStartedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatTurnStarted;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1139,7 +1139,7 @@ public sealed record ChatTurnStartedAction
 /// markdown part, then use this action to append text to it.</summary>
 public sealed record ChatDeltaAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatDelta;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1165,7 +1165,7 @@ public sealed record ChatDeltaAction
 /// <summary>Structured content appended to the response.</summary>
 public sealed record ChatResponsePartAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatResponsePart;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1210,7 +1210,7 @@ public sealed record ChatToolCallStartAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallStart;
 
     /// <summary>Internal tool name (for debugging/logging)</summary>
     public required string ToolName { get; init; }
@@ -1247,7 +1247,7 @@ public sealed record ChatToolCallDeltaAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallDelta;
 
     /// <summary>Partial parameter content to append, if provided by the host.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1289,7 +1289,7 @@ public sealed record ChatToolCallReadyAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallReady;
 
     /// <summary>Final contributor metadata. MUST NOT change execution ownership established
     /// at `chat/toolCallStart`; a client contributor must keep the same `clientId`.</summary>
@@ -1419,7 +1419,7 @@ public sealed record ChatToolCallCompleteAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallComplete;
 
     /// <summary>Execution result</summary>
     public required ToolCallResult Result { get; init; }
@@ -1450,7 +1450,7 @@ public sealed record ChatToolCallResultConfirmedAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallResultConfirmed;
 
     /// <summary>Whether the result was approved</summary>
     public bool Approved { get; init; }
@@ -1485,7 +1485,7 @@ public sealed record ChatToolCallContentChangedAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallContentChanged;
 
     /// <summary>The current partial content for the running tool call</summary>
     public required List<ToolResultContent> Content { get; init; }
@@ -1522,7 +1522,7 @@ public sealed record ChatToolCallAuthRequiredAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallAuthRequired;
 
     /// <summary>The authentication challenge blocking this invocation.</summary>
     public required McpAuthRequirement Auth { get; init; }
@@ -1553,13 +1553,13 @@ public sealed record ChatToolCallAuthResolvedAction
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallAuthResolved;
 }
 
 /// <summary>Turn finished — the assistant is idle.</summary>
 public sealed record ChatTurnCompleteAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatTurnComplete;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1585,7 +1585,7 @@ public sealed record ChatTurnCompleteAction
 /// <summary>Turn was aborted; server stops processing.</summary>
 public sealed record ChatTurnCancelledAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatTurnCancelled;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1611,7 +1611,7 @@ public sealed record ChatTurnCancelledAction
 /// <summary>Error during turn processing.</summary>
 public sealed record ChatErrorAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatError;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1646,7 +1646,7 @@ public sealed record ChatErrorAction
 /// `session/chatUpdated` so `ChatSummary.activity` stays in sync.</summary>
 public sealed record ChatActivityChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatActivityChanged;
 
     /// <summary>Human-readable description of current activity; omit or set `undefined` to clear</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1664,7 +1664,7 @@ public sealed record ChatActivityChangedAction
 /// {@link AgentCapabilities.multipleWorkingDirectories}.</summary>
 public sealed record ChatWorkingDirectorySetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatWorkingDirectorySet;
 
     /// <summary>The working directory to add to this chat's subset.</summary>
     public required string Directory { get; init; }
@@ -1678,7 +1678,7 @@ public sealed record ChatWorkingDirectorySetAction
 /// chat's subset — the directory remains in the session's set.</summary>
 public sealed record ChatWorkingDirectoryRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatWorkingDirectoryRemoved;
 
     /// <summary>The working directory to remove from this chat's subset.</summary>
     public required string Directory { get; init; }
@@ -1687,7 +1687,7 @@ public sealed record ChatWorkingDirectoryRemovedAction
 /// <summary>Token usage report for a turn.</summary>
 public sealed record ChatUsageAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatUsage;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1713,7 +1713,7 @@ public sealed record ChatUsageAction
 /// reasoning part, then use this action to append text to it.</summary>
 public sealed record ChatReasoningAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatReasoning;
 
     /// <summary>Turn identifier</summary>
     public required string TurnId { get; init; }
@@ -1747,7 +1747,7 @@ public sealed record ChatReasoningAction
 /// `chat/turnStarted` with an edited message.</summary>
 public sealed record ChatTruncatedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatTruncated;
 
     /// <summary>Keep turns up to and including this turn. Omit to clear all turns.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1763,7 +1763,7 @@ public sealed record ChatTruncatedAction
 /// retained turns are now loaded.</summary>
 public sealed record ChatTurnsLoadedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatTurnsLoaded;
 
     /// <summary>Older completed turns loaded into the state, ordered oldest-first.</summary>
     public required List<Turn> Turns { get; init; }
@@ -1784,7 +1784,7 @@ public sealed record ChatTurnsLoadedAction
 /// A client is only allowed to send {@link MessageKind.User} messages.</summary>
 public sealed record ChatPendingMessageSetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatPendingMessageSet;
 
     /// <summary>Whether this is a steering or queued message</summary>
     public PendingMessageKind Kind { get; init; }
@@ -1803,7 +1803,7 @@ public sealed record ChatPendingMessageSetAction
 /// injecting a steering message into the current turn).</summary>
 public sealed record ChatPendingMessageRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatPendingMessageRemoved;
 
     /// <summary>Whether this is a steering or queued message</summary>
     public PendingMessageKind Kind { get; init; }
@@ -1821,7 +1821,7 @@ public sealed record ChatPendingMessageRemovedAction
 /// view of the queue never silently drops messages).</summary>
 public sealed record ChatQueuedMessagesReorderedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatQueuedMessagesReordered;
 
     /// <summary>Queued message IDs in the desired order</summary>
     public required List<string> Order { get; init; }
@@ -1840,7 +1840,7 @@ public sealed record ChatQueuedMessagesReorderedAction
 /// A client is only allowed to draft {@link MessageKind.User} messages.</summary>
 public sealed record ChatDraftChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatDraftChanged;
 
     /// <summary>New draft message, or `undefined` to clear it</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1854,7 +1854,7 @@ public sealed record ChatDraftChangedAction
 /// are preserved unless `request.answers` is provided.</summary>
 public sealed record ChatInputRequestedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatInputRequested;
 
     /// <summary>Input request to create or replace</summary>
     public required ChatInputRequest Request { get; init; }
@@ -1865,7 +1865,7 @@ public sealed record ChatInputRequestedAction
 /// Dispatching with `answer: undefined` removes that question's answer draft.</summary>
 public sealed record ChatInputAnswerChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatInputAnswerChanged;
 
     /// <summary>Input request identifier</summary>
     public required string RequestId { get; init; }
@@ -1885,7 +1885,7 @@ public sealed record ChatInputAnswerChangedAction
 /// response and final answers on the existing {@link InputRequestResponsePart}.</summary>
 public sealed record ChatInputCompletedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatInputCompleted;
 
     /// <summary>Input request identifier</summary>
     public required string RequestId { get; init; }
@@ -1903,7 +1903,7 @@ public sealed record ChatInputCompletedAction
 /// whenever it transitions to {@link ChangesetStatus.Error | Error}.</summary>
 public sealed record ChangesetStatusChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetStatusChanged;
 
     /// <summary>New computation lifecycle status.</summary>
     public ChangesetStatus Status { get; init; }
@@ -1917,7 +1917,7 @@ public sealed record ChangesetStatusChangedAction
 /// replaces an existing one identified by {@link ChangesetFile.id}.</summary>
 public sealed record ChangesetFileSetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetFileSet;
 
     /// <summary>The new or replacement file entry.</summary>
     public required ChangesetFile File { get; init; }
@@ -1929,7 +1929,7 @@ public sealed record ChangesetFileSetAction
 /// no longer in scope (e.g. a renamed file is replaced by a new entry).</summary>
 public sealed record ChangesetFileRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetFileRemoved;
 
     /// <summary>The {@link ChangesetFile.id} of the file to remove.</summary>
     public required string FileId { get; init; }
@@ -1958,7 +1958,7 @@ public sealed record ChangesetFileRemovedAction
 /// with `reviewed: false`.</summary>
 public sealed record ChangesetFilesReviewChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetFilesReviewChanged;
 
     /// <summary>The {@link ChangesetFile.id | ids} of the files whose review state changed.</summary>
     public required List<string> Files { get; init; }
@@ -1976,7 +1976,7 @@ public sealed record ChangesetFilesReviewChangedAction
 /// {@link ChangesetOperationsChangedAction} for incremental updates.</summary>
 public sealed record ChangesetContentChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetContentChanged;
 
     /// <summary>Full replacement file list.</summary>
     public required List<ChangesetFile> Files { get; init; }
@@ -1991,7 +1991,7 @@ public sealed record ChangesetContentChangedAction
 /// removes it entirely when `operations` is `undefined`).</summary>
 public sealed record ChangesetOperationsChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetOperationsChanged;
 
     /// <summary>Updated operation list. Pass `undefined` to clear all operations.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2010,7 +2010,7 @@ public sealed record ChangesetOperationsChangedAction
 /// or otherwise replace the operation list itself.</summary>
 public sealed record ChangesetOperationStatusChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetOperationStatusChanged;
 
     /// <summary>The {@link ChangesetOperation.id} whose status changed.</summary>
     public required string OperationId { get; init; }
@@ -2039,7 +2039,7 @@ public sealed record ChangesetOperationStatusChangedAction
 /// `root/sessionRemoved`) for the "going away" case.</summary>
 public sealed record ChangesetClearedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChangesetCleared;
 }
 
 /// <summary>Fired when the list of known terminals changes.
@@ -2048,7 +2048,7 @@ public sealed record ChangesetClearedAction
 /// `terminals` entirely.</summary>
 public sealed record RootTerminalsChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.RootTerminalsChanged;
 
     /// <summary>Updated terminal list (full replacement)</summary>
     public required List<TerminalInfo> Terminals { get; init; }
@@ -2066,7 +2066,7 @@ public sealed record RootTerminalsChangedAction
 /// is server-authoritative output (pty → server → client).</summary>
 public sealed record TerminalDataAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalData;
 
     /// <summary>Output data (may contain ANSI escape sequences)</summary>
     public required string Data { get; init; }
@@ -2081,7 +2081,7 @@ public sealed record TerminalDataAction
 /// See `terminal/data` for why these two actions are kept separate.</summary>
 public sealed record TerminalInputAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalInput;
 
     /// <summary>Input data to send to the pty</summary>
     public required string Data { get; init; }
@@ -2093,7 +2093,7 @@ public sealed record TerminalInputAction
 /// clients of the actual terminal dimensions.</summary>
 public sealed record TerminalResizedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalResized;
 
     /// <summary>Terminal width in columns</summary>
     public long Cols { get; init; }
@@ -2108,7 +2108,7 @@ public sealed record TerminalResizedAction
 /// the claim.</summary>
 public sealed record TerminalClaimedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalClaimed;
 
     /// <summary>The new claim</summary>
     public required TerminalClaim Claim { get; init; }
@@ -2120,7 +2120,7 @@ public sealed record TerminalClaimedAction
 /// escape sequences), or dispatched by a client to rename a terminal.</summary>
 public sealed record TerminalTitleChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalTitleChanged;
 
     /// <summary>New terminal title</summary>
     public required string Title { get; init; }
@@ -2129,7 +2129,7 @@ public sealed record TerminalTitleChangedAction
 /// <summary>Terminal working directory changed.</summary>
 public sealed record TerminalCwdChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalCwdChanged;
 
     /// <summary>New working directory</summary>
     public required string Cwd { get; init; }
@@ -2138,7 +2138,7 @@ public sealed record TerminalCwdChangedAction
 /// <summary>Terminal process exited.</summary>
 public sealed record TerminalExitedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalExited;
 
     /// <summary>Process exit code. `undefined` if the process was killed without an exit code.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2148,7 +2148,7 @@ public sealed record TerminalExitedAction
 /// <summary>Terminal scrollback buffer cleared.</summary>
 public sealed record TerminalClearedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalCleared;
 }
 
 /// <summary>Shell integration has loaded and the terminal now supports command
@@ -2159,7 +2159,7 @@ public sealed record TerminalClearedAction
 /// (or `terminal/commandExecuted`) has been received.</summary>
 public sealed record TerminalCommandDetectionAvailableAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalCommandDetectionAvailable;
 }
 
 /// <summary>A command has been submitted to the shell and is now executing.
@@ -2167,7 +2167,7 @@ public sealed record TerminalCommandDetectionAvailableAction
 /// `terminal/commandFinished`) constitute this command's output.</summary>
 public sealed record TerminalCommandExecutedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalCommandExecuted;
 
     /// <summary>Stable identifier for this command, scoped to the terminal URI.
     /// Allows correlating `commandExecuted` → `commandFinished` pairs.</summary>
@@ -2188,7 +2188,7 @@ public sealed record TerminalCommandExecutedAction
 /// the complete output of the command.</summary>
 public sealed record TerminalCommandFinishedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.TerminalCommandFinished;
 
     /// <summary>Matches the `commandId` from the corresponding `commandExecuted`</summary>
     public required string CommandId { get; init; }
@@ -2212,7 +2212,7 @@ public sealed record TerminalCommandFinishedAction
 /// them directly off the action stream and apply their own logic.</summary>
 public sealed record ResourceWatchChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ResourceWatchChanged;
 
     /// <summary>The set of changes in this batch, wrapped for forward compatibility.</summary>
     public JsonElement Changes { get; init; }
@@ -2232,7 +2232,7 @@ public sealed record ResourceWatchChangedAction
 /// annotation, to keep wire updates small.</summary>
 public sealed record AnnotationsSetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AnnotationsSet;
 
     /// <summary>The new or replacement annotation. MUST contain at least one entry.</summary>
     public required Annotation Annotation { get; init; }
@@ -2246,7 +2246,7 @@ public sealed record AnnotationsSetAction
 /// annotation — rather than {@link AnnotationsEntryRemovedAction}.</summary>
 public sealed record AnnotationsRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AnnotationsRemoved;
 
     /// <summary>The {@link Annotation.id} of the annotation to remove.</summary>
     public required string AnnotationId { get; init; }
@@ -2259,7 +2259,7 @@ public sealed record AnnotationsRemovedAction
 /// is a no-op.</summary>
 public sealed record AnnotationsEntrySetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AnnotationsEntrySet;
 
     /// <summary>The {@link Annotation.id} the entry belongs to.</summary>
     public required string AnnotationId { get; init; }
@@ -2277,7 +2277,7 @@ public sealed record AnnotationsEntrySetAction
 /// current state the action is a no-op.</summary>
 public sealed record AnnotationsEntryRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AnnotationsEntryRemoved;
 
     /// <summary>The {@link Annotation.id} the entry belongs to.</summary>
     public required string AnnotationId { get; init; }
@@ -2304,7 +2304,7 @@ public sealed record AnnotationsEntryRemovedAction
 /// a no-op.</summary>
 public sealed record AnnotationsUpdatedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AnnotationsUpdated;
 
     /// <summary>The {@link Annotation.id} of the annotation to update.</summary>
     public required string AnnotationId { get; init; }
@@ -2345,7 +2345,7 @@ public sealed record AnnotationsUpdatedAction
 /// Rejections leave the catalogue unchanged.</summary>
 public sealed record AutomationCreateRequestedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationCreateRequested;
 
     /// <summary>Client-chosen `ahp-automation:` URI that becomes {@link AutomationState.resource}.</summary>
     public required string Resource { get; init; }
@@ -2369,7 +2369,7 @@ public sealed record AutomationCreateRequestedAction
 /// server order wins.</summary>
 public sealed record AutomationUpdateRequestedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationUpdateRequested;
 
     /// <summary>Target {@link AutomationState.resource}.</summary>
     public required string Resource { get; init; }
@@ -2385,7 +2385,7 @@ public sealed record AutomationUpdateRequestedAction
 /// replaced in place. A previously unseen resource is appended.</summary>
 public sealed record AutomationSetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationSet;
 
     /// <summary>Full new or replacement automation state.</summary>
     public required AutomationState Automation { get; init; }
@@ -2401,7 +2401,7 @@ public sealed record AutomationSetAction
 /// Removing an unknown resource is a no-op.</summary>
 public sealed record AutomationRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationRemoved;
 
     /// <summary>{@link AutomationState.resource} to remove.</summary>
     public required string Resource { get; init; }
@@ -2412,7 +2412,7 @@ public sealed record AutomationRemovedAction
 /// The host dispatches this action for every lifecycle transition.</summary>
 public sealed record AutomationRunLifecycleChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationRunLifecycleChanged;
 
     /// <summary>Complete replacement {@link AutomationRunState.lifecycle}.</summary>
     public required AutomationRunLifecycle Lifecycle { get; init; }
@@ -2423,7 +2423,7 @@ public sealed record AutomationRunLifecycleChangedAction
 /// Session URIs are unique. Setting an existing URI is a no-op.</summary>
 public sealed record AutomationRunSessionSetAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationRunSessionSet;
 
     /// <summary>Session URI to append to {@link AutomationRunState.sessions} when not already linked.</summary>
     public required string Session { get; init; }
@@ -2435,7 +2435,7 @@ public sealed record AutomationRunSessionSetAction
 /// {@link AutomationRunState.primarySession}. An unknown URI is a no-op.</summary>
 public sealed record AutomationRunSessionRemovedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationRunSessionRemoved;
 
     /// <summary>Entry in {@link AutomationRunState.sessions} to remove.</summary>
     public required string Session { get; init; }
@@ -2444,7 +2444,7 @@ public sealed record AutomationRunSessionRemovedAction
 /// <summary>Select or clear the session clients should open first for this run.</summary>
 public sealed record AutomationRunPrimarySessionChangedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationRunPrimarySessionChanged;
 
     /// <summary>New {@link AutomationRunState.primarySession}, or omitted to clear the selection.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2464,7 +2464,7 @@ public sealed record AutomationRunPrimarySessionChangedAction
 /// effect.</summary>
 public sealed record AutomationRunCancelRequestedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.AutomationRunCancelRequested;
 }
 
 // ─── Partial Summaries (action-discovered) ───────────────────────────

--- a/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Commands.generated.cs
+++ b/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Commands.generated.cs
@@ -351,7 +351,7 @@ public sealed record ReconnectParams
 public sealed record ReconnectReplayResult
 {
     /// <summary>Discriminant</summary>
-    public ReconnectResultType Type { get; init; }
+    public ReconnectResultType Type { get; init; } = ReconnectResultType.Replay;
 
     /// <summary>Missed action envelopes since `lastSeenServerSeq`</summary>
     public required List<ActionEnvelope> Actions { get; init; }
@@ -367,7 +367,7 @@ public sealed record ReconnectReplayResult
 public sealed record ReconnectSnapshotResult
 {
     /// <summary>Discriminant</summary>
-    public ReconnectResultType Type { get; init; }
+    public ReconnectResultType Type { get; init; } = ReconnectResultType.Snapshot;
 
     /// <summary>Fresh snapshots for each subscription</summary>
     public required List<Snapshot> Snapshots { get; init; }
@@ -531,7 +531,7 @@ public sealed record DisposeSessionParams
 public sealed record ForkChatSource
 {
     /// <summary>Discriminant</summary>
-    public ChatSourceKind Kind { get; init; }
+    public ChatSourceKind Kind { get; init; } = ChatSourceKind.Fork;
 
     /// <summary>URI of the existing source chat.</summary>
     public required string Chat { get; init; }
@@ -547,7 +547,7 @@ public sealed record ForkChatSource
 public sealed record SideChatSource
 {
     /// <summary>Discriminant</summary>
-    public ChatSourceKind Kind { get; init; }
+    public ChatSourceKind Kind { get; init; } = ChatSourceKind.SideChat;
 
     /// <summary>URI of the existing source chat.</summary>
     public required string Chat { get; init; }

--- a/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/State.generated.cs
+++ b/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/State.generated.cs
@@ -1078,7 +1078,7 @@ public sealed record ConfigPropertySchema
 public sealed record ConfigSchema
 {
     /// <summary>JSON Schema: always `'object'`</summary>
-    public required string Type { get; init; }
+    public string Type { get; init; } = "object";
 
     /// <summary>JSON Schema: property descriptors keyed by property id</summary>
     public required Dictionary<string, ConfigPropertySchema> Properties { get; init; }
@@ -1275,7 +1275,7 @@ public sealed record ChatInputTextQuestion
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Required { get; init; }
 
-    public ChatInputQuestionKind Kind { get; init; }
+    public ChatInputQuestionKind Kind { get; init; } = ChatInputQuestionKind.Text;
 
     /// <summary>Format hint for text questions, such as `email`, `uri`, `date`, or `date-time`</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1343,7 +1343,7 @@ public sealed record ChatInputBooleanQuestion
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Required { get; init; }
 
-    public ChatInputQuestionKind Kind { get; init; }
+    public ChatInputQuestionKind Kind { get; init; } = ChatInputQuestionKind.Boolean;
 
     /// <summary>Default boolean value</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1367,7 +1367,7 @@ public sealed record ChatInputSingleSelectQuestion
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Required { get; init; }
 
-    public ChatInputQuestionKind Kind { get; init; }
+    public ChatInputQuestionKind Kind { get; init; } = ChatInputQuestionKind.SingleSelect;
 
     /// <summary>Options the user may select from</summary>
     public required List<ChatInputOption> Options { get; init; }
@@ -1394,7 +1394,7 @@ public sealed record ChatInputMultiSelectQuestion
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Required { get; init; }
 
-    public ChatInputQuestionKind Kind { get; init; }
+    public ChatInputQuestionKind Kind { get; init; } = ChatInputQuestionKind.MultiSelect;
 
     /// <summary>Options the user may select from</summary>
     public required List<ChatInputOption> Options { get; init; }
@@ -1442,28 +1442,28 @@ public sealed class ChatInputRequest
 /// <summary>Value captured for one answer.</summary>
 public sealed record ChatInputTextAnswerValue
 {
-    public ChatInputAnswerValueKind Kind { get; init; }
+    public ChatInputAnswerValueKind Kind { get; init; } = ChatInputAnswerValueKind.Text;
 
     public required string Value { get; init; }
 }
 
 public sealed record ChatInputNumberAnswerValue
 {
-    public ChatInputAnswerValueKind Kind { get; init; }
+    public ChatInputAnswerValueKind Kind { get; init; } = ChatInputAnswerValueKind.Number;
 
     public double Value { get; init; }
 }
 
 public sealed record ChatInputBooleanAnswerValue
 {
-    public ChatInputAnswerValueKind Kind { get; init; }
+    public ChatInputAnswerValueKind Kind { get; init; } = ChatInputAnswerValueKind.Boolean;
 
     public bool Value { get; init; }
 }
 
 public sealed record ChatInputSelectedAnswerValue
 {
-    public ChatInputAnswerValueKind Kind { get; init; }
+    public ChatInputAnswerValueKind Kind { get; init; } = ChatInputAnswerValueKind.Selected;
 
     public required string Value { get; init; }
 
@@ -1474,7 +1474,7 @@ public sealed record ChatInputSelectedAnswerValue
 
 public sealed record ChatInputSelectedManyAnswerValue
 {
-    public ChatInputAnswerValueKind Kind { get; init; }
+    public ChatInputAnswerValueKind Kind { get; init; } = ChatInputAnswerValueKind.SelectedMany;
 
     public required List<string> Value { get; init; }
 
@@ -1495,7 +1495,7 @@ public sealed record ChatInputAnswered
 public sealed record ChatInputSkipped
 {
     /// <summary>Answer state</summary>
-    public ChatInputAnswerState State { get; init; }
+    public ChatInputAnswerState State { get; init; } = ChatInputAnswerState.Skipped;
 
     /// <summary>Free-form reason or value captured while skipping, if any</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1695,7 +1695,7 @@ public sealed record SessionChatInputRequest
     /// chat first.</summary>
     public required string Chat { get; init; }
 
-    public SessionInputRequestKind Kind { get; init; }
+    public SessionInputRequestKind Kind { get; init; } = SessionInputRequestKind.ChatInput;
 
     /// <summary>The mirrored chat input request.</summary>
     public required ChatInputRequest Request { get; init; }
@@ -1723,7 +1723,7 @@ public sealed record SessionToolConfirmationRequest
     /// chat first.</summary>
     public required string Chat { get; init; }
 
-    public SessionInputRequestKind Kind { get; init; }
+    public SessionInputRequestKind Kind { get; init; } = SessionInputRequestKind.ToolConfirmation;
 
     /// <summary>The turn the tool call belongs to.</summary>
     public required string TurnId { get; init; }
@@ -1763,7 +1763,7 @@ public sealed record SessionToolClientExecutionRequest
     /// chat first.</summary>
     public required string Chat { get; init; }
 
-    public SessionInputRequestKind Kind { get; init; }
+    public SessionInputRequestKind Kind { get; init; } = SessionInputRequestKind.ToolClientExecution;
 
     /// <summary>The turn the tool call belongs to.</summary>
     public required string TurnId { get; init; }
@@ -1804,7 +1804,7 @@ public sealed record SessionToolAuthenticationRequest
     /// chat first.</summary>
     public required string Chat { get; init; }
 
-    public SessionInputRequestKind Kind { get; init; }
+    public SessionInputRequestKind Kind { get; init; } = SessionInputRequestKind.ToolAuthentication;
 
     /// <summary>The turn the tool call belongs to.</summary>
     public required string TurnId { get; init; }
@@ -2009,7 +2009,7 @@ public sealed record SessionConfigPropertySchema
 public sealed record SessionConfigSchema
 {
     /// <summary>JSON Schema: always `'object'`</summary>
-    public required string Type { get; init; }
+    public string Type { get; init; } = "object";
 
     /// <summary>JSON Schema: property descriptors keyed by property id</summary>
     public required Dictionary<string, SessionConfigPropertySchema> Properties { get; init; }
@@ -2234,7 +2234,7 @@ public sealed record SimpleMessageAttachment
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
     /// <summary>Discriminant</summary>
-    public MessageAttachmentKind Type { get; init; }
+    public MessageAttachmentKind Type { get; init; } = MessageAttachmentKind.Simple;
 
     /// <summary>Representation of the attachment as it should be shown to the model.
     ///
@@ -2285,7 +2285,7 @@ public sealed record MessageEmbeddedResourceAttachment
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
     /// <summary>Discriminant</summary>
-    public MessageAttachmentKind Type { get; init; }
+    public MessageAttachmentKind Type { get; init; } = MessageAttachmentKind.EmbeddedResource;
 
     /// <summary>Base64-encoded binary data</summary>
     public required string Data { get; init; }
@@ -2352,7 +2352,7 @@ public sealed record MessageResourceAttachment
     public string? Nonce { get; init; }
 
     /// <summary>Discriminant</summary>
-    public MessageAttachmentKind Type { get; init; }
+    public MessageAttachmentKind Type { get; init; } = MessageAttachmentKind.Resource;
 
     /// <summary>Optional selection within the referenced textual resource.
     ///
@@ -2402,7 +2402,7 @@ public sealed record MessageAnnotationsAttachment
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
     /// <summary>Discriminant</summary>
-    public MessageAttachmentKind Type { get; init; }
+    public MessageAttachmentKind Type { get; init; } = MessageAttachmentKind.Annotations;
 
     /// <summary>The annotations channel URI (typically `ahp-session:/&lt;uuid&gt;/annotations`).
     /// Matches {@link AnnotationsSummary.resource}.</summary>
@@ -2469,7 +2469,7 @@ public sealed record MessageChatAttachment
     public Dictionary<string, JsonElement>? Meta { get; init; }
 
     /// <summary>Discriminant</summary>
-    public MessageAttachmentKind Type { get; init; }
+    public MessageAttachmentKind Type { get; init; } = MessageAttachmentKind.Chat;
 
     /// <summary>URI of the referenced chat.</summary>
     public required string Resource { get; init; }
@@ -2483,7 +2483,7 @@ public sealed record MessageChatAttachment
 public sealed class MarkdownResponsePart
 {
     /// <summary>Discriminant</summary>
-    public ResponsePartKind Kind { get; set; }
+    public ResponsePartKind Kind { get; set; } = ResponsePartKind.Markdown;
 
     /// <summary>Part identifier, used by `chat/delta` to target this part for content appends</summary>
     public required string Id { get; set; }
@@ -2530,7 +2530,7 @@ public sealed record ResourceResponsePart
     public string? Nonce { get; init; }
 
     /// <summary>Discriminant</summary>
-    public ResponsePartKind Kind { get; init; }
+    public ResponsePartKind Kind { get; init; } = ResponsePartKind.ContentRef;
 }
 
 /// <summary>A tool call represented as a response part.
@@ -2541,7 +2541,7 @@ public sealed record ResourceResponsePart
 public sealed class ToolCallResponsePart
 {
     /// <summary>Discriminant</summary>
-    public ResponsePartKind Kind { get; set; }
+    public ResponsePartKind Kind { get; set; } = ResponsePartKind.ToolCall;
 
     /// <summary>Full tool call lifecycle state</summary>
     public required ToolCallState ToolCall { get; set; }
@@ -2551,7 +2551,7 @@ public sealed class ToolCallResponsePart
 public sealed class ReasoningResponsePart
 {
     /// <summary>Discriminant</summary>
-    public ResponsePartKind Kind { get; set; }
+    public ResponsePartKind Kind { get; set; } = ResponsePartKind.Reasoning;
 
     /// <summary>Part identifier, used by `chat/reasoning` to target this part for content appends</summary>
     public required string Id { get; set; }
@@ -2569,7 +2569,7 @@ public sealed class ReasoningResponsePart
 public sealed record SystemNotificationResponsePart
 {
     /// <summary>Discriminant</summary>
-    public ResponsePartKind Kind { get; init; }
+    public ResponsePartKind Kind { get; init; } = ResponsePartKind.SystemNotification;
 
     /// <summary>The text of the system notification</summary>
     public required StringOrMarkdown Content { get; init; }
@@ -2599,7 +2599,7 @@ public sealed record SystemNotificationResponsePart
 public sealed record InputRequestResponsePart
 {
     /// <summary>Discriminant</summary>
-    public ResponsePartKind Kind { get; init; }
+    public ResponsePartKind Kind { get; init; } = ResponsePartKind.InputRequest;
 
     /// <summary>The request, carrying its `id`, `message`, `url`, `questions`, and current
     /// draft or submitted `answers`.</summary>
@@ -2665,7 +2665,7 @@ public sealed record ToolCallRiskAssessmentLoadingState
 {
     public ToolCallRiskAssessmentKind Kind { get; init; }
 
-    public ToolCallRiskAssessmentStatus Status { get; init; }
+    public ToolCallRiskAssessmentStatus Status { get; init; } = ToolCallRiskAssessmentStatus.Loading;
 }
 
 /// <summary>The model judge has completed its evaluation.</summary>
@@ -2673,7 +2673,7 @@ public sealed record ToolCallRiskAssessmentCompleteState
 {
     public ToolCallRiskAssessmentKind Kind { get; init; }
 
-    public ToolCallRiskAssessmentStatus Status { get; init; }
+    public ToolCallRiskAssessmentStatus Status { get; init; } = ToolCallRiskAssessmentStatus.Complete;
 
     public required StringOrMarkdown Reason { get; init; }
 
@@ -2710,7 +2710,7 @@ public sealed class ToolCallStreamingState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; set; }
 
-    public ToolCallStatus Status { get; set; }
+    public ToolCallStatus Status { get; set; } = ToolCallStatus.Streaming;
 
     /// <summary>Partial parameters accumulated from tool-call deltas.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2763,7 +2763,7 @@ public sealed record ToolCallPendingConfirmationState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ToolInput? ToolInput { get; init; }
 
-    public ToolCallStatus Status { get; init; }
+    public ToolCallStatus Status { get; init; } = ToolCallStatus.PendingConfirmation;
 
     /// <summary>Short title for the confirmation prompt (e.g. `"Run in terminal"`, `"Write file"`)</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2837,7 +2837,7 @@ public sealed class ToolCallRunningState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ConfirmationOption? SelectedOption { get; set; }
 
-    public ToolCallStatus Status { get; set; }
+    public ToolCallStatus Status { get; set; } = ToolCallStatus.Running;
 
     /// <summary>Partial content produced while the tool is still executing.
     ///
@@ -2920,7 +2920,7 @@ public sealed record ToolCallAuthRequiredState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ConfirmationOption? SelectedOption { get; init; }
 
-    public ToolCallStatus Status { get; init; }
+    public ToolCallStatus Status { get; init; } = ToolCallStatus.AuthRequired;
 
     /// <summary>The authentication challenge blocking this invocation.</summary>
     public required McpAuthRequirement Auth { get; init; }
@@ -3000,7 +3000,7 @@ public sealed record ToolCallPendingResultConfirmationState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ConfirmationOption? SelectedOption { get; init; }
 
-    public ToolCallStatus Status { get; init; }
+    public ToolCallStatus Status { get; init; } = ToolCallStatus.PendingResultConfirmation;
 }
 
 /// <summary>Tool completed successfully or with an error.</summary>
@@ -3073,7 +3073,7 @@ public sealed record ToolCallCompletedState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ConfirmationOption? SelectedOption { get; init; }
 
-    public ToolCallStatus Status { get; init; }
+    public ToolCallStatus Status { get; init; } = ToolCallStatus.Completed;
 }
 
 /// <summary>Tool call was cancelled before execution.</summary>
@@ -3117,7 +3117,7 @@ public sealed record ToolCallCancelledState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ToolInput? ToolInput { get; init; }
 
-    public ToolCallStatus Status { get; init; }
+    public ToolCallStatus Status { get; init; } = ToolCallStatus.Cancelled;
 
     /// <summary>Why the tool was cancelled</summary>
     public ToolCallCancellationReason Reason { get; init; }
@@ -3206,7 +3206,7 @@ public sealed record ToolAnnotations
 /// Mirrors MCP `TextContent`.</summary>
 public sealed record ToolResultTextContent
 {
-    public ToolResultContentType Type { get; init; }
+    public ToolResultContentType Type { get; init; } = ToolResultContentType.Text;
 
     /// <summary>The text content</summary>
     public required string Text { get; init; }
@@ -3217,7 +3217,7 @@ public sealed record ToolResultTextContent
 /// Mirrors MCP `EmbeddedResource` for inline binary data.</summary>
 public sealed record ToolResultEmbeddedResourceContent
 {
-    public ToolResultContentType Type { get; init; }
+    public ToolResultContentType Type { get; init; } = ToolResultContentType.EmbeddedResource;
 
     /// <summary>Base64-encoded data</summary>
     public required string Data { get; init; }
@@ -3246,7 +3246,7 @@ public sealed record ToolResultResourceContent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Nonce { get; init; }
 
-    public ToolResultContentType Type { get; init; }
+    public ToolResultContentType Type { get; init; } = ToolResultContentType.Resource;
 }
 
 /// <summary>Describes a file modification performed by a tool.</summary>
@@ -3264,7 +3264,7 @@ public sealed record ToolResultFileEditContent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public JsonElement? Diff { get; init; }
 
-    public ToolResultContentType Type { get; init; }
+    public ToolResultContentType Type { get; init; } = ToolResultContentType.FileEdit;
 }
 
 /// <summary>A reference to a terminal whose output is relevant to this tool result.
@@ -3278,7 +3278,7 @@ public sealed record ToolResultFileEditContent
 /// running afterwards.</summary>
 public sealed record ToolResultTerminalContent
 {
-    public ToolResultContentType Type { get; init; }
+    public ToolResultContentType Type { get; init; } = ToolResultContentType.Terminal;
 
     /// <summary>Terminal URI (subscribable for full terminal state)</summary>
     public required string Resource { get; init; }
@@ -3325,7 +3325,7 @@ public sealed record TerminalCommandResult
 /// whose `toolCallId` identifies the tool call that emitted this content.</summary>
 public sealed record ToolResultSubagentContent
 {
-    public ToolResultContentType Type { get; init; }
+    public ToolResultContentType Type { get; init; } = ToolResultContentType.Subagent;
 
     /// <summary>Worker chat URI (subscribable for full chat state)</summary>
     public required string Resource { get; init; }
@@ -3345,19 +3345,19 @@ public sealed record ToolResultSubagentContent
 /// <summary>Container is being loaded by the host.</summary>
 public sealed record CustomizationLoadingState
 {
-    public CustomizationLoadStatus Kind { get; init; }
+    public CustomizationLoadStatus Kind { get; init; } = CustomizationLoadStatus.Loading;
 }
 
 /// <summary>Container loaded successfully.</summary>
 public sealed record CustomizationLoadedState
 {
-    public CustomizationLoadStatus Kind { get; init; }
+    public CustomizationLoadStatus Kind { get; init; } = CustomizationLoadStatus.Loaded;
 }
 
 /// <summary>Container partially loaded but has warnings.</summary>
 public sealed record CustomizationDegradedState
 {
-    public CustomizationLoadStatus Kind { get; init; }
+    public CustomizationLoadStatus Kind { get; init; } = CustomizationLoadStatus.Degraded;
 
     /// <summary>Human-readable description of the warning.</summary>
     public required string Message { get; init; }
@@ -3366,7 +3366,7 @@ public sealed record CustomizationDegradedState
 /// <summary>Container failed to load.</summary>
 public sealed record CustomizationErrorState
 {
-    public CustomizationLoadStatus Kind { get; init; }
+    public CustomizationLoadStatus Kind { get; init; } = CustomizationLoadStatus.Error;
 
     /// <summary>Human-readable error message.</summary>
     public required string Message { get; init; }
@@ -3430,7 +3430,7 @@ public sealed class PluginCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<ChildCustomization>? Children { get; set; }
 
-    public CustomizationType Type { get; set; }
+    public CustomizationType Type { get; set; } = CustomizationType.Plugin;
 
     /// <summary>Explicit enablement decisions. See {@link McpServerCustomization.enablement}.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -3512,7 +3512,7 @@ public sealed record ClientPluginCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<ChildCustomization>? Children { get; init; }
 
-    public CustomizationType Type { get; init; }
+    public CustomizationType Type { get; init; } = CustomizationType.Plugin;
 
     /// <summary>Explicit enablement decisions. See {@link McpServerCustomization.enablement}.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -3609,7 +3609,7 @@ public sealed class DirectoryCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<ChildCustomization>? Children { get; set; }
 
-    public CustomizationType Type { get; set; }
+    public CustomizationType Type { get; set; } = CustomizationType.Directory;
 
     /// <summary>Whether this container is currently enabled.</summary>
     public bool Enabled { get; set; }
@@ -3680,7 +3680,7 @@ public sealed record AgentCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Enabled { get; init; }
 
-    public CustomizationType Type { get; init; }
+    public CustomizationType Type { get; init; } = CustomizationType.Agent;
 
     /// <summary>Short description of what the agent specializes in and when to
     /// invoke it. Sourced from the agent file's frontmatter `description`.</summary>
@@ -3776,7 +3776,7 @@ public sealed record SkillCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Enabled { get; init; }
 
-    public CustomizationType Type { get; init; }
+    public CustomizationType Type { get; init; } = CustomizationType.Skill;
 
     /// <summary>Short description used for help text and auto-invocation matching.
     /// Sourced from the skill's frontmatter `description`.</summary>
@@ -3851,7 +3851,7 @@ public sealed record PromptCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Enabled { get; init; }
 
-    public CustomizationType Type { get; init; }
+    public CustomizationType Type { get; init; } = CustomizationType.Prompt;
 
     /// <summary>Short description of what the prompt does.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -3921,7 +3921,7 @@ public sealed record RuleCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Enabled { get; init; }
 
-    public CustomizationType Type { get; init; }
+    public CustomizationType Type { get; init; } = CustomizationType.Rule;
 
     /// <summary>Description of what the rule enforces.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -3994,7 +3994,7 @@ public sealed record HookCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Enabled { get; init; }
 
-    public CustomizationType Type { get; init; }
+    public CustomizationType Type { get; init; } = CustomizationType.Hook;
 }
 
 /// <summary>An MCP server contributed by a plugin or directory.
@@ -4044,7 +4044,7 @@ public sealed class McpServerCustomization
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, JsonElement>? Meta { get; set; }
 
-    public CustomizationType Type { get; set; }
+    public CustomizationType Type { get; set; } = CustomizationType.McpServer;
 
     /// <summary>Explicit enablement decisions for this customization, one entry per scope
     /// that has one. This is a wire contract: producers MUST publish entries
@@ -4159,13 +4159,13 @@ public sealed record AhpMcpUiHostCapabilities
 /// <summary>Server is registered with the host but has not yet started.</summary>
 public sealed record McpServerStartingState
 {
-    public McpServerStatus Kind { get; init; }
+    public McpServerStatus Kind { get; init; } = McpServerStatus.Starting;
 }
 
 /// <summary>Server is running and serving requests.</summary>
 public sealed record McpServerReadyState
 {
-    public McpServerStatus Kind { get; init; }
+    public McpServerStatus Kind { get; init; } = McpServerStatus.Ready;
 }
 
 /// <summary>A pre-registered OAuth client that clients use instead of dynamic client
@@ -4276,7 +4276,7 @@ public sealed record McpServerAuthRequiredState
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; init; }
 
-    public McpServerStatus Kind { get; init; }
+    public McpServerStatus Kind { get; init; } = McpServerStatus.AuthRequired;
 }
 
 /// <summary>Server failed to start, crashed, or otherwise transitioned to a
@@ -4284,7 +4284,7 @@ public sealed record McpServerAuthRequiredState
 /// for authentication failures.</summary>
 public sealed record McpServerErrorState
 {
-    public McpServerStatus Kind { get; init; }
+    public McpServerStatus Kind { get; init; } = McpServerStatus.Error;
 
     /// <summary>Error details.</summary>
     public required ErrorInfo Error { get; init; }
@@ -4294,12 +4294,12 @@ public sealed record McpServerErrorState
 /// session entirely shortly after this state.</summary>
 public sealed record McpServerStoppedState
 {
-    public McpServerStatus Kind { get; init; }
+    public McpServerStatus Kind { get; init; } = McpServerStatus.Stopped;
 }
 
 public sealed record ToolCallClientContributor
 {
-    public ToolCallContributorKind Kind { get; init; }
+    public ToolCallContributorKind Kind { get; init; } = ToolCallContributorKind.Client;
 
     /// <summary>If this tool is provided by a client, the `clientId` of the owning client.
     /// Absent for server-side tools.
@@ -4311,7 +4311,7 @@ public sealed record ToolCallClientContributor
 
 public sealed record ToolCallMcpContributor
 {
-    public ToolCallContributorKind Kind { get; init; }
+    public ToolCallContributorKind Kind { get; init; } = ToolCallContributorKind.MCP;
 
     /// <summary>Customization ID of the corresponding MCP server in {@link SessionState.customizations}.</summary>
     public required string CustomizationId { get; init; }
@@ -4356,7 +4356,7 @@ public sealed record TerminalInfo
 public sealed record TerminalClientClaim
 {
     /// <summary>Discriminant</summary>
-    public TerminalClaimKind Kind { get; init; }
+    public TerminalClaimKind Kind { get; init; } = TerminalClaimKind.Client;
 
     /// <summary>The `clientId` of the claiming client</summary>
     public required string ClientId { get; init; }
@@ -4366,7 +4366,7 @@ public sealed record TerminalClientClaim
 public sealed record TerminalSessionClaim
 {
     /// <summary>Discriminant</summary>
-    public TerminalClaimKind Kind { get; init; }
+    public TerminalClaimKind Kind { get; init; } = TerminalClaimKind.Session;
 
     /// <summary>Session URI that claimed the terminal</summary>
     public required string Session { get; init; }
@@ -4435,7 +4435,7 @@ public sealed class TerminalState
 /// or from terminals that do not support command detection.</summary>
 public sealed class TerminalUnclassifiedPart
 {
-    public required string Type { get; set; }
+    public string Type { get; set; } = "unclassified";
 
     /// <summary>Accumulated VT output. Appended to by `terminal/data` when no command is executing.</summary>
     public required string Value { get; set; }
@@ -4448,7 +4448,7 @@ public sealed class TerminalUnclassifiedPart
 /// is mutated in-place with `isComplete: true` and the completion metadata.</summary>
 public sealed class TerminalCommandPart
 {
-    public required string Type { get; set; }
+    public string Type { get; set; } = "command";
 
     /// <summary>Stable id matching the `commandId` on the corresponding
     /// `terminal/commandExecuted` and `terminal/commandFinished` actions.</summary>
@@ -4942,7 +4942,7 @@ public sealed record AnnotationEntry
 /// for this session's transcript, tools, confirmations, and changes.</summary>
 public sealed record AutomationSessionOrigin
 {
-    public SessionOriginKind Kind { get; init; }
+    public SessionOriginKind Kind { get; init; } = SessionOriginKind.Automation;
 
     /// <summary>Owning {@link AutomationState.resource}.</summary>
     public required string Automation { get; init; }
@@ -4954,13 +4954,13 @@ public sealed record AutomationSessionOrigin
 /// <summary>A terminal process that is still running.</summary>
 public sealed record TerminalRunningLifecycleState
 {
-    public TerminalLifecycleStatus Status { get; init; }
+    public TerminalLifecycleStatus Status { get; init; } = TerminalLifecycleStatus.Running;
 }
 
 /// <summary>A terminal process that has exited.</summary>
 public sealed record TerminalExitedLifecycleState
 {
-    public TerminalLifecycleStatus Status { get; init; }
+    public TerminalLifecycleStatus Status { get; init; } = TerminalLifecycleStatus.Exited;
 
     /// <summary>Process exit code, if the runtime reported one.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -5008,7 +5008,7 @@ public sealed record AutomationScheduleTrigger
     /// run.</summary>
     public required string Id { get; init; }
 
-    public AutomationTriggerKind Kind { get; init; }
+    public AutomationTriggerKind Kind { get; init; } = AutomationTriggerKind.Schedule;
 
     /// <summary>Recurrence and time zone evaluated by the host.</summary>
     public required AutomationSchedule Schedule { get; init; }
@@ -5033,7 +5033,7 @@ public sealed record AutomationEventTrigger
     /// run.</summary>
     public required string Id { get; init; }
 
-    public AutomationTriggerKind Kind { get; init; }
+    public AutomationTriggerKind Kind { get; init; } = AutomationTriggerKind.Event;
 
     /// <summary>Matches {@link AutomationTriggerDefinition.type}.</summary>
     public required string Type { get; init; }
@@ -5259,13 +5259,13 @@ public sealed class AutomationCatalogState
 /// <summary>Origin recorded for a client-requested manual run.</summary>
 public sealed record AutomationManualRunOrigin
 {
-    public AutomationRunOriginKind Kind { get; init; }
+    public AutomationRunOriginKind Kind { get; init; } = AutomationRunOriginKind.Manual;
 }
 
 /// <summary>Origin recorded for a run created by one of the automation's triggers.</summary>
 public sealed record AutomationTriggeredRunOrigin
 {
-    public AutomationRunOriginKind Kind { get; init; }
+    public AutomationRunOriginKind Kind { get; init; } = AutomationRunOriginKind.Trigger;
 
     /// <summary>Matches the stable {@link AutomationScheduleTrigger.id} or
     /// {@link AutomationEventTrigger.id} in the definition.</summary>
@@ -5290,7 +5290,7 @@ public sealed record AutomationTriggeredRunOrigin
 /// <summary>A durable run exists but has not begun external execution.</summary>
 public sealed record AutomationPendingRunLifecycle
 {
-    public AutomationRunStatus Status { get; init; }
+    public AutomationRunStatus Status { get; init; } = AutomationRunStatus.Pending;
 
     /// <summary>Run creation timestamp in ISO 8601 format.</summary>
     public required string CreatedAt { get; init; }
@@ -5303,7 +5303,7 @@ public sealed record AutomationPendingRunLifecycle
 /// required.</summary>
 public sealed record AutomationRunningRunLifecycle
 {
-    public AutomationRunStatus Status { get; init; }
+    public AutomationRunStatus Status { get; init; } = AutomationRunStatus.Running;
 
     /// <summary>Run creation timestamp in ISO 8601 format.</summary>
     public required string CreatedAt { get; init; }
@@ -5315,7 +5315,7 @@ public sealed record AutomationRunningRunLifecycle
 /// <summary>Terminal lifecycle for a successfully completed run.</summary>
 public sealed record AutomationCompletedRunLifecycle
 {
-    public AutomationRunStatus Status { get; init; }
+    public AutomationRunStatus Status { get; init; } = AutomationRunStatus.Completed;
 
     /// <summary>Run creation timestamp in ISO 8601 format.</summary>
     public required string CreatedAt { get; init; }
@@ -5337,7 +5337,7 @@ public sealed record AutomationCompletedRunLifecycle
 /// session-template validation or workspace preparation.</summary>
 public sealed record AutomationFailedRunLifecycle
 {
-    public AutomationRunStatus Status { get; init; }
+    public AutomationRunStatus Status { get; init; } = AutomationRunStatus.Failed;
 
     /// <summary>Run creation timestamp in ISO 8601 format.</summary>
     public required string CreatedAt { get; init; }
@@ -5359,7 +5359,7 @@ public sealed record AutomationFailedRunLifecycle
 /// pending.</summary>
 public sealed record AutomationCancelledRunLifecycle
 {
-    public AutomationRunStatus Status { get; init; }
+    public AutomationRunStatus Status { get; init; } = AutomationRunStatus.Cancelled;
 
     /// <summary>Run creation timestamp in ISO 8601 format.</summary>
     public required string CreatedAt { get; init; }

--- a/clients/dotnet/tests/AgentHostProtocol.Tests/DiscriminantDefaultTests.cs
+++ b/clients/dotnet/tests/AgentHostProtocol.Tests/DiscriminantDefaultTests.cs
@@ -1,0 +1,135 @@
+// DiscriminantDefaultTests — every generated action record must carry its own
+// discriminant, without the caller setting it.
+//
+// The generator used to emit `public ActionType Type { get; init; }` with no
+// initializer. `ActionType` is an ordinary (non-[Flags]) enum, so `default` is its
+// FIRST member, `RootAgentsChanged` — a valid value. UnionConverter.Write serializes
+// by the runtime type so "every property (including the variant's own discriminator
+// field) is written", which means an action built without explicitly setting Type
+// went onto the wire tagged `root/agentsChanged`. Silently, and for 95 record types.
+//
+// Nothing caught it: the suite was green before the fix, and the shared round-trip
+// corpus has no fixture for any affected variant. This file is that missing test.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AgentHostProtocol;
+using Xunit;
+
+namespace AgentHostProtocol.Tests;
+
+public class DiscriminantDefaultTests
+{
+    /// <summary>
+    /// Action records whose wire value has NO member in <see cref="ActionType"/> at all,
+    /// so they cannot express their own discriminant and are excluded below.
+    ///
+    /// These are the hand-written session actions in the generator's
+    /// SESSION_ACTION_TYPES_CS block. They DESERIALIZE correctly — StateActionConverter's
+    /// variant map keys on the wire string — but there is no enum member to serialize
+    /// back out, so reading one and writing it returns `root/agentsChanged`. That is a
+    /// round-trip break, and a worse defect than the missing initializer this file guards.
+    ///
+    /// It is deliberately NOT fixed here: the repair is either adding these 19 members to
+    /// ActionType or moving these records to a plain string discriminant, and that is a
+    /// protocol-level call. Tracked upstream; when it is ruled on, delete the entry and
+    /// this test starts covering it.
+    /// </summary>
+    private static readonly HashSet<string> KnownMissingFromActionType = new(StringComparer.Ordinal)
+    {
+        "SessionTurnStartedAction",
+        "SessionDeltaAction",
+        "SessionResponsePartAction",
+        "SessionToolCallStartAction",
+        "SessionToolCallDeltaAction",
+        "SessionToolCallReadyAction",
+        "SessionToolCallCompleteAction",
+        "SessionToolCallResultConfirmedAction",
+        "SessionToolCallConfirmedAction",
+        "SessionToolCallContentChangedAction",
+        "SessionTurnCompleteAction",
+        "SessionTurnCancelledAction",
+        "SessionErrorAction",
+        "SessionUsageAction",
+        "SessionReasoningAction",
+        "SessionPendingMessageSetAction",
+        "SessionPendingMessageRemovedAction",
+        "SessionQueuedMessagesReorderedAction",
+        "SessionTruncatedAction",
+    };
+
+    private static IEnumerable<Type> ActionRecords() =>
+        typeof(ActionType).Assembly
+            .GetExportedTypes()
+            .Where(t => t.IsClass
+                        && !t.IsAbstract
+                        && t.Name.EndsWith("Action", StringComparison.Ordinal)
+                        && t.GetProperty("Type")?.PropertyType == typeof(ActionType))
+            .OrderBy(t => t.Name, StringComparer.Ordinal);
+
+    [Fact]
+    public void EveryActionRecordDefaultsToItsOwnDiscriminant()
+    {
+        var wrong = new List<string>();
+        var checkedCount = 0;
+
+        foreach (var recordType in ActionRecords())
+        {
+            if (KnownMissingFromActionType.Contains(recordType.Name)) continue;
+
+            // `RootAgentsChangedAction` -> the `RootAgentsChanged` member of ActionType.
+            var memberName = recordType.Name[..^"Action".Length];
+            if (!Enum.TryParse(typeof(ActionType), memberName, ignoreCase: false, out var expected))
+            {
+                wrong.Add($"{recordType.Name}: no ActionType member named '{memberName}' — " +
+                          "either the record is misnamed or it belongs in KnownMissingFromActionType");
+                continue;
+            }
+
+            // `required` is a compile-time constraint, so reflection can build these
+            // without supplying the payload we do not care about here.
+            var instance = Activator.CreateInstance(recordType)!;
+            var actual = recordType.GetProperty("Type")!.GetValue(instance);
+            checkedCount++;
+
+            if (!Equals(actual, expected))
+            {
+                wrong.Add($"{recordType.Name}.Type defaulted to {actual} (wire " +
+                          $"'{WireValueOf((ActionType)actual!)}') but should be {expected} " +
+                          $"(wire '{WireValueOf((ActionType)expected!)}')");
+            }
+        }
+
+        Assert.True(checkedCount > 50, $"expected to cover most action records, only saw {checkedCount}");
+        Assert.True(
+            wrong.Count == 0,
+            $"{wrong.Count} action record(s) serialize with the wrong discriminant:\n  " +
+            string.Join("\n  ", wrong));
+    }
+
+    /// <summary>
+    /// Guards the exclusion list itself. If someone adds the missing members to
+    /// ActionType, the entry must be removed rather than left to rot — otherwise the
+    /// list silently keeps a now-testable record out of coverage.
+    /// </summary>
+    [Fact]
+    public void KnownMissingListDoesNotOutliveTheGapItDocuments()
+    {
+        var nowResolvable = KnownMissingFromActionType
+            .Where(name => Enum.TryParse(typeof(ActionType), name[..^"Action".Length], false, out _))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            nowResolvable.Count == 0,
+            "ActionType now has members for these, so they are no longer 'known missing' — " +
+            "remove them from KnownMissingFromActionType so the test above covers them:\n  " +
+            string.Join("\n  ", nowResolvable));
+    }
+
+    private static string WireValueOf(ActionType value) =>
+        typeof(ActionType).GetField(value.ToString())
+            ?.GetCustomAttribute<WireValueAttribute>()?.Value ?? value.ToString();
+}

--- a/docs/.changes/20260824-dotnet-discriminant-defaults.json
+++ b/docs/.changes/20260824-dotnet-discriminant-defaults.json
@@ -1,0 +1,5 @@
+{
+  "type": "fixed",
+  "message": "Generated .NET records now initialize their literal discriminant instead of falling back to `default(ActionType)`, which is a valid enum member (`root/agentsChanged`) and so silently mis-tagged any action constructed without setting `Type`.",
+  "targets": ["dotnet"]
+}

--- a/scripts/generate-csharp.ts
+++ b/scripts/generate-csharp.ts
@@ -237,6 +237,13 @@ interface CsProp {
   doc: string;
   isLiteralDiscriminant: boolean;
   literalValue?: string;
+  /**
+   * The C# expression a literal discriminant initializes to — `ActionType.RootAgentsChanged`
+   * for an enum-member discriminant, `"user"` for a string-literal one. Undefined for a
+   * discriminant whose TS type is a UNION of enum members: those have no single correct
+   * value, so they must stay uninitialized.
+   */
+  literalInit?: string;
 }
 
 function getPropertyType(prop: PropertySignature): string {
@@ -324,6 +331,7 @@ function extractProps(iface: InterfaceDeclaration, project: Project): CsProp[] {
     const stringLiteral = tsType.match(/^'([^']+)'$/);
     let isLiteralDiscriminant = false;
     let literalValue: string | undefined;
+    let literalInit: string | undefined;
 
     const tsPropLower = tsName.toLowerCase();
     if (['type', 'kind', 'status', 'state'].includes(tsPropLower)) {
@@ -336,11 +344,16 @@ function extractProps(iface: InterfaceDeclaration, project: Project): CsProp[] {
           if (mem) {
             isLiteralDiscriminant = true;
             literalValue = String(mem.getValue());
+            // The C# enum mirrors the TS enum's NAME (generateStringEnum emits
+            // `mem.getName()`), while literalValue holds the WIRE value. The
+            // initializer needs the former.
+            literalInit = `${enumName}.${memberName}`;
           }
         }
       } else if (stringLiteral) {
         isLiteralDiscriminant = true;
         literalValue = stringLiteral[1];
+        literalInit = JSON.stringify(stringLiteral[1]);
       } else if (/^\w+\.\w+(\s*\|\s*\w+\.\w+)+$/.test(tsType)) {
         isLiteralDiscriminant = true;
       }
@@ -366,6 +379,7 @@ function extractProps(iface: InterfaceDeclaration, project: Project): CsProp[] {
       doc: getPropertyDoc(p),
       isLiteralDiscriminant,
       literalValue,
+      literalInit,
     });
   }
   return result;
@@ -543,8 +557,18 @@ function generateCsClass(csName: string, props: CsProp[], opts: StructOpts = {})
       lines.push('    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]');
       csType = `${csType}?`;
     }
-    const def = csPropDefault(p.csType, p.optional);
-    const req = csRequiredModifier(p.csType, p.optional);
+    // A literal discriminant initializes to its own constant. Without this the
+    // property falls back to `default(T)`, and because the C# enums are ordinary
+    // (non-flags) enums whose zero value is a real member, that silently produces a
+    // VALID BUT WRONG discriminant on the wire — e.g. every uninitialised action
+    // serialising as the first ActionType member. Emitting the initializer is also
+    // why `required` is dropped here: requiring callers to set a constant is the
+    // very thing being fixed.
+    const discriminantInit = p.isLiteralDiscriminant && p.literalInit
+      ? ` = ${p.literalInit};`
+      : undefined;
+    const def = discriminantInit ?? csPropDefault(p.csType, p.optional);
+    const req = discriminantInit ? '' : csRequiredModifier(p.csType, p.optional);
     lines.push(`    public ${req}${csType} ${p.csName} { ${accessor} }${def}`);
   });
   lines.push('}');

--- a/scripts/generate-csharp.ts
+++ b/scripts/generate-csharp.ts
@@ -1590,7 +1590,7 @@ function generateMergedChatToolCallConfirmedClass(): string {
 /// </summary>
 public sealed record ChatToolCallConfirmedAction
 {
-    public ActionType Type { get; init; }
+    public ActionType Type { get; init; } = ActionType.ChatToolCallConfirmed;
 
     public required string TurnId { get; init; }
 


### PR DESCRIPTION
## Summary

`scripts/generate-csharp.ts` computes each literal discriminant's value and then discards it. `literalValue` is assigned at `:338`/`:343` and stored on the descriptor at `:368`, and nothing ever reads it — `grep -n literalValue scripts/generate-csharp.ts` returns only those declaration and write sites.

So generated records emit their discriminant with no initializer:

```csharp
public ActionType Type { get; init; }
```

These are ordinary (non-`[Flags]`) enums whose zero value is a real member, so `default(ActionType)` is `ActionType.RootAgentsChanged`:

```csharp
var action = new StateAction(new ChatDraftChangedAction { /* ... */ });
// serializes as {"type":"root/agentsChanged", ...}
```

`UnionConverter.Write` serializes by the runtime type specifically so that *"every property (including the variant's own discriminator field) is written"*, so the record's own `Type` property is what reaches the wire. This is a silent mis-tag, not a cosmetic default.

**95 records** across `Actions.generated.cs`, `State.generated.cs` and `Commands.generated.cs` now carry their discriminant.

## Why this is .NET-specific

Not the missing initializer — the fact that C#'s zero value is a *valid* member.

- **Rust** can't express it: `StateAction` is `#[serde(tag = "type")]` over an enum, so the discriminant is carried by the variant and there is nothing to default. Swift and Kotlin have the same shape.
- **Go** can express it, but `type ActionType string` means the zero value is `""` — not a valid discriminant, so it fails loudly.
- **C#** is the only client whose default is a well-formed, wrong value.

## The fix

Carry the C# initializer expression alongside the wire value and emit it. The `required` modifier is dropped on an initialized discriminant — requiring callers to set a constant is the thing being fixed. Discriminants with no single correct value stay uninitialized by construction.

94 of the 95 are generated. The 95th, `ChatToolCallConfirmedAction`, is hand-written in the generator rather than generated — but unlike the session actions below it *does* have a matching `ActionType` member, so it is fixed by hand in the same block.

## Tests

`dotnet test`: **498 passed, 0 failed.**

`DiscriminantDefaultTests.EveryActionRecordDefaultsToItsOwnDiscriminant` reflects over every exported record with an `ActionType Type` property, derives the expected member from the record name, and asserts the default matches. Against the pre-fix generator it fails with 94 named records:

```
94 action record(s) serialize with the wrong discriminant:
  AnnotationsEntryRemovedAction.Type defaulted to RootAgentsChanged (wire 'root/agentsChanged')
    but should be AnnotationsEntryRemoved (wire 'annotations/entryRemoved')
  ...
```

`KnownMissingListDoesNotOutliveTheGapItDocuments` guards the exclusion list itself: it fails if `ActionType` ever gains members for the excluded names, so the list cannot silently keep a now-testable record out of coverage.

## A separate, deeper finding — needs a ruling, not a patch

**19 hand-written session action records** in `SESSION_ACTION_TYPES_CS` are deliberately not fixed here, because there is nothing correct to set them to. Their wire values are **not members of the `ActionType` enum at all**:

```
session/turnStarted   session/delta            session/responsePart
session/toolCallStart session/toolCallDelta    session/toolCallReady
session/toolCallComplete   session/toolCallResultConfirmed
session/toolCallConfirmed  session/toolCallContentChanged
session/turnComplete  session/turnCancelled    session/error
session/usage         session/reasoning        session/truncated
session/pendingMessageSet  session/pendingMessageRemoved
session/queuedMessagesReordered
```

They deserialize correctly, because the variant map keys on the wire string:

```csharp
["session/turnStarted"] = typeof(SessionTurnStartedAction),
```

But on the way out, `SessionTurnStartedAction.Type` is an `ActionType` with no member for `session/turnStarted`, so it serializes as `root/agentsChanged`. **Read a `session/turnStarted` action and write it back and its type changes** — a round-trip fidelity break, and a worse one than the defect this PR fixes.

The options are a protocol-level call rather than a client one: add the 19 members to `ActionType`, or move these records to a plain `string` discriminant, or something else you'd prefer. Happy to implement whichever you pick — deleting an entry from the exclusion list is what switches coverage on.

**Neither defect is reachable by the shared corpus.** Of the 42 fixtures in `types/test-cases/round-trips/`, **zero** cover any of those 19 wire values. Adding them is a `types/` change affecting every client, so it isn't in this PR — but it's probably the higher-leverage half, and I'd be glad to do it as a follow-up.

## Notes

- The generator plus its three regenerated outputs, one new test file, and a `### Fixed` changelog entry. `npm run generate:dotnet` is the only thing that touched the generated files.
- Orthogonal to the serializer/AOT work in #411 — the defect is present at that PR's head too, and this applies cleanly on top.
