### PR TITLE
generators: let a derived interface's property override win

### DIFF
--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -99,7 +99,10 @@ func toolCallMeta(tc ahptypes.ToolCallState) toolCallCommon {
 	case *ahptypes.ToolCallRunningState:
 		return toolCallCommon{v.ToolCallId, v.ToolName, v.DisplayName, v.Intention, v.ToolInput, v.Contributor, v.Meta}
 	case *ahptypes.ToolCallAuthRequiredState:
-		return toolCallCommon{v.ToolCallId, v.ToolName, v.DisplayName, v.Intention, v.ToolInput, v.Contributor, v.Meta}
+		// ToolCallAuthRequiredState narrows Contributor to the MCP variant; widen it
+		// back to the union toolCallCommon shares with every variant.
+		mcp := v.Contributor
+		return toolCallCommon{v.ToolCallId, v.ToolName, v.DisplayName, v.Intention, v.ToolInput, &ahptypes.ToolCallContributor{Value: &mcp}, v.Meta}
 	case *ahptypes.ToolCallPendingResultConfirmationState:
 		return toolCallCommon{v.ToolCallId, v.ToolName, v.DisplayName, v.Intention, v.ToolInput, v.Contributor, v.Meta}
 	case *ahptypes.ToolCallCompletedState:
@@ -1396,7 +1399,11 @@ func applyToolCallAuthRequired(state *ahptypes.ChatState, a *ahptypes.ChatToolCa
 		if s.Contributor == nil {
 			return tc
 		}
-		if _, ok := s.Contributor.Value.(*ahptypes.ToolCallMcpContributor); !ok {
+		// Auth is only ever required for an MCP-contributed tool call, which is why
+		// ToolCallAuthRequiredState narrows Contributor to the MCP variant. Bind that
+		// payload here; any other contributor is a no-op.
+		mcp, ok := s.Contributor.Value.(*ahptypes.ToolCallMcpContributor)
+		if !ok {
 			return tc
 		}
 		meta := s.Meta
@@ -1410,7 +1417,7 @@ func applyToolCallAuthRequired(state *ahptypes.ChatState, a *ahptypes.ChatToolCa
 			DisplayName:       s.DisplayName,
 			Intention:         s.Intention,
 			ToolInput:         s.ToolInput,
-			Contributor:       s.Contributor,
+			Contributor:       *mcp,
 			Meta:              meta,
 			InvocationMessage: s.InvocationMessage,
 			Confirmed:         s.Confirmed,
@@ -1431,6 +1438,8 @@ func applyToolCallAuthResolved(state *ahptypes.ChatState, a *ahptypes.ChatToolCa
 		if a.Meta != nil {
 			meta = a.Meta
 		}
+		// Widen the narrowed MCP contributor back to the union RunningState holds.
+		mcp := s.Contributor
 		return ahptypes.ToolCallState{Value: &ahptypes.ToolCallRunningState{
 			Status:            ahptypes.ToolCallStatusRunning,
 			ToolCallId:        s.ToolCallId,
@@ -1438,7 +1447,7 @@ func applyToolCallAuthResolved(state *ahptypes.ChatState, a *ahptypes.ChatToolCa
 			DisplayName:       s.DisplayName,
 			Intention:         s.Intention,
 			ToolInput:         s.ToolInput,
-			Contributor:       s.Contributor,
+			Contributor:       &ahptypes.ToolCallContributor{Value: &mcp},
 			Meta:              meta,
 			InvocationMessage: s.InvocationMessage,
 			Confirmed:         s.Confirmed,

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -93,7 +93,7 @@ const (
 // This MUST be the first message sent by the client.
 type InitializeParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -273,7 +273,7 @@ type Implementation struct {
 // provides fresh snapshots.
 type ReconnectParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -369,7 +369,7 @@ type SubscribeResult struct {
 // updates. The server also broadcasts a `root/sessionAdded` notification to all
 // clients.
 type CreateSessionParams struct {
-	// Channel URI this command targets.
+	// Session URI (client-chosen, e.g. `ahp-session:/<uuid>`)
 	Channel URI `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
@@ -462,7 +462,7 @@ type SideChatSource struct {
 
 // Creates a new chat within a session.
 type CreateChatParams struct {
-	// Channel URI this command targets.
+	// Session URI containing the new chat.
 	Channel URI `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
@@ -520,7 +520,7 @@ type DisposeChatParams struct {
 // fetches.
 type ListSessionsParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -561,7 +561,7 @@ type ListSessionsResult struct {
 // same permission/`resourceRequest` flow regardless of which peer initiated.
 type ResourceReadParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -601,7 +601,7 @@ type ResourceReadResult struct {
 // sent in either direction.
 type ResourceWriteParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -653,7 +653,7 @@ type ResourceWriteResult struct {
 // sent in either direction.
 type ResourceListParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -684,7 +684,7 @@ type DirectoryEntry struct {
 // sent in either direction.
 type ResourceCopyParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -709,7 +709,7 @@ type ResourceCopyResult struct {
 // sent in either direction.
 type ResourceDeleteParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -735,7 +735,7 @@ type ResourceDeleteResult struct {
 // sent in either direction.
 type ResourceMoveParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -767,7 +767,7 @@ type ResourceMoveResult struct {
 // sent in either direction.
 type ResourceResolveParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -813,7 +813,7 @@ type ResourceResolveResult struct {
 // sent in either direction.
 type ResourceMkdirParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -850,7 +850,7 @@ type ResourceMkdirResult struct {
 // neither flag set is treated as `read: true` by receivers.
 type ResourceRequestParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -887,7 +887,7 @@ type ResourceRequestResult struct {
 // the same permission flow as `resourceRead`/`resourceWrite`.
 type CreateResourceWatchParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -925,7 +925,7 @@ type CreateResourceWatchResult struct {
 // loaded window, the host MUST eagerly load enough older turns into state for
 // that operation to reduce against valid state.
 type FetchTurnsParams struct {
-	// Channel URI this command targets.
+	// Chat URI
 	Channel URI `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
@@ -979,7 +979,7 @@ type DispatchActionParams struct {
 // to the server via this command.
 type AuthenticateParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -1013,7 +1013,7 @@ type AuthenticateResult struct {
 // state updates. The server dispatches `root/terminalsChanged` to update the
 // root terminal list.
 type CreateTerminalParams struct {
-	// Channel URI this command targets.
+	// Terminal URI (client-chosen).
 	Channel URI `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
@@ -1053,7 +1053,7 @@ type DisposeTerminalParams struct {
 // server-resolved defaults to pass to `createSession`.
 type ResolveSessionConfigParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -1080,7 +1080,7 @@ type ResolveSessionConfigResult struct {
 // values with display metadata.
 type SessionConfigCompletionsParams struct {
 	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -1120,7 +1120,7 @@ type SessionConfigValueItem struct {
 // client SHOULD debounce calls to avoid flooding the server with requests on
 // every keystroke.
 type CompletionsParams struct {
-	// Channel URI this command targets.
+	// The chat URI the completion is being requested for.
 	Channel URI `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
@@ -1182,7 +1182,7 @@ type CompletionsResult struct {
 // SHOULD NOT synthesise local optimistic changes for invocations unless
 // the server explicitly opts in via a future capability.
 type InvokeChangesetOperationParams struct {
-	// Channel URI this command targets.
+	// The expanded changeset URI.
 	Channel URI `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
@@ -1229,8 +1229,8 @@ type ChangesetOperationFollowUp struct {
 // choices. Saved {@link AutomationEventTrigger} values retain their selected
 // event descriptors for display but do not establish current availability.
 type ListAutomationTriggerDefinitionsParams struct {
-	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	// Trigger definitions are discovered from the root channel.
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -1253,8 +1253,8 @@ type ListAutomationTriggerDefinitionsResult struct {
 // Manual execution is independent of {@link AutomationDefinition.enabled}.
 // The host persists the run before beginning session side effects.
 type RunAutomationParams struct {
-	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	// Manual runs are scoped to the catalogue channel.
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`
@@ -1279,8 +1279,8 @@ type RunAutomationResult struct {
 // `ahp-automations://` channel, keeping all catalogue subscribers synchronized
 // through the normal action stream.
 type FetchAutomationRunsParams struct {
-	// Channel URI this command targets.
-	Channel URI `json:"channel"`
+	// Run-history loading is scoped to the catalogue channel.
+	Channel string `json:"channel"`
 	// Optional JSON-serializable metadata associated with this request.
 	// Receivers MUST ignore keys they do not understand.
 	Meta map[string]json.RawMessage `json:"_meta,omitempty"`

--- a/clients/go/ahptypes/state.generated.go
+++ b/clients/go/ahptypes/state.generated.go
@@ -2172,8 +2172,8 @@ type ToolCallAuthRequiredState struct {
 	DisplayName string `json:"displayName"`
 	// Human-readable description of what the tool invocation intends to do
 	Intention *string `json:"intention,omitempty"`
-	// Reference to the contributor of the tool being called.
-	Contributor *ToolCallContributor `json:"contributor,omitempty"`
+	// The MCP server that contributed this tool call — always MCP, never a client tool.
+	Contributor ToolCallMcpContributor `json:"contributor"`
 	// Additional provider-specific metadata for this tool call.
 	//
 	// This MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -217,7 +217,17 @@ private fun toolCallBase(tc: ToolCallState): ToolCallBase = when (tc) {
         ToolCallBase(it.toolCallId, it.toolName, it.displayName, it.intention, it.toolInput, it.contributor, it.meta)
     }
     is ToolCallStateAuthRequired -> tc.value.let {
-        ToolCallBase(it.toolCallId, it.toolName, it.displayName, it.intention, it.toolInput, it.contributor, it.meta)
+        // ToolCallAuthRequiredState narrows `contributor` to the MCP payload; wrap it
+        // back into the union ToolCallBase shares with every variant.
+        ToolCallBase(
+            it.toolCallId,
+            it.toolName,
+            it.displayName,
+            it.intention,
+            it.toolInput,
+            ToolCallContributorMcp(it.contributor),
+            it.meta,
+        )
     }
     is ToolCallStatePendingResultConfirmation -> tc.value.let {
         ToolCallBase(it.toolCallId, it.toolName, it.displayName, it.intention, it.toolInput, it.contributor, it.meta)
@@ -1277,7 +1287,10 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
                                 displayName = base.displayName,
                                 intention = base.intention,
                                 toolInput = tc.value.toolInput,
-                                contributor = contributor,
+                                // Auth is only ever required for an MCP-contributed tool
+                                // call; unwrap the union to the MCP payload the narrowed
+                                // `contributor` field requires.
+                                contributor = contributor.value,
                                 meta = base.meta,
                                 invocationMessage = tc.value.invocationMessage,
                                 confirmed = tc.value.confirmed,

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -580,7 +580,7 @@ data class SubscribeResult(
 @Serializable
 data class CreateSessionParams(
     /**
-     * Channel URI this command targets.
+     * Session URI (client-chosen, e.g. `ahp-session:/<uuid>`)
      */
     val channel: String,
     /**
@@ -655,7 +655,7 @@ data class DisposeSessionParams(
 @Serializable
 data class CreateChatParams(
     /**
-     * Channel URI this command targets.
+     * Session URI containing the new chat.
      */
     val channel: String,
     /**
@@ -1141,7 +1141,7 @@ data class CreateResourceWatchResult(
 @Serializable
 data class FetchTurnsParams(
     /**
-     * Channel URI this command targets.
+     * Chat URI
      */
     val channel: String,
     /**
@@ -1227,7 +1227,7 @@ class AuthenticateResult
 @Serializable
 data class CreateTerminalParams(
     /**
-     * Channel URI this command targets.
+     * Terminal URI (client-chosen).
      */
     val channel: String,
     /**
@@ -1450,7 +1450,7 @@ data class SessionConfigValueItem(
 @Serializable
 data class CompletionsParams(
     /**
-     * Channel URI this command targets.
+     * The chat URI the completion is being requested for.
      */
     val channel: String,
     /**
@@ -1517,7 +1517,7 @@ data class CompletionsResult(
 @Serializable
 data class InvokeChangesetOperationParams(
     /**
-     * Channel URI this command targets.
+     * The expanded changeset URI.
      */
     val channel: String,
     /**
@@ -1561,7 +1561,7 @@ data class ChangesetOperationFollowUp(
 @Serializable
 data class ListAutomationTriggerDefinitionsParams(
     /**
-     * Channel URI this command targets.
+     * Trigger definitions are discovered from the root channel.
      */
     val channel: String,
     /**
@@ -1595,7 +1595,7 @@ data class ListAutomationTriggerDefinitionsResult(
 @Serializable
 data class RunAutomationParams(
     /**
-     * Channel URI this command targets.
+     * Manual runs are scoped to the catalogue channel.
      */
     val channel: String,
     /**
@@ -1627,7 +1627,7 @@ data class RunAutomationResult(
 @Serializable
 data class FetchAutomationRunsParams(
     /**
-     * Channel URI this command targets.
+     * Run-history loading is scoped to the catalogue channel.
      */
     val channel: String,
     /**

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/State.generated.kt
@@ -3149,9 +3149,9 @@ data class ToolCallAuthRequiredState(
      */
     val intention: String? = null,
     /**
-     * Reference to the contributor of the tool being called.
+     * The MCP server that contributed this tool call — always MCP, never a client tool.
      */
-    val contributor: ToolCallContributor? = null,
+    val contributor: ToolCallMcpContributor,
     /**
      * Additional provider-specific metadata for this tool call.
      *

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -191,7 +191,7 @@ pub enum ResourceWriteMode {
 #[serde(rename_all = "camelCase")]
 pub struct InitializeParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -404,7 +404,7 @@ pub struct Implementation {
 #[serde(rename_all = "camelCase")]
 pub struct ReconnectParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -553,7 +553,7 @@ pub struct SubscribeResult {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateSessionParams {
-    /// Channel URI this command targets.
+    /// Session URI (client-chosen, e.g. `ahp-session:/<uuid>`)
     pub channel: Uri,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -658,7 +658,7 @@ pub struct SideChatSource {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateChatParams {
-    /// Channel URI this command targets.
+    /// Session URI containing the new chat.
     pub channel: Uri,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -725,7 +725,7 @@ pub struct DisposeChatParams {
 #[serde(rename_all = "camelCase")]
 pub struct ListSessionsParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -774,7 +774,7 @@ pub struct ListSessionsResult {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceReadParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -821,7 +821,7 @@ pub struct ResourceReadResult {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceWriteParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -882,7 +882,7 @@ pub struct ResourceWriteResult {}
 #[serde(rename_all = "camelCase")]
 pub struct ResourceListParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -920,7 +920,7 @@ pub struct DirectoryEntry {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceCopyParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -950,7 +950,7 @@ pub struct ResourceCopyResult {}
 #[serde(rename_all = "camelCase")]
 pub struct ResourceDeleteParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -981,7 +981,7 @@ pub struct ResourceDeleteResult {}
 #[serde(rename_all = "camelCase")]
 pub struct ResourceMoveParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1018,7 +1018,7 @@ pub struct ResourceMoveResult {}
 #[serde(rename_all = "camelCase")]
 pub struct ResourceResolveParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1075,7 +1075,7 @@ pub struct ResourceResolveResult {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceMkdirParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1116,7 +1116,7 @@ pub struct ResourceMkdirResult {}
 #[serde(rename_all = "camelCase")]
 pub struct ResourceRequestParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1159,7 +1159,7 @@ pub struct ResourceRequestResult {}
 #[serde(rename_all = "camelCase")]
 pub struct CreateResourceWatchParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1205,7 +1205,7 @@ pub struct CreateResourceWatchResult {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchTurnsParams {
-    /// Channel URI this command targets.
+    /// Chat URI
     pub channel: Uri,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1268,7 +1268,7 @@ pub struct DispatchActionParams {
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticateParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1307,7 +1307,7 @@ pub struct AuthenticateResult {}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTerminalParams {
-    /// Channel URI this command targets.
+    /// Terminal URI (client-chosen).
     pub channel: Uri,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1357,7 +1357,7 @@ pub struct DisposeTerminalParams {
 #[serde(rename_all = "camelCase")]
 pub struct ResolveSessionConfigParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1392,7 +1392,7 @@ pub struct ResolveSessionConfigResult {
 #[serde(rename_all = "camelCase")]
 pub struct SessionConfigCompletionsParams {
     /// Channel URI this command targets.
-    pub channel: Uri,
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1444,7 +1444,7 @@ pub struct SessionConfigValueItem {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionsParams {
-    /// Channel URI this command targets.
+    /// The chat URI the completion is being requested for.
     pub channel: Uri,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1515,7 +1515,7 @@ pub struct CompletionsResult {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InvokeChangesetOperationParams {
-    /// Channel URI this command targets.
+    /// The expanded changeset URI.
     pub channel: Uri,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1573,8 +1573,8 @@ pub struct ChangesetOperationFollowUp {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListAutomationTriggerDefinitionsParams {
-    /// Channel URI this command targets.
-    pub channel: Uri,
+    /// Trigger definitions are discovered from the root channel.
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1605,8 +1605,8 @@ pub struct ListAutomationTriggerDefinitionsResult {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunAutomationParams {
-    /// Channel URI this command targets.
-    pub channel: Uri,
+    /// Manual runs are scoped to the catalogue channel.
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1636,8 +1636,8 @@ pub struct RunAutomationResult {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchAutomationRunsParams {
-    /// Channel URI this command targets.
-    pub channel: Uri,
+    /// Run-history loading is scoped to the catalogue channel.
+    pub channel: String,
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]

--- a/clients/rust/crates/ahp-types/src/state.rs
+++ b/clients/rust/crates/ahp-types/src/state.rs
@@ -3411,9 +3411,9 @@ pub struct ToolCallAuthRequiredState {
     /// Human-readable description of what the tool invocation intends to do
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intention: Option<String>,
-    /// Reference to the contributor of the tool being called.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contributor: Option<ToolCallContributor>,
+    /// The MCP server that contributed this tool call — always MCP, never a client tool.
+    #[serde(with = "serde_tool_call_mcp_contributor_as_mcp")]
+    pub contributor: ToolCallMcpContributor,
     /// Additional provider-specific metadata for this tool call.
     ///
     /// This MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)
@@ -6074,4 +6074,48 @@ pub enum SnapshotState {
     Automations(Box<AutomationCatalogState>),
     AutomationRun(Box<AutomationRunState>),
     Root(Box<RootState>),
+}
+
+// ─── Serde helpers: inject the union discriminant for narrowed payloads ───
+
+/// Serializes a `ToolCallMcpContributor` with the `kind: mcp` union
+/// discriminant injected, matching the tagged-union wire form, and REJECTS a
+/// foreign discriminant on the way in.
+///
+/// The field is narrowed to one variant's payload, so any other `kind` is
+/// malformed input. Decoding it anyway would silently re-emit it as
+/// `mcp` -- rewriting a tag the peer sent. Mirrors
+/// `deserialize_running_tool_call`, which errors the same way on a wrong
+/// `status`.
+mod serde_tool_call_mcp_contributor_as_mcp {
+    use super::ToolCallMcpContributor;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    pub fn serialize<S: Serializer>(
+        value: &ToolCallMcpContributor,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut v = serde_json::to_value(value).map_err(serde::ser::Error::custom)?;
+        if let serde_json::Value::Object(ref mut map) = v {
+            map.insert(
+                "kind".to_string(),
+                serde_json::Value::String("mcp".to_string()),
+            );
+        }
+        v.serialize(serializer)
+    }
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<ToolCallMcpContributor, D::Error> {
+        let raw = serde_json::Value::deserialize(deserializer)?;
+        match raw.get("kind").and_then(serde_json::Value::as_str) {
+            None | Some("mcp") => {}
+            Some(other) => {
+                return Err(serde::de::Error::custom(format!(
+                    "expected {} {:?}, got {:?}",
+                    "kind", "mcp", other
+                )));
+            }
+        }
+        serde_json::from_value(raw).map_err(serde::de::Error::custom)
+    }
 }

--- a/clients/rust/crates/ahp-types/tests/narrowed_union_wire.rs
+++ b/clients/rust/crates/ahp-types/tests/narrowed_union_wire.rs
@@ -1,0 +1,83 @@
+// narrowed_union_wire.rs — regression test for the union-payload narrowing.
+//
+// `ToolCallAuthRequiredState.contributor` narrows the `ToolCallContributor`
+// tagged union to its `ToolCallMcpContributor` payload. In Rust the union
+// discriminant (`#[serde(tag = "kind")]`) lives on the enum, not the payload
+// struct — `ToolCallMcpContributor` has no `kind` field — so serializing the
+// bare payload would drop `"kind":"mcp"` from the wire. The generator emits a
+// serde-`with` module that injects it. This test pins that the type stays
+// narrowed AND the wire stays tagged, deserialize→serialize.
+
+use ahp_types::state::ToolCallAuthRequiredState;
+
+/// A wire-shaped `auth-required` tool call: `contributor` carries the union tag
+/// `"kind":"mcp"`, as an MCP server would send it.
+fn wire() -> serde_json::Value {
+    serde_json::json!({
+        "status": "auth-required",
+        "toolCallId": "tc1",
+        "toolName": "search",
+        "displayName": "Search",
+        "invocationMessage": "Search: foo",
+        "toolInput": "foo",
+        "confirmed": "not-needed",
+        "contributor": { "kind": "mcp", "customizationId": "mcp-1" },
+        "auth": {
+            "reason": "required",
+            "resource": {
+                "resource": "https://mcp.example.com",
+                "authorization_servers": ["https://auth.example.com"]
+            }
+        }
+    })
+}
+
+#[test]
+fn narrowed_contributor_deserializes_dropping_the_tag() {
+    let s: ToolCallAuthRequiredState = serde_json::from_value(wire()).unwrap();
+    // The tag is consumed; the field is the narrowed payload type.
+    assert_eq!(s.contributor.customization_id, "mcp-1");
+}
+
+#[test]
+fn narrowed_contributor_reserializes_with_the_tag() {
+    let s: ToolCallAuthRequiredState = serde_json::from_value(wire()).unwrap();
+    let out = serde_json::to_value(&s).unwrap();
+    let c = &out["contributor"];
+    // The narrowed payload still emits the union discriminant on the wire.
+    assert_eq!(c["kind"], "mcp", "wire dropped the union tag: {c}");
+    assert_eq!(c["customizationId"], "mcp-1");
+}
+
+/// A field narrowed to one variant's payload must REJECT a foreign discriminant rather
+/// than decode it and silently re-emit it as its own.
+///
+/// Without the check in the generated `deserialize`, `kind: "client"` decodes fine (the
+/// payload struct does not `deny_unknown_fields`) and then re-serializes as `kind: "mcp"`
+/// -- so this change would fix tag LOSS and introduce tag REWRITING, which is worse. The
+/// repo already rejects a mismatched discriminant this way in `deserialize_running_tool_call`.
+#[test]
+fn narrowed_contributor_rejects_a_foreign_tag() {
+    let mut w = wire();
+    w["contributor"]["kind"] = serde_json::json!("client");
+
+    let decoded: Result<ToolCallAuthRequiredState, _> = serde_json::from_value(w);
+    assert!(
+        decoded.is_err(),
+        "a foreign contributor tag must be rejected, not decoded and silently re-tagged as mcp"
+    );
+}
+
+/// An absent tag is still accepted: the payload struct is the narrowed type either way,
+/// and a peer that omits the redundant discriminant is not sending something wrong.
+#[test]
+fn narrowed_contributor_accepts_an_absent_tag() {
+    let mut w = wire();
+    w["contributor"] = serde_json::json!({ "customizationId": "mcp-1" });
+
+    let s: ToolCallAuthRequiredState = serde_json::from_value(w).expect("absent tag is fine");
+    assert_eq!(s.contributor.customization_id, "mcp-1");
+    // ...and it is re-emitted WITH the tag, which is the whole point of the with-module.
+    let out = serde_json::to_value(&s).unwrap();
+    assert_eq!(out["contributor"]["kind"], "mcp");
+}

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -196,7 +196,9 @@ fn tool_call_meta(tc: &ToolCallState) -> ToolCallBase {
             display_name: s.display_name.clone(),
             intention: s.intention.clone(),
             tool_input: s.tool_input.clone(),
-            contributor: s.contributor.clone(),
+            // AuthRequired narrows contributor to the MCP payload; widen it back
+            // to the union for the generic ToolCallBase projection.
+            contributor: Some(ToolCallContributor::Mcp(s.contributor.clone())),
             meta: s.meta.clone(),
         },
         ToolCallState::PendingResultConfirmation(s) => ToolCallBase {
@@ -1635,16 +1637,19 @@ fn apply_tool_call_auth_required(
         let meta = a.meta.clone().or(base.meta);
         match tc {
             ToolCallState::Running(s) => {
-                if !matches!(s.contributor, Some(ToolCallContributor::Mcp(_))) {
+                // Only an MCP-contributed call can pause for auth. That is exactly the
+                // narrowed contributor type ToolCallAuthRequiredState carries, so pull
+                // the MCP payload out of the wide union; any other contributor is a no-op.
+                let Some(ToolCallContributor::Mcp(contributor)) = s.contributor.clone() else {
                     return ToolCallState::Running(s);
-                }
+                };
                 ToolCallState::AuthRequired(Box::new(ToolCallAuthRequiredState {
                     tool_call_id: base.tool_call_id,
                     tool_name: base.tool_name,
                     display_name: base.display_name,
                     intention: base.intention,
                     tool_input: s.tool_input,
-                    contributor: s.contributor,
+                    contributor,
                     meta,
                     invocation_message: s.invocation_message,
                     confirmed: s.confirmed,
@@ -1673,7 +1678,8 @@ fn apply_tool_call_auth_resolved(
                 display_name: base.display_name,
                 intention: base.intention,
                 tool_input: s.tool_input,
-                contributor: s.contributor,
+                // Widen the narrowed MCP payload back to the union for the running state.
+                contributor: Some(ToolCallContributor::Mcp(s.contributor)),
                 meta,
                 invocation_message: s.invocation_message,
                 confirmed: s.confirmed,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -609,7 +609,7 @@ public struct SubscribeResult: Codable, Sendable {
 }
 
 public struct CreateSessionParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// Session URI (client-chosen, e.g. `ahp-session:/<uuid>`)
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -703,7 +703,7 @@ public struct DisposeSessionParams: Codable, Sendable {
 }
 
 public struct CreateChatParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// Session URI containing the new chat.
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1363,7 +1363,7 @@ public struct CreateResourceWatchResult: Codable, Sendable {
 }
 
 public struct FetchTurnsParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// Chat URI
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1483,7 +1483,7 @@ public struct AuthenticateResult: Codable, Sendable {
 }
 
 public struct CreateTerminalParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// Terminal URI (client-chosen).
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1779,7 +1779,7 @@ public struct SessionConfigValueItem: Codable, Sendable {
 }
 
 public struct CompletionsParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// The chat URI the completion is being requested for.
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1862,7 +1862,7 @@ public struct CompletionsResult: Codable, Sendable {
 }
 
 public struct InvokeChangesetOperationParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// The expanded changeset URI.
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1923,7 +1923,7 @@ public struct ChangesetOperationFollowUp: Codable, Sendable {
 }
 
 public struct ListAutomationTriggerDefinitionsParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// Trigger definitions are discovered from the root channel.
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -1970,7 +1970,7 @@ public struct ListAutomationTriggerDefinitionsResult: Codable, Sendable {
 }
 
 public struct RunAutomationParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// Manual runs are scoped to the catalogue channel.
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.
@@ -2014,7 +2014,7 @@ public struct RunAutomationResult: Codable, Sendable {
 }
 
 public struct FetchAutomationRunsParams: Codable, Sendable {
-    /// Channel URI this command targets.
+    /// Run-history loading is scoped to the catalogue channel.
     public var channel: String
     /// Optional JSON-serializable metadata associated with this request.
     /// Receivers MUST ignore keys they do not understand.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/State.generated.swift
@@ -3527,8 +3527,8 @@ public struct ToolCallAuthRequiredState: Codable, Sendable {
     public var displayName: String
     /// Human-readable description of what the tool invocation intends to do
     public var intention: String?
-    /// Reference to the contributor of the tool being called.
-    public var contributor: ToolCallContributor?
+    /// The MCP server that contributed this tool call — always MCP, never a client tool.
+    public var contributor: ToolCallMcpContributor
     /// Additional provider-specific metadata for this tool call.
     ///
     /// This MAY include a `ui` field corresponding to the MCP Apps (SEP-1865)
@@ -3575,7 +3575,7 @@ public struct ToolCallAuthRequiredState: Codable, Sendable {
         toolName: String,
         displayName: String,
         intention: String? = nil,
-        contributor: ToolCallContributor? = nil,
+        contributor: ToolCallMcpContributor,
         meta: [String: AnyCodable]? = nil,
         invocationMessage: StringOrMarkdown,
         toolInput: ToolInput? = nil,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -458,7 +458,10 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
     case .chatToolCallAuthRequired(let a):
         return refreshChatSummaryStatus(updateToolCall(state: state, turnId: a.turnId, toolCallId: a.toolCallId) { tc in
             guard case .running(let running) = tc else { return tc }
-            guard let contributor = running.contributor, case .mcp = contributor else { return tc }
+            // Auth is only ever required for an MCP-contributed tool call, which is why
+            // `ToolCallAuthRequiredState` narrows `contributor` to the MCP payload.
+            // Bind that payload here; any other contributor is a no-op.
+            guard let contributor = running.contributor, case .mcp(let mcpContributor) = contributor else { return tc }
 
             let base = tc.baseFields
             let meta = a.meta ?? base.meta
@@ -467,7 +470,7 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
                 toolName: base.toolName,
                 displayName: base.displayName,
                 intention: base.intention,
-                contributor: contributor,
+                contributor: mcpContributor,
                 meta: meta,
                 invocationMessage: running.invocationMessage,
                 toolInput: running.toolInput,

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/ToolCallStateExtensions.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/ToolCallStateExtensions.swift
@@ -59,10 +59,12 @@ extension ToolCallState {
                                        toolInput: s.toolInput,
                                        contributor: s.contributor, meta: s.meta)
         case .authRequired(let s):
+            // `ToolCallAuthRequiredState` narrows `contributor` to the MCP payload;
+            // wrap it back into the union these base fields share with every variant.
             return ToolCallBaseFields(toolCallId: s.toolCallId, toolName: s.toolName,
                                        displayName: s.displayName, intention: s.intention,
                                        toolInput: s.toolInput,
-                                       contributor: s.contributor, meta: s.meta)
+                                       contributor: .mcp(s.contributor), meta: s.meta)
         case .pendingResultConfirmation(let s):
             return ToolCallBaseFields(toolCallId: s.toolCallId, toolName: s.toolName,
                                        displayName: s.displayName, intention: s.intention,

--- a/docs/.changes/20260824-derived-property-override.json
+++ b/docs/.changes/20260824-derived-property-override.json
@@ -1,0 +1,5 @@
+{
+  "type": "fixed",
+  "message": "The rust, go, kotlin and swift generators now use a derived interface's narrowed property instead of the base declaration, so a field narrowed to one variant of a discriminated union is generated as that payload type and keeps its union discriminant on the wire.",
+  "targets": ["rust", "go", "kotlin", "swift"]
+}

--- a/scripts/generate-go.ts
+++ b/scripts/generate-go.ts
@@ -264,6 +264,50 @@ function getPropertyDoc(prop: PropertySignature): string {
   return jsDocs[0].getDescription().trim();
 }
 
+/**
+ * Group every declaration of each property name, ordered base → derived.
+ *
+ * `getAllProperties` appends an interface's own properties AFTER the ones it
+ * inherits, so a name declared by both a base and the interface itself lands in
+ * the list twice, with the interface's own (the override) last.
+ *
+ * The dedupe SEMANTICS are `generate-json-schema.ts`'s, not new: its
+ * `getAllInterfaceProperties` already resolves a name to its LAST declaration,
+ * emitted at its FIRST declaration's position (`byName.set(prop.getName(), prop)`
+ * then `[...byName.values()]`). This generator keeps the whole ordered LIST rather
+ * than only that winner, because the doc must cascade: a narrowing override usually
+ * carries no prose of its own, so the base's doc has to survive, and the
+ * winner-only shape discards the base. (The schema generator accepts that loss:
+ * `InitializeParams.channel` ships with no `description`.)
+ */
+function groupDeclarationsByName(props: PropertySignature[]): Map<string, PropertySignature[]> {
+  const byName = new Map<string, PropertySignature[]>();
+  for (const p of props) {
+    const decls = byName.get(p.getName());
+    if (decls) decls.push(p);
+    else byName.set(p.getName(), [p]);
+  }
+  return byName;
+}
+
+/**
+ * Resolve the doc comment for a property from its declarations (base → derived).
+ *
+ * The type comes from the most-derived declaration, but an override is often
+ * declared purely to narrow the type and carries no prose of its own (e.g.
+ * `InitializeParams.channel: 'ahp-root://'` re-declares `BaseParams.channel`
+ * only to pin the literal). Falling back to the nearest ancestor that documents
+ * the property keeps the base's prose cascading, while an override that *does*
+ * document itself (e.g. `CreateSessionParams.channel`) still wins.
+ */
+function resolvePropertyDoc(decls: PropertySignature[]): string {
+  for (let i = decls.length - 1; i >= 0; i--) {
+    const doc = getPropertyDoc(decls[i]);
+    if (doc) return doc;
+  }
+  return '';
+}
+
 function hasFormatFloat(prop: PropertySignature): boolean {
   for (const doc of prop.getJsDocs()) {
     for (const tag of doc.getTags()) {
@@ -309,10 +353,23 @@ function extractProps(iface: InterfaceDeclaration, project: Project): GoProp[] {
   const seen = new Set<string>();
   const result: GoProp[] = [];
 
-  for (const p of allProps) {
-    const tsName = p.getName();
+  // A derived interface may narrow an inherited property (e.g.
+  // `ToolCallAuthRequiredState.contributor` narrows the optional
+  // `ToolCallContributor` on `ToolCallBase` to a required
+  // `ToolCallMcpContributor`), and that override is the real contract. Take the
+  // type/optionality from the most-derived declaration, but emit the field at the
+  // position of its first (base) declaration so inherited field order stays
+  // stable. The doc is resolved separately: a narrowing override usually has no
+  // prose of its own, and the base's must still cascade.
+  const declsByName = groupDeclarationsByName(allProps);
+
+  for (const declared of allProps) {
+    const tsName = declared.getName();
     if (seen.has(tsName)) continue;
     seen.add(tsName);
+
+    const decls = declsByName.get(tsName) ?? [declared];
+    const p = decls[decls.length - 1];
 
     const tsType = getPropertyType(p);
 
@@ -369,7 +426,7 @@ function extractProps(iface: InterfaceDeclaration, project: Project): GoProp[] {
       wireName,
       goType,
       optional,
-      doc: getPropertyDoc(p),
+      doc: resolvePropertyDoc(decls),
       isLiteralDiscriminant,
       literalValue,
     });

--- a/scripts/generate-kotlin.ts
+++ b/scripts/generate-kotlin.ts
@@ -241,6 +241,50 @@ function getPropertyDoc(prop: PropertySignature): string {
   return jsDocs[0].getDescription().trim();
 }
 
+/**
+ * Group every declaration of each property name, ordered base → derived.
+ *
+ * `getAllProperties` appends an interface's own properties AFTER the ones it
+ * inherits, so a name declared by both a base and the interface itself lands in
+ * the list twice, with the interface's own (the override) last.
+ *
+ * The dedupe SEMANTICS are `generate-json-schema.ts`'s, not new: its
+ * `getAllInterfaceProperties` already resolves a name to its LAST declaration,
+ * emitted at its FIRST declaration's position (`byName.set(prop.getName(), prop)`
+ * then `[...byName.values()]`). This generator keeps the whole ordered LIST rather
+ * than only that winner, because the doc must cascade: a narrowing override usually
+ * carries no prose of its own, so the base's doc has to survive, and the
+ * winner-only shape discards the base. (The schema generator accepts that loss:
+ * `InitializeParams.channel` ships with no `description`.)
+ */
+function groupDeclarationsByName(props: PropertySignature[]): Map<string, PropertySignature[]> {
+  const byName = new Map<string, PropertySignature[]>();
+  for (const p of props) {
+    const decls = byName.get(p.getName());
+    if (decls) decls.push(p);
+    else byName.set(p.getName(), [p]);
+  }
+  return byName;
+}
+
+/**
+ * Resolve the doc comment for a property from its declarations (base → derived).
+ *
+ * The type comes from the most-derived declaration, but an override is often
+ * declared purely to narrow the type and carries no prose of its own (e.g.
+ * `InitializeParams.channel: 'ahp-root://'` re-declares `BaseParams.channel`
+ * only to pin the literal). Falling back to the nearest ancestor that documents
+ * the property keeps the base's prose cascading, while an override that *does*
+ * document itself (e.g. `CreateSessionParams.channel`) still wins.
+ */
+function resolvePropertyDoc(decls: PropertySignature[]): string {
+  for (let i = decls.length - 1; i >= 0; i--) {
+    const doc = getPropertyDoc(decls[i]);
+    if (doc) return doc;
+  }
+  return '';
+}
+
 /** Returns true if the property has a `@format float` JSDoc tag. */
 function hasFormatFloat(prop: PropertySignature): boolean {
   for (const doc of prop.getJsDocs()) {
@@ -294,14 +338,27 @@ function extractProps(iface: InterfaceDeclaration, project: Project): KotlinProp
   const allProps = getAllProperties(iface, project);
   const seen = new Set<string>();
 
+  // A derived interface may narrow an inherited property (e.g.
+  // `ToolCallAuthRequiredState.contributor` narrows the optional
+  // `ToolCallContributor` on `ToolCallBase` to a required
+  // `ToolCallMcpContributor`), and that override is the real contract. Take the
+  // type/optionality from the most-derived declaration, but emit the property at
+  // the position of its first (base) declaration so inherited property order stays
+  // stable. The doc is resolved separately: a narrowing override usually has no
+  // prose of its own, and the base's must still cascade.
+  const declsByName = groupDeclarationsByName(allProps);
+
   return allProps
     .filter(p => {
+      // Deduplicate, keeping the first (base) declaration's position.
       const name = p.getName();
       if (seen.has(name)) return false;
       seen.add(name);
       return true;
     })
-    .map(p => {
+    .map(declared => {
+      const decls = declsByName.get(declared.getName()) ?? [declared];
+      const p = decls[decls.length - 1];
       const tsName = p.getName();
       const tsType = getPropertyType(p);
       let kt = mapType(tsType);
@@ -323,7 +380,7 @@ function extractProps(iface: InterfaceDeclaration, project: Project): KotlinProp
         wireName: tsName,
         type: finalType,
         optional: isOptional,
-        doc: getPropertyDoc(p),
+        doc: resolvePropertyDoc(decls),
       };
     });
 }

--- a/scripts/generate-rust.ts
+++ b/scripts/generate-rust.ts
@@ -225,6 +225,77 @@ interface RustProp {
   doc: string;
   isLiteralDiscriminant: boolean;
   literalValue?: string;
+  /** Name of a generated serde-`with` module that injects the union discriminant
+   * on serialize, for a field narrowed to a discriminated-union payload. */
+  serdeWith?: string;
+}
+
+// Serde `with` modules generated for union-payload narrowings, keyed by module
+// name (deduped across fields in a file). A field like
+// `contributor: ToolCallMcpContributor` (narrowed from the `ToolCallContributor`
+// tagged union) is typed as the narrowed payload; this module injects
+// `"kind":"mcp"` on serialize so the wire still matches the union tag. Populated
+// during struct generation, drained into the file by `drainSerdeTagModules`.
+// Cleared per file. A field that populates this in a file that never drains it
+// produces a `#[serde(with = ...)]` referencing an undefined module, i.e. a loud
+// compile error, never silent wire corruption.
+const serdeTagModules = new Map<string, string>();
+
+/** Emit + clear every serde-`with` module collected for the current file. */
+function drainSerdeTagModules(): string {
+  if (serdeTagModules.size === 0) return '';
+  const mods = [...serdeTagModules.values()].join('\n\n');
+  serdeTagModules.clear();
+  return '// ─── Serde helpers: inject the union discriminant for narrowed payloads ───\n\n' + mods;
+}
+
+/**
+ * Register (deduped) a serde-`with` module that serializes a narrowed
+ * union-payload field with its discriminant injected, and returns its name.
+ * `discriminant` is the union's tag field (e.g. `kind`); `wireValue` is the
+ * variant's wire tag (e.g. `mcp`); `payloadType` is the narrowed Rust type.
+ */
+function registerSerdeTagModule(payloadType: string, discriminant: string, wireValue: string): string {
+  const modName = `serde_${toSnakeCase(payloadType)}_as_${toSnakeCase(wireValue)}`;
+  if (!serdeTagModules.has(modName)) {
+    const dk = JSON.stringify(discriminant);
+    const dv = JSON.stringify(wireValue);
+    serdeTagModules.set(modName, [
+      `/// Serializes a \`${payloadType}\` with the \`${discriminant}: ${wireValue}\` union`,
+      `/// discriminant injected, matching the tagged-union wire form, and REJECTS a`,
+      `/// foreign discriminant on the way in.`,
+      `///`,
+      `/// The field is narrowed to one variant's payload, so any other \`${discriminant}\` is`,
+      `/// malformed input. Decoding it anyway would silently re-emit it as`,
+      `/// \`${wireValue}\` -- rewriting a tag the peer sent. Mirrors`,
+      `/// \`deserialize_running_tool_call\`, which errors the same way on a wrong`,
+      `/// \`status\`.`,
+      `mod ${modName} {`,
+      `    use super::${payloadType};`,
+      `    use serde::{Deserialize, Deserializer, Serialize, Serializer};`,
+      `    pub fn serialize<S: Serializer>(value: &${payloadType}, serializer: S) -> Result<S::Ok, S::Error> {`,
+      `        let mut v = serde_json::to_value(value).map_err(serde::ser::Error::custom)?;`,
+      `        if let serde_json::Value::Object(ref mut map) = v {`,
+      `            map.insert(${dk}.to_string(), serde_json::Value::String(${dv}.to_string()));`,
+      `        }`,
+      `        v.serialize(serializer)`,
+      `    }`,
+      `    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<${payloadType}, D::Error> {`,
+      `        let raw = serde_json::Value::deserialize(deserializer)?;`,
+      `        match raw.get(${dk}).and_then(serde_json::Value::as_str) {`,
+      `            None | Some(${dv}) => {}`,
+      `            Some(other) => {`,
+      `                return Err(serde::de::Error::custom(format!(`,
+      `                    "expected {} {:?}, got {:?}", ${dk}, ${dv}, other`,
+      `                )));`,
+      `            }`,
+      `        }`,
+      `        serde_json::from_value(raw).map_err(serde::de::Error::custom)`,
+      `    }`,
+      `}`,
+    ].join('\n'));
+  }
+  return modName;
 }
 
 function getPropertyType(prop: PropertySignature): string {
@@ -237,6 +308,56 @@ function getPropertyDoc(prop: PropertySignature): string {
   const jsDocs = prop.getJsDocs();
   if (jsDocs.length === 0) return '';
   return jsDocs[0].getDescription().trim();
+}
+
+/**
+ * Group every declaration of each property name, ordered base → derived.
+ *
+ * `getAllProperties` appends an interface's own properties AFTER the ones it
+ * inherits, so a name declared by both a base and the interface itself lands in
+ * the list twice, with the interface's own (the override) last.
+ *
+ * The dedupe SEMANTICS are `generate-json-schema.ts`'s, not new: its
+ * `getAllInterfaceProperties` already resolves a name to its LAST declaration,
+ * emitted at its FIRST declaration's position (`byName.set(prop.getName(), prop)`
+ * then `[...byName.values()]`). This generator keeps the whole ordered LIST rather
+ * than only that winner, because two things here need the BASE declaration, which
+ * the winner-only shape discards:
+ *
+ *   1. the doc cascade — a narrowing override usually carries no prose of its own,
+ *      so the base's doc must still reach the generated code. (The schema generator
+ *      accepts that loss: `InitializeParams.channel` ships with no `description`.)
+ *   2. `findNarrowedUnionPayload` — when an override narrows to a variant payload of
+ *      an inherited discriminated union, the field is typed as the narrowed payload
+ *      (like every other override), and a serde-`with` module re-injects the union
+ *      discriminant on serialize; identifying that case needs the base declaration.
+ */
+function groupDeclarationsByName(props: PropertySignature[]): Map<string, PropertySignature[]> {
+  const byName = new Map<string, PropertySignature[]>();
+  for (const p of props) {
+    const decls = byName.get(p.getName());
+    if (decls) decls.push(p);
+    else byName.set(p.getName(), [p]);
+  }
+  return byName;
+}
+
+/**
+ * Resolve the doc comment for a property from its declarations (base → derived).
+ *
+ * The type comes from the most-derived declaration, but an override is often
+ * declared purely to narrow the type and carries no prose of its own (e.g.
+ * `InitializeParams.channel: 'ahp-root://'` re-declares `BaseParams.channel`
+ * only to pin the literal). Falling back to the nearest ancestor that documents
+ * the property keeps the base's prose cascading, while an override that *does*
+ * document itself (e.g. `CreateSessionParams.channel`) still wins.
+ */
+function resolvePropertyDoc(decls: PropertySignature[]): string {
+  for (let i = decls.length - 1; i >= 0; i--) {
+    const doc = getPropertyDoc(decls[i]);
+    if (doc) return doc;
+  }
+  return '';
 }
 
 /** Returns true if the property has a `@format float` JSDoc tag. */
@@ -277,10 +398,31 @@ function extractProps(iface: InterfaceDeclaration, project: Project): RustProp[]
   const seen = new Set<string>();
   const result: RustProp[] = [];
 
-  for (const p of allProps) {
-    const tsName = p.getName();
+  // A derived interface may narrow an inherited property (e.g.
+  // `InitializeParams.channel` narrows `BaseParams.channel` from `URI` to the
+  // literal `'ahp-root://'`), and that override is the real contract. Take the
+  // type/optionality from the most-derived declaration, but emit the field at the
+  // position of its first (base) declaration so inherited field order stays
+  // stable. The doc is resolved separately: a narrowing override usually has no
+  // prose of its own, and the base's must still cascade.
+  const declsByName = groupDeclarationsByName(allProps);
+
+  for (const declared of allProps) {
+    const tsName = declared.getName();
     if (seen.has(tsName)) continue;
     seen.add(tsName);
+
+    const decls = declsByName.get(tsName) ?? [declared];
+
+    // A field narrowed to a variant payload of an inherited discriminated union
+    // (e.g. `contributor: ToolCallMcpContributor` from the `ToolCallContributor`
+    // union) is typed as the narrowed payload, same as every other override. The
+    // one Rust-specific wrinkle: the union's discriminant (`#[serde(tag = "kind")]`)
+    // lives on the enum, not the payload struct, so serializing the bare payload
+    // would drop `"kind":"mcp"` from the wire. A generated serde-`with` module
+    // injects it back (registered below); the type stays narrowed like the others.
+    const narrowedUnion = findNarrowedUnionPayload(decls);
+    const p = decls[decls.length - 1];
 
     const tsType = getPropertyType(p);
 
@@ -331,15 +473,34 @@ function extractProps(iface: InterfaceDeclaration, project: Project): RustProp[]
       rustType = `Option<${rustType}>`;
     }
 
+    const doc = resolvePropertyDoc(decls);
+
+    // A narrowed union payload keeps the narrowed type; a serde-`with` module
+    // re-injects the union discriminant on serialize so the wire stays tagged.
+    // (Option-wrapped narrowings would need the module to be Option-aware; none
+    // exist today, so fail loudly rather than emit a wrong shape.)
+    let serdeWith: string | undefined;
+    if (narrowedUnion) {
+      if (optional) {
+        throw new Error(
+          `${iface.getName()}.${tsName} narrows to a union payload AND is optional; ` +
+          `the serde-with tag-injection module is not Option-aware. Extend registerSerdeTagModule.`,
+        );
+      }
+      const { union, variant } = narrowedUnion;
+      serdeWith = registerSerdeTagModule(rustType, union.discriminantField, variant.wireValue);
+    }
+
     result.push({
       rustName,
       wireName,
       rustType,
       optional,
       renamed,
-      doc: getPropertyDoc(p),
+      doc,
       isLiteralDiscriminant,
       literalValue,
+      serdeWith,
     });
   }
   return result;
@@ -595,6 +756,7 @@ function generateRustStruct(rustName: string, props: RustProp[], opts: StructOpt
     }
     const attrs: string[] = [];
     if (p.renamed) attrs.push(`rename = ${JSON.stringify(p.wireName)}`);
+    if (p.serdeWith) attrs.push(`with = ${JSON.stringify(p.serdeWith)}`);
     if (p.optional) {
       attrs.push('default');
       attrs.push('skip_serializing_if = "Option::is_none"');
@@ -691,6 +853,14 @@ interface UnionConfig {
 }
 
 function generateDiscriminatedUnion(project: Project, cfg: UnionConfig): string {
+  // Emission IS the definition of "this union exists", so registering here rather than
+  // asserting membership is what actually makes the registry unable to drift: a union
+  // cannot be emitted without becoming findable. A miss fails silently otherwise --
+  // findNarrowedUnionPayload returns undefined, the field narrows, no serde-`with`
+  // module is generated, and the discriminant is dropped on the wire with nothing to
+  // notice. `StateAction` in particular is built from runtime-computed variants and so
+  // can never appear in a static const list.
+  getUnionRegistry().set(cfg.name, cfg);
   const unknown = discriminatedUnionAllowsUnknown(
     project,
     cfg.discriminantField,
@@ -1219,6 +1389,38 @@ const AUTOMATION_RUN_LIFECYCLE_UNION: UnionConfig = {
   ],
 };
 
+/**
+ * Every discriminated union emitted into `state.rs`, in emission order.
+ *
+ * Doubles as part of the registry consulted by {@link findNarrowedUnionPayload},
+ * so the set of unions the generator knows about cannot drift from the set it
+ * actually emits.
+ */
+const STATE_UNIONS: UnionConfig[] = [
+  RESPONSE_PART_UNION,
+  TOOL_CALL_STATE_UNION,
+  TOOL_CALL_CONFIRMATION_STATE_UNION,
+  TERMINAL_CLAIM_UNION,
+  TERMINAL_CONTENT_PART_UNION,
+  CHAT_INPUT_QUESTION_UNION,
+  CHAT_INPUT_ANSWER_VALUE_UNION,
+  CHAT_INPUT_ANSWER_UNION,
+  TOOL_RESULT_CONTENT_UNION,
+  MESSAGE_ATTACHMENT_UNION,
+  CUSTOMIZATION_UNION,
+  CHILD_CUSTOMIZATION_UNION,
+  CUSTOMIZATION_LOAD_STATE_UNION,
+  MCP_SERVER_STATUS_UNION,
+  TOOL_CALL_CONTRIBUTOR_UNION,
+  TOOL_CALL_RISK_ASSESSMENT_UNION,
+  TERMINAL_LIFECYCLE_STATE_UNION,
+  SESSION_INPUT_REQUEST_UNION,
+  SESSION_ORIGIN_UNION,
+  AUTOMATION_TRIGGER_UNION,
+  AUTOMATION_RUN_ORIGIN_UNION,
+  AUTOMATION_RUN_LIFECYCLE_UNION,
+];
+
 function generateChatOrigin(project: Project): string {
   const originKind = findEnum(project, 'ChatOriginKind');
   if (!originKind) throw new Error('ChatOriginKind enum not found');
@@ -1304,6 +1506,7 @@ pub enum ToolInput {
 }
 
 function generateStateFile(project: Project): string {
+  serdeTagModules.clear();
   const lines: string[] = [GENERATED_HEADER];
 
   lines.push('// ─── Enums ────────────────────────────────────────────────────────────\n');
@@ -1349,52 +1552,18 @@ function generateStateFile(project: Project): string {
   lines.push('// ─── Discriminated Unions ─────────────────────────────────────────────\n');
   lines.push(generateChatOrigin(project));
   lines.push('');
-  lines.push(generateDiscriminatedUnion(project, RESPONSE_PART_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_STATE_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONFIRMATION_STATE_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TERMINAL_CLAIM_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TERMINAL_CONTENT_PART_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_QUESTION_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_ANSWER_VALUE_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, CHAT_INPUT_ANSWER_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TOOL_RESULT_CONTENT_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, MESSAGE_ATTACHMENT_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, CHILD_CUSTOMIZATION_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, CUSTOMIZATION_LOAD_STATE_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, MCP_SERVER_STATUS_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_CONTRIBUTOR_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TOOL_CALL_RISK_ASSESSMENT_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, TERMINAL_LIFECYCLE_STATE_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, SESSION_INPUT_REQUEST_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, SESSION_ORIGIN_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, AUTOMATION_TRIGGER_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_ORIGIN_UNION));
-  lines.push('');
-  lines.push(generateDiscriminatedUnion(project, AUTOMATION_RUN_LIFECYCLE_UNION));
-  lines.push('');
+  for (const union of STATE_UNIONS) {
+    lines.push(generateDiscriminatedUnion(project, union));
+    lines.push('');
+  }
   lines.push(generateSnapshotState());
   lines.push('');
+
+  const serdeMods = drainSerdeTagModules();
+  if (serdeMods) {
+    lines.push(serdeMods);
+    lines.push('');
+  }
 
   return lines.join('\n');
 }
@@ -1704,6 +1873,87 @@ const CHAT_SOURCE_UNION: UnionConfig = {
     { variantName: 'SideChat', innerType: 'SideChatSource', wireValue: 'sideChat' },
   ],
 };
+
+/**
+ * Every `#[serde(tag = "...")]` enum this generator emits, keyed by Rust name.
+ *
+ * These are exactly the unions whose variant payload structs are emitted with
+ * `omitDiscriminants: true` — the discriminant lives on the enum tag, so the
+ * payload struct itself has no such field. That is what makes narrowing a
+ * property to one of these payloads a wire regression; see
+ * {@link findNarrowedUnionPayload}.
+ *
+ * Seeded lazily from the `UnionConfig` consts declared throughout this file
+ * (`extractProps`, declared above them, only ever runs after module evaluation), then
+ * topped up by `generateDiscriminatedUnion`, which registers whatever it emits. The
+ * const seed is what makes lookups order-independent for the common case; the
+ * registration on emit is what stops an emitted union -- including a runtime-built one
+ * like `StateAction` -- from being absent.
+ */
+let unionRegistry: Map<string, UnionConfig> | undefined;
+function getUnionRegistry(): Map<string, UnionConfig> {
+  if (!unionRegistry) {
+    unionRegistry = new Map(
+      [...STATE_UNIONS, RECONNECT_RESULT_UNION, CHAT_SOURCE_UNION].map(u => [u.name, u]),
+    );
+  }
+  return unionRegistry;
+}
+
+/**
+ * Strip `| undefined` / `| null` and whitespace, returning the bare type name if
+ * what remains is a single identifier (e.g. `ToolCallContributor | undefined` →
+ * `ToolCallContributor`). Returns undefined for anything structural.
+ */
+function bareTypeName(tsType: string): string | undefined {
+  const stripped = tsType
+    .split('|')
+    .map(t => t.trim())
+    .filter(t => t !== 'undefined' && t !== 'null');
+  if (stripped.length !== 1) return undefined;
+  return /^\w+$/.test(stripped[0]) ? stripped[0] : undefined;
+}
+
+/**
+ * Detect a property override that narrows an inherited discriminated union to
+ * one of that union's *variant payload structs* — e.g.
+ * `ToolCallAuthRequiredState.contributor` narrowing `ToolCallContributor` (a
+ * `#[serde(tag = "kind")]` enum) to `ToolCallMcpContributor` (its `Mcp` payload).
+ *
+ * The payload struct is emitted with `omitDiscriminants: true` because its
+ * discriminant becomes the enum's tag, so a field typed as the payload *directly*
+ * — rather than reached through the enum — would serialize without `"kind":"mcp"`
+ * and drop the discriminator from the wire. Every other client is unaffected:
+ * their payload types carry their own `kind` field.
+ *
+ * The field is still typed as the narrowed payload, like every other override;
+ * a generated serde-`with` module (see `registerSerdeTagModule`) injects the
+ * discriminant on serialize so the wire stays tagged. This function's job is to
+ * detect the case and surface the union + variant, so the caller can register
+ * that module. It searches base-ward from the override for the nearest ancestor
+ * declaring the union, so multi-level inheritance chains resolve correctly.
+ *
+ * @returns the ancestor declaration to take the type from, plus the union and
+ * variant involved — or undefined when this is not a union-payload narrowing
+ * (e.g. `InitializeParams.channel`, which narrows a plain `URI` to a string
+ * literal and must still be narrowed).
+ */
+function findNarrowedUnionPayload(
+  decls: PropertySignature[],
+): { baseDecl: PropertySignature; union: UnionConfig; variant: UnionVariant } | undefined {
+  if (decls.length < 2) return undefined;
+  const overrideType = bareTypeName(getPropertyType(decls[decls.length - 1]));
+  if (!overrideType) return undefined;
+
+  for (let i = decls.length - 2; i >= 0; i--) {
+    const baseType = bareTypeName(getPropertyType(decls[i]));
+    if (!baseType || baseType === overrideType) continue;
+    const union = getUnionRegistry().get(baseType);
+    const variant = union?.variants.find(v => v.innerType === overrideType);
+    if (union && variant) return { baseDecl: decls[i], union, variant };
+  }
+  return undefined;
+}
 
 function generateCommandsFile(project: Project): string {
   const lines: string[] = [GENERATED_HEADER];

--- a/scripts/generate-swift.ts
+++ b/scripts/generate-swift.ts
@@ -202,6 +202,50 @@ function getPropertyDoc(prop: PropertySignature): string {
   return jsDocs[0].getDescription().trim();
 }
 
+/**
+ * Group every declaration of each property name, ordered base → derived.
+ *
+ * `getAllProperties` appends an interface's own properties AFTER the ones it
+ * inherits, so a name declared by both a base and the interface itself lands in
+ * the list twice, with the interface's own (the override) last.
+ *
+ * The dedupe SEMANTICS are `generate-json-schema.ts`'s, not new: its
+ * `getAllInterfaceProperties` already resolves a name to its LAST declaration,
+ * emitted at its FIRST declaration's position (`byName.set(prop.getName(), prop)`
+ * then `[...byName.values()]`). This generator keeps the whole ordered LIST rather
+ * than only that winner, because the doc must cascade: a narrowing override usually
+ * carries no prose of its own, so the base's doc has to survive, and the
+ * winner-only shape discards the base. (The schema generator accepts that loss:
+ * `InitializeParams.channel` ships with no `description`.)
+ */
+function groupDeclarationsByName(props: PropertySignature[]): Map<string, PropertySignature[]> {
+  const byName = new Map<string, PropertySignature[]>();
+  for (const p of props) {
+    const decls = byName.get(p.getName());
+    if (decls) decls.push(p);
+    else byName.set(p.getName(), [p]);
+  }
+  return byName;
+}
+
+/**
+ * Resolve the doc comment for a property from its declarations (base → derived).
+ *
+ * The type comes from the most-derived declaration, but an override is often
+ * declared purely to narrow the type and carries no prose of its own (e.g.
+ * `InitializeParams.channel: 'ahp-root://'` re-declares `BaseParams.channel`
+ * only to pin the literal). Falling back to the nearest ancestor that documents
+ * the property keeps the base's prose cascading, while an override that *does*
+ * document itself (e.g. `CreateSessionParams.channel`) still wins.
+ */
+function resolvePropertyDoc(decls: PropertySignature[]): string {
+  for (let i = decls.length - 1; i >= 0; i--) {
+    const doc = getPropertyDoc(decls[i]);
+    if (doc) return doc;
+  }
+  return '';
+}
+
 /** Returns true if the property has a `@format float` JSDoc tag. */
 function hasFormatFloat(prop: PropertySignature): boolean {
   for (const doc of prop.getJsDocs()) {
@@ -255,18 +299,30 @@ function extractProps(iface: InterfaceDeclaration, project: Project): SwiftProp[
   const allProps = getAllProperties(iface, project);
   const seen = new Set<string>();
 
+  // A derived interface may narrow an inherited property (e.g.
+  // `ToolCallAuthRequiredState.contributor` narrows the optional
+  // `ToolCallContributor` on `ToolCallBase` to a required
+  // `ToolCallMcpContributor`), and that override is the real contract. Take the
+  // type/optionality from the most-derived declaration, but emit the property at
+  // the position of its first (base) declaration so inherited property order stays
+  // stable. The doc is resolved separately: a narrowing override usually has no
+  // prose of its own, and the base's must still cascade.
+  const declsByName = groupDeclarationsByName(allProps);
+
   return allProps
     .filter(p => {
-      // Deduplicate (later declaration wins)
+      // Deduplicate, keeping the first (base) declaration's position.
       const name = p.getName();
       if (seen.has(name)) return false;
       seen.add(name);
       return true;
     })
-    .map(p => {
+    .map(declared => {
+      const decls = declsByName.get(declared.getName()) ?? [declared];
+      const p = decls[decls.length - 1];
       const tsName = p.getName();
       const tsType = getPropertyType(p);
-        let swiftT = mapType(tsType, tsName, iface.getName());
+      let swiftT = mapType(tsType, tsName, iface.getName());
       // `@format float` overrides the default Int → Double for number properties.
       if (swiftT === 'Int' && hasFormatFloat(p)) {
         swiftT = 'Double';
@@ -285,7 +341,7 @@ function extractProps(iface: InterfaceDeclaration, project: Project): SwiftProp[
         wireName: tsName,
         type: finalType,
         optional: isOptional,
-        doc: getPropertyDoc(p),
+        doc: resolvePropertyDoc(decls),
       };
     });
 }


### PR DESCRIPTION
## Summary

An interface that narrows an inherited property was generating the **base** property's type in the rust, go, kotlin and swift generators. Where the base is a discriminated union and the override narrows it to one variant's payload, the generated field is wider than the contract — and the payload struct it should have narrowed to is emitted with `omitDiscriminants`, so a value round-tripped through the wide field loses its tag.

This takes the most-derived declaration of each property.

## Why now, and where the precedent comes from

I wrote the C# version of this in #206, which @connor4312 approved and merged on 2026-08-23. `scripts/generate-csharp.ts` already resolves each property to its most-derived declaration and names the motivating case in a comment (`ToolCallAuthRequiredState.contributor`). So this finishes what that started rather than proposing a new idea.

Two of six generators were correct; four were not. The visible symptom is a disagreement between two first-party clients — .NET emits

```csharp
public required ToolCallMcpContributor Contributor { get; init; }
```

while Go emits

```go
Contributor *ToolCallContributor
```

still carrying the base type's doc comment.

## The Rust half

Rust needs the narrowed payload re-tagged on the wire, since serde's tag lives on the enum and not on the payload struct. A generated serde-`with` module injects the discriminant on serialize.

It also **rejects a foreign discriminant on deserialize**. That part matters: decoding one anyway would re-emit another peer's tag as our own, which is a worse defect than the tag loss being fixed. This mirrors `deserialize_running_tool_call`, which already errors on a mismatched `status`. `narrowed_contributor_rejects_a_foreign_tag` fails without it.

The union registry backing the narrowing lookup is populated by `generateDiscriminatedUnion` itself, so a union cannot be emitted without becoming findable. Asserting membership instead would not hold — `StateAction` is built from runtime-computed variants and can never appear in a static const list.

## Things you'll notice in the diff

- **38 lines of `Uri` → `String`** (19 in Go `commands.generated.go`, 19 in Rust `commands.rs`). This is the loudest thing in the diff and it is not the point of the PR. Cause: `channel` narrows to the literal `'ahp-root://'`. Non-breaking — both are aliases (`type URI = string`, `pub type Uri = String`).
- **A doc-comment cascade** across four files: a narrowed property now carries its *own* doc instead of the base's. That is a second behaviour change and an improvement over the C# precedent, which ships `InitializeParams.Channel` with no summary at all.
- **Hand-written reducer changes** in all four clients. Narrowing the field pushes the wrap/unwrap to the call sites; that is where the per-client diffs come from.

**Why not just drop `omitDiscriminants` in Rust, the way Go does it?** Serde's `tag = "kind"` inserts the key itself, so the payload struct would emit it twice. That is what the `with` module exists to avoid.

## Tests

- rust: 70 across 6 suites, plus `cargo fmt --check` and `cargo clippy -D warnings` clean
- go: all packages ok, `gofmt` clean
- swift: 121
- kotlin: 366
- all four generators regenerate clean

Happy to add a shared round-trip fixture under `types/test-cases/round-trips/` covering a narrowed union payload if you'd prefer cross-client proof over the Rust-only test — that corpus is the natural home for it and I'd rather add it here than leave the other three languages resting on the existing reducer fixtures.
