### PR TITLE
auth: scope MCP tokens by server name

### DIFF
--- a/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Commands.generated.cs
+++ b/clients/dotnet/src/AgentHostProtocol.Abstractions/Generated/Commands.generated.cs
@@ -1275,6 +1275,12 @@ public sealed record AuthenticateParams
     /// token.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? Scopes { get; init; }
+
+    /// <summary>Exact, case-sensitive MCP server configuration name when the token resolves
+    /// a server-owned authentication request. The host MUST apply the token only
+    /// to that named server. Omit for provider-level protected resources.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ServerName { get; init; }
 }
 
 /// <summary>Result of the `authenticate` command.

--- a/clients/go/ahptypes/commands.generated.go
+++ b/clients/go/ahptypes/commands.generated.go
@@ -1016,6 +1016,10 @@ type AuthenticateParams struct {
 	// Omit when the client doesn't track granted scopes separately from the
 	// token.
 	Scopes []string `json:"scopes,omitempty"`
+	// Exact, case-sensitive MCP server configuration name when the token resolves
+	// a server-owned authentication request. The host MUST apply the token only
+	// to that named server. Omit for provider-level protected resources.
+	ServerName *string `json:"serverName,omitempty"`
 }
 
 // Result of the `authenticate` command.

--- a/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
+++ b/clients/kotlin/src/main/kotlin/com/microsoft/agenthostprotocol/generated/Commands.generated.kt
@@ -1242,7 +1242,13 @@ data class AuthenticateParams(
      * Omit when the client doesn't track granted scopes separately from the
      * token.
      */
-    val scopes: List<String>? = null
+    val scopes: List<String>? = null,
+    /**
+     * Exact, case-sensitive MCP server configuration name when the token resolves
+     * a server-owned authentication request. The host MUST apply the token only
+     * to that named server. Omit for provider-level protected resources.
+     */
+    val serverName: String? = null
 )
 
 @Serializable

--- a/clients/rust/crates/ahp-types/src/commands.rs
+++ b/clients/rust/crates/ahp-types/src/commands.rs
@@ -1309,6 +1309,11 @@ pub struct AuthenticateParams {
     /// token.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
+    /// Exact, case-sensitive MCP server configuration name when the token resolves
+    /// a server-owned authentication request. The host MUST apply the token only
+    /// to that named server. Omit for provider-level protected resources.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_name: Option<String>,
 }
 
 /// Result of the `authenticate` command.

--- a/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
+++ b/clients/swift/AgentHostProtocol/Sources/AgentHostProtocol/Generated/Commands.generated.swift
@@ -1484,6 +1484,10 @@ public struct AuthenticateParams: Codable, Sendable {
     /// Omit when the client doesn't track granted scopes separately from the
     /// token.
     public var scopes: [String]?
+    /// Exact, case-sensitive MCP server configuration name when the token resolves
+    /// a server-owned authentication request. The host MUST apply the token only
+    /// to that named server. Omit for provider-level protected resources.
+    public var serverName: String?
 
     enum CodingKeys: String, CodingKey {
         case channel
@@ -1492,6 +1496,7 @@ public struct AuthenticateParams: Codable, Sendable {
         case token
         case expiresIn
         case scopes
+        case serverName
     }
 
     public init(
@@ -1500,7 +1505,8 @@ public struct AuthenticateParams: Codable, Sendable {
         resource: String,
         token: String,
         expiresIn: Int? = nil,
-        scopes: [String]? = nil
+        scopes: [String]? = nil,
+        serverName: String? = nil
     ) {
         self.channel = channel
         self.meta = meta
@@ -1508,6 +1514,7 @@ public struct AuthenticateParams: Codable, Sendable {
         self.token = token
         self.expiresIn = expiresIn
         self.scopes = scopes
+        self.serverName = serverName
     }
 }
 

--- a/docs/.changes/20260904-server-scoped-mcp-authentication.json
+++ b/docs/.changes/20260904-server-scoped-mcp-authentication.json
@@ -1,0 +1,4 @@
+{
+  "type": "security",
+  "message": "Scope MCP authentication tokens to the named server when multiple servers share a protected resource."
+}

--- a/docs/specification/authentication.md
+++ b/docs/specification/authentication.md
@@ -118,11 +118,25 @@ If the client retained the original token response, it MUST subtract elapsed tim
 
 `scopes` is optional and lets the client tell the server which OAuth scopes the pushed token actually grants — useful when resolving a `requiredScopes` challenge (from a live `McpServerAuthRequiredState` or `ToolCallAuthRequiredState.auth`) without the server needing to decode an opaque token.
 
+`serverName` is optional for provider-level resources and required when the
+token resolves an authentication challenge from a particular MCP server. Its
+value is the exact, case-sensitive MCP server configuration name advertised by
+the corresponding MCP customization or tool-call state. When present, the host
+MUST apply the token only to that named server, even when other MCP servers
+advertise the same `resource` and scopes.
+
 If the token is invalid or the resource is unrecognized, the server MUST return a JSON-RPC error (e.g. `AuthRequired` `-32007` or `InvalidParams` `-32602`).
 
-### Why keyed by `resource`?
+### Why keyed by `resource` and optional `serverName`?
 
 The RFC 9728 `resource` field is already a unique identifier for the protected resource. Using it directly as the correlation key between discovery and token delivery avoids inventing a parallel ID scheme. Clients match tokens to resources using standard OAuth 2.0 semantics.
+
+Different MCP server configurations can intentionally share one protected
+resource while using distinct OAuth clients or accounts. For those
+server-owned challenges, `serverName` adds the configuration identity needed
+to prevent one server's token from satisfying a sibling server's pending
+request. Provider-level authentication continues to omit `serverName` and
+remains keyed by `resource` and scopes.
 
 ## Error Handling
 

--- a/schema/commands.schema.json
+++ b/schema/commands.schema.json
@@ -886,6 +886,10 @@
             "type": "string"
           },
           "description": "OAuth scopes the token grants, when known. Lets the server determine\nwhether a specific challenge — e.g. the `requiredScopes` on a live\n`McpServerAuthRequiredState` or `ToolCallAuthRequiredState.auth` — is\nsatisfied without decoding the (opaque, server-specific) token itself.\nOmit when the client doesn't track granted scopes separately from the\ntoken."
+        },
+        "serverName": {
+          "type": "string",
+          "description": "Exact, case-sensitive MCP server configuration name when the token resolves\na server-owned authentication request. The host MUST apply the token only\nto that named server. Omit for provider-level protected resources."
         }
       },
       "required": [

--- a/types/common/commands.ts
+++ b/types/common/commands.ts
@@ -1183,6 +1183,12 @@ export interface AuthenticateParams extends BaseParams {
    * token.
    */
   scopes?: string[];
+   /**
+    * Exact, case-sensitive MCP server configuration name when the token resolves
+    * a server-owned authentication request. The host MUST apply the token only
+    * to that named server. Omit for provider-level protected resources.
+    */
+   serverName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- add an optional, exact `serverName` to `authenticate` requests for MCP-owned challenges
- require hosts to apply named tokens only to that MCP server, even when sibling servers share the same OAuth resource and scopes
- update the authentication specification, JSON schema, all generated client mirrors, and the security changelog fragment

## Validation

- [x] protocol type-check
- [x] TypeScript protocol, generator, and changelog tests
- [x] change-fragment validation
- [x] generated schema and client diffs checked against the repository generator
- [ ] full `npm test` (local `npm ci` is blocked by an `ENOTCONN` registry error; CI should run the canonical dependency/toolchain matrix)

## Compatibility

The field is optional. Existing provider-level authentication and older clients continue to key tokens by resource and scopes; clients resolving a specific MCP challenge can opt into server-scoped routing.
