### PR TITLE
ci: harden Windows NuGet dry runs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Generators emit canonical LF output. Keep Windows checkouts from converting
+# committed generated files before drift checks regenerate them.
+clients/dotnet/src/**/Generated/*.generated.cs text eol=lf
+
+# Release metadata is generated as canonical JSON and compared byte-for-byte
+# apart from checkout line endings.
+clients/*/release-metadata.json text eol=lf

--- a/clients/dotnet/pipeline.yml
+++ b/clients/dotnet/pipeline.yml
@@ -30,9 +30,7 @@ resources:
     - repository: templates
       type: github
       name: microsoft/vscode-engineering
-      # Temporary while the reusable NuGet template is under review. Switch
-      # this back to `main` before marking the AHP PR ready to merge.
-      ref: refs/heads/connor4312/nuget-package-template
+      ref: refs/heads/main
       endpoint: Monaco
 
 extends:

--- a/clients/dotnet/pipeline.yml
+++ b/clients/dotnet/pipeline.yml
@@ -135,6 +135,33 @@ extends:
         displayName: 📦 Pack signed .NET libraries
 
       - pwsh: |
+          # Avoid NuGet's Windows path normalization bug for local-first
+          # repeated --source arguments (NuGet/Home#14624).
+          $configPath = Join-Path '$(Agent.TempDirectory)' 'ahp-aot-nuget.config'
+          $settings = [System.Xml.XmlWriterSettings]::new()
+          $settings.Indent = $true
+          $writer = [System.Xml.XmlWriter]::Create($configPath, $settings)
+          try {
+            $writer.WriteStartDocument()
+            $writer.WriteStartElement('configuration')
+            $writer.WriteStartElement('packageSources')
+            $writer.WriteStartElement('clear')
+            $writer.WriteEndElement()
+            $writer.WriteStartElement('add')
+            $writer.WriteAttributeString('key', 'signed-packages')
+            $writer.WriteAttributeString('value', '$(Build.ArtifactStagingDirectory)/nuget')
+            $writer.WriteEndElement()
+            $writer.WriteStartElement('add')
+            $writer.WriteAttributeString('key', 'vscode')
+            $writer.WriteAttributeString('value', '$(NUGET_RESTORE_SOURCE)')
+            $writer.WriteEndElement()
+            $writer.WriteEndElement()
+            $writer.WriteEndElement()
+            $writer.WriteEndDocument()
+          } finally {
+            $writer.Dispose()
+          }
+
           $arguments = @(
             'restore'
             'tests/AgentHostProtocol.AotSmoke/AgentHostProtocol.AotSmoke.csproj'
@@ -142,10 +169,8 @@ extends:
             'win-x64'
             '--packages'
             'artifacts/package-consumer-cache'
-            '--source'
-            '$(Build.ArtifactStagingDirectory)/nuget'
-            '--source'
-            '$(NUGET_RESTORE_SOURCE)'
+            '--configfile'
+            $configPath
             '-p:UsePackedPackages=true'
           )
           & dotnet @arguments

--- a/clients/dotnet/pipeline.yml
+++ b/clients/dotnet/pipeline.yml
@@ -134,13 +134,24 @@ extends:
         workingDirectory: clients/dotnet
         displayName: 📦 Pack signed .NET libraries
 
-      - script: >-
-          dotnet restore tests/AgentHostProtocol.AotSmoke/AgentHostProtocol.AotSmoke.csproj
-          --runtime win-x64
-          --packages artifacts/package-consumer-cache
-          --source "$(Build.ArtifactStagingDirectory)/nuget"
-          --source "$(NUGET_RESTORE_SOURCE)"
-          -p:UsePackedPackages=true
+      - pwsh: |
+          $arguments = @(
+            'restore'
+            'tests/AgentHostProtocol.AotSmoke/AgentHostProtocol.AotSmoke.csproj'
+            '--runtime'
+            'win-x64'
+            '--packages'
+            'artifacts/package-consumer-cache'
+            '--source'
+            '$(Build.ArtifactStagingDirectory)/nuget'
+            '--source'
+            '$(NUGET_RESTORE_SOURCE)'
+            '-p:UsePackedPackages=true'
+          )
+          & dotnet @arguments
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
         workingDirectory: clients/dotnet
         displayName: 📦 Restore Native AOT smoke test from packages
 

--- a/scripts/verify-release-metadata.ts
+++ b/scripts/verify-release-metadata.ts
@@ -231,7 +231,9 @@ function main(): void {
     }
     const expected = computeReleaseMetadata(client, ROOT, registrySupported);
     const expectedSerialized = serializeReleaseMetadata(expected);
-    const actualSerialized = fs.readFileSync(metaPath, 'utf-8');
+    // Git may materialize text files with CRLF on Windows agents. Compare the
+    // JSON's canonical formatting independently of checkout line endings.
+    const actualSerialized = fs.readFileSync(metaPath, 'utf-8').replaceAll('\r\n', '\n');
 
     if (expectedSerialized !== actualSerialized) {
       // Parse the actual file for a more useful diff in the error message.


### PR DESCRIPTION
## Summary

- make generated-artifact verification stable on Windows checkouts
- normalize CRLF before exact release-metadata formatting comparisons
- force canonical LF checkout for generated .NET sources and release metadata
- restore the Native AOT package smoke test through an isolated NuGet configuration to avoid NuGet/Home#14624
- consume the merged signed NuGet pipeline template from `microsoft/vscode-engineering@main`

## Validation

- `npm test`
- fresh checkout with `core.autocrlf=true`: `npm run generate:dotnet` leaves generated sources clean
- `npm run verify:release-metadata` under Windows-style checkout conditions
- Azure DevOps signed dry run build 468604 passed build, tests, Native AOT package consumption, ESRP content signing, NuGet signing, and signed artifact publication with `publish: false`
- updated pipeline YAML parses successfully

## Final ADO verification

Target branch: `connor4312/nuget-dry-run-fixes`

Run once more at `493cf741` with the default `publish: false`. This verifies the exact merged `vscode-engineering@main` template before this PR is made ready and merged.
