### PR TITLE
Clipped edge label in mermaid diagram

### DIFF
--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -27,7 +27,7 @@ flowchart LR
         AC["SessionActiveClient\n.customizations"]
     end
 
-    AI -- "host resolves & parses\non session create" --> SC        
+    AI -- "host resolves & parses\non session create" --> SC
     AC -- "client publishes\nClientPluginCustomization\nvia activeClientSet" --> SC
 ```
 

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -27,8 +27,8 @@ flowchart LR
         AC["SessionActiveClient\n.customizations"]
     end
 
-    AI -- "host resolves & parses\non session create" --> SC
-    AC -- "client publishes ClientPluginCustomization\nvia activeClientSet" --> SC
+    AI -- "host resolves & parses\non session create" --> SC        
+    AC -- "client publishes\nClientPluginCustomization\nvia activeClientSet" --> SC
 ```
 
 Clients publish in Open Plugins shape only. They MAY synthesize a virtual plugin in memory if their real source is on disk; mapping a workspace location to a physical directory is the host's job, not the client's.


### PR DESCRIPTION
The "via activeClientSet" line was rendered outside the label's background box. After the change, the label background renders correctly instead of clipping the last line.

<img width="1398" height="460" alt="image" src="https://github.com/user-attachments/assets/87c89019-096b-47ea-9574-2f6ff8c4689b" />

**Solution:**  Pre-wrap the label into 3 explicit lines so no renderer needs to auto-wrap it.
