### PR TITLE
chat: make the turnStarted reducer case idempotent

### DIFF
--- a/clients/dotnet/src/AgentHostProtocol/Reducers.cs
+++ b/clients/dotnet/src/AgentHostProtocol/Reducers.cs
@@ -1093,6 +1093,13 @@ public static class Reducers
 
     private static ReduceOutcome ApplyChatTurnStarted(ChatState state, ChatTurnStartedAction a)
     {
+        // A replayed start must not reset the turn in progress or resurrect a finished one.
+        if ((state.ActiveTurn is not null && state.ActiveTurn.Id == a.TurnId)
+            || state.Turns.Exists(t => t.Id == a.TurnId))
+        {
+            return ReduceOutcome.NoOp;
+        }
+
         state.ActiveTurn = new ActiveTurn
         {
             Id = a.TurnId,

--- a/clients/go/ahp/reducers.go
+++ b/clients/go/ahp/reducers.go
@@ -1058,6 +1058,15 @@ func ApplyActionToSession(state *ahptypes.SessionState, action ahptypes.StateAct
 }
 
 func applyTurnStarted(state *ahptypes.ChatState, a *ahptypes.ChatTurnStartedAction) ReduceOutcome {
+	// A replayed start must not reset the turn in progress or resurrect a finished one.
+	if state.ActiveTurn != nil && state.ActiveTurn.Id == a.TurnId {
+		return ReduceOutcomeNoOp
+	}
+	for _, turn := range state.Turns {
+		if turn.Id == a.TurnId {
+			return ReduceOutcomeNoOp
+		}
+	}
 	state.ActiveTurn = &ahptypes.ActiveTurn{
 		Id:            a.TurnId,
 		StartedAt:     a.StartedAt,

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/Reducers.kt
@@ -867,32 +867,39 @@ public fun chatReducer(state: ChatState, action: StateAction): ChatState = when 
 
     is StateActionChatTurnStarted -> {
         val a = action.value
-        val withTurn = state.copy(
-            activeTurn = ActiveTurn(
-                id = a.turnId,
-                startedAt = a.startedAt,
-                message = a.message,
-                responseParts = emptyList(),
-                usage = null,
-            ),
-        )
-        val withStatus = withTurn.copy(
-            status = withStatusFlag(chatSummaryStatus(withTurn), SessionStatus.IS_READ, false),
-            modifiedAt = a.startedAt,
-        )
-        if (a.queuedMessageId == null) {
-            withStatus
+        // A replayed start must not reset the turn in progress or resurrect a finished one.
+        val alreadyStarted = state.activeTurn?.id == a.turnId ||
+            state.turns.any { it.id == a.turnId }
+        if (alreadyStarted) {
+            state
         } else {
-            var next = withStatus
-            if (next.steeringMessage?.id == a.queuedMessageId) {
-                next = next.copy(steeringMessage = null)
+            val withTurn = state.copy(
+                activeTurn = ActiveTurn(
+                    id = a.turnId,
+                    startedAt = a.startedAt,
+                    message = a.message,
+                    responseParts = emptyList(),
+                    usage = null,
+                ),
+            )
+            val withStatus = withTurn.copy(
+                status = withStatusFlag(chatSummaryStatus(withTurn), SessionStatus.IS_READ, false),
+                modifiedAt = a.startedAt,
+            )
+            if (a.queuedMessageId == null) {
+                withStatus
+            } else {
+                var next = withStatus
+                if (next.steeringMessage?.id == a.queuedMessageId) {
+                    next = next.copy(steeringMessage = null)
+                }
+                val queued = next.queuedMessages
+                if (queued != null) {
+                    val filtered = queued.filter { it.id != a.queuedMessageId }
+                    next = next.copy(queuedMessages = filtered.ifEmpty { null })
+                }
+                next
             }
-            val queued = next.queuedMessages
-            if (queued != null) {
-                val filtered = queued.filter { it.id != a.queuedMessageId }
-                next = next.copy(queuedMessages = filtered.ifEmpty { null })
-            }
-            next
         }
     }
 

--- a/clients/rust/crates/ahp/src/reducers.rs
+++ b/clients/rust/crates/ahp/src/reducers.rs
@@ -1325,6 +1325,12 @@ pub fn apply_action_to_chat(state: &mut ChatState, action: &StateAction) -> Redu
 }
 
 fn apply_turn_started(state: &mut ChatState, a: &ChatTurnStartedAction) -> ReduceOutcome {
+    // A replayed start must not reset the turn in progress or resurrect a finished one.
+    let already_started = state.active_turn.as_ref().is_some_and(|t| t.id == a.turn_id)
+        || state.turns.iter().any(|t| t.id == a.turn_id);
+    if already_started {
+        return ReduceOutcome::NoOp;
+    }
     state.active_turn = Some(ActiveTurn {
         id: a.turn_id.clone(),
         started_at: a.started_at.clone(),

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Reducers.swift
@@ -127,6 +127,12 @@ public func chatReducer(state: ChatState, action: StateAction) -> ChatState {
     // ── Turn Lifecycle ────────────────────────────────────────────────────
 
     case .chatTurnStarted(let a):
+        // A replayed start must not reset the turn in progress or resurrect a finished one.
+        let alreadyStarted = state.activeTurn?.id == a.turnId
+            || state.turns.contains { $0.id == a.turnId }
+        if alreadyStarted {
+            return state
+        }
         var next = state
         next.modifiedAt = a.startedAt
         next.activeTurn = ActiveTurn(

--- a/docs/.changes/20260902-idempotent-chat-turnstarted.json
+++ b/docs/.changes/20260902-idempotent-chat-turnstarted.json
@@ -1,0 +1,4 @@
+{
+  "type": "fixed",
+  "message": "`chat/turnStarted` is a no-op when its `turnId` is already the active turn or an already-completed turn, so a replayed start no longer resets a streaming turn."
+}

--- a/docs/guide/state-model.md
+++ b/docs/guide/state-model.md
@@ -207,6 +207,8 @@ ActiveTurn {
 }
 ```
 
+A `chat/turnStarted` whose `turnId` is already the active turn, or names a turn that has already completed, is a no-op. A client that replays its own optimistic turn start over confirmed state therefore never resets a turn in progress.
+
 ### User Messages
 
 ```typescript

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -356,6 +356,7 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
     // ── Turn Lifecycle ────────────────────────────────────────────────────
 
     case ActionType.ChatTurnStarted: {
+      // A replayed start must not reset the turn in progress or resurrect a finished one.
       const alreadyStarted = state.activeTurn?.id === action.turnId
         || state.turns.some(turn => turn.id === action.turnId);
       if (alreadyStarted) {

--- a/types/channels-chat/reducer.ts
+++ b/types/channels-chat/reducer.ts
@@ -356,6 +356,11 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
     // ── Turn Lifecycle ────────────────────────────────────────────────────
 
     case ActionType.ChatTurnStarted: {
+      const alreadyStarted = state.activeTurn?.id === action.turnId
+        || state.turns.some(turn => turn.id === action.turnId);
+      if (alreadyStarted) {
+        return state;
+      }
       let next: ChatState = {
         ...state,
         activeTurn: {

--- a/types/test-cases/reducers/272-chat-turnstarted-for-active-turn-is-no-op.json
+++ b/types/test-cases/reducers/272-chat-turnstarted-for-active-turn-is-no-op.json
@@ -1,0 +1,67 @@
+{
+  "description": "chat/turnStarted for the active turn is a no-op",
+  "reducer": "chat",
+  "initial": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "startedAt": "1970-01-01T00:00:01.000Z",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [
+        {
+          "kind": "markdown",
+          "id": "md-1",
+          "content": "Hello world"
+        }
+      ],
+      "usage": null
+    },
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 8,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/turnStarted",
+      "turnId": "turn-1",
+      "startedAt": "1970-01-01T00:00:01.000Z",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      }
+    }
+  ],
+  "expected": {
+    "turns": [],
+    "activeTurn": {
+      "id": "turn-1",
+      "startedAt": "1970-01-01T00:00:01.000Z",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      },
+      "responseParts": [
+        {
+          "kind": "markdown",
+          "id": "md-1",
+          "content": "Hello world"
+        }
+      ],
+      "usage": null
+    },
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 8,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  }
+}

--- a/types/test-cases/reducers/273-chat-turnstarted-for-completed-turn-is-no-op.json
+++ b/types/test-cases/reducers/273-chat-turnstarted-for-completed-turn-is-no-op.json
@@ -1,0 +1,69 @@
+{
+  "description": "chat/turnStarted for a completed turn is a no-op",
+  "reducer": "chat",
+  "initial": {
+    "turns": [
+      {
+        "id": "turn-1",
+        "message": {
+          "text": "Hello",
+          "origin": {
+            "kind": "user"
+          }
+        },
+        "responseParts": [
+          {
+            "kind": "markdown",
+            "id": "md-1",
+            "content": "Hello world"
+          }
+        ],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 1,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  },
+  "actions": [
+    {
+      "type": "chat/turnStarted",
+      "turnId": "turn-1",
+      "startedAt": "1970-01-01T00:00:01.000Z",
+      "message": {
+        "text": "Hello",
+        "origin": {
+          "kind": "user"
+        }
+      }
+    }
+  ],
+  "expected": {
+    "turns": [
+      {
+        "id": "turn-1",
+        "message": {
+          "text": "Hello",
+          "origin": {
+            "kind": "user"
+          }
+        },
+        "responseParts": [
+          {
+            "kind": "markdown",
+            "id": "md-1",
+            "content": "Hello world"
+          }
+        ],
+        "usage": null,
+        "state": "complete"
+      }
+    ],
+    "resource": "copilot:/test-session",
+    "title": "Test Session",
+    "status": 1,
+    "modifiedAt": "1970-01-01T00:00:02.000Z"
+  }
+}


### PR DESCRIPTION
Makes the `chat/turnStarted` reducer case a no-op when the turn it names is already active or already in the turn list.

## Why

A client that applies its own dispatched actions optimistically keeps them pending until the host echoes them, and replays every still-pending action over confirmed state on each confirmed action. Some paths never echo, so a pending `chat/turnStarted` can be replayed indefinitely. Today that case unconditionally rebuilds `activeTurn` with empty `responseParts`, so one stranded start wipes the streamed content on every delta. That is the mechanism behind microsoft/vscode#332087, where responses render only at turn end.

The guard also covers a start replayed after the turn completed and was confirmed through a snapshot, which would otherwise resurrect a finished turn as an empty active one. Ignoring a start for a completed turn is the right semantics: restarting a finished turn is `chat/turnResume`'s job, and turn ids are unique.

## What changed

- `types/channels-chat/reducer.ts`: return the state unchanged when `activeTurn.id` or any entry in `turns` already carries `action.turnId`.
- Fixtures `272-chat-turnstarted-for-active-turn-is-no-op` and `273-chat-turnstarted-for-completed-turn-is-no-op`, with `expected` equal to `initial`.
- A change fragment and one paragraph under "Active Turn" in the state-model guide stating the rule.

`tsc` clean, the reducer test suite passes (280), eslint clean, the fragment check passes.

## Not done here

I did not change the Go, Kotlin, Swift and .NET reducers, so the two new fixtures will fail in their fixture-driven suites until they get the same two-line guard. I am happy to add those in this PR if parity in one change is preferred.

*AI disclosure: this comment and the related code were written with the assistance of AI.*

<!-- public-patch-collection:start -->
### Public patches and patcher scripts

[Source patch and installed-bundle workaround mapping](https://github.com/RyanEwen/vscode-patches/blob/main/docs/patches/agent-host-protocol-433.md). The [public collection](https://github.com/RyanEwen/vscode-patches) includes the maintained patchers, rollback instructions, regression scripts, and historical snapshots. Build restrictions and exact installer coverage are documented there.
<!-- public-patch-collection:end -->
