### PR TITLE
Credit initial .NET client authorship and correct package docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ against them.
 | `clients/swift/` | Swift package (consumed by SwiftPM at the repo root). |
 | `clients/typescript/` | npm package `@microsoft/agent-host-protocol`. |
 | `clients/go/` | Go module (`ahptypes`, `ahp`, `ahpws`). |
-| `clients/dotnet/` | .NET / NuGet packages (`Microsoft.AgentHostProtocol`, `.Abstractions`, `.WebSockets`). |
+| `clients/dotnet/` | .NET / NuGet packages (`Microsoft.AgentHostProtocol`, `.Abstractions`). |
 | `.github/workflows/` | CI and per-artifact publish pipelines. |
 
 ## Local dev loop

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -187,7 +187,6 @@ trigger started the run.
 4. Merge to `main`.
 5. Tag: `git tag dotnet/v0.X.Y && git push origin dotnet/v0.X.Y`.
 6. Publish the libraries (`Microsoft.AgentHostProtocol`,
-   `Microsoft.AgentHostProtocol.Abstractions`,
    `Microsoft.AgentHostProtocol.Abstractions`) to NuGet.org. This client does
    not ship its own publish automation — the maintainers wire the
    `dotnet pack` + `dotnet nuget push` step into their own release pipeline,

--- a/clients/dotnet/README.md
+++ b/clients/dotnet/README.md
@@ -163,6 +163,13 @@ local NuGet packages, and runs it as a native executable with
 initialization, reconnect replay, subscriptions and reducers, custom generic
 requests and notifications, and typed and raw inbound request handling.
 
+## Authorship
+
+Joshua Mouch contributed the initial first-party .NET client and the
+handwritten C# reducers in [PR #206](https://github.com/microsoft/agent-host-protocol/pull/206).
+The generated wire and model sources described above are separate generated
+artifacts.
+
 ## Releasing
 
 1. Bump [`VERSION`](VERSION).


### PR DESCRIPTION
## Summary

- credit Joshua Mouch for contributing the initial first-party .NET client and handwritten C# reducers in PR #206
- distinguish those handwritten reducers from the separately generated wire and model sources
- correct the contributor and release documentation to list the two packages the .NET client actually ships

## Validation

- npm run verify:changelog
- npm run verify:change-fragments
- git diff --check

This is a documentation-only correction, so it does not add a changelog fragment.